### PR TITLE
fix(#41): prevent thread message queue from permanently blocking on relay errors

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -276,7 +276,7 @@ export async function startBot(token: string): Promise<void> {
         console.error(`[Bot] Relay error in thread ${threadId}:`, err);
         try {
           await thread.send(
-            `⚠️ Claude Code への中継中にエラーが発生しました: ${err instanceof Error ? err.message : String(err)}`
+            `⚠️ Claude Code への中継中にエラーが発生しました: ${(err instanceof Error ? err.message : String(err)).slice(0, 1900)}`
           );
         } catch (sendErr) {
           console.error(`[Bot] Failed to send error notification to thread ${threadId}:`, sendErr);

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -38,7 +38,17 @@ export async function startBot(token: string): Promise<void> {
 
   function enqueueForThread(threadId: string, task: () => Promise<void>): void {
     const prev = threadQueues.get(threadId) ?? Promise.resolve();
-    const next = prev.then(task, task);
+    // Wrap task in try-catch to prevent unhandled rejections from breaking
+    // the promise chain. Without this, one failed relay permanently blocks
+    // all subsequent messages for this thread (#41).
+    const safeTask = async () => {
+      try {
+        await task();
+      } catch (err) {
+        console.error(`[Bot] Unhandled error in thread queue ${threadId}:`, err);
+      }
+    };
+    const next = prev.then(safeTask, safeTask);
     threadQueues.set(threadId, next);
     next.finally(() => {
       if (threadQueues.get(threadId) === next) {
@@ -162,7 +172,9 @@ export async function startBot(token: string): Promise<void> {
 
     // Check if this thread has an active session
     if (!sessionManager.has(threadId)) {
-      return; // Not a session thread, ignore
+      // Log when a message arrives for a thread that once had a session (helps debug #41)
+      console.debug(`[Bot] Ignoring message in thread ${threadId} (no active session)`);
+      return;
     }
 
     const thread = message.channel as ThreadChannel;
@@ -262,9 +274,13 @@ export async function startBot(token: string): Promise<void> {
         }
       } catch (err) {
         console.error(`[Bot] Relay error in thread ${threadId}:`, err);
-        await thread.send(
-          `⚠️ Claude Code への中継中にエラーが発生しました: ${err instanceof Error ? err.message : String(err)}`
-        );
+        try {
+          await thread.send(
+            `⚠️ Claude Code への中継中にエラーが発生しました: ${err instanceof Error ? err.message : String(err)}`
+          );
+        } catch (sendErr) {
+          console.error(`[Bot] Failed to send error notification to thread ${threadId}:`, sendErr);
+        }
       }
     });
   });

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -52,10 +52,19 @@ function tmuxSend(sessionName: string, extraArgs: string[]): void {
     return;
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
-    if (code !== "ETIMEDOUT") throw err;
+    if (code !== "ETIMEDOUT") {
+      console.error(`[Relay] tmux send-keys failed (code=${code}):`, err);
+      throw err;
+    }
     // Give tmux a breather and try one more time.
+    console.warn(`[Relay] tmux send-keys ETIMEDOUT for ${sessionName}, retrying...`);
     execSync("sleep 0.25");
-    execFileSync(TMUX_PATH, args, { timeout: PER_CALL_TIMEOUT });
+    try {
+      execFileSync(TMUX_PATH, args, { timeout: PER_CALL_TIMEOUT });
+    } catch (retryErr) {
+      console.error(`[Relay] tmux send-keys retry also failed for ${sessionName}:`, retryErr);
+      throw retryErr;
+    }
   }
 }
 

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -1,4 +1,4 @@
-import { execSync, execFileSync } from "child_process";
+import { execFileSync } from "child_process";
 import { resolve } from "path";
 import { homedir } from "os";
 import { mkdirSync, writeFileSync, unlinkSync } from "fs";
@@ -44,25 +44,31 @@ async function downloadAttachment(attachment: AttachmentInfo): Promise<string> {
  * We retry once after a 250ms pause so a flaky moment doesn't surface to
  * the user as a `send-keys` failure.
  */
-function tmuxSend(sessionName: string, extraArgs: string[]): void {
+/** Summarize an execFileSync error without leaking message content from spawnargs. */
+function summarizeExecError(err: unknown): { code?: string; status?: number; signal?: string } {
+  const e = err as NodeJS.ErrnoException & { status?: number; signal?: string };
+  return { code: e.code, status: e.status, signal: e.signal };
+}
+
+async function tmuxSend(sessionName: string, extraArgs: string[]): Promise<void> {
   const args = ["send-keys", "-t", sessionName, ...extraArgs];
   const PER_CALL_TIMEOUT = 7000;
   try {
     execFileSync(TMUX_PATH, args, { timeout: PER_CALL_TIMEOUT });
     return;
   } catch (err) {
-    const code = (err as NodeJS.ErrnoException).code;
-    if (code !== "ETIMEDOUT") {
-      console.error(`[Relay] tmux send-keys failed (code=${code}):`, err);
+    const summary = summarizeExecError(err);
+    if (summary.code !== "ETIMEDOUT") {
+      console.error(`[Relay] tmux send-keys failed:`, summary);
       throw err;
     }
-    // Give tmux a breather and try one more time.
+    // Give tmux a breather and try one more time (non-blocking).
     console.warn(`[Relay] tmux send-keys ETIMEDOUT for ${sessionName}, retrying...`);
-    execSync("sleep 0.25");
+    await new Promise((r) => setTimeout(r, 250));
     try {
       execFileSync(TMUX_PATH, args, { timeout: PER_CALL_TIMEOUT });
     } catch (retryErr) {
-      console.error(`[Relay] tmux send-keys retry also failed for ${sessionName}:`, retryErr);
+      console.error(`[Relay] tmux send-keys retry also failed for ${sessionName}:`, summarizeExecError(retryErr));
       throw retryErr;
     }
   }
@@ -116,10 +122,10 @@ export async function relayMessage(
   const literalText = fullMessage.replace(/\n/g, " ");
 
   try {
-    tmuxSend(tmuxSessionName, ["-l", literalText]);
+    await tmuxSend(tmuxSessionName, ["-l", literalText]);
     // Small pause so the TUI finishes ingesting the text before Enter.
     await new Promise((r) => setTimeout(r, 100));
-    tmuxSend(tmuxSessionName, ["C-m"]);
+    await tmuxSend(tmuxSessionName, ["C-m"]);
   } catch (err) {
     scheduleCleanup(localFiles, 5 * 60_000);
     return {

--- a/supervisor/tests/session/queue-resilience.test.ts
+++ b/supervisor/tests/session/queue-resilience.test.ts
@@ -1,0 +1,161 @@
+import { test, expect, describe } from "bun:test";
+
+/**
+ * Tests for the enqueueForThread pattern used in bot.ts (#41).
+ * Verifies that the thread message queue recovers from task failures
+ * instead of permanently blocking subsequent messages.
+ */
+
+// Reproduce the enqueueForThread implementation (safe version from fix)
+function createSafeQueue() {
+  const threadQueues = new Map<string, Promise<void>>();
+  const log: string[] = [];
+
+  function enqueueForThread(threadId: string, task: () => Promise<void>): void {
+    const prev = threadQueues.get(threadId) ?? Promise.resolve();
+    const safeTask = async () => {
+      try {
+        await task();
+      } catch (err) {
+        log.push(`caught: ${err}`);
+      }
+    };
+    const next = prev.then(safeTask, safeTask);
+    threadQueues.set(threadId, next);
+    next.finally(() => {
+      if (threadQueues.get(threadId) === next) {
+        threadQueues.delete(threadId);
+      }
+    });
+  }
+
+  return { enqueueForThread, threadQueues, log };
+}
+
+
+describe("enqueueForThread resilience (#41)", () => {
+  test("safe queue: task error does not block subsequent tasks", async () => {
+    const { enqueueForThread, log } = createSafeQueue();
+    const results: string[] = [];
+
+    // Task 1: throws an error
+    enqueueForThread("thread-1", async () => {
+      throw new Error("relay failed");
+    });
+
+    // Task 2: should still execute despite Task 1 failure
+    const task2Done = new Promise<void>((resolve) => {
+      enqueueForThread("thread-1", async () => {
+        results.push("task2-ok");
+        resolve();
+      });
+    });
+
+    await task2Done;
+    expect(results).toContain("task2-ok");
+    expect(log).toContain("caught: Error: relay failed");
+  });
+
+  test("safe queue: multiple consecutive errors don't accumulate", async () => {
+    const { enqueueForThread, log } = createSafeQueue();
+    const results: string[] = [];
+
+    // 3 consecutive failures
+    for (let i = 0; i < 3; i++) {
+      enqueueForThread("thread-1", async () => {
+        throw new Error(`fail-${i}`);
+      });
+    }
+
+    // Task 4: should still work
+    const task4Done = new Promise<void>((resolve) => {
+      enqueueForThread("thread-1", async () => {
+        results.push("task4-ok");
+        resolve();
+      });
+    });
+
+    await task4Done;
+    expect(results).toContain("task4-ok");
+    expect(log.length).toBe(3);
+  });
+
+  test("safe queue: different threads are independent", async () => {
+    const { enqueueForThread } = createSafeQueue();
+    const results: string[] = [];
+
+    // Thread A fails
+    enqueueForThread("thread-A", async () => {
+      throw new Error("A failed");
+    });
+
+    // Thread B should be unaffected
+    const taskBDone = new Promise<void>((resolve) => {
+      enqueueForThread("thread-B", async () => {
+        results.push("B-ok");
+        resolve();
+      });
+    });
+
+    await taskBDone;
+    expect(results).toContain("B-ok");
+  });
+
+  test("safe queue: tasks execute in order within a thread", async () => {
+    const { enqueueForThread } = createSafeQueue();
+    const order: number[] = [];
+
+    const allDone = new Promise<void>((resolve) => {
+      for (let i = 1; i <= 5; i++) {
+        enqueueForThread("thread-1", async () => {
+          order.push(i);
+          if (i === 5) resolve();
+        });
+      }
+    });
+
+    await allDone;
+    expect(order).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  test("safe queue: catches errors that were unhandled before #41 fix", async () => {
+    const { enqueueForThread, log } = createSafeQueue();
+
+    // Before #41 fix, this error would propagate as an unhandled rejection,
+    // crashing the process or permanently blocking the queue chain.
+    enqueueForThread("thread-1", async () => {
+      throw new Error("would be unhandled without safeTask wrapper");
+    });
+
+    await new Promise((r) => setTimeout(r, 50));
+    expect(log.length).toBe(1);
+    expect(log[0]).toContain("would be unhandled");
+  });
+
+  test("safe queue: error in error-handler does not block queue", async () => {
+    const { enqueueForThread, log } = createSafeQueue();
+    const results: string[] = [];
+
+    // Simulate the real bug: relay fails, then error notification also fails
+    enqueueForThread("thread-1", async () => {
+      try {
+        throw new Error("relay failed");
+      } catch {
+        // Simulate thread.send() failing (Discord API error)
+        throw new Error("Discord send failed");
+      }
+    });
+
+    // Next message should still work
+    const task2Done = new Promise<void>((resolve) => {
+      enqueueForThread("thread-1", async () => {
+        results.push("recovered");
+        resolve();
+      });
+    });
+
+    await task2Done;
+    expect(results).toContain("recovered");
+    expect(log).toContain("caught: Error: Discord send failed");
+  });
+});


### PR DESCRIPTION
## Summary

- `enqueueForThread()` の task を `safeTask` ラッパーで包み、未捕捉例外によるキューチェーン永久ブロックを防止
- エラー通知の `thread.send()` 自体の失敗も catch し、Discord API エラーがキューを壊さないように
- `sessionManager.has()` false 時の debug ログ追加（silent return の可視化）
- `tmuxSend()` のリトライパスにログ追加（ETIMEDOUT/非ETIMEDOUT 両方）

## Test plan

- [x] キュー復元力テスト 6件追加（エラー後の復帰、連続エラー、スレッド間独立性、実行順序）
- [x] 既存テスト 80/80 全パス
- [x] ビルド成功

Closes #41
Closes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * スレッドごとのキューでタスク失敗が以降の処理を中断しないよう堅牢化しました。
  * セッション未存在時の受信イベントでデバッグログを出すようにしました。
  * エラー通知を送信する際の失敗を内部で扱い、送信メッセージを長さで切り詰めるようにしました。
  * 外部送信処理の再試行とタイムアウトの扱いを改善しました。

* **Tests**
  * キューの耐障害性と順序維持を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->