### PR TITLE
feat: progress relay v2 — file-based URL + detailed tool targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,11 @@ pids/
 # Screenshots (local only)
 screenshots/
 
+# Generated plist (contains local paths; regenerate via scripts/install-hijoguchi.sh)
+com.claude-hub.hijoguchi.plist
+
+# Supervisor relay URL marker files
+.supervisor-relay-url
+
 # Claude Code local state
 .claude/

--- a/com.claude-hub.hijoguchi.plist
+++ b/com.claude-hub.hijoguchi.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude-hub.hijoguchi</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/usr/bin/caffeinate</string>
+        <string>-dimsu</string>
+        <string>/Users/harieshokunin/claude-hub/scripts/start-hijoguchi.sh</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/harieshokunin/claude-hub</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/harieshokunin/.local/bin:/Users/harieshokunin/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <key>HOME</key>
+        <string>/Users/harieshokunin</string>
+    </dict>
+
+    <key>KeepAlive</key>
+    <dict>
+        <key>SuccessfulExit</key>
+        <false/>
+    </dict>
+
+    <key>ThrottleInterval</key>
+    <integer>15</integer>
+
+    <key>StandardOutPath</key>
+    <string>/Users/harieshokunin/claude-hub/logs/hijoguchi.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/harieshokunin/claude-hub/logs/hijoguchi.stderr.log</string>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/com.claude-hub.hijoguchi.plist.template
+++ b/com.claude-hub.hijoguchi.plist.template
@@ -10,18 +10,18 @@
     <array>
         <string>/usr/bin/caffeinate</string>
         <string>-dimsu</string>
-        <string>/Users/harieshokunin/claude-hub/scripts/start-hijoguchi.sh</string>
+        <string>__HOME__/claude-hub/scripts/start-hijoguchi.sh</string>
     </array>
 
     <key>WorkingDirectory</key>
-    <string>/Users/harieshokunin/claude-hub</string>
+    <string>__HOME__/claude-hub</string>
 
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/Users/harieshokunin/.local/bin:/Users/harieshokunin/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>__HOME__/.local/bin:__HOME__/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
         <key>HOME</key>
-        <string>/Users/harieshokunin</string>
+        <string>__HOME__</string>
     </dict>
 
     <key>KeepAlive</key>
@@ -34,9 +34,9 @@
     <integer>15</integer>
 
     <key>StandardOutPath</key>
-    <string>/Users/harieshokunin/claude-hub/logs/hijoguchi.stdout.log</string>
+    <string>__HOME__/claude-hub/logs/hijoguchi.stdout.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/harieshokunin/claude-hub/logs/hijoguchi.stderr.log</string>
+    <string>__HOME__/claude-hub/logs/hijoguchi.stderr.log</string>
 
     <key>RunAtLoad</key>
     <true/>

--- a/scripts/install-hijoguchi.sh
+++ b/scripts/install-hijoguchi.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Install the claudeHubExit (hijoguchi) launchd service.
+# Generates plist from template, installs to ~/Library/LaunchAgents, and loads it.
+#
+# Usage: bash scripts/install-hijoguchi.sh
+#   --uninstall   Stop and remove the service
+
+set -euo pipefail
+
+LABEL="com.claude-hub.hijoguchi"
+TEMPLATE="$(cd "$(dirname "$0")/.." && pwd)/com.claude-hub.hijoguchi.plist.template"
+PLIST_DIR="$HOME/Library/LaunchAgents"
+PLIST="$PLIST_DIR/$LABEL.plist"
+GUI_UID=$(id -u)
+
+if [ "${1:-}" = "--uninstall" ]; then
+  echo "[install] Uninstalling $LABEL..."
+  launchctl bootout "gui/$GUI_UID/$LABEL" 2>/dev/null || true
+  rm -f "$PLIST"
+  echo "[install] Done. Service removed."
+  exit 0
+fi
+
+if [ ! -f "$TEMPLATE" ]; then
+  echo "[install] ERROR: Template not found: $TEMPLATE" >&2
+  exit 1
+fi
+
+echo "[install] Generating plist from template..."
+echo "[install]   HOME=$HOME"
+mkdir -p "$PLIST_DIR"
+sed "s|__HOME__|$HOME|g" "$TEMPLATE" > "$PLIST"
+echo "[install] Written: $PLIST"
+
+# Stop existing service if running
+launchctl bootout "gui/$GUI_UID/$LABEL" 2>/dev/null || true
+
+echo "[install] Loading service..."
+launchctl bootstrap "gui/$GUI_UID" "$PLIST"
+
+echo "[install] Verifying..."
+STATE=$(launchctl print "gui/$GUI_UID/$LABEL" 2>&1 | grep "state" | head -1 || echo "unknown")
+echo "[install] $STATE"
+echo "[install] Done. Use 'launchctl kickstart -k gui/$GUI_UID/$LABEL' to restart."

--- a/scripts/start-hijoguchi.sh
+++ b/scripts/start-hijoguchi.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# claudeHubExit watchdog — keeps a tmux session named 'claudeHubExit' alive
+# running `claude --channels plugin:discord@claude-plugins-official`.
+#
+# Invoked by launchd (com.claude-hub.hijoguchi). Exits only on SIGTERM
+# from launchd; on any Claude crash, restarts the tmux session after a short
+# backoff. launchd KeepAlive restarts this script if it dies entirely.
+#
+# See docs/bot-operations.md for rationale.
+
+set -u
+
+SESSION=claudeHubExit
+CLAUDE_HUB_DIR="$HOME/claude-hub"
+LOG_DIR="$CLAUDE_HUB_DIR/logs"
+CLAUDE_BIN="$HOME/.local/bin/claude"
+TMUX_BIN="/opt/homebrew/bin/tmux"
+BACKOFF_SEC=5
+
+mkdir -p "$LOG_DIR"
+
+# Clean shutdown on SIGTERM from launchd
+trap 'echo "[hijoguchi] SIGTERM received, killing tmux session"; "$TMUX_BIN" kill-session -t "$SESSION" 2>/dev/null; exit 0' TERM INT
+
+echo "[hijoguchi] watchdog starting at $(date)"
+
+while true; do
+  # Ensure no stale session
+  "$TMUX_BIN" kill-session -t "$SESSION" 2>/dev/null
+
+  echo "[hijoguchi] starting tmux session '$SESSION' at $(date)"
+  "$TMUX_BIN" new-session -d -s "$SESSION" -c "$CLAUDE_HUB_DIR" \
+    "$CLAUDE_BIN --channels plugin:discord@claude-plugins-official --dangerously-skip-permissions"
+
+  # Block while the session exists
+  while "$TMUX_BIN" has-session -t "$SESSION" 2>/dev/null; do
+    sleep 10
+  done
+
+  echo "[hijoguchi] session '$SESSION' ended at $(date), backing off ${BACKOFF_SEC}s"
+  sleep "$BACKOFF_SEC"
+done

--- a/scripts/start-hijoguchi.sh
+++ b/scripts/start-hijoguchi.sh
@@ -14,7 +14,7 @@ SESSION=claudeHubExit
 CLAUDE_HUB_DIR="$HOME/claude-hub"
 LOG_DIR="$CLAUDE_HUB_DIR/logs"
 CLAUDE_BIN="$HOME/.local/bin/claude"
-TMUX_BIN="/opt/homebrew/bin/tmux"
+TMUX_BIN="${TMUX_PATH:-/opt/homebrew/bin/tmux}"
 BACKOFF_SEC=5
 
 mkdir -p "$LOG_DIR"

--- a/supervisor/hooks/progress-relay.sh
+++ b/supervisor/hooks/progress-relay.sh
@@ -1,41 +1,95 @@
 #!/bin/bash
 # Claude Code PostToolUse hook: sends tool progress to Supervisor's HTTP relay.
-# Called with JSON on stdin containing tool_name, tool_input, etc.
-# Requires: SUPERVISOR_RELAY_URL environment variable (e.g., http://localhost:PORT/relay/THREAD_ID).
+# Called with JSON on stdin containing tool_name, tool_input, cwd, etc.
+#
+# Relay URL is read from $CWD/.supervisor-relay-url (written by SessionManager).
+# Claude Code hooks don't inherit custom env vars, so we use filesystem.
+#
+# Sends: { tool, message } where message is a short human-readable target
+# extracted from tool_input (e.g., "pgrep -fl claude" for Bash).
 
+INPUT=$(cat)
+MAX_LEN=80
+
+# Read cwd from hook JSON to find the relay URL file
+CWD=$(echo "$INPUT" | jq -r '.cwd // ""')
+if [ -z "$CWD" ]; then
+  exit 0
+fi
+
+RELAY_URL_FILE="${CWD}/.supervisor-relay-url"
+if [ ! -f "$RELAY_URL_FILE" ]; then
+  exit 0
+fi
+
+SUPERVISOR_RELAY_URL=$(cat "$RELAY_URL_FILE")
 if [ -z "$SUPERVISOR_RELAY_URL" ]; then
   exit 0
 fi
 
-# Extract thread ID from relay URL: http://localhost:PORT/relay/THREAD_ID
 THREAD_ID="${SUPERVISOR_RELAY_URL##*/relay/}"
 if [ -z "$THREAD_ID" ]; then
   exit 0
 fi
 
-# Build progress URL from relay URL
-PROGRESS_URL="${SUPERVISOR_RELAY_URL/\/relay\//\/progress\/}"
+PROGRESS_URL="${SUPERVISOR_RELAY_URL/relay/progress}"
 
-INPUT=$(cat)
 TOOL_NAME=$(echo "$INPUT" | jq -r '.tool_name // "unknown"')
 
-# Skip noisy tools to avoid spamming Discord
+# Extract a short target string per tool type.
 case "$TOOL_NAME" in
-  Read|Glob|Grep|Bash)
-    MESSAGE="実行完了"
+  Bash)
+    TARGET=$(echo "$INPUT" | jq -r '.tool_input.command // ""' | tr '\n' ' ' | tr -s ' ')
     ;;
-  Write|Edit)
-    MESSAGE="ファイル更新"
+  Read|Edit|Write|NotebookEdit)
+    FP=$(echo "$INPUT" | jq -r '.tool_input.file_path // ""')
+    TARGET="${FP##*/}"
     ;;
-  Agent)
-    MESSAGE="サブエージェント実行中"
+  Glob)
+    TARGET=$(echo "$INPUT" | jq -r '.tool_input.pattern // ""')
+    ;;
+  Grep)
+    PAT=$(echo "$INPUT" | jq -r '.tool_input.pattern // ""')
+    PATH_F=$(echo "$INPUT" | jq -r '.tool_input.path // .tool_input.glob // ""')
+    if [ -n "$PATH_F" ]; then
+      TARGET="$PAT ($PATH_F)"
+    else
+      TARGET="$PAT"
+    fi
+    ;;
+  Agent|Task)
+    DESC=$(echo "$INPUT" | jq -r '.tool_input.description // ""')
+    SUB=$(echo "$INPUT" | jq -r '.tool_input.subagent_type // ""')
+    if [ -n "$DESC" ] && [ -n "$SUB" ]; then
+      TARGET="[$SUB] $DESC"
+    elif [ -n "$DESC" ]; then
+      TARGET="$DESC"
+    else
+      TARGET="$SUB"
+    fi
+    ;;
+  WebFetch)
+    TARGET=$(echo "$INPUT" | jq -r '.tool_input.url // ""')
+    ;;
+  WebSearch)
+    TARGET=$(echo "$INPUT" | jq -r '.tool_input.query // ""')
     ;;
   *)
-    MESSAGE="実行完了"
+    TARGET=""
     ;;
 esac
 
-jq -n --arg tool "$TOOL_NAME" --arg message "$MESSAGE" \
+# Truncate to keep Discord messages readable
+if [ ${#TARGET} -gt $MAX_LEN ]; then
+  TARGET="${TARGET:0:$MAX_LEN}…"
+fi
+
+# Skip if we have no useful target (don't spam Discord with bare tool names)
+if [ -z "$TARGET" ]; then
+  exit 0
+fi
+
+jq -n --arg tool "$TOOL_NAME" --arg message "$TARGET" \
   '{"tool": $tool, "message": $message}' | \
 curl -s -X POST "$PROGRESS_URL" \
   -H "Content-Type: application/json" \

--- a/supervisor/hooks/progress-relay.sh
+++ b/supervisor/hooks/progress-relay.sh
@@ -75,7 +75,7 @@ case "$TOOL_NAME" in
     TARGET=$(echo "$INPUT" | jq -r '.tool_input.query // ""')
     ;;
   *)
-    TARGET=""
+    TARGET="(実行完了)"
     ;;
 esac
 

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -1,6 +1,6 @@
 import { execSync } from "child_process";
 import { randomUUID } from "crypto";
-import { existsSync, mkdirSync, writeFileSync } from "fs";
+import { existsSync, mkdirSync } from "fs";
 import { resolve } from "path";
 import { homedir } from "os";
 import type { SessionInfo, StopReason } from "./types";
@@ -121,17 +121,11 @@ export class SessionManager {
     // Build the claude command — unset ANTHROPIC_API_KEY to use Claude Max subscription
     const relayUrl = `http://localhost:${getRelayPort()}/relay/${threadId}`;
 
-    // Write relay URL to a file in the project dir so PostToolUse hooks can read it.
-    // Claude Code hooks don't inherit custom env vars from the parent shell,
-    // so we pass the relay URL via filesystem instead.
-    const relayUrlFile = resolve(config.dir, ".supervisor-relay-url");
-    writeFileSync(relayUrlFile, relayUrl, "utf8");
-
     const claudeCmd = [
       "unset ANTHROPIC_API_KEY",
       `export PATH="${resolve(homedir(), ".local/bin")}:${resolve(homedir(), ".bun/bin")}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"`,
       `export SUPERVISOR_RELAY_URL="${relayUrl}"`,
-      `printf '%s' "${relayUrl}" > "${config.dir}/.supervisor-relay-url"`,
+      `printf "%s" "${relayUrl}" > "${config.dir}/.supervisor-relay-url"`,
       `cd "${config.dir}"`,
       `exec ${CLAUDE_PATH} --dangerously-skip-permissions --name "${config.channelName}"`,
     ].join(" && ");

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -1,6 +1,6 @@
 import { execSync } from "child_process";
 import { randomUUID } from "crypto";
-import { existsSync, mkdirSync } from "fs";
+import { existsSync, mkdirSync, writeFileSync } from "fs";
 import { resolve } from "path";
 import { homedir } from "os";
 import type { SessionInfo, StopReason } from "./types";
@@ -120,10 +120,18 @@ export class SessionManager {
 
     // Build the claude command — unset ANTHROPIC_API_KEY to use Claude Max subscription
     const relayUrl = `http://localhost:${getRelayPort()}/relay/${threadId}`;
+
+    // Write relay URL to a file in the project dir so PostToolUse hooks can read it.
+    // Claude Code hooks don't inherit custom env vars from the parent shell,
+    // so we pass the relay URL via filesystem instead.
+    const relayUrlFile = resolve(config.dir, ".supervisor-relay-url");
+    writeFileSync(relayUrlFile, relayUrl, "utf8");
+
     const claudeCmd = [
       "unset ANTHROPIC_API_KEY",
       `export PATH="${resolve(homedir(), ".local/bin")}:${resolve(homedir(), ".bun/bin")}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"`,
       `export SUPERVISOR_RELAY_URL="${relayUrl}"`,
+      `printf '%s' "${relayUrl}" > "${config.dir}/.supervisor-relay-url"`,
       `cd "${config.dir}"`,
       `exec ${CLAUDE_PATH} --dangerously-skip-permissions --name "${config.channelName}"`,
     ].join(" && ");

--- a/supervisor/tests/hooks/progress-relay.test.ts
+++ b/supervisor/tests/hooks/progress-relay.test.ts
@@ -1,0 +1,185 @@
+// supervisor/tests/hooks/progress-relay.test.ts
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { $ } from "bun";
+import { resolve } from "path";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+
+const HOOK_PATH = resolve(import.meta.dir, "../../hooks/progress-relay.sh");
+
+/**
+ * Helper: create a temp dir with .supervisor-relay-url and a mock curl script.
+ * Returns { dir, curlArgsFile, mockBinDir } for assertions.
+ */
+function setupTestEnv(relayUrl: string) {
+  const dir = mkdtempSync(resolve(tmpdir(), "progress-relay-test-"));
+  writeFileSync(resolve(dir, ".supervisor-relay-url"), relayUrl, "utf8");
+
+  // Mock curl: writes all args to a file, reads stdin -d @- and writes it too
+  const mockBinDir = resolve(dir, "mock-bin");
+  mkdirSync(mockBinDir, { recursive: true });
+
+  const curlArgsFile = resolve(dir, "curl-args.txt");
+  const curlStdinFile = resolve(dir, "curl-stdin.json");
+
+  // The mock curl captures args and stdin data
+  const mockCurl = `#!/bin/bash
+echo "$@" > "${curlArgsFile}"
+# Read stdin if -d @- is in the args
+for arg in "$@"; do
+  if [ "$arg" = "@-" ]; then
+    cat > "${curlStdinFile}"
+    break
+  fi
+done
+`;
+  const mockCurlPath = resolve(mockBinDir, "curl");
+  writeFileSync(mockCurlPath, mockCurl, { mode: 0o755 });
+
+  return { dir, curlArgsFile, curlStdinFile, mockBinDir };
+}
+
+function cleanup(dir: string) {
+  rmSync(dir, { recursive: true, force: true });
+}
+
+function makeInput(toolName: string, toolInput: Record<string, unknown>, cwd: string): string {
+  return JSON.stringify({ tool_name: toolName, tool_input: toolInput, cwd });
+}
+
+// ---------------------------------------------------------------------------
+// Test 1: URL replacement — no backslash-escaped slashes
+// ---------------------------------------------------------------------------
+describe("progress-relay.sh URL replacement", () => {
+  let env: ReturnType<typeof setupTestEnv>;
+
+  beforeEach(() => {
+    env = setupTestEnv("http://localhost:12345/relay/thread123");
+  });
+
+  afterEach(() => {
+    cleanup(env.dir);
+  });
+
+  test("PROGRESS_URL has no backslash-escaped slashes", async () => {
+    const input = makeInput("Bash", { command: "echo test" }, env.dir);
+
+    await $`echo ${input} | PATH=${env.mockBinDir}:$PATH bash ${HOOK_PATH}`
+      .quiet()
+      .nothrow();
+
+    const curlArgs = readFileSync(env.curlArgsFile, "utf8");
+    // The URL passed to curl should be http://localhost:12345/progress/thread123
+    expect(curlArgs).toContain("http://localhost:12345/progress/thread123");
+    // Must NOT contain escaped slashes like \/
+    expect(curlArgs).not.toContain("\\/");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 2: Static analysis — manager.ts writes .supervisor-relay-url
+// ---------------------------------------------------------------------------
+describe("manager.ts .supervisor-relay-url write", () => {
+  test("start() contains printf to .supervisor-relay-url in tmux command", () => {
+    const managerSource = readFileSync(
+      resolve(import.meta.dir, "../../src/session/manager.ts"),
+      "utf8"
+    );
+
+    // The tmux command string should include writing the relay URL file
+    expect(managerSource).toMatch(/\.supervisor-relay-url/);
+    // Check for the printf pattern that writes the relay URL
+    expect(managerSource).toMatch(
+      /printf\s+'%s'\s+.*\.supervisor-relay-url/
+    );
+  });
+
+  test("start() also writes relay URL via writeFileSync", () => {
+    const managerSource = readFileSync(
+      resolve(import.meta.dir, "../../src/session/manager.ts"),
+      "utf8"
+    );
+
+    // Verify the Node.js writeFileSync call for the relay URL file
+    // The variable and the filename string are on separate lines, so check both exist
+    expect(managerSource).toMatch(/relayUrlFile.*\.supervisor-relay-url/);
+    expect(managerSource).toMatch(/writeFileSync\(relayUrlFile/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 3: E2E — tool type → message extraction
+// ---------------------------------------------------------------------------
+describe("progress-relay.sh tool message extraction", () => {
+  let env: ReturnType<typeof setupTestEnv>;
+
+  beforeEach(() => {
+    env = setupTestEnv("http://localhost:12345/relay/thread123");
+  });
+
+  afterEach(() => {
+    cleanup(env.dir);
+  });
+
+  async function runHookAndGetMessage(
+    toolName: string,
+    toolInput: Record<string, unknown>
+  ): Promise<{ tool: string; message: string } | null> {
+    const input = makeInput(toolName, toolInput, env.dir);
+
+    await $`echo ${input} | PATH=${env.mockBinDir}:$PATH bash ${HOOK_PATH}`
+      .quiet()
+      .nothrow();
+
+    try {
+      const stdinData = readFileSync(env.curlStdinFile, "utf8");
+      return JSON.parse(stdinData);
+    } catch {
+      // curl was not called (no stdin file)
+      return null;
+    }
+  }
+
+  test("Bash: extracts command as target", async () => {
+    const result = await runHookAndGetMessage("Bash", {
+      command: "git status",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.tool).toBe("Bash");
+    expect(result!.message.trim()).toBe("git status");
+  });
+
+  test("Read: extracts basename of file_path", async () => {
+    const result = await runHookAndGetMessage("Read", {
+      file_path: "/Users/foo/bar/baz.ts",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.tool).toBe("Read");
+    expect(result!.message).toBe("baz.ts");
+  });
+
+  test("Grep: extracts pattern and path", async () => {
+    const result = await runHookAndGetMessage("Grep", {
+      pattern: "TODO",
+      path: "src/",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.tool).toBe("Grep");
+    expect(result!.message).toBe("TODO (src/)");
+  });
+
+  test("Agent: extracts [subagent_type] description", async () => {
+    const result = await runHookAndGetMessage("Agent", {
+      description: "Code review",
+      subagent_type: "code-reviewer",
+    });
+    expect(result).not.toBeNull();
+    expect(result!.tool).toBe("Agent");
+    expect(result!.message).toBe("[code-reviewer] Code review");
+  });
+
+  test("Unknown tool: curl is NOT called (skip)", async () => {
+    const result = await runHookAndGetMessage("Unknown", {});
+    expect(result).toBeNull();
+  });
+});

--- a/supervisor/tests/hooks/progress-relay.test.ts
+++ b/supervisor/tests/hooks/progress-relay.test.ts
@@ -88,22 +88,20 @@ describe("manager.ts .supervisor-relay-url write", () => {
 
     // The tmux command string should include writing the relay URL file
     expect(managerSource).toMatch(/\.supervisor-relay-url/);
-    // Check for the printf pattern that writes the relay URL
+    // Check for the printf pattern that writes the relay URL (double-quoted for tmux safety)
     expect(managerSource).toMatch(
-      /printf\s+'%s'\s+.*\.supervisor-relay-url/
+      /printf\s+"%s"\s+.*\.supervisor-relay-url/
     );
   });
 
-  test("start() also writes relay URL via writeFileSync", () => {
+  test("start() does NOT use writeFileSync (printf in tmux is sufficient)", () => {
     const managerSource = readFileSync(
       resolve(import.meta.dir, "../../src/session/manager.ts"),
       "utf8"
     );
 
-    // Verify the Node.js writeFileSync call for the relay URL file
-    // The variable and the filename string are on separate lines, so check both exist
-    expect(managerSource).toMatch(/relayUrlFile.*\.supervisor-relay-url/);
-    expect(managerSource).toMatch(/writeFileSync\(relayUrlFile/);
+    // writeFileSync for relay URL should have been removed
+    expect(managerSource).not.toMatch(/writeFileSync\(relayUrlFile/);
   });
 });
 
@@ -178,8 +176,42 @@ describe("progress-relay.sh tool message extraction", () => {
     expect(result!.message).toBe("[code-reviewer] Code review");
   });
 
-  test("Unknown tool: curl is NOT called (skip)", async () => {
+  test("Unknown tool: sends fallback message", async () => {
     const result = await runHookAndGetMessage("Unknown", {});
-    expect(result).toBeNull();
+    expect(result).not.toBeNull();
+    expect(result!.tool).toBe("Unknown");
+    expect(result!.message).toBe("(実行完了)");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Test 4: bash -n syntax check on the tmux command string from manager.ts
+// ---------------------------------------------------------------------------
+describe("manager.ts tmux command syntax", () => {
+  test("claudeCmd assembled by start() is valid bash syntax", async () => {
+    // Reconstruct the same command shape that manager.ts builds at runtime,
+    // substituting concrete dummy values for the TypeScript template expressions.
+    const claudeCmd = [
+      "unset ANTHROPIC_API_KEY",
+      'export PATH="/tmp/.local/bin:/tmp/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"',
+      'export SUPERVISOR_RELAY_URL="http://localhost:12345/relay/thread-abc"',
+      'printf "%s" "http://localhost:12345/relay/thread-abc" > "/tmp/project/.supervisor-relay-url"',
+      'cd "/tmp/project"',
+      'exec /tmp/claude --dangerously-skip-permissions --name "my-channel"',
+    ].join(" && ");
+
+    // Verify this matches the structure in the source
+    const managerSource = readFileSync(
+      resolve(import.meta.dir, "../../src/session/manager.ts"),
+      "utf8"
+    );
+    // Ensure printf uses double quotes (not single) for tmux compatibility
+    expect(managerSource).toMatch(/printf "%s"/);
+    // Ensure the join pattern is " && "
+    expect(managerSource).toMatch(/\.join\(" && "\)/);
+
+    // Run bash -n to check syntax (no execution, just parse)
+    const result = await $`bash -n -c ${claudeCmd}`.quiet().nothrow();
+    expect(result.exitCode).toBe(0);
   });
 });


### PR DESCRIPTION
## Summary
- **progress-relay.sh**: env var → file-based relay URL（Claude Code hooks don't inherit custom env vars）
- **progress-relay.sh**: ツール別のターゲット抽出（`🔧 Bash: git status` 形式）
- **bot.ts**: 表示フォーマット更新
- **manager.ts**: `.supervisor-relay-url` ファイルをセッション起動時に書き込み
- **hijoguchi**: claudeHubExit launchd watchdog 永続化ファイル追加
- **CI テスト**: URL 置換、ファイル書き込み、ツール抽出 E2E（8テスト追加）

## Root Cause
bash の `${var/\/relay\//\/progress\/}` が replacement 内の `\` をリテラルとして残し、`\/progress\/` という不正 URL を生成 → curl が silent fail していた。

## Test plan
- [x] `bun test` 全68テスト PASS（新規8含む）
- [x] Discord team-salary スレッドで `🔧 Bash: whoami` の表示確認済み
- [ ] CI green 確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * バックグラウンドサービスの自動起動・管理機能を追加しました。

* **Tests**
  * 監視機能の動作を検証するテストスイートを追加しました。

* **Improvements**
  * ツール実行の進行状況追跡機能の精度を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->