### PR TITLE
feat: forward Claude responses to vive-reading TTS webhook

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -81,7 +81,7 @@ export async function startBot(token: string): Promise<void> {
       try {
         const channel = await client.channels.fetch(event.threadId);
         if (channel?.isThread()) {
-          await channel.send(`🔧 \`${event.tool}\` ${event.message}`);
+          await channel.send(`🔧 \`${event.tool}\`: ${event.message}`);
         }
       } catch (err) {
         console.error(`[Bot] Progress send error for thread ${event.threadId}:`, err);
@@ -205,6 +205,9 @@ export async function startBot(token: string): Promise<void> {
           }
         }
 
+        // Forward to vive-reading TTS webhook (fire-and-forget)
+        forwardToViveReading(threadId, thread.name ?? "", result.text);
+
         // Attach generated files referenced in the response text
         try {
           const session = sessionManager.get(threadId);
@@ -259,4 +262,23 @@ export async function startBot(token: string): Promise<void> {
   process.on("SIGINT", shutdown);
 
   await client.login(token);
+}
+
+const VIVE_READING_URL = process.env.VIVE_READING_WEBHOOK_URL ?? "http://localhost:3456/api/webhook";
+
+function forwardToViveReading(threadId: string, channel: string, text: string): void {
+  if (!text?.trim()) return;
+  fetch(VIVE_READING_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      source: "discord",
+      channel,
+      author: "Claude",
+      content: text,
+    }),
+  }).catch((err) => {
+    // Fire-and-forget: don't let TTS webhook failure affect Discord delivery
+    console.warn(`[Bot] vive-reading webhook failed (non-blocking): ${err.message}`);
+  });
 }

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -267,18 +267,37 @@ export async function startBot(token: string): Promise<void> {
 const VIVE_READING_URL = process.env.VIVE_READING_WEBHOOK_URL ?? "http://localhost:3456/api/webhook";
 
 function forwardToViveReading(threadId: string, channel: string, text: string): void {
-  if (!text?.trim()) return;
-  fetch(VIVE_READING_URL, {
-    method: "POST",
-    headers: { "Content-Type": "application/json" },
-    body: JSON.stringify({
-      source: "discord",
-      channel,
-      author: "Claude",
-      content: text,
-    }),
-  }).catch((err) => {
-    // Fire-and-forget: don't let TTS webhook failure affect Discord delivery
-    console.warn(`[Bot] vive-reading webhook failed (non-blocking): ${err.message}`);
-  });
+  try {
+    if (!text?.trim()) return;
+
+    // Strip code blocks before sending to TTS — reading raw code aloud hurts quality
+    const cleanedText = text.replace(/```[\s\S]*?```/g, "(コードブロック省略)").trim();
+    if (!cleanedText) return;
+
+    fetch(VIVE_READING_URL, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        source: "discord",
+        channel,
+        author: "Claude",
+        content: cleanedText,
+      }),
+    })
+      .then(async (res) => {
+        if (!res.ok) {
+          const body = await res.text().catch(() => "");
+          throw new Error(`HTTP ${res.status}${body ? `: ${body.slice(0, 200)}` : ""}`);
+        }
+      })
+      .catch((err: unknown) => {
+        // Fire-and-forget: don't let TTS webhook failure affect Discord delivery
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(`[Bot] vive-reading webhook failed for thread ${threadId} (async): ${msg}`);
+      });
+  } catch (err) {
+    // Guard against synchronous exceptions (e.g., malformed URL) — still fire-and-forget
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[Bot] vive-reading webhook failed for thread ${threadId} (sync): ${msg}`);
+  }
 }


### PR DESCRIPTION
## Summary
- Claude Code応答をDiscordに送信した直後、vive-reading TTSサーバーにもwebhookで転送
- fire-and-forget方式。TTS側の障害がDiscord配信に影響しない
- `VIVE_READING_WEBHOOK_URL` 環境変数で設定可能（デフォルト: `http://localhost:3456/api/webhook`）

## Changes
- `supervisor/src/bot.ts`: `forwardToViveReading()` 関数追加、応答送信後に呼び出し

## Test plan
- [ ] vive-reading serverを起動し、Discordでメッセージを送信→webhookが届くことを確認
- [ ] vive-reading serverが停止中でもDiscord配信に影響がないことを確認
- [ ] `VIVE_READING_WEBHOOK_URL` 環境変数で別URLを指定できることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

* **新機能**
  * テキスト読み上げサービスへのメッセージ転送を追加（送信は非同期の遅延処理）。空白のみのメッセージは送信されません。
  * 送信前にコードブロックを除去して投稿します。

* **改善**
  * Discordスレッドに送信されるツールのステータスメッセージ書式を更新しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->