### PR TITLE
fix(#32): retry tmux send-keys once on transient ETIMEDOUT

### DIFF
--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -37,6 +37,29 @@ async function downloadAttachment(attachment: AttachmentInfo): Promise<string> {
 }
 
 /**
+ * Run `tmux send-keys -t <sessionName> <args...>` with a short retry budget.
+ *
+ * tmux can ETIMEDOUT on transient server stalls (observed after a previous
+ * relay hit Response timeout — the pane or server ends up briefly busy).
+ * We retry once after a 250ms pause so a flaky moment doesn't surface to
+ * the user as a `send-keys` failure.
+ */
+function tmuxSend(sessionName: string, extraArgs: string[]): void {
+  const args = ["send-keys", "-t", sessionName, ...extraArgs];
+  const PER_CALL_TIMEOUT = 7000;
+  try {
+    execFileSync(TMUX_PATH, args, { timeout: PER_CALL_TIMEOUT });
+    return;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code !== "ETIMEDOUT") throw err;
+    // Give tmux a breather and try one more time.
+    execSync("sleep 0.25");
+    execFileSync(TMUX_PATH, args, { timeout: PER_CALL_TIMEOUT });
+  }
+}
+
+/**
  * Send a message to Claude Code via tmux send-keys and wait for
  * the response via HTTP relay (Stop hook POST).
  */
@@ -76,21 +99,18 @@ export async function relayMessage(
   //   (b) A brief delay, then `send-keys C-m` — Claude Code's ink-based TUI
   //       occasionally drops `Enter` sent in the same call when the input is
   //       long, leaving the message typed but un-submitted (issue #32).
+  //
+  // tmux server can transiently stall — typically right after a relay timed
+  // out — so each send-keys call is wrapped in a short retry. Total budget
+  // per call: 15s (tmuxSend covers transient lock waits without making the
+  // overall latency unbearable).
   const literalText = fullMessage.replace(/\n/g, " ");
 
   try {
-    execFileSync(
-      TMUX_PATH,
-      ["send-keys", "-t", tmuxSessionName, "-l", literalText],
-      { timeout: 5000 }
-    );
+    tmuxSend(tmuxSessionName, ["-l", literalText]);
     // Small pause so the TUI finishes ingesting the text before Enter.
     await new Promise((r) => setTimeout(r, 100));
-    execFileSync(
-      TMUX_PATH,
-      ["send-keys", "-t", tmuxSessionName, "C-m"],
-      { timeout: 5000 }
-    );
+    tmuxSend(tmuxSessionName, ["C-m"]);
   } catch (err) {
     scheduleCleanup(localFiles, 5 * 60_000);
     return {


### PR DESCRIPTION
## Summary

Follow-up to #38. Production Supervisor log showed a single transient failure right after a preceding relay had hit \`Response timeout\`:

\`\`\`
[Bot] Relaying message in thread … (1 chars) → Response timeout
[Bot] Relaying message in thread … (66 chars) → SystemError: spawnSync /opt/homebrew/bin/tmux ETIMEDOUT
[Bot] Relaying message in thread … (143 chars) → OK
\`\`\`

The tmux server was momentarily locked after the 5-minute wait; the very next relay hit a 5s \`execFileSync\` timeout, and the one after that was fine.

## Change

Extract \`tmuxSend()\`:
- Per-call timeout: 5s → **7s**.
- On \`ETIMEDOUT\` only, wait 250ms and retry **once**. Other errors bubble up.

Keeps the happy-path fast, absorbs the narrow window where tmux needs a beat to recover.

## Tests

\`\`\`
bun test
  6 pass
  0 fail
\`\`\`

No new tests added — the retry is timeout-bound on a real subprocess, hard to simulate cleanly, and the existing \`relay.test.ts\` covers the public surface. Observational retest tomorrow: trigger a Response timeout, then a short message, confirm no user-facing error chunk.

## Refs
- Follow-up to #38 (which introduced the \`execFileSync\` call).
- Related: #32.