### PR TITLE
fix: forward late Stop hook POSTs (Monitor split-turn relay bug)

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -15,7 +15,7 @@ import { createSessionCommand, createSessionHandler } from "./commands/session";
 import { CHANNEL_MAP } from "./config/channels";
 import type { AttachmentInfo } from "./session/relay";
 import { updateSessionClaudeId } from "./infra/db";
-import { onProgress } from "./session/relay-server";
+import { onProgress, onLateResponse } from "./session/relay-server";
 import {
   extractFilePaths,
   collectAttachableFiles,
@@ -85,6 +85,27 @@ export async function startBot(token: string): Promise<void> {
         }
       } catch (err) {
         console.error(`[Bot] Progress send error for thread ${event.threadId}:`, err);
+      }
+    });
+
+    // Register late-response callback: when a Stop hook POST arrives after
+    // the initial relay already resolved (e.g. Monitor/background-task split
+    // a single user turn into multiple assistant turns), forward the follow-up
+    // text directly to the Discord thread so it isn't dropped.
+    onLateResponse(async (event) => {
+      try {
+        const channel = await client.channels.fetch(event.threadId);
+        if (!channel?.isThread()) return;
+        console.log(
+          `[Bot] Late response for thread ${event.threadId} (${event.chunks.length} chunks, ${event.text.length} chars)`
+        );
+        for (const chunk of event.chunks) {
+          if (chunk.trim()) {
+            await channel.send(chunk);
+          }
+        }
+      } catch (err) {
+        console.error(`[Bot] Late response send error for thread ${event.threadId}:`, err);
       }
     });
   });

--- a/supervisor/src/session/relay-server.ts
+++ b/supervisor/src/session/relay-server.ts
@@ -13,7 +13,14 @@ export interface ProgressEvent {
   message: string;
 }
 
+export interface LateResponseEvent {
+  threadId: string;
+  chunks: string[];
+  text: string;
+}
+
 type ProgressCallback = (event: ProgressEvent) => void;
+type LateResponseCallback = (event: LateResponseEvent) => void;
 
 interface PendingRequest {
   resolve: (result: RelayResult) => void;
@@ -25,9 +32,14 @@ const pendingRequests = new Map<string, PendingRequest>();
 let server: ReturnType<typeof Bun.serve> | null = null;
 let relayPort = 0;
 let progressCallback: ProgressCallback | null = null;
+let lateResponseCallback: LateResponseCallback | null = null;
 
 export function onProgress(callback: ProgressCallback): void {
   progressCallback = callback;
+}
+
+export function onLateResponse(callback: LateResponseCallback): void {
+  lateResponseCallback = callback;
 }
 
 export function startRelayServer(): void {
@@ -68,32 +80,44 @@ export function startRelayServer(): void {
         if (!threadId) {
           return new Response("Invalid thread ID", { status: 400 });
         }
-        const pending = pendingRequests.get(threadId);
-
-        if (!pending) {
-          return new Response("Not found", { status: 404 });
-        }
-
+        let body: Record<string, unknown>;
         try {
-          const body = await req.json() as Record<string, unknown>;
-          const text =
-            typeof body.text === "string"
-              ? body.text
-              : typeof body.last_assistant_message === "string"
-                ? body.last_assistant_message
-                : "";
-          const sessionId =
-            typeof body.session_id === "string" ? body.session_id : undefined;
-          const chunks = formatForDiscord(text);
-
-          clearTimeout(pending.timer);
-          pending.resolve({ text, chunks, claudeSessionId: sessionId });
-          pendingRequests.delete(threadId);
-
-          return new Response("ok", { status: 200 });
+          body = await req.json() as Record<string, unknown>;
         } catch {
           return new Response("Invalid JSON", { status: 400 });
         }
+
+        const text =
+          typeof body.text === "string"
+            ? body.text
+            : typeof body.last_assistant_message === "string"
+              ? body.last_assistant_message
+              : "";
+        const sessionId =
+          typeof body.session_id === "string" ? body.session_id : undefined;
+        const chunks = formatForDiscord(text);
+
+        const pending = pendingRequests.get(threadId);
+        if (pending) {
+          clearTimeout(pending.timer);
+          pending.resolve({ text, chunks, claudeSessionId: sessionId });
+          pendingRequests.delete(threadId);
+          return new Response("ok", { status: 200 });
+        }
+
+        // Late-arriving Stop event (e.g., Monitor completion split the turn
+        // into a second assistant message after the first already resolved).
+        // Forward to Discord as a follow-up message so responses aren't lost.
+        if (text && lateResponseCallback) {
+          try {
+            lateResponseCallback({ threadId, chunks, text });
+          } catch (err) {
+            console.error("[relay-server] lateResponseCallback error:", err);
+          }
+          return new Response("forwarded", { status: 202 });
+        }
+
+        return new Response("Not found", { status: 404 });
       }
 
       return new Response("Not found", { status: 404 });
@@ -117,6 +141,8 @@ export function stopRelayServer(): void {
   server.stop(true);
   server = null;
   relayPort = 0;
+  progressCallback = null;
+  lateResponseCallback = null;
 }
 
 export function waitForRelay(

--- a/supervisor/tests/session/relay-server.test.ts
+++ b/supervisor/tests/session/relay-server.test.ts
@@ -4,6 +4,8 @@ import {
   stopRelayServer,
   waitForRelay,
   getRelayPort,
+  onLateResponse,
+  type LateResponseEvent,
 } from "../../src/session/relay-server";
 
 describe("relay-server", () => {
@@ -69,6 +71,52 @@ describe("relay-server", () => {
     } catch {
       expect(true).toBe(true);
     }
+  });
+
+  test("late-arriving POST invokes onLateResponse callback (202) instead of dropping", async () => {
+    startRelayServer();
+    const port = getRelayPort();
+
+    const received: LateResponseEvent[] = [];
+    onLateResponse((event) => received.push(event));
+
+    // Simulate Monitor pattern: first Stop POST resolves the pending request
+    const promise = waitForRelay("thread-monitor", 5000);
+    await fetch(`http://localhost:${port}/relay/thread-monitor`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "Script is running in the background." }),
+    });
+    await promise;
+
+    // Second Stop POST arrives after Monitor completes and Claude produces
+    // the real answer — must be forwarded, not dropped as 404.
+    const res = await fetch(`http://localhost:${port}/relay/thread-monitor`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "18 件の下書きがあります。" }),
+    });
+
+    expect(res.status).toBe(202);
+    expect(received.length).toBe(1);
+    const late = received[0]!;
+    expect(late.threadId).toBe("thread-monitor");
+    expect(late.text).toBe("18 件の下書きがあります。");
+    expect(late.chunks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  test("POST with empty text and no pending returns 404 even with late handler", async () => {
+    startRelayServer();
+    const port = getRelayPort();
+
+    onLateResponse(() => {});
+
+    const res = await fetch(`http://localhost:${port}/relay/orphan-thread`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "" }),
+    });
+    expect(res.status).toBe(404);
   });
 
   test("multiple threads can wait concurrently", async () => {


### PR DESCRIPTION
## Summary
- Fix: when Claude uses Monitor/`run_in_background`, a single user turn produces **2 assistant turns** (ack → real answer). Each fires the Stop hook, but the relay only had one pending waiter per thread — the second POST was dropped with 404 and the real answer never reached Discord.
- Added `onLateResponse` callback in `relay-server.ts`; `bot.ts` registers it and sends the late-arriving chunks as a follow-up message to the Discord thread.
- Empty-text POSTs still 404 (orphan rejection preserved).

## Repro (what triggered this)
In team-salary thread, user asked "note.com の下書き一覧を取得して" → Claude ran `npx tsx scripts/find-note-drafts.ts` via `run_in_background` + Monitor.
- tmux pane: full 18-IDs response returned.
- Discord: only `Script is running in the background. Waiting for completion.` (61 chars) arrived, then silence.

Supervisor log showed exactly 1 pair of `Relaying message → Got 1 chunks → Sending chunk (61 chars)` for the 29-char user prompt, with no subsequent activity — Stop hook's second POST hit the orphan-404 path.

## Test plan
- [x] `bun test` — 74/74 pass (relay-server tests now include Monitor split-turn repro: late POST returns 202 and fires the callback; empty-text POST still 404)
- [x] `bunx tsc --noEmit` — clean
- [x] `launchctl kickstart -k gui/501/com.claude-hub.supervisor` → curl probe `POST /relay/fake-thread {"text":"probe"}` returns 202 (callback invoked)
- [ ] **E2E**: fresh team-salary session, ask Claude to run a script via `run_in_background` + Monitor, confirm Discord receives both the intermediate ack **and** the final response as two separate messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)