### PR TITLE
feat: リモートセッション起動時に agent-base を自動セットアップ

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -76,5 +76,18 @@
       "Read(//**/id_rsa*)",
       "Read(//**/id_ed25519*)"
     ]
+  },
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "startup|resume",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/setup-agent-base.sh"
+          }
+        ]
+      }
+    ]
   }
 }

--- a/scripts/setup-agent-base.sh
+++ b/scripts/setup-agent-base.sh
@@ -4,17 +4,29 @@ set -e
 # ローカルでは動かさない
 [ "$CLAUDE_CODE_REMOTE" != "true" ] && exit 0
 
-# 既にあればスキップ
-[ -d "$HOME/agent-base" ] && exit 0
+AGENT_BASE_DIR="$HOME/agent-base"
+REPO_URL="https://github.com/miyashita337/agent-base.git"
 
-# clone（この時点では $GH_TOKEN が使える）
-git clone "https://x-access-token:${GH_TOKEN}@github.com/miyashita337/agent-base.git" "$HOME/agent-base"
+# clone（未取得のときだけ）。GH_TOKEN が .git/config に残らないよう clone 直後に URL を差し替える
+if [ ! -d "$AGENT_BASE_DIR" ]; then
+  git clone "https://x-access-token:${GH_TOKEN}@github.com/miyashita337/agent-base.git" "$AGENT_BASE_DIR"
+  git -C "$AGENT_BASE_DIR" remote set-url origin "$REPO_URL"
+fi
 
-# ~/.claude/ に symlink
+# ~/.claude/ に symlink を張る（clone スキップ時も毎回再生成して冪等）
 mkdir -p "$HOME/.claude"
 for dir in commands skills agents hooks; do
-  [ -d "$HOME/agent-base/$dir" ] && ln -sf "$HOME/agent-base/$dir" "$HOME/.claude/$dir"
+  src="$AGENT_BASE_DIR/$dir"
+  dst="$HOME/.claude/$dir"
+  [ -d "$src" ] || continue
+  # 既存が通常ディレクトリなら退避（ln -sf はディレクトリを置換せず内側に symlink を作ってしまう）
+  if [ -d "$dst" ] && [ ! -L "$dst" ]; then
+    mv "$dst" "${dst}.bak.$(date +%Y%m%d%H%M%S)"
+  fi
+  ln -sfn "$src" "$dst"
 done
-[ -f "$HOME/agent-base/CLAUDE.md" ] && ln -sf "$HOME/agent-base/CLAUDE.md" "$HOME/.claude/CLAUDE.md"
+if [ -f "$AGENT_BASE_DIR/CLAUDE.md" ]; then
+  ln -sf "$AGENT_BASE_DIR/CLAUDE.md" "$HOME/.claude/CLAUDE.md"
+fi
 
 exit 0

--- a/scripts/setup-agent-base.sh
+++ b/scripts/setup-agent-base.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+set -e
+
+# ローカルでは動かさない
+[ "$CLAUDE_CODE_REMOTE" != "true" ] && exit 0
+
+# 既にあればスキップ
+[ -d "$HOME/agent-base" ] && exit 0
+
+# clone（この時点では $GH_TOKEN が使える）
+git clone "https://x-access-token:${GH_TOKEN}@github.com/miyashita337/agent-base.git" "$HOME/agent-base"
+
+# ~/.claude/ に symlink
+mkdir -p "$HOME/.claude"
+for dir in commands skills agents hooks; do
+  [ -d "$HOME/agent-base/$dir" ] && ln -sf "$HOME/agent-base/$dir" "$HOME/.claude/$dir"
+done
+[ -f "$HOME/agent-base/CLAUDE.md" ] && ln -sf "$HOME/agent-base/CLAUDE.md" "$HOME/.claude/CLAUDE.md"
+
+exit 0


### PR DESCRIPTION

<img width="893" height="1178" alt="image" src="https://github.com/user-attachments/assets/ff318dec-85b5-4cb6-ab89-631e22338ee9" />

## Summary
- ClaudeCOdeWebのアプリでセットアップスクリプトが機能しないので仕込みで入れる
- `SessionStart` (startup|resume) フックで `scripts/setup-agent-base.sh` を実行
- `CLAUDE_CODE_REMOTE=true` のリモートセッションでのみ `miyashita337/agent-base` を `\$HOME/agent-base` へ clone
- `commands` / `skills` / `agents` / `hooks` / `CLAUDE.md` を `~/.claude/` に symlink し、ローカル開発環境と同等の支援設定を再現

## Motivation
- リモート Claude Code セッションでは `~/.claude/` が毎回クリーンなため、ローカルに揃えているルール・スキル・hook が効かない
- 毎回手動 clone / symlink を張り直すのは非現実的なので、SessionStart フックで冪等に初期化する

## Behavior
| 条件 | 挙動 |
|---|---|
| `CLAUDE_CODE_REMOTE != "true"` | 早期 exit（ローカルでは何もしない） |
| `~/agent-base` が既に存在 | 早期 exit（冪等） |
| それ以外 | `git clone` → `~/.claude/*` に symlink |

- 認証は `GH_TOKEN` を `x-access-token` として埋め込む HTTPS clone
- `set -e` + 各 symlink は `[ -d ... ]` / `[ -f ... ]` で存在チェックしてから張る

## Test plan
- [x] `bash -n scripts/setup-agent-base.sh` で構文 OK
- [ ] ローカル (`CLAUDE_CODE_REMOTE` 未設定) で SessionStart → 何も起きない（早期 exit）
- [ ] リモート初回 (`CLAUDE_CODE_REMOTE=true`, `~/agent-base` なし) で clone + symlink 生成
- [ ] リモート 2 回目 (`~/agent-base` あり) で early exit
- [ ] `GH_TOKEN` 未設定時のエラーは set -e で即失敗（ログで分かる）

## Notes
- `.claude/settings.json` は `.gitignore` (`\.claude/`) 対象だが、既存の `.claude/rules/domain-expert.md` と同様に個別ファイルを force-add で追跡

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* **セッション起動時の自動初期化機能**: エージェント環境がセッション開始時に自動的にセットアップされるようになりました。エージェント関連のコマンド、スキル、設定が自動的に統合されます。プロジェクト利用開始時の初期セットアップがスムーズになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->