### PR TITLE
fix(#11,#32): auto-approve protected-path PermissionRequest + reliable tmux submit

### DIFF
--- a/supervisor/hooks/auto-approve-permission.sh
+++ b/supervisor/hooks/auto-approve-permission.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+# PermissionRequest hook: Supervisorヘッドレスセッションでは自動承認
+# SUPERVISOR_RELAY_URL が設定されている場合のみ有効（通常セッションには影響しない）
+
+if [ -z "$SUPERVISOR_RELAY_URL" ]; then
+  exit 0
+fi
+
+INPUT=$(cat)
+TOOL=$(echo "$INPUT" | jq -r '.tool_name // "unknown"')
+FILE=$(echo "$INPUT" | jq -r '.tool_input.file_path // .tool_input.command // "N/A"' | head -c 120)
+
+echo "[$(date -u +%Y-%m-%dT%H:%M:%SZ)] tool=$TOOL target=$FILE" >> /tmp/supervisor-permissions.log
+
+jq -n '{
+  "hookSpecificOutput": {
+    "hookEventName": "PermissionRequest",
+    "decision": {
+      "behavior": "allow"
+    }
+  }
+}'

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 import { resolve } from "path";
 import { homedir } from "os";
 import { mkdirSync, writeFileSync, unlinkSync } from "fs";
@@ -68,17 +68,27 @@ export async function relayMessage(
     }
   }
 
-  // 2. Escape and send via tmux send-keys
-  const escaped = fullMessage
-    .replace(/\\/g, "\\\\")
-    .replace(/"/g, '\\"')
-    .replace(/\$/g, "\\$")
-    .replace(/`/g, "\\`")
-    .replace(/\n/g, " ");
+  // 2. Send via tmux send-keys using execFileSync (argv array, no shell).
+  // We issue the input and the submit as two separate calls:
+  //   (a) `send-keys -l <literal>` — tmux forwards the bytes verbatim.
+  //       Argv-based invocation avoids shell-escape hazards (backticks, $,
+  //       quotes, backslashes) that corrupted long messages in earlier builds.
+  //   (b) A brief delay, then `send-keys C-m` — Claude Code's ink-based TUI
+  //       occasionally drops `Enter` sent in the same call when the input is
+  //       long, leaving the message typed but un-submitted (issue #32).
+  const literalText = fullMessage.replace(/\n/g, " ");
 
   try {
-    execSync(
-      `${TMUX_PATH} send-keys -t "${tmuxSessionName}" "${escaped}" Enter`,
+    execFileSync(
+      TMUX_PATH,
+      ["send-keys", "-t", tmuxSessionName, "-l", literalText],
+      { timeout: 5000 }
+    );
+    // Small pause so the TUI finishes ingesting the text before Enter.
+    await new Promise((r) => setTimeout(r, 100));
+    execFileSync(
+      TMUX_PATH,
+      ["send-keys", "-t", tmuxSessionName, "C-m"],
       { timeout: 5000 }
     );
   } catch (err) {

--- a/supervisor/tests/hooks/auto-approve-permission.test.ts
+++ b/supervisor/tests/hooks/auto-approve-permission.test.ts
@@ -1,0 +1,37 @@
+import { test, expect, describe } from "bun:test";
+import { $ } from "bun";
+import { resolve } from "path";
+
+const HOOK_PATH = resolve(import.meta.dir, "../../hooks/auto-approve-permission.sh");
+
+describe("auto-approve-permission.sh", () => {
+  test("exits silently when SUPERVISOR_RELAY_URL is not set", async () => {
+    const input = JSON.stringify({ tool_name: "Read", tool_input: { file_path: "/tmp/x" } });
+    const result = await $`echo ${input} | env -i PATH=${process.env.PATH} bash ${HOOK_PATH}`.quiet().nothrow();
+    expect(result.exitCode).toBe(0);
+    expect(result.stdout.toString()).toBe("");
+  });
+
+  test("returns allow decision when SUPERVISOR_RELAY_URL is set", async () => {
+    const input = JSON.stringify({
+      tool_name: "Write",
+      tool_input: { file_path: "/tmp/.claude/commands/x.md" },
+    });
+    const result = await $`echo ${input} | SUPERVISOR_RELAY_URL=http://localhost:9999/relay/t bash ${HOOK_PATH}`.quiet().nothrow();
+    expect(result.exitCode).toBe(0);
+    const output = JSON.parse(result.stdout.toString());
+    expect(output.hookSpecificOutput.hookEventName).toBe("PermissionRequest");
+    expect(output.hookSpecificOutput.decision.behavior).toBe("allow");
+  });
+
+  test("handles Bash tool by reading command field", async () => {
+    const input = JSON.stringify({
+      tool_name: "Bash",
+      tool_input: { command: "ls /etc" },
+    });
+    const result = await $`echo ${input} | SUPERVISOR_RELAY_URL=http://localhost:9999/relay/t bash ${HOOK_PATH}`.quiet().nothrow();
+    expect(result.exitCode).toBe(0);
+    const output = JSON.parse(result.stdout.toString());
+    expect(output.hookSpecificOutput.decision.behavior).toBe("allow");
+  });
+});


### PR DESCRIPTION
## Summary

Headless Supervisor sessions hung whenever Claude Code tried to touch a protected path (`.claude/commands/`, `.claude/agents/`, etc.) and when long / special-character messages were relayed. Root-causing it turned up **two independent bugs**, both fixed here.

| Issue | Bug | Fix |
|---|---|---|
| **#11** | `--dangerously-skip-permissions` still emits a `PermissionRequest` for protected paths, which had no handler in Supervisor sessions, so the TUI sat on "Do you want to create?" until the relay timed out. | New `supervisor/hooks/auto-approve-permission.sh` returns `{decision: {behavior: "allow"}}` when `SUPERVISOR_RELAY_URL` is set. |
| **#32** | `relayMessage` used ``execSync(`tmux send-keys … "\${escaped}" Enter`)`` — (a) backticks in the message were interpreted by the shell and dropped, (b) `Enter` sent together with long text was occasionally ignored by Claude Code's ink TUI, leaving the message typed but un-submitted. | Switch to `execFileSync` (argv, no shell) and split text + `C-m` into two `send-keys` calls with a 100 ms pause. |

## Wiring (documented for user setup)

Add to `~/.claude/settings.json` once per machine:

```jsonc
"PermissionRequest": [{
  "matcher": "",
  "hooks": [{
    "type": "command",
    "command": "bash /Users/you/claude-hub/supervisor/hooks/auto-approve-permission.sh",
    "timeout": 3
  }]
}]
```

The hook is a no-op when `SUPERVISOR_RELAY_URL` is unset, so it is safe in non-Supervisor sessions.

## E2E evidence (observed live on a restarted Supervisor)

Discord thread → Supervisor relay → Claude Code in `~/team_salary` was asked to write `.claude/commands/e2e-test.md`:

```
[17:24:09Z] tool=Write target=/Users/harieshokunin/team_salary/.claude/commands/e2e-test.md
```

tmux pane:
```
⏺ Write(.claude/commands/e2e-test.md)
  ⎿  Wrote 1 lines to .claude/commands/e2e-test.md
      1 # e2e-ok
  ⎿  Allowed by PermissionRequest hook
⏺ OK
```

- File was created with the expected content.
- Hook logged the decision to `/tmp/supervisor-permissions.log`.
- No TUI dialog, no `claudeHubExit` DM Allow/Deny buttons, no relay timeout.
- The 113-char message with backticks was delivered verbatim (the old relay had been dropping the ``` `.claude/commands/e2e-test.md` ``` backticked portion).

## Tests

```
cd supervisor && bun test
   69 pass
    0 fail
```

Including `tests/hooks/auto-approve-permission.test.ts` (3/3) covering: (1) no-op when env var unset, (2) allow JSON when set, (3) Bash tool input shape.

## Out of scope / follow-ups

- #12 (fallback for permission prompts the hook *cannot* intercept, e.g. OS-level dialogs) stays open — this PR only solves the PermissionRequest-event path.
- The investigation also identified that `claudeHubExit` (hijoguchi, running with `--channels plugin:discord`) receives thread messages *in parallel* to the Supervisor relay. That produced the Allow/Deny DM buttons seen earlier. This is not a #11 bug and is left as-is for now.

## Test plan

- [x] `bun test` (69 pass)
- [x] Live Discord E2E: `/session start` → write-to-protected-path request → observed hook fire + file creation + reply
- [x] Regression check: long message with backticks is now delivered intact
- [ ] Leave `SUPERVISOR_RELAY_URL` unset test in your own shell to confirm no-op: `env -u SUPERVISOR_RELAY_URL bash supervisor/hooks/auto-approve-permission.sh < /dev/null; echo $?` should print `0` with no output

## Refs
- Fixes #11
- Fixes #32
- Related #12