### PR TITLE
fix(#11): PermissionRequest 自動承認フックでヘッドレスセッションのデッドロックを防止

### DIFF
--- a/supervisor/hooks/auto-approve-permission.sh
+++ b/supervisor/hooks/auto-approve-permission.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# PermissionRequest hook: Supervisor経由のヘッドレスセッションでは自動承認
+# SUPERVISOR_RELAY_URL が設定されている場合のみ有効（通常セッションには影響しない）
+
+if [ -z "$SUPERVISOR_RELAY_URL" ]; then
+  exit 0  # Supervisorセッションでなければスキップ（通常のダイアログを表示）
+fi
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // "unknown"')
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.command // "N/A"' | head -c 120)
+
+# ログ出力（Phase 2 の発生頻度計測用）
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] tool=$TOOL target=$FILE" >> /tmp/supervisor-permissions.log
+
+# Supervisorセッションではすべて自動承認
+jq -n '{
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionRequest",
+    "decision": {
+      "behavior": "allow"
+    }
+  }
+}'

--- a/supervisor/tests/hooks/auto-approve-permission.test.ts
+++ b/supervisor/tests/hooks/auto-approve-permission.test.ts
@@ -1,0 +1,37 @@
+import { test, expect, describe } from "bun:test";
+import { $ } from "bun";
+import { resolve } from "path";
+
+const HOOK_PATH = resolve(import.meta.dir, "../../hooks/auto-approve-permission.sh");
+
+describe("auto-approve-permission.sh", () => {
+  test("exits silently when SUPERVISOR_RELAY_URL is not set", async () => {
+    const input = JSON.stringify({ tool_name: "Read", tool_input: { file_path: "/tmp/x" } });
+    const result = await $`echo ${input} | env -i PATH=${process.env.PATH} bash ${HOOK_PATH}`.quiet().nothrow();
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toBe("");
+  });
+
+  test("returns allow decision when SUPERVISOR_RELAY_URL is set", async () => {
+    const input = JSON.stringify({
+      tool_name: "Write",
+      tool_input: { file_path: "/tmp/.claude/commands/x.md" },
+    });
+    const result = await $`echo ${input} | SUPERVISOR_RELAY_URL=http://localhost:9999/relay/t bash ${HOOK_PATH}`.quiet().nothrow();
+    expect(result.exitCode).toBe(0);
+    const output = JSON.parse(result.stdout.toString());
+    expect(output.hookSpecificOutput.hookEventName).toBe("PermissionRequest");
+    expect(output.hookSpecificOutput.decision.behavior).toBe("allow");
+  });
+
+  test("handles Bash tool by reading command field", async () => {
+    const input = JSON.stringify({
+      tool_name: "Bash",
+      tool_input: { command: "ls /etc" },
+    });
+    const result = await $`echo ${input} | SUPERVISOR_RELAY_URL=http://localhost:9999/relay/t bash ${HOOK_PATH}`.quiet().nothrow();
+    expect(result.exitCode).toBe(0);
+    const output = JSON.parse(result.stdout.toString());
+    expect(output.hookSpecificOutput.decision.behavior).toBe("allow");
+  });
+});


### PR DESCRIPTION
## Summary

Supervisor 経由のヘッドレス tmux セッションで `.claude/` 等の protected path に触れた際に TUI パーミッションダイアログが出てデッドロックする問題 (#11) を、PermissionRequest hook で自動承認することで回避する。

- `supervisor/hooks/auto-approve-permission.sh` を追加
  - `SUPERVISOR_RELAY_URL` が**未設定**のセッションでは即 exit（通常セッションへ影響なし）
  - 設定されている場合のみ `{"decision": {"behavior": "allow"}}` を返す
  - 発動ログを `/tmp/supervisor-permissions.log` に記録（#12 の対象把握用）
- `supervisor/tests/hooks/auto-approve-permission.test.ts` を追加（bun test 3件 pass）
- フック登録は既存の `progress-relay` / `stop-relay` と同様に **ユーザーの `~/.claude/settings.json`** に書く運用（repo には含めない）

## Scope

- #11 の **メインストリーム対策**: PermissionRequest として Claude Code から明示的に委譲されるダイアログをカバーする
- #12 で扱うべき**フォールバック対象外**:
  - OS / 外部ツール側のネイティブダイアログ（macOS 権限、1Password 等）
  - Claude Code 起動前に出るもの
  - これらは本 PR ではカバーしない。ユーザーコメント (#11) でも「全ダイアログは捌けない前提で別策を」と指示あり

## Test plan

- [x] `cd supervisor && bun test tests/hooks/auto-approve-permission.test.ts` が 3/3 pass
- [x] `env -u SUPERVISOR_RELAY_URL bash supervisor/hooks/auto-approve-permission.sh` → 無出力、exit 0
- [x] `SUPERVISOR_RELAY_URL=http://x bash …` → allow JSON 出力
- [ ] 実機で Supervisor 経由の Claude Code に `.claude/commands/x.md` 書込みをさせてダイアログが出ないことを確認
- [ ] ログ `/tmp/supervisor-permissions.log` に tool/target が記録されることを確認

## Refs

- Fixes: #11
- Related: #12 (uncovered-dialog fallback)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 権限承認の自動化機能が実装されました。特定の設定下において、ツール実行時の権限承認プロセスが自動的に処理されるようになり、ワークフローの効率化が図られます。

* **テスト**
  * 新機能の動作を検証するテストスイートを追加しました。複数のシナリオで正常に機能することを確認します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->