### PR TITLE
feat(#54): protect-config.sh env ガード (SUPERVISOR_RELAY_URL / CLAUDE_SKIP_PROTECT)

### DIFF
--- a/scripts/protect-config.sh
+++ b/scripts/protect-config.sh
@@ -24,22 +24,37 @@ if [ -n "${CLAUDE_SKIP_PROTECT:-}" ]; then
 fi
 
 if [ -n "${SUPERVISOR_RELAY_URL:-}" ]; then
-  # Loopback-only allowlist. Anything else (public DNS, LAN IP, other schemes)
-  # is treated as a relay-redirection attempt.
+  # Loopback-only allowlist. The optional trailing segment accepts any of
+  # "/path", "?query", or "#fragment" so valid localhost URLs with query
+  # parameters (e.g. `http://localhost:3000?token=x`) are not rejected.
+  # Anything else (public DNS, LAN IP, other schemes) is treated as a
+  # relay-redirection attempt.
   if ! printf '%s' "${SUPERVISOR_RELAY_URL}" \
-      | grep -qE '^(https?|wss?)://(localhost|127\.0\.0\.1|\[::1\])(:[0-9]+)?(/.*)?$'; then
+      | grep -qE '^(https?|wss?)://(localhost|127\.0\.0\.1|\[::1\])(:[0-9]+)?([/?#].*)?$'; then
     echo "[protect-config] BLOCKED: SUPERVISOR_RELAY_URL is not a loopback URL: ${SUPERVISOR_RELAY_URL}" >&2
-    echo "[protect-config] Allowed schemes/hosts: (http|https|ws|wss)://(localhost|127.0.0.1|[::1])[:port][/path]" >&2
+    echo "[protect-config] Allowed: (http|https|ws|wss)://(localhost|127.0.0.1|[::1])[:port][/path|?query|#frag]" >&2
     exit 2
   fi
 fi
 
-# --- config-file protection (original behaviour) --------------------------
+# --- config-file protection -----------------------------------------------
 
 INPUT=$(cat)
 
-if ! command -v jq &> /dev/null; then
+# Empty stdin: nothing to inspect. Treat as pass-through so manual `bash
+# scripts/protect-config.sh` with no input (e.g. env-guard-only invocations)
+# doesn't trip jq on older versions that error on empty input.
+if [ -z "${INPUT}" ]; then
   exit 0
+fi
+
+# jq is required to parse hook input. Fail-closed (exit 2) rather than
+# fail-open (exit 0) so a missing dependency can't silently disable protection
+# for the tracked linter/formatter config files.
+if ! command -v jq &> /dev/null; then
+  echo "[protect-config] BLOCKED: jq is required but not found on PATH." >&2
+  echo "[protect-config] Install jq (e.g. 'brew install jq') to use this hook." >&2
+  exit 2
 fi
 
 TOOL_NAME=$(printf '%s' "${INPUT}" | jq -r '.tool_name // empty')
@@ -89,7 +104,7 @@ done
 # tsconfig.json: block disabling strict mode (new files still allowed)
 if [ "${BASENAME}" = "tsconfig.json" ] && [ "${TOOL_NAME}" = "Edit" ]; then
   OLD_STRING=$(printf '%s' "${INPUT}" | jq -r '.tool_input.old_string // empty')
-  if printf '%s' "${OLD_STRING}" | grep -qiE '"strict":\s*true'; then
+  if printf '%s' "${OLD_STRING}" | grep -qiE '"strict":[[:space:]]*true'; then
     echo "[protect-config] BLOCKED: Disabling strict mode in tsconfig.json is not allowed." >&2
     exit 2
   fi

--- a/scripts/protect-config.sh
+++ b/scripts/protect-config.sh
@@ -1,0 +1,108 @@
+#!/bin/bash
+# Linter/Formatter config protection hook (PreToolUse).
+#
+# Responsibilities:
+#   1. Reject env-var bypass attempts (S8 #54 / Epic #45) — fail-closed.
+#   2. Block Write/Edit of tracked linter/formatter config files so agents fix
+#      the code instead of weakening the rules.
+#
+# Env guards (run BEFORE reading stdin so malformed/empty input can't bypass):
+#   - CLAUDE_SKIP_PROTECT : presence is rejected regardless of value.
+#   - SUPERVISOR_RELAY_URL: only loopback (localhost / 127.0.0.1 / [::1]) with
+#     http|https|ws|wss scheme is allowed; any other host is blocked.
+#
+# Variable refs use ${VAR} form (RW-006: avoid $VAR adjacent to non-ASCII bytes).
+
+set -euo pipefail
+
+# --- env-var guards (S8 #54) ----------------------------------------------
+
+if [ -n "${CLAUDE_SKIP_PROTECT:-}" ]; then
+  echo "[protect-config] BLOCKED: CLAUDE_SKIP_PROTECT bypass is rejected." >&2
+  echo "[protect-config] Fix the underlying rule/config issue instead of disabling this hook." >&2
+  exit 2
+fi
+
+if [ -n "${SUPERVISOR_RELAY_URL:-}" ]; then
+  # Loopback-only allowlist. Anything else (public DNS, LAN IP, other schemes)
+  # is treated as a relay-redirection attempt.
+  if ! printf '%s' "${SUPERVISOR_RELAY_URL}" \
+      | grep -qE '^(https?|wss?)://(localhost|127\.0\.0\.1|\[::1\])(:[0-9]+)?(/.*)?$'; then
+    echo "[protect-config] BLOCKED: SUPERVISOR_RELAY_URL is not a loopback URL: ${SUPERVISOR_RELAY_URL}" >&2
+    echo "[protect-config] Allowed schemes/hosts: (http|https|ws|wss)://(localhost|127.0.0.1|[::1])[:port][/path]" >&2
+    exit 2
+  fi
+fi
+
+# --- config-file protection (original behaviour) --------------------------
+
+INPUT=$(cat)
+
+if ! command -v jq &> /dev/null; then
+  exit 0
+fi
+
+TOOL_NAME=$(printf '%s' "${INPUT}" | jq -r '.tool_name // empty')
+
+if [ "${TOOL_NAME}" != "Write" ] && [ "${TOOL_NAME}" != "Edit" ]; then
+  exit 0
+fi
+
+FILE_PATH=$(printf '%s' "${INPUT}" | jq -r '.tool_input.file_path // .tool_input.filePath // empty')
+
+if [ -z "${FILE_PATH}" ]; then
+  exit 0
+fi
+
+BASENAME=$(basename "${FILE_PATH}")
+
+PROTECTED_FILES=(
+  "biome.json"
+  "biome.jsonc"
+  ".eslintrc"
+  ".eslintrc.js"
+  ".eslintrc.cjs"
+  ".eslintrc.json"
+  ".eslintrc.yml"
+  "eslint.config.js"
+  "eslint.config.mjs"
+  "eslint.config.ts"
+  ".prettierrc"
+  ".prettierrc.js"
+  ".prettierrc.json"
+  ".prettierrc.yml"
+  "commitlint.config.js"
+  "commitlint.config.ts"
+  "ruff.toml"
+  "clippy.toml"
+  ".rustfmt.toml"
+)
+
+for protected in "${PROTECTED_FILES[@]}"; do
+  if [ "${BASENAME}" = "${protected}" ]; then
+    echo "[protect-config] BLOCKED: ${BASENAME} is a protected linter/formatter config." >&2
+    echo "[protect-config] Fix the code to satisfy the rules, don't weaken the rules." >&2
+    exit 2
+  fi
+done
+
+# tsconfig.json: block disabling strict mode (new files still allowed)
+if [ "${BASENAME}" = "tsconfig.json" ] && [ "${TOOL_NAME}" = "Edit" ]; then
+  OLD_STRING=$(printf '%s' "${INPUT}" | jq -r '.tool_input.old_string // empty')
+  if printf '%s' "${OLD_STRING}" | grep -qiE '"strict":\s*true'; then
+    echo "[protect-config] BLOCKED: Disabling strict mode in tsconfig.json is not allowed." >&2
+    exit 2
+  fi
+fi
+
+# pyproject.toml: block edits to [tool.ruff*] sections
+if [ "${BASENAME}" = "pyproject.toml" ] && [ "${TOOL_NAME}" = "Edit" ]; then
+  OLD_STRING=$(printf '%s' "${INPUT}" | jq -r '.tool_input.old_string // empty')
+  if printf '%s' "${OLD_STRING}" | grep -qiE '\[tool\.ruff'; then
+    echo "[protect-config] BLOCKED: Modifying [tool.ruff] config in pyproject.toml is not allowed." >&2
+    echo "[protect-config] Fix the code to satisfy ruff rules instead." >&2
+    exit 2
+  fi
+fi
+
+exit 0

--- a/scripts/protect-config.sh
+++ b/scripts/protect-config.sh
@@ -101,19 +101,48 @@ for protected in "${PROTECTED_FILES[@]}"; do
   fi
 done
 
-# tsconfig.json: block disabling strict mode (new files still allowed)
-if [ "${BASENAME}" = "tsconfig.json" ] && [ "${TOOL_NAME}" = "Edit" ]; then
-  OLD_STRING=$(printf '%s' "${INPUT}" | jq -r '.tool_input.old_string // empty')
-  if printf '%s' "${OLD_STRING}" | grep -qiE '"strict":[[:space:]]*true'; then
-    echo "[protect-config] BLOCKED: Disabling strict mode in tsconfig.json is not allowed." >&2
-    exit 2
-  fi
+# tsconfig.json guards.
+#   Edit : block if `old_string` contains `"strict": true` — the edit is
+#          removing/replacing the strict flag, i.e. disabling strict mode.
+#   Write: block any full-file rewrite. Whether the new content keeps or drops
+#          `strict` can't be judged without reading the existing file; blocking
+#          the rewrite entirely is the conservative choice. Legitimate tweaks
+#          should go through Edit, which keeps the strict-removal guard intact.
+if [ "${BASENAME}" = "tsconfig.json" ]; then
+  case "${TOOL_NAME}" in
+    Edit)
+      OLD_STRING=$(printf '%s' "${INPUT}" | jq -r '.tool_input.old_string // empty')
+      if printf '%s' "${OLD_STRING}" | grep -qiE '"strict":[[:space:]]*true'; then
+        echo "[protect-config] BLOCKED: Disabling strict mode in tsconfig.json is not allowed." >&2
+        exit 2
+      fi
+      ;;
+    Write)
+      echo "[protect-config] BLOCKED: Full rewrite of tsconfig.json is not allowed." >&2
+      echo "[protect-config] Use Edit for scoped changes so the strict-mode guard can evaluate the diff." >&2
+      exit 2
+      ;;
+  esac
 fi
 
-# pyproject.toml: block edits to [tool.ruff*] sections
-if [ "${BASENAME}" = "pyproject.toml" ] && [ "${TOOL_NAME}" = "Edit" ]; then
-  OLD_STRING=$(printf '%s' "${INPUT}" | jq -r '.tool_input.old_string // empty')
-  if printf '%s' "${OLD_STRING}" | grep -qiE '\[tool\.ruff'; then
+# pyproject.toml guards.
+#   Edit : block if `old_string` contains `[tool.ruff` — modifying ruff config.
+#   Write: block if `content` contains `[tool.ruff` — new file declares ruff
+#          config (could be adding, removing, or modifying it). Conservative
+#          but keeps the "don't touch ruff config via this hook" invariant.
+if [ "${BASENAME}" = "pyproject.toml" ]; then
+  case "${TOOL_NAME}" in
+    Edit)
+      PAYLOAD=$(printf '%s' "${INPUT}" | jq -r '.tool_input.old_string // empty')
+      ;;
+    Write)
+      PAYLOAD=$(printf '%s' "${INPUT}" | jq -r '.tool_input.content // empty')
+      ;;
+    *)
+      PAYLOAD=''
+      ;;
+  esac
+  if printf '%s' "${PAYLOAD}" | grep -qiE '\[tool\.ruff'; then
     echo "[protect-config] BLOCKED: Modifying [tool.ruff] config in pyproject.toml is not allowed." >&2
     echo "[protect-config] Fix the code to satisfy ruff rules instead." >&2
     exit 2

--- a/scripts/test-protect-config.sh
+++ b/scripts/test-protect-config.sh
@@ -25,39 +25,43 @@ t1_syntax_check() {
   bash -n "${TARGET}"
 }
 
-# AC-2: CLAUDE_SKIP_PROTECT (any non-empty value) is rejected.
+# AC-2: CLAUDE_SKIP_PROTECT (any non-empty value) is rejected with exit 2.
+# We assert exit code == 2 (not just non-zero) so the test catches regressions
+# where a different failure code (e.g. jq's exit 4) silently satisfies the
+# rejection expectation.
 t2_skip_protect_rejected() {
   local out rc
   out=$(CLAUDE_SKIP_PROTECT=1 bash "${TARGET}" </dev/null 2>&1) && rc=0 || rc=$?
-  [ "${rc}" -ne 0 ] && echo "${out}" | grep -Fq 'CLAUDE_SKIP_PROTECT'
+  [ "${rc}" -eq 2 ] && echo "${out}" | grep -Fq 'CLAUDE_SKIP_PROTECT'
 }
 
 # AC-2 variant: truthy-looking strings are also rejected (presence, not value).
 t2b_skip_protect_any_value() {
   local rc
   CLAUDE_SKIP_PROTECT=yes bash "${TARGET}" </dev/null >/dev/null 2>&1 && rc=0 || rc=$?
-  [ "${rc}" -ne 0 ]
+  [ "${rc}" -eq 2 ]
 }
 
-# AC-1: External SUPERVISOR_RELAY_URL is blocked.
+# AC-1: External SUPERVISOR_RELAY_URL is blocked with exit 2.
 t3_external_url_blocked() {
   local out rc
   out=$(SUPERVISOR_RELAY_URL='https://evil.example.com/relay' \
         bash "${TARGET}" </dev/null 2>&1) && rc=0 || rc=$?
-  [ "${rc}" -ne 0 ] && echo "${out}" | grep -Fq 'SUPERVISOR_RELAY_URL'
+  [ "${rc}" -eq 2 ] && echo "${out}" | grep -Fq 'SUPERVISOR_RELAY_URL'
 }
 
-# AC-1 variant: LAN IPs are NOT loopback — must be blocked.
+# AC-1 variant: LAN IPs are NOT loopback — must be blocked with exit 2.
 t3b_lan_ip_blocked() {
   local rc
   SUPERVISOR_RELAY_URL='http://192.168.1.10:3000/' \
     bash "${TARGET}" </dev/null >/dev/null 2>&1 && rc=0 || rc=$?
-  [ "${rc}" -ne 0 ]
+  [ "${rc}" -eq 2 ]
 }
 
 # AC-1 inverse: loopback URL passes the guard.
 t4_loopback_allowed() {
-  # Empty stdin + jq present → script's body exits 0 after TOOL_NAME empty check.
+  # Empty stdin + jq present → script's body exits 0 after the empty-input
+  # early-return (added post-review to avoid jq errors on blank stdin).
   SUPERVISOR_RELAY_URL='http://localhost:3000/relay' \
     bash "${TARGET}" </dev/null >/dev/null 2>&1
 }
@@ -70,6 +74,13 @@ t4b_loopback_variants_allowed() {
     bash "${TARGET}" </dev/null >/dev/null 2>&1
 }
 
+# AC-1 inverse: loopback URL with query string (no trailing slash) passes.
+# Regression guard for the regex tightening found in review.
+t4c_loopback_with_query() {
+  SUPERVISOR_RELAY_URL='http://localhost:3000?token=abc' \
+    bash "${TARGET}" </dev/null >/dev/null 2>&1
+}
+
 # AC-4: guard emits a log line tagged [protect-config] BLOCKED on rejection.
 t5_guard_logs_on_block() {
   local out
@@ -77,11 +88,12 @@ t5_guard_logs_on_block() {
   echo "${out}" | grep -qE '^\[protect-config\] BLOCKED:'
 }
 
-# Env guard fires before stdin parsing — even garbage input is rejected.
+# Env guard fires before stdin parsing — even garbage input is rejected with
+# exit 2 (not jq's exit 4 from failing to parse the non-JSON body).
 t6_env_guard_fast_fail() {
   local out rc
   out=$(CLAUDE_SKIP_PROTECT=1 bash "${TARGET}" <<<'not-json garbage' 2>&1) && rc=0 || rc=$?
-  [ "${rc}" -ne 0 ] && echo "${out}" | grep -Fq 'CLAUDE_SKIP_PROTECT'
+  [ "${rc}" -eq 2 ] && echo "${out}" | grep -Fq 'CLAUDE_SKIP_PROTECT'
 }
 
 # No env → default pass-through (exit 0) for empty stdin.
@@ -91,9 +103,11 @@ t7_passthrough_no_env() {
 }
 
 # RW-006 regression: no bare $VAR followed by a non-ASCII byte in source.
-# Any match means the ${VAR} discipline regressed.
+# Uses perl slurp mode (-0777) because BSD `grep -P` is not POSIX and isn't
+# compiled in on stock macOS. Test passes when perl exits non-zero (no match).
 t8_rw006_braced_vars() {
-  ! LC_ALL=C grep -nP '\$[A-Za-z_][A-Za-z0-9_]*[^\x00-\x7f]' "${TARGET}" >/dev/null 2>&1
+  ! LC_ALL=C perl -0777 -ne \
+    'exit(/\$[A-Za-z_][A-Za-z0-9_]*[^\x00-\x7f]/ ? 0 : 1)' "${TARGET}"
 }
 
 run "T1 syntax check (AC-3)"                     t1_syntax_check
@@ -103,6 +117,7 @@ run "T3 external URL blocked (AC-1)"             t3_external_url_blocked
 run "T3b LAN IP blocked"                         t3b_lan_ip_blocked
 run "T4 loopback URL allowed"                    t4_loopback_allowed
 run "T4b 127.0.0.1 / [::1] allowed"              t4b_loopback_variants_allowed
+run "T4c loopback + query string allowed"        t4c_loopback_with_query
 run "T5 log line on block (AC-4)"                t5_guard_logs_on_block
 run "T6 env guard precedes stdin parse"          t6_env_guard_fast_fail
 run "T7 no env → pass-through"                   t7_passthrough_no_env

--- a/scripts/test-protect-config.sh
+++ b/scripts/test-protect-config.sh
@@ -1,0 +1,117 @@
+#!/bin/bash
+# Unit tests for scripts/protect-config.sh env-var guards (S8 #54).
+# Run standalone: bash scripts/test-protect-config.sh
+# Exits 0 on all-pass, 1 on any failure.
+#
+# Test case functions (tN_*) are invoked through `run "..." fn_name`.
+# shellcheck disable=SC2329
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="${SCRIPT_DIR}/protect-config.sh"
+
+fail=0
+run() {
+  local name="$1"; shift
+  if "$@"; then echo "PASS ${name}"; else echo "FAIL ${name}"; fail=1; fi
+}
+
+# Ensure a clean env baseline; individual tests re-export as needed.
+unset CLAUDE_SKIP_PROTECT SUPERVISOR_RELAY_URL
+
+# AC-3: script parses without syntax errors.
+t1_syntax_check() {
+  bash -n "${TARGET}"
+}
+
+# AC-2: CLAUDE_SKIP_PROTECT (any non-empty value) is rejected.
+t2_skip_protect_rejected() {
+  local out rc
+  out=$(CLAUDE_SKIP_PROTECT=1 bash "${TARGET}" </dev/null 2>&1) && rc=0 || rc=$?
+  [ "${rc}" -ne 0 ] && echo "${out}" | grep -Fq 'CLAUDE_SKIP_PROTECT'
+}
+
+# AC-2 variant: truthy-looking strings are also rejected (presence, not value).
+t2b_skip_protect_any_value() {
+  local rc
+  CLAUDE_SKIP_PROTECT=yes bash "${TARGET}" </dev/null >/dev/null 2>&1 && rc=0 || rc=$?
+  [ "${rc}" -ne 0 ]
+}
+
+# AC-1: External SUPERVISOR_RELAY_URL is blocked.
+t3_external_url_blocked() {
+  local out rc
+  out=$(SUPERVISOR_RELAY_URL='https://evil.example.com/relay' \
+        bash "${TARGET}" </dev/null 2>&1) && rc=0 || rc=$?
+  [ "${rc}" -ne 0 ] && echo "${out}" | grep -Fq 'SUPERVISOR_RELAY_URL'
+}
+
+# AC-1 variant: LAN IPs are NOT loopback — must be blocked.
+t3b_lan_ip_blocked() {
+  local rc
+  SUPERVISOR_RELAY_URL='http://192.168.1.10:3000/' \
+    bash "${TARGET}" </dev/null >/dev/null 2>&1 && rc=0 || rc=$?
+  [ "${rc}" -ne 0 ]
+}
+
+# AC-1 inverse: loopback URL passes the guard.
+t4_loopback_allowed() {
+  # Empty stdin + jq present → script's body exits 0 after TOOL_NAME empty check.
+  SUPERVISOR_RELAY_URL='http://localhost:3000/relay' \
+    bash "${TARGET}" </dev/null >/dev/null 2>&1
+}
+
+# AC-1 inverse: 127.0.0.1 and [::1] variants also pass.
+t4b_loopback_variants_allowed() {
+  SUPERVISOR_RELAY_URL='ws://127.0.0.1:8080/' \
+    bash "${TARGET}" </dev/null >/dev/null 2>&1 \
+  && SUPERVISOR_RELAY_URL='https://[::1]/x' \
+    bash "${TARGET}" </dev/null >/dev/null 2>&1
+}
+
+# AC-4: guard emits a log line tagged [protect-config] BLOCKED on rejection.
+t5_guard_logs_on_block() {
+  local out
+  out=$(CLAUDE_SKIP_PROTECT=1 bash "${TARGET}" </dev/null 2>&1 || true)
+  echo "${out}" | grep -qE '^\[protect-config\] BLOCKED:'
+}
+
+# Env guard fires before stdin parsing — even garbage input is rejected.
+t6_env_guard_fast_fail() {
+  local out rc
+  out=$(CLAUDE_SKIP_PROTECT=1 bash "${TARGET}" <<<'not-json garbage' 2>&1) && rc=0 || rc=$?
+  [ "${rc}" -ne 0 ] && echo "${out}" | grep -Fq 'CLAUDE_SKIP_PROTECT'
+}
+
+# No env → default pass-through (exit 0) for empty stdin.
+t7_passthrough_no_env() {
+  unset CLAUDE_SKIP_PROTECT SUPERVISOR_RELAY_URL
+  bash "${TARGET}" </dev/null >/dev/null 2>&1
+}
+
+# RW-006 regression: no bare $VAR followed by a non-ASCII byte in source.
+# Any match means the ${VAR} discipline regressed.
+t8_rw006_braced_vars() {
+  ! LC_ALL=C grep -nP '\$[A-Za-z_][A-Za-z0-9_]*[^\x00-\x7f]' "${TARGET}" >/dev/null 2>&1
+}
+
+run "T1 syntax check (AC-3)"                     t1_syntax_check
+run "T2 CLAUDE_SKIP_PROTECT rejected (AC-2)"     t2_skip_protect_rejected
+run "T2b any non-empty value rejected"           t2b_skip_protect_any_value
+run "T3 external URL blocked (AC-1)"             t3_external_url_blocked
+run "T3b LAN IP blocked"                         t3b_lan_ip_blocked
+run "T4 loopback URL allowed"                    t4_loopback_allowed
+run "T4b 127.0.0.1 / [::1] allowed"              t4b_loopback_variants_allowed
+run "T5 log line on block (AC-4)"                t5_guard_logs_on_block
+run "T6 env guard precedes stdin parse"          t6_env_guard_fast_fail
+run "T7 no env → pass-through"                   t7_passthrough_no_env
+run "T8 no bare \$VAR before non-ASCII"          t8_rw006_braced_vars
+
+if [ "${fail}" -eq 0 ]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+else
+  echo "SOME TESTS FAILED"
+  exit 1
+fi

--- a/scripts/test-protect-config.sh
+++ b/scripts/test-protect-config.sh
@@ -110,6 +110,42 @@ t8_rw006_braced_vars() {
     'exit(/\$[A-Za-z_][A-Za-z0-9_]*[^\x00-\x7f]/ ? 0 : 1)' "${TARGET}"
 }
 
+# Write-tool regression: any Write of tsconfig.json is blocked. Without this
+# the full-file rewrite could drop strict mode silently (bypassing the Edit
+# check on old_string). Legitimate tweaks must go through Edit.
+t9_write_tsconfig_blocked() {
+  local out rc input
+  input='{"tool_name":"Write","tool_input":{"file_path":"/repo/tsconfig.json","content":"{\"compilerOptions\":{\"target\":\"ES2022\"}}"}}'
+  out=$(printf '%s' "${input}" | bash "${TARGET}" 2>&1) && rc=0 || rc=$?
+  [ "${rc}" -eq 2 ] && echo "${out}" | grep -Fq 'tsconfig.json'
+}
+
+# Write of pyproject.toml with [tool.ruff*] in new content is blocked.
+t10_write_pyproject_ruff_blocked() {
+  local out rc input
+  input='{"tool_name":"Write","tool_input":{"file_path":"/repo/pyproject.toml","content":"[tool.ruff]\nline-length = 100"}}'
+  out=$(printf '%s' "${input}" | bash "${TARGET}" 2>&1) && rc=0 || rc=$?
+  [ "${rc}" -eq 2 ] && echo "${out}" | grep -Fq '[tool.ruff]'
+}
+
+# Edit path still works (regression). Keeps the legacy old_string check honest.
+t11_edit_tsconfig_strict_still_blocked() {
+  local out rc input
+  input='{"tool_name":"Edit","tool_input":{"file_path":"/repo/tsconfig.json","old_string":"\"strict\": true"}}'
+  out=$(printf '%s' "${input}" | bash "${TARGET}" 2>&1) && rc=0 || rc=$?
+  [ "${rc}" -eq 2 ] && echo "${out}" | grep -Fq 'strict mode in tsconfig.json'
+}
+
+# Write of pyproject.toml WITHOUT [tool.ruff] (e.g. only [project] metadata)
+# must pass through — we only want to block ruff-config writes, not all
+# pyproject.toml edits.
+t12_write_pyproject_benign_allowed() {
+  local rc input
+  input='{"tool_name":"Write","tool_input":{"file_path":"/repo/pyproject.toml","content":"[project]\nname=\"x\""}}'
+  printf '%s' "${input}" | bash "${TARGET}" >/dev/null 2>&1 && rc=0 || rc=$?
+  [ "${rc}" -eq 0 ]
+}
+
 run "T1 syntax check (AC-3)"                     t1_syntax_check
 run "T2 CLAUDE_SKIP_PROTECT rejected (AC-2)"     t2_skip_protect_rejected
 run "T2b any non-empty value rejected"           t2b_skip_protect_any_value
@@ -122,6 +158,10 @@ run "T5 log line on block (AC-4)"                t5_guard_logs_on_block
 run "T6 env guard precedes stdin parse"          t6_env_guard_fast_fail
 run "T7 no env → pass-through"                   t7_passthrough_no_env
 run "T8 no bare \$VAR before non-ASCII"          t8_rw006_braced_vars
+run "T9 Write tsconfig blocked (any content)"    t9_write_tsconfig_blocked
+run "T10 Write pyproject ruff blocked"           t10_write_pyproject_ruff_blocked
+run "T11 Edit tsconfig strict still blocked"     t11_edit_tsconfig_strict_still_blocked
+run "T12 Write pyproject w/o ruff allowed"       t12_write_pyproject_benign_allowed
 
 if [ "${fail}" -eq 0 ]; then
   echo "ALL TESTS PASSED"


### PR DESCRIPTION
Closes #54 — Epic #45 Wave 3 S8。

## Summary

- `scripts/protect-config.sh` を新規追加。既存の `~/.claude/hooks/protect-config.sh`（Write/Edit config 保護）の **前段** に env-var 事前チェック + fail-closed を追加
- `CLAUDE_SKIP_PROTECT` が **非空** なら reject（AC-2、値は問わない）
- `SUPERVISOR_RELAY_URL` が **loopback 以外**（localhost / 127.0.0.1 / [::1] + http|https|ws|wss）なら reject（AC-1）
- env ガードは **stdin 読み込みより前** に発火するので、不正 JSON や空入力でもバイパス不能
- `scripts/test-protect-config.sh` を新規追加（T1–T8、計 11 ケース）
- 変数参照は全て `${VAR}` 形式で統一（RW-006: bash `$VAR` 全角衝突防止）、T8 で regression 検知

## AC マッピング

| AC | 内容 | カバー |
|---|---|---|
| AC-1 | `SUPERVISOR_RELAY_URL` 外部 URL は block | T3（https://evil.example.com）, T3b（LAN IP） |
| AC-2 | `CLAUDE_SKIP_PROTECT=1` 拒否（意図的バイパス禁止） | T2, T2b（任意非空値）, T6（stdin 前発火） |
| AC-3 | `bash -n scripts/protect-config.sh` 構文エラーなし | T1 |
| AC-4 | ガード発動時にログ出力 | T5（`^\[protect-config\] BLOCKED:` 行 grep） |

## 統合ジャーニーAC 検証ログ

```
$ CLAUDE_SKIP_PROTECT=1 bash scripts/protect-config.sh </dev/null; echo "exit=$?"
[protect-config] BLOCKED: CLAUDE_SKIP_PROTECT bypass is rejected.
[protect-config] Fix the underlying rule/config issue instead of disabling this hook.
exit=2
```

## Test plan

- [x] `bash -n scripts/protect-config.sh` 構文 OK
- [x] `bash scripts/test-protect-config.sh` → `ALL TESTS PASSED`（11/11 PASS）
- [x] 統合ジャーニーAC: `CLAUDE_SKIP_PROTECT=1 bash scripts/protect-config.sh </dev/null` → exit 2 + 拒否ログ
- [x] loopback URL は通過（T4: `http://localhost:3000`、T4b: `ws://127.0.0.1:8080`, `https://[::1]/x`）
- [x] RW-006 regression check（T8: `$VAR` 直後に非 ASCII バイトなし）

## 設計メモ

- **allowlist 方式**: SUPERVISOR_RELAY_URL は loopback のみ許可。LAN IP（例 `192.168.x.x`）・DNS ホスト・非 http/ws 系スキームは全て block（T3b で検証）
- **presence check**: CLAUDE_SKIP_PROTECT は値を問わず存在するだけで拒否。`=0` / `=false` / `=yes` 全て同じ扱い（T2b）
- **fail-fast**: env チェックを `INPUT=$(cat)` より前に配置。`garbage` を stdin に流しても env ガードが先に block（T6）
- **デプロイ**: 本 PR は repo 側の source of truth を追加するのみ。`~/.claude/hooks/protect-config.sh` への反映は別途（後続 Issue で install スクリプト化予定）
- **S3 (#49) との一貫性**: `[A-Z][A-Z0-9_]*` regex を使った fail-closed パターンの精神を継承（S3 は token 未解決、S8 は env 不正値。共に明示的 exit 2）

## 依存

- Epic #45 の S3 (#49) merge 済み。S7 (#53) / S9 (#55) と並列可

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ファイル操作に対する検証メカニズムが追加されました。

* **テスト**
  * 検証メカニズムを検証するためのテストスクリプトが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->