### PR TITLE
chore(ci): add Codecov coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,11 +66,20 @@ jobs:
           SUPERVISOR_DB_PATH: ":memory:"
           TMUX_PATH: /usr/bin/tmux
         run: |
-          bun test tests/session/output-formatter.test.ts \
+          bun test --coverage --coverage-reporter=lcov \
+                   tests/session/output-formatter.test.ts \
                    tests/session/relay.test.ts \
                    tests/session/relay-server.test.ts \
                    tests/hooks/stop-relay.test.ts \
                    tests/infra/db.test.ts
+
+      - name: Upload coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: supervisor/coverage/lcov.info
+          flags: unit-tests
+          fail_ci_if_error: false
 
   # Local-only tests (require tmux/Claude CLI or local config):
   #   manager.test.ts  — tmux + Claude Code CLI


### PR DESCRIPTION
## Summary

- Add `--coverage --coverage-reporter=lcov` flags to `bun test` in the `unit-test` job to generate lcov coverage reports
- Add a new step using `codecov/codecov-action@v5` to upload coverage data to Codecov (tokenless, public repo)
- Upload runs with `if: always()` so coverage is reported even if some tests fail
- `fail_ci_if_error: false` ensures Codecov upload issues don't block CI

## Test plan

- [ ] CI workflow runs successfully on this PR
- [ ] Coverage report is generated at `supervisor/coverage/lcov.info`
- [ ] Codecov receives the upload and shows coverage data

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * テスト実行時のコードカバレッジ計測機能を拡張しました。
  * カバレッジレポートの自動アップロード機能をCI/CDパイプラインに追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->