### PR TITLE
fix(#9): set KeepAlive=true in supervisor plist

### DIFF
--- a/com.claude-hub.supervisor.plist
+++ b/com.claude-hub.supervisor.plist
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude-hub.supervisor</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/caffeinate</string>
+        <string>-dimsu</string>
+        <string>/Users/harieshokunin/.bun/bin/bun</string>
+        <string>run</string>
+        <string>/Users/harieshokunin/claude-hub/supervisor/index.ts</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/harieshokunin/claude-hub/supervisor</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/harieshokunin/.local/bin:/Users/harieshokunin/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>ThrottleInterval</key>
+    <integer>10</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/harieshokunin/claude-hub/logs/supervisor.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/harieshokunin/claude-hub/logs/supervisor.stderr.log</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>Nice</key>
+    <integer>5</integer>
+
+    <key>SoftResourceLimits</key>
+    <dict>
+        <key>NumberOfFiles</key>
+        <integer>4096</integer>
+    </dict>
+
+    <key>ExitTimeOut</key>
+    <integer>30</integer>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>


### PR DESCRIPTION
## Summary
- `com.claude-hub.supervisor.plist` の `KeepAlive` を `<dict><SuccessfulExit>false</></>` から `<true/>` に変更
- launchd が異常終了だけでなく正常終了時も supervisor を respawn するようになり、常時起動保証が成立

## Context
#9 の AC-3/AC-5 対応。原因1(二重throw)・2(unhandledRejection) は既に #22 で解消済のため、残っていた plist のみを本PRで修正。

なお main に一度直pushしてしまい revert したため、本ブランチは revert を取り込んだ上で同変更を再適用する構成になっています。

## Verification
- plutil -lint PASS
- launchctl reload 後 `properties = keepalive` 確認
- SIGTERM → 1秒以内に新PID で autorespawn (AC-5)

## Test plan
- [x] plist 構文チェック
- [x] launchctl reload
- [x] SIGTERM→autorespawn
- [ ] 24h 無停止観測

Closes #9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * バックグラウンドサービスの新しい設定を追加しました。このサービスはシステム起動時に自動的に開始され、ログファイルに出力を記録し、CPU優先度とリソース制限を適切に設定しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->