### PR TITLE
fix(#48): start-hijoguchi.sh クォート + tmux has-session 検証 + prompt guard

### DIFF
--- a/scripts/hijoguchi-system-prompt.md
+++ b/scripts/hijoguchi-system-prompt.md
@@ -1,0 +1,13 @@
+<!--
+  hijoguchi (claudeHubExit Bot) system-prompt placeholder.
+
+  This file is read at startup by scripts/start-hijoguchi.sh and passed to
+  `claude --append-system-prompt "$(cat ...)"`. S2 (#48) ships only this
+  infrastructure (quoting + guard + tmux verify + logging). S3 (#49) will
+  replace the body below with the real routing / scope rules.
+
+  Keeping the stub intentionally minimal so current production behaviour is
+  not altered before S3 lands.
+-->
+
+# hijoguchi system prompt (S2 stub — replaced by S3 #49)

--- a/scripts/start-hijoguchi.sh
+++ b/scripts/start-hijoguchi.sh
@@ -11,32 +11,57 @@
 set -u
 
 SESSION=claudeHubExit
-CLAUDE_HUB_DIR="$HOME/claude-hub"
-LOG_DIR="$CLAUDE_HUB_DIR/logs"
-CLAUDE_BIN="$HOME/.local/bin/claude"
+CLAUDE_HUB_DIR="${HOME}/claude-hub"
+LOG_DIR="${CLAUDE_HUB_DIR}/logs"
+CLAUDE_BIN="${HOME}/.local/bin/claude"
 TMUX_BIN="${TMUX_PATH:-/opt/homebrew/bin/tmux}"
 BACKOFF_SEC=5
+# System-prompt file for `claude --append-system-prompt`. Overridable via env
+# so tests / alt deploys can swap it. S3 (#49) populates the real content.
+SYSTEM_PROMPT_FILE="${SYSTEM_PROMPT_FILE:-${CLAUDE_HUB_DIR}/scripts/hijoguchi-system-prompt.md}"
+# Wait before checking the freshly-created tmux session. Short is fine because
+# tmux new-session -d returns after the server has recorded the session.
+TMUX_VERIFY_SLEEP_SEC=1
 
-mkdir -p "$LOG_DIR"
+mkdir -p "${LOG_DIR}"
+
+# Guard: abort if the system-prompt file is missing. Without this the claude
+# invocation would silently pass `--append-system-prompt ""` and behaviour
+# would drift from what S3 defines.
+if [ ! -f "${SYSTEM_PROMPT_FILE}" ]; then
+  echo "[hijoguchi] ERROR: system-prompt file not found: ${SYSTEM_PROMPT_FILE}" >&2
+  exit 1
+fi
+
+echo "[hijoguchi] system_prompt_file=${SYSTEM_PROMPT_FILE}"
 
 # Clean shutdown on SIGTERM from launchd
-trap 'echo "[hijoguchi] SIGTERM received, killing tmux session"; "$TMUX_BIN" kill-session -t "$SESSION" 2>/dev/null; exit 0' TERM INT
+trap 'echo "[hijoguchi] SIGTERM received, killing tmux session"; "${TMUX_BIN}" kill-session -t "${SESSION}" 2>/dev/null; exit 0' TERM INT
 
 echo "[hijoguchi] watchdog starting at $(date)"
 
 while true; do
   # Ensure no stale session
-  "$TMUX_BIN" kill-session -t "$SESSION" 2>/dev/null
+  "${TMUX_BIN}" kill-session -t "${SESSION}" 2>/dev/null
 
-  echo "[hijoguchi] starting tmux session '$SESSION' at $(date)"
-  "$TMUX_BIN" new-session -d -s "$SESSION" -c "$CLAUDE_HUB_DIR" \
-    "$CLAUDE_BIN --channels plugin:discord@claude-plugins-official --dangerously-skip-permissions"
+  echo "[hijoguchi] starting tmux session '${SESSION}' at $(date)"
+  "${TMUX_BIN}" new-session -d -s "${SESSION}" -c "${CLAUDE_HUB_DIR}" \
+    "${CLAUDE_BIN} --channels plugin:discord@claude-plugins-official --dangerously-skip-permissions --append-system-prompt \"\$(cat \"${SYSTEM_PROMPT_FILE}\")\""
+
+  # Verify the session actually came up (AC-2). If not, log and back off.
+  sleep "${TMUX_VERIFY_SLEEP_SEC}"
+  if ! "${TMUX_BIN}" has-session -t "${SESSION}" 2>/dev/null; then
+    echo "[hijoguchi] ERROR: tmux session '${SESSION}' failed to start" >&2
+    sleep "${BACKOFF_SEC}"
+    continue
+  fi
+  echo "[hijoguchi] tmux session verified: ${SESSION}"
 
   # Block while the session exists
-  while "$TMUX_BIN" has-session -t "$SESSION" 2>/dev/null; do
+  while "${TMUX_BIN}" has-session -t "${SESSION}" 2>/dev/null; do
     sleep 10
   done
 
-  echo "[hijoguchi] session '$SESSION' ended at $(date), backing off ${BACKOFF_SEC}s"
-  sleep "$BACKOFF_SEC"
+  echo "[hijoguchi] session '${SESSION}' ended at $(date), backing off ${BACKOFF_SEC}s"
+  sleep "${BACKOFF_SEC}"
 done

--- a/scripts/start-hijoguchi.sh
+++ b/scripts/start-hijoguchi.sh
@@ -28,8 +28,8 @@ mkdir -p "${LOG_DIR}"
 # Guard: abort if the system-prompt file is missing. Without this the claude
 # invocation would silently pass `--append-system-prompt ""` and behaviour
 # would drift from what S3 defines.
-if [ ! -f "${SYSTEM_PROMPT_FILE}" ]; then
-  echo "[hijoguchi] ERROR: system-prompt file not found: ${SYSTEM_PROMPT_FILE}" >&2
+if [ ! -r "${SYSTEM_PROMPT_FILE}" ]; then
+  echo "[hijoguchi] ERROR: system-prompt file not readable: ${SYSTEM_PROMPT_FILE}" >&2
   exit 1
 fi
 
@@ -45,8 +45,17 @@ while true; do
   "${TMUX_BIN}" kill-session -t "${SESSION}" 2>/dev/null
 
   echo "[hijoguchi] starting tmux session '${SESSION}' at $(date)"
-  "${TMUX_BIN}" new-session -d -s "${SESSION}" -c "${CLAUDE_HUB_DIR}" \
-    "${CLAUDE_BIN} --channels plugin:discord@claude-plugins-official --dangerously-skip-permissions --append-system-prompt \"\$(cat \"${SYSTEM_PROMPT_FILE}\")\""
+  # Read the prompt in the parent shell and escape every argument with %q so
+  # the string handed to tmux's child shell re-parses back to the exact same
+  # argv — prompt content with $VAR, backticks, or quotes cannot leak into
+  # command evaluation, and CLAUDE_BIN paths with spaces remain intact.
+  SYSTEM_PROMPT_CONTENT="$(cat "${SYSTEM_PROMPT_FILE}")"
+  CLAUDE_CMD=$(printf '%q ' \
+    "${CLAUDE_BIN}" \
+    --channels plugin:discord@claude-plugins-official \
+    --dangerously-skip-permissions \
+    --append-system-prompt "${SYSTEM_PROMPT_CONTENT}")
+  "${TMUX_BIN}" new-session -d -s "${SESSION}" -c "${CLAUDE_HUB_DIR}" "${CLAUDE_CMD}"
 
   # Verify the session actually came up (AC-2). If not, log and back off.
   sleep "${TMUX_VERIFY_SLEEP_SEC}"


### PR DESCRIPTION
## Summary

Epic #45 の Phase 1 / S2。S3 (#49) で `--append-system-prompt` を本格適用する前の土台固め。

- `SYSTEM_PROMPT_FILE` 変数を導入（env 上書き可）+ `"${VAR}"` 形式で全箇所クォート
- ファイル欠如で起動 abort するガードを追加（AC-3）
- 起動ログに system-prompt パスを記録（AC-4）
- `tmux new-session` 後に `has-session` 検証、失敗時は ERROR log + backoff（AC-2）
- 既存の `$VAR` を全て `${VAR}` に統一（RW-006 対策）
- `scripts/hijoguchi-system-prompt.md` を最小 stub として新規追加。S3 が本文を差し替える前提でプロダクション継続性を担保

## AC 検証結果

| AC | 検証内容 | 実測 | 判定 |
|---|---|---|---|
| AC-1 | `"${SYSTEM_PROMPT_FILE}"` クォート | grep で 2 箇所確認 | PASS |
| AC-2 | tmux has-session 検証 | `has-session -t "${SESSION}"` line 53 / 61 | PASS |
| AC-3 | 存在しない場合 abort | `SYSTEM_PROMPT_FILE=/nonexistent bash …` → exit 1, ERROR log | PASS |
| AC-4 | パス ログ記録 | `[hijoguchi] system_prompt_file=<path>` line 36 | PASS |
| AC-5 | `bash -n` 構文 | エラーなし | PASS |

統合ジャーニーAC: tmux 起動 + 両行ログ（`system_prompt_file=` / `tmux session verified:`）を script 内で出力。実機 tmux 起動検証は launchd 再読み込みを伴うため S3 マージ時にまとめて実施予定。

## Test plan

- [x] `bash -n scripts/start-hijoguchi.sh`（構文）
- [x] guard 負の経路: `SYSTEM_PROMPT_FILE=/nonexistent …` → exit 1
- [x] `${VAR}` 形式のみ（RW-006）: `grep '\$[A-Za-z_]'` 0 hits
- [ ] S3 マージ時に launchd reload → tmux 実機検証

## RW-006 準拠

本 PR で追加／変更した bash 変数展開は全て `${VAR}` 形式。`grep -nE '\$[A-Za-z_][A-Za-z0-9_]*' scripts/start-hijoguchi.sh` で 0 hits。

Closes #48
Refs: #45 (epic)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * システムプロンプト設定ファイルのサポートを追加しました。
  * スタートアップスクリプトに事前チェック機能を追加し、必要なファイルが存在することを確認するようにしました。
  * スタートアップスクリプトに自動リトライロジックを実装し、セッション起動の信頼性が向上しました。
  * Claude CLIがシステムプロンプトを引数として読み込むようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->