### PR TITLE
feat(#50): add team-salary session log audit script

### DIFF
--- a/scripts/audit-team-salary-logs.sh
+++ b/scripts/audit-team-salary-logs.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# audit-team-salary-logs.sh
+#
+# Audit logs/sessions/team-salary_* for leakage of claudeHubExit context
+# and other cross-project secrets (Discord tokens, API keys, internal paths).
+#
+# Usage:  ./scripts/audit-team-salary-logs.sh
+# Exit:   0 = no leak detected, 1 = leak detected (and quarantined)
+# Issue:  https://github.com/miyashita337/claude-hub/issues/50
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+LOG_DIR="${REPO_ROOT}/logs/sessions"
+QUARANTINE_DIR="${LOG_DIR}/quarantine"
+ISSUE_URL="https://github.com/miyashita337/claude-hub/issues/50"
+
+shopt -s nullglob
+targets=( "${LOG_DIR}"/team-salary_*.log )
+shopt -u nullglob
+
+echo "=== team-salary log audit ==="
+echo "scan root : ${LOG_DIR}"
+echo "issue     : ${ISSUE_URL}"
+
+if [[ ${#targets[@]} -eq 0 ]]; then
+    echo "target    : 0 files"
+    echo "result    : PASS (no files to audit)"
+    exit 0
+fi
+
+first_date=""
+last_date=""
+total_bytes=0
+for f in "${targets[@]}"; do
+    base="$(basename "$f")"
+    date_part="${base#team-salary_}"
+    date_part="${date_part%%T*}"
+    if [[ -z "$first_date" || "$date_part" < "$first_date" ]]; then first_date="$date_part"; fi
+    if [[ -z "$last_date"  || "$date_part" > "$last_date"  ]]; then last_date="$date_part"; fi
+    size=$(wc -c <"$f" | tr -d ' ')
+    total_bytes=$((total_bytes + size))
+done
+echo "target    : ${#targets[@]} files, ${total_bytes} bytes, ${first_date} .. ${last_date}"
+
+PATTERNS=(
+    'claudeHubExit'
+    'hijoguchi'
+    'hijoguchi-system-prompt'
+    'DISCORD_BOT_TOKEN[=: ]'
+    'Authorization:[[:space:]]*Bearer'
+    'sk-ant-[A-Za-z0-9_-]{10,}'
+    'ghp_[A-Za-z0-9]{20,}'
+    'ghs_[A-Za-z0-9]{20,}'
+    '[A-Za-z0-9_-]{24,}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}'
+    'team-salary/src/'
+    'team-salary/secrets/'
+    'team-salary/.env'
+)
+
+hit_count=0
+hit_files=()
+declare -a hit_lines
+
+for f in "${targets[@]}"; do
+    file_hit=0
+    for pat in "${PATTERNS[@]}"; do
+        while IFS= read -r line; do
+            hit_count=$((hit_count + 1))
+            hit_lines+=("$(basename "$f"): ${line}")
+            file_hit=1
+        done < <(grep -nE "$pat" "$f" 2>/dev/null || true)
+    done
+    if [[ $file_hit -eq 1 ]]; then
+        hit_files+=("$f")
+    fi
+done
+
+if [[ $hit_count -eq 0 ]]; then
+    echo "patterns  : ${#PATTERNS[@]} checked"
+    echo "hits      : 0"
+    echo "result    : PASS (no leakage detected)"
+    exit 0
+fi
+
+echo "patterns  : ${#PATTERNS[@]} checked"
+echo "hits      : ${hit_count} across ${#hit_files[@]} files"
+echo "result    : FAIL — see ${ISSUE_URL}"
+echo ""
+echo "--- detected lines ---"
+for line in "${hit_lines[@]}"; do
+    echo "$line" >&2
+done
+
+mkdir -p "$QUARANTINE_DIR"
+for f in "${hit_files[@]}"; do
+    dest="${QUARANTINE_DIR}/$(basename "$f")"
+    mv "$f" "$dest"
+    echo "quarantined: $(basename "$f") -> quarantine/" >&2
+done
+
+exit 1

--- a/scripts/audit-team-salary-logs.sh
+++ b/scripts/audit-team-salary-logs.sh
@@ -62,15 +62,25 @@ hit_count=0
 hit_files=()
 declare -a hit_lines
 
+# Build a single multi-pattern grep invocation (one pass per file) to avoid
+# N_files * N_patterns subprocess overhead.
+grep_args=()
+for pat in "${PATTERNS[@]}"; do
+    grep_args+=("-e" "$pat")
+done
+
 for f in "${targets[@]}"; do
     file_hit=0
-    for pat in "${PATTERNS[@]}"; do
-        while IFS= read -r line; do
-            hit_count=$((hit_count + 1))
-            hit_lines+=("$(basename "$f"): ${line}")
-            file_hit=1
-        done < <(grep -nE "$pat" "$f" 2>/dev/null || true)
-    done
+    # grep -o emits only the matching substring, keeping the line number prefix
+    # from -n but dropping the full line content. This prevents secrets (Discord
+    # tokens, API keys, Authorization headers) from leaking into CI build logs
+    # when the audit FAILs — reviewers need to look at the quarantined file.
+    while IFS= read -r match; do
+        lineno="${match%%:*}"
+        hit_count=$((hit_count + 1))
+        hit_lines+=("$(basename "$f"):${lineno}")
+        file_hit=1
+    done < <(grep -noE "${grep_args[@]}" "$f" 2>/dev/null || true)
     if [[ $file_hit -eq 1 ]]; then
         hit_files+=("$f")
     fi
@@ -87,10 +97,11 @@ echo "patterns  : ${#PATTERNS[@]} checked"
 echo "hits      : ${hit_count} across ${#hit_files[@]} files"
 echo "result    : FAIL — see ${ISSUE_URL}"
 echo ""
-echo "--- detected lines ---"
-for line in "${hit_lines[@]}"; do
-    echo "$line" >&2
+echo "--- detected (filename:lineno only, content redacted) ---"
+for ref in "${hit_lines[@]}"; do
+    echo "$ref" >&2
 done
+echo "inspect the quarantined file directly for details." >&2
 
 mkdir -p "$QUARANTINE_DIR"
 for f in "${hit_files[@]}"; do

--- a/scripts/audit-team-salary-logs.sh
+++ b/scripts/audit-team-salary-logs.sh
@@ -53,9 +53,9 @@ PATTERNS=(
     'ghp_[A-Za-z0-9]{20,}'
     'ghs_[A-Za-z0-9]{20,}'
     '[A-Za-z0-9_-]{24,}\.[A-Za-z0-9_-]{6}\.[A-Za-z0-9_-]{27,}'
-    'team-salary/src/'
-    'team-salary/secrets/'
-    'team-salary/.env'
+    'team[-_]salary/src/'
+    'team[-_]salary/secrets/'
+    'team[-_]salary/\.env'
 )
 
 hit_count=0
@@ -75,12 +75,30 @@ for f in "${targets[@]}"; do
     # from -n but dropping the full line content. This prevents secrets (Discord
     # tokens, API keys, Authorization headers) from leaking into CI build logs
     # when the audit FAILs — reviewers need to look at the quarantined file.
-    while IFS= read -r match; do
-        lineno="${match%%:*}"
-        hit_count=$((hit_count + 1))
-        hit_lines+=("$(basename "$f"):${lineno}")
-        file_hit=1
-    done < <(grep -noE "${grep_args[@]}" "$f" 2>/dev/null || true)
+    #
+    # We explicitly distinguish grep exit 1 (no match) from exit >=2 (regex
+    # syntax error, I/O error, permission denied) — a silent `|| true` would
+    # let a broken pattern or unreadable file fool the audit into reporting
+    # PASS. Fail-closed on anything other than clean no-match.
+    set +e
+    grep_output="$(grep -noE "${grep_args[@]}" "$f" 2>/dev/null)"
+    grep_status=$?
+    set -e
+
+    if [[ $grep_status -gt 1 ]]; then
+        echo "grep failed (exit ${grep_status}) while scanning $(basename "$f"); aborting audit" >&2
+        exit 2
+    fi
+
+    if [[ -n "$grep_output" ]]; then
+        while IFS= read -r match; do
+            lineno="${match%%:*}"
+            hit_count=$((hit_count + 1))
+            hit_lines+=("$(basename "$f"):${lineno}")
+            file_hit=1
+        done <<< "$grep_output"
+    fi
+
     if [[ $file_hit -eq 1 ]]; then
         hit_files+=("$f")
     fi
@@ -106,6 +124,12 @@ echo "inspect the quarantined file directly for details." >&2
 mkdir -p "$QUARANTINE_DIR"
 for f in "${hit_files[@]}"; do
     dest="${QUARANTINE_DIR}/$(basename "$f")"
+    # Refuse to overwrite an existing quarantined file — the earlier file is
+    # forensic evidence that must not be silently clobbered by a re-run.
+    if [[ -e "$dest" ]]; then
+        echo "quarantine destination already exists: $(basename "$dest"); refusing to overwrite" >&2
+        exit 1
+    fi
     mv "$f" "$dest"
     echo "quarantined: $(basename "$f") -> quarantine/" >&2
 done


### PR DESCRIPTION
## Summary

- Adds `scripts/audit-team-salary-logs.sh`: reads `logs/sessions/team-salary_*.log` and greps 12 leakage patterns (claudeHubExit, hijoguchi, Discord token, API keys, internal paths).
- Exit 0 when clean, exit 1 + move offenders to `logs/sessions/quarantine/` on hit.
- Epic #45 Wave 1 / S4.

## Audit execution

| Metric | Value |
|---|---|
| Files scanned | 5 |
| Total bytes | 532 |
| Date range | 2026-03-29 (single day) |
| Patterns checked | 12 |
| Hits | **0** |
| Quarantined | 0 |
| Exit code | 0 |

Detailed report appended to Issue #50 body under `## 監査レポート`.

## AC

- [x] AC-1: grep で他プロジェクト情報混入なしを確認 (12 patterns, 0 hits)
- [x] AC-2: 混入あれば quarantine 移動 + Issue リスト化 (該当なし)
- [x] AC-3: Issue #50 本文に「## 監査レポート」セクション追加
- [x] AC-4: 対象ログ件数・日付範囲明記 (5 件 / 2026-03-29)
- [x] 統合ジャーニー AC: `scripts/audit-team-salary-logs.sh` exit 0

## Test plan

- [x] スクリプト実行 → exit 0
- [x] グロブ重複カウント (5→9) のバグを修正し、単一グロブ `team-salary_*.log` で dedupe 済
- [x] 検知パターン 12 件全て 0 hits を確認
- [x] quarantine ディレクトリが作成されていないこと (hits=0 のため)

Closes #50
Refs #45 (Epic S4)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **その他**
  * ログファイル監査スクリプトを新たに追加しました。このスクリプトはログファイルをスキャンし、一致するファイルを隔離ディレクトリに移動します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->