### PR TITLE
feat(#49): claudeHubExit ルーティングルール + HIJOGUCHI_CHANNEL_ID テンプレ展開

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,6 @@ com.claude-hub.hijoguchi.plist
 
 # Supervisor relay URL marker files
 .supervisor-relay-url
-
+.superpowers/
 # Claude Code local state
 .claude/

--- a/scripts/hijoguchi-system-prompt.md
+++ b/scripts/hijoguchi-system-prompt.md
@@ -1,13 +1,40 @@
-<!--
-  hijoguchi (claudeHubExit Bot) system-prompt placeholder.
+# claudeHubExit ルーティング/スコープルール (#49)
 
-  This file is read at startup by scripts/start-hijoguchi.sh and passed to
-  `claude --append-system-prompt "$(cat ...)"`. S2 (#48) ships only this
-  infrastructure (quoting + guard + tmux verify + logging). S3 (#49) will
-  replace the body below with the real routing / scope rules.
+あなたは Discord Bot `claudeHubExit` として動作している。
+Discord メッセージは `<channel source="discord" chat_id="..." message_id="..." user="..." ts="...">` の形式で届く。
 
-  Keeping the stub intentionally minimal so current production behaviour is
-  not altered before S3 lands.
--->
+## 応答条件 (BLOCKING)
 
-# hijoguchi system prompt (S2 stub — replaced by S3 #49)
+以下の **いずれか1つ** を満たす場合のみ応答する。
+
+### 条件1: Primary チャンネル内 (通常運用)
+- メッセージの `chat_id` が `{{HIJOGUCHI_CHANNEL_ID}}` (= `#claude-hub-hijoguchi`) → **通常応答**
+
+### 条件2: 自分宛メンション
+- メッセージ本文に **自分 (claudeHubExit Bot) 宛** のメンションタグが含まれる → **応答可**
+- 他のユーザー / Bot 宛の `<@...>` メンションは無視する (それらに応答しない)
+- access.json により非 Primary チャンネルでは owner からのメッセージのみ到達するため、自分宛メンションは信頼できる
+
+### 条件3: claude-hub 保守議題
+- メッセージ内容に次のいずれかのキーワードを含む (大文字・小文字を区別しない) → **応答可**
+  - `supervisor` / `tmux` / `hijoguchi` / `claude-hub` / `claudeHubExit`
+- キーワードは固有名詞 / 専用語のみ。一般語は含めない (例: "bot" 単体は誤発火するので対象外)
+
+## 応答しない条件
+
+上記 3 条件を **すべて満たさない** メッセージは、以下のように扱う:
+
+- 完全に沈黙する
+- Reply tool を呼ばない
+- 定型返信も返さない
+- リアクションを付けない
+- 何の処理も行わない
+
+### 沈黙が必須のケース例
+- 他 Bot スレッド (team-salary 等) でメンション無し・議題外の発言
+- DM / 他チャンネルでの雑談
+- 他プロジェクトの議論（割り込み禁止）
+
+## 例外的ルール
+- Primary チャンネル内であっても、応答に claude-hub 保守議題以外の専門内容 (他プロジェクトのコード実装等) が混じる場合は、対象範囲外である旨を簡潔に案内して終了する
+- 「このチャンネルで対応してほしい」等の越境要求には応じない

--- a/scripts/hijoguchi-system-prompt.md
+++ b/scripts/hijoguchi-system-prompt.md
@@ -11,7 +11,7 @@ Discord メッセージは `<channel source="discord" chat_id="..." message_id="
 - メッセージの `chat_id` が `{{HIJOGUCHI_CHANNEL_ID}}` (= `#claude-hub-hijoguchi`) → **通常応答**
 
 ### 条件2: 自分宛メンション
-- メッセージ本文に **自分 (claudeHubExit Bot) 宛** のメンションタグが含まれる → **応答可**
+- メッセージ本文に `{{HIJOGUCHI_BOT_MENTION}}` (= claudeHubExit Bot 宛の Discord メンションタグ) が含まれる → **応答可**
 - 他のユーザー / Bot 宛の `<@...>` メンションは無視する (それらに応答しない)
 - access.json により非 Primary チャンネルでは owner からのメッセージのみ到達するため、自分宛メンションは信頼できる
 

--- a/scripts/start-hijoguchi.sh
+++ b/scripts/start-hijoguchi.sh
@@ -19,6 +19,11 @@ BACKOFF_SEC=5
 # System-prompt file for `claude --append-system-prompt`. Overridable via env
 # so tests / alt deploys can swap it. S3 (#49) populates the real content.
 SYSTEM_PROMPT_FILE="${SYSTEM_PROMPT_FILE:-${CLAUDE_HUB_DIR}/scripts/hijoguchi-system-prompt.md}"
+# Template placeholders injected into the system-prompt. Keeping IDs out of the
+# prompt source (AC-4 / #49) means the prompt .md is agnostic of deployment;
+# production ID lives here as the default so launchd needs no extra env wiring.
+# Override via the HIJOGUCHI_CHANNEL_ID env var for tests / alt deploys.
+HIJOGUCHI_CHANNEL_ID="${HIJOGUCHI_CHANNEL_ID:-1487701062205964329}"
 # Wait before checking the freshly-created tmux session. Short is fine because
 # tmux new-session -d returns after the server has recorded the session.
 TMUX_VERIFY_SLEEP_SEC=1
@@ -35,6 +40,25 @@ fi
 
 echo "[hijoguchi] system_prompt_file=${SYSTEM_PROMPT_FILE}"
 
+# Render the prompt once (AC-4 template expansion). Re-reading per restart is
+# unnecessary — the launchd wrapper re-execs this script on crash anyway.
+SYSTEM_PROMPT_CONTENT="$(cat "${SYSTEM_PROMPT_FILE}")"
+SYSTEM_PROMPT_CONTENT="${SYSTEM_PROMPT_CONTENT//\{\{HIJOGUCHI_CHANNEL_ID\}\}/${HIJOGUCHI_CHANNEL_ID}}"
+
+# Fail closed on unresolved tokens so a renamed placeholder can't silently ship
+# the literal "{{FOO}}" into Claude's context. Matches only well-formed
+# `{{UPPER_SNAKE}}` to avoid firing on stray docs containing `{{` or `}}`.
+if [[ "${SYSTEM_PROMPT_CONTENT}" =~ \{\{[A-Z_]+\}\} ]]; then
+  echo "[hijoguchi] ERROR: unresolved template token in rendered prompt: ${BASH_REMATCH[0]}" >&2
+  exit 1
+fi
+
+# Dry-run: render and print the prompt, then exit. Used by tests (AC-4).
+if [ "${HIJOGUCHI_RENDER_ONLY:-0}" = "1" ]; then
+  printf '%s\n' "${SYSTEM_PROMPT_CONTENT}"
+  exit 0
+fi
+
 # Clean shutdown on SIGTERM from launchd
 trap 'echo "[hijoguchi] SIGTERM received, killing tmux session"; "${TMUX_BIN}" kill-session -t "${SESSION}" 2>/dev/null; exit 0' TERM INT
 
@@ -45,11 +69,10 @@ while true; do
   "${TMUX_BIN}" kill-session -t "${SESSION}" 2>/dev/null
 
   echo "[hijoguchi] starting tmux session '${SESSION}' at $(date)"
-  # Read the prompt in the parent shell and escape every argument with %q so
-  # the string handed to tmux's child shell re-parses back to the exact same
-  # argv — prompt content with $VAR, backticks, or quotes cannot leak into
-  # command evaluation, and CLAUDE_BIN paths with spaces remain intact.
-  SYSTEM_PROMPT_CONTENT="$(cat "${SYSTEM_PROMPT_FILE}")"
+  # Escape every argument with %q so the string handed to tmux's child shell
+  # re-parses back to the exact same argv — prompt content with $VAR, backticks,
+  # or quotes cannot leak into command evaluation, and CLAUDE_BIN paths with
+  # spaces remain intact. SYSTEM_PROMPT_CONTENT is rendered once above.
   CLAUDE_CMD=$(printf '%q ' \
     "${CLAUDE_BIN}" \
     --channels plugin:discord@claude-plugins-official \

--- a/scripts/start-hijoguchi.sh
+++ b/scripts/start-hijoguchi.sh
@@ -21,14 +21,14 @@ BACKOFF_SEC=5
 SYSTEM_PROMPT_FILE="${SYSTEM_PROMPT_FILE:-${CLAUDE_HUB_DIR}/scripts/hijoguchi-system-prompt.md}"
 # Template placeholders injected into the system-prompt. Keeping IDs out of the
 # prompt source (AC-4 / #49) means the prompt .md is agnostic of deployment;
-# production ID lives here as the default so launchd needs no extra env wiring.
-# Override via the HIJOGUCHI_CHANNEL_ID env var for tests / alt deploys.
+# production IDs live here as defaults so launchd needs no extra env wiring.
+# Override via env vars for tests / alt deploys. Full fail-closed (no default)
+# requires plist env-var plumbing — tracked as follow-up hardening Issue.
 HIJOGUCHI_CHANNEL_ID="${HIJOGUCHI_CHANNEL_ID:-1487701062205964329}"
+HIJOGUCHI_BOT_MENTION="${HIJOGUCHI_BOT_MENTION:-<@1487717424173416538>}"
 # Wait before checking the freshly-created tmux session. Short is fine because
 # tmux new-session -d returns after the server has recorded the session.
 TMUX_VERIFY_SLEEP_SEC=1
-
-mkdir -p "${LOG_DIR}"
 
 # Guard: abort if the system-prompt file is missing. Without this the claude
 # invocation would silently pass `--append-system-prompt ""` and behaviour
@@ -38,37 +38,46 @@ if [ ! -r "${SYSTEM_PROMPT_FILE}" ]; then
   exit 1
 fi
 
-echo "[hijoguchi] system_prompt_file=${SYSTEM_PROMPT_FILE}"
+echo "[hijoguchi] system_prompt_file=${SYSTEM_PROMPT_FILE}" >&2
 
 # Render the prompt once (AC-4 template expansion). Re-reading per restart is
 # unnecessary — the launchd wrapper re-execs this script on crash anyway.
 SYSTEM_PROMPT_CONTENT="$(cat "${SYSTEM_PROMPT_FILE}")"
+# NOTE: `\{\{` escapes are REQUIRED — without them bash interprets the pattern
+# as brace expansion and collapses it to a literal `}}`, silently producing a
+# broken prompt. See PR #62 review discussion.
 SYSTEM_PROMPT_CONTENT="${SYSTEM_PROMPT_CONTENT//\{\{HIJOGUCHI_CHANNEL_ID\}\}/${HIJOGUCHI_CHANNEL_ID}}"
+SYSTEM_PROMPT_CONTENT="${SYSTEM_PROMPT_CONTENT//\{\{HIJOGUCHI_BOT_MENTION\}\}/${HIJOGUCHI_BOT_MENTION}}"
 
 # Fail closed on unresolved tokens so a renamed placeholder can't silently ship
-# the literal "{{FOO}}" into Claude's context. Matches only well-formed
-# `{{UPPER_SNAKE}}` to avoid firing on stray docs containing `{{` or `}}`.
-if [[ "${SYSTEM_PROMPT_CONTENT}" =~ \{\{[A-Z_]+\}\} ]]; then
+# the literal "{{FOO}}" into Claude's context. Matches `{{UPPER_SNAKE_OR_DIGIT}}`
+# so tokens like `{{CHANNEL_ID_1}}` are also caught.
+if [[ "${SYSTEM_PROMPT_CONTENT}" =~ \{\{[A-Z][A-Z0-9_]*\}\} ]]; then
   echo "[hijoguchi] ERROR: unresolved template token in rendered prompt: ${BASH_REMATCH[0]}" >&2
   exit 1
 fi
 
 # Dry-run: render and print the prompt, then exit. Used by tests (AC-4).
+# Kept before any filesystem side effects so render-only stdout stays clean.
 if [ "${HIJOGUCHI_RENDER_ONLY:-0}" = "1" ]; then
   printf '%s\n' "${SYSTEM_PROMPT_CONTENT}"
   exit 0
 fi
 
-# Clean shutdown on SIGTERM from launchd
-trap 'echo "[hijoguchi] SIGTERM received, killing tmux session"; "${TMUX_BIN}" kill-session -t "${SESSION}" 2>/dev/null; exit 0' TERM INT
+# Create log dir only for real launches. Deferred past render-only so tests
+# don't create directories as a side effect of `HIJOGUCHI_RENDER_ONLY=1`.
+mkdir -p "${LOG_DIR}"
 
-echo "[hijoguchi] watchdog starting at $(date)"
+# Clean shutdown on SIGTERM from launchd
+trap 'echo "[hijoguchi] SIGTERM received, killing tmux session" >&2; "${TMUX_BIN}" kill-session -t "${SESSION}" 2>/dev/null; exit 0' TERM INT
+
+echo "[hijoguchi] watchdog starting at $(date)" >&2
 
 while true; do
   # Ensure no stale session
   "${TMUX_BIN}" kill-session -t "${SESSION}" 2>/dev/null
 
-  echo "[hijoguchi] starting tmux session '${SESSION}' at $(date)"
+  echo "[hijoguchi] starting tmux session '${SESSION}' at $(date)" >&2
   # Escape every argument with %q so the string handed to tmux's child shell
   # re-parses back to the exact same argv — prompt content with $VAR, backticks,
   # or quotes cannot leak into command evaluation, and CLAUDE_BIN paths with
@@ -87,13 +96,13 @@ while true; do
     sleep "${BACKOFF_SEC}"
     continue
   fi
-  echo "[hijoguchi] tmux session verified: ${SESSION}"
+  echo "[hijoguchi] tmux session verified: ${SESSION}" >&2
 
   # Block while the session exists
   while "${TMUX_BIN}" has-session -t "${SESSION}" 2>/dev/null; do
     sleep 10
   done
 
-  echo "[hijoguchi] session '${SESSION}' ended at $(date), backing off ${BACKOFF_SEC}s"
+  echo "[hijoguchi] session '${SESSION}' ended at $(date), backing off ${BACKOFF_SEC}s" >&2
   sleep "${BACKOFF_SEC}"
 done

--- a/scripts/test-start-hijoguchi.sh
+++ b/scripts/test-start-hijoguchi.sh
@@ -12,6 +12,11 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 TARGET="${SCRIPT_DIR}/start-hijoguchi.sh"
 PROMPT_FILE="${SCRIPT_DIR}/hijoguchi-system-prompt.md"
 
+# Pin the prompt file to the in-tree fixture so tests don't pick up a stale
+# copy from `~/claude-hub/scripts/` when run from a worktree or alternate
+# checkout. Individual tests can still override by re-exporting.
+export SYSTEM_PROMPT_FILE="${PROMPT_FILE}"
+
 fail=0
 run() {
   local name="$1"; shift
@@ -23,7 +28,7 @@ t1_channel_id_expanded() {
 }
 
 t2_no_residual_tokens() {
-  ! HIJOGUCHI_RENDER_ONLY=1 bash "${TARGET}" 2>&1 | grep -Eq '\{\{[A-Z_]+\}\}'
+  ! HIJOGUCHI_RENDER_ONLY=1 bash "${TARGET}" 2>&1 | grep -Eq '\{\{[A-Z][A-Z0-9_]*\}\}'
 }
 
 t3_env_override() {
@@ -55,9 +60,16 @@ t7_source_has_placeholder() {
 }
 
 # AC-1 smoke: rendered prompt still defines the primary-channel condition
-# after template expansion. Catches silent deletion of Condition 1.
+# after template expansion. Cross-checks both the condition heading and the
+# expanded chat_id so silent deletion of Condition 1 can't pass just because
+# the format-description line still mentions 'chat_id'.
 t8_rendered_has_primary_rule() {
-  HIJOGUCHI_RENDER_ONLY=1 bash "${TARGET}" 2>&1 | grep -Fq 'chat_id'
+  local channel_id="TEST_PRIMARY_123"
+  local out
+  out=$(HIJOGUCHI_RENDER_ONLY=1 HIJOGUCHI_CHANNEL_ID="${channel_id}" \
+    bash "${TARGET}" 2>&1)
+  echo "${out}" | grep -Fq '### 条件1: Primary チャンネル内' && \
+    echo "${out}" | grep -Fq "メッセージの \`chat_id\` が \`${channel_id}\`"
 }
 
 # AC-3 smoke: rendered prompt still includes the maintenance-keyword list.
@@ -70,6 +82,15 @@ t9_rendered_has_keywords() {
     echo "${out}" | grep -Fq 'hijoguchi'
 }
 
+# AC-2 smoke: Bot mention placeholder expands via HIJOGUCHI_BOT_MENTION env
+# var. Ensures the self-mention rule can be unambiguously tied to a specific
+# Bot ID per deployment.
+t10_bot_mention_expanded() {
+  local mention="<@99999999>"
+  HIJOGUCHI_RENDER_ONLY=1 HIJOGUCHI_BOT_MENTION="${mention}" \
+    bash "${TARGET}" 2>&1 | grep -Fq "${mention}"
+}
+
 run "T1 channel ID expanded"          t1_channel_id_expanded
 run "T2 no residual {{}} tokens"      t2_no_residual_tokens
 run "T3 env override works"           t3_env_override
@@ -79,6 +100,7 @@ run "T6 source has no hardcoded ID"   t6_source_no_hardcoded_id
 run "T7 source has {{placeholder}}"   t7_source_has_placeholder
 run "T8 rendered has primary rule"    t8_rendered_has_primary_rule
 run "T9 rendered has keyword list"    t9_rendered_has_keywords
+run "T10 bot mention expanded"        t10_bot_mention_expanded
 
 if [ "${fail}" -eq 0 ]; then
   echo "ALL TESTS PASSED"

--- a/scripts/test-start-hijoguchi.sh
+++ b/scripts/test-start-hijoguchi.sh
@@ -1,0 +1,89 @@
+#!/bin/bash
+# Unit tests for scripts/start-hijoguchi.sh prompt rendering (#49 AC-4).
+# Run standalone: bash scripts/test-start-hijoguchi.sh
+# Exits 0 on all-pass, 1 on any failure.
+#
+# Test case functions (tN_*) are invoked indirectly through `run "..." fn_name`.
+# shellcheck disable=SC2329
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+TARGET="${SCRIPT_DIR}/start-hijoguchi.sh"
+PROMPT_FILE="${SCRIPT_DIR}/hijoguchi-system-prompt.md"
+
+fail=0
+run() {
+  local name="$1"; shift
+  if "$@"; then echo "PASS ${name}"; else echo "FAIL ${name}"; fail=1; fi
+}
+
+t1_channel_id_expanded() {
+  HIJOGUCHI_RENDER_ONLY=1 bash "${TARGET}" 2>&1 | grep -Fq '1487701062205964329'
+}
+
+t2_no_residual_tokens() {
+  ! HIJOGUCHI_RENDER_ONLY=1 bash "${TARGET}" 2>&1 | grep -Eq '\{\{[A-Z_]+\}\}'
+}
+
+t3_env_override() {
+  HIJOGUCHI_RENDER_ONLY=1 HIJOGUCHI_CHANNEL_ID=TEST_CHAN_99 \
+    bash "${TARGET}" 2>&1 | grep -Fq 'TEST_CHAN_99'
+}
+
+t4_unresolved_token_fails() {
+  local tmpfile
+  tmpfile=$(mktemp)
+  # shellcheck disable=SC2064
+  trap "rm -f '${tmpfile}'" RETURN
+  echo "chan={{UNKNOWN_TOKEN}}" > "${tmpfile}"
+  ! HIJOGUCHI_RENDER_ONLY=1 SYSTEM_PROMPT_FILE="${tmpfile}" \
+      bash "${TARGET}" >/dev/null 2>&1
+}
+
+t5_missing_prompt_fails() {
+  ! HIJOGUCHI_RENDER_ONLY=1 SYSTEM_PROMPT_FILE=/nonexistent/path \
+      bash "${TARGET}" >/dev/null 2>&1
+}
+
+t6_source_no_hardcoded_id() {
+  ! grep -Fq '1487701062205964329' "${PROMPT_FILE}"
+}
+
+t7_source_has_placeholder() {
+  grep -Fq '{{HIJOGUCHI_CHANNEL_ID}}' "${PROMPT_FILE}"
+}
+
+# AC-1 smoke: rendered prompt still defines the primary-channel condition
+# after template expansion. Catches silent deletion of Condition 1.
+t8_rendered_has_primary_rule() {
+  HIJOGUCHI_RENDER_ONLY=1 bash "${TARGET}" 2>&1 | grep -Fq 'chat_id'
+}
+
+# AC-3 smoke: rendered prompt still includes the maintenance-keyword list.
+# Guards against someone stripping keywords (which would break off-primary
+# routing for legitimate claude-hub maintenance discussion).
+t9_rendered_has_keywords() {
+  local out
+  out=$(HIJOGUCHI_RENDER_ONLY=1 bash "${TARGET}" 2>&1)
+  echo "${out}" | grep -Fq 'supervisor' && \
+    echo "${out}" | grep -Fq 'hijoguchi'
+}
+
+run "T1 channel ID expanded"          t1_channel_id_expanded
+run "T2 no residual {{}} tokens"      t2_no_residual_tokens
+run "T3 env override works"           t3_env_override
+run "T4 unresolved token → exit 1"    t4_unresolved_token_fails
+run "T5 missing prompt → exit 1"      t5_missing_prompt_fails
+run "T6 source has no hardcoded ID"   t6_source_no_hardcoded_id
+run "T7 source has {{placeholder}}"   t7_source_has_placeholder
+run "T8 rendered has primary rule"    t8_rendered_has_primary_rule
+run "T9 rendered has keyword list"    t9_rendered_has_keywords
+
+if [ "${fail}" -eq 0 ]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+else
+  echo "SOME TESTS FAILED"
+  exit 1
+fi


### PR DESCRIPTION
## 概要

Issue #49 (Epic #45 / 案B 段階適用 Cycle 1) を解消。`claudeHubExit` Bot の応答条件を明文化し、`HIJOGUCHI_CHANNEL_ID` / `HIJOGUCHI_BOT_MENTION` をテンプレート展開で注入する仕組みを追加。

## 主な変更点

- **`scripts/hijoguchi-system-prompt.md`**: 応答条件を 3 つ (primary channel / 自分宛メンション / claude-hub 保守議題キーワード) に明文化。いずれも満たさない場合は完全沈黙 (定型文も返さない) を BLOCKING として記述。`{{HIJOGUCHI_CHANNEL_ID}}` / `{{HIJOGUCHI_BOT_MENTION}}` プレースホルダー化。
- **`scripts/start-hijoguchi.sh`**: 起動時に prompt を 1 回だけ render。未解決の `{{UPPER_SNAKE}}` トークンが残れば fail-closed で `exit 1`。テスト用 dry-run モード (`HIJOGUCHI_RENDER_ONLY=1`) を追加。
- **`scripts/test-start-hijoguchi.sh`**: 10 ケースのユニットテスト。AC-4 (ソースへの chat_id ハードコード無し) と回帰スモーク (primary rule / keyword list が rendered に残存) を検証。

## AC 検証結果

| AC | 内容 | 判定 |
|---|---|---|
| AC-1 | `@claudeHubExit` メンションで応答可能 | PASS (runtime 確認済み) |
| AC-2 | access.json 通過 + 保守キーワードで応答可能、キーワード単独は非バイパス | PASS (多層防御維持) |
| AC-3 | 他 Bot スレッドでメンションなし・議題外 → 完全沈黙 | PASS (30 秒 silence 確認) |
| AC-4 | hijoguchi channel ID のハードコード排除 (テンプレ展開) | PASS (`test-start-hijoguchi.sh` T1-T10) |
| AC-5 | Bot 再起動後もロジック保持 | PASS (launchd restart 後同一動作) |

## レビュー対応 (コミット c8e7695)

PR #62 の coderabbit / gemini コメントに対応:

- `{{HIJOGUCHI_BOT_MENTION}}` プレースホルダー導入で Bot ID 曖昧性を排除
- unresolved-token regex を `[A-Z][A-Z0-9_]*` に拡張し数字を含むトークンも fail-closed 検出
- render-only モードで filesystem / stdout 副作用を除去
- テストの `SYSTEM_PROMPT_FILE` を in-tree fixture に pin
- T8 強化 (section heading + 展開後 chat_id の両方 verify) / T10 追加 (Bot mention 展開)

### 意図的に見送った提案

- **`{{` エスケープ削除 (gemini)**: T8 強化後のテストで brace expansion により `{{...}}` が `}}` に collapse し prompt が silent 破壊されることを検出。エスケープ必須と判定、コメントで根拠明記。
- **`HIJOGUCHI_CHANNEL_ID` default 削除 (coderabbit must)**: plist が gitignore 管理で PR 単独では破壊的 (launchd restart でサービス停止)。AC-4 の意図「ID を prompt source から排除」は充足済みのため、default は disaster-recovery fallback として残し、fail-closed 完全対応は後続 hardening Issue に分離。

## テスト

```bash
bash scripts/test-start-hijoguchi.sh
```

- T1-T10 全 PASS を CI / ローカルで確認
- 実 Discord での AC-1/2/3/5 runtime 検証済み

## 関連

- Issue: #49
- Epic: #45
- 依存: #47 (access.json), #48 (クォート修正)