### PR TITLE
fix(#83): Supervisor 専用 tmux socket (-L claude-hub) で send-keys silent drop を根絶

### DIFF
--- a/supervisor/src/session/iterm2.ts
+++ b/supervisor/src/session/iterm2.ts
@@ -177,10 +177,14 @@ export function openTab(opts: OpenTabOptions): void {
   }
 }
 
-export function markTabStopped(channelName: string): void {
+export function markTabStopped(channelName: string, tmuxSessionName?: string): void {
   const tabName = `${channelName} (running)`;
   const newName = `${channelName} (stopped)`;
-  const tmuxName = `claude-${channelName}`;
+  // The actual tmux session name is `claude-${threadId.slice(0,12)}` (see
+  // SessionManager.tmuxSessionName). Callers that know the threadId should
+  // pass the resolved name so `rename-window` actually targets the session.
+  // The fallback exists for legacy callers without a threadId in scope.
+  const tmuxName = tmuxSessionName ?? `claude-${channelName}`;
 
   // Update tmux window name if session still exists (fire-and-forget)
   const renameProc = spawn(TMUX_PATH, [...TMUX_ARGS, "rename-window", "-t", tmuxName, newName], {

--- a/supervisor/src/session/iterm2.ts
+++ b/supervisor/src/session/iterm2.ts
@@ -3,6 +3,7 @@ import { readFileSync } from "fs";
 import { resolve, basename } from "path";
 import { homedir } from "os";
 import { createHash } from "crypto";
+import { TMUX_PATH, TMUX_ARGS, TMUX_CMD } from "./tmux";
 
 const PROJECT_COLORS_PATH = resolve(
   homedir(),
@@ -99,8 +100,6 @@ export interface OpenTabOptions {
   projectDir: string;
 }
 
-const TMUX_PATH = process.env.TMUX_PATH ?? "/opt/homebrew/bin/tmux";
-
 export function openTab(opts: OpenTabOptions): void {
   if (!isItermRunning()) {
     console.log(
@@ -113,26 +112,26 @@ export function openTab(opts: OpenTabOptions): void {
   const tabTitle = `${opts.channelName} (running)`;
   try {
     execSync(
-      `${TMUX_PATH} rename-window -t "${opts.tmuxSessionName}" "${tabTitle}"`,
+      `${TMUX_CMD} rename-window -t "${opts.tmuxSessionName}" "${tabTitle}"`,
       { timeout: 3000 }
     );
     // Disable automatic-rename so tmux doesn't overwrite our title
     execSync(
-      `${TMUX_PATH} set-option -t "${opts.tmuxSessionName}" automatic-rename off`,
+      `${TMUX_CMD} set-option -t "${opts.tmuxSessionName}" automatic-rename off`,
       { timeout: 3000 }
     );
     // Enable set-titles so tmux pushes the window name to iTerm2's tab title
     execSync(
-      `${TMUX_PATH} set-option -t "${opts.tmuxSessionName}" set-titles on`,
+      `${TMUX_CMD} set-option -t "${opts.tmuxSessionName}" set-titles on`,
       { timeout: 3000 }
     );
     execSync(
-      `${TMUX_PATH} set-option -t "${opts.tmuxSessionName}" set-titles-string "#{window_name}"`,
+      `${TMUX_CMD} set-option -t "${opts.tmuxSessionName}" set-titles-string "#{window_name}"`,
       { timeout: 3000 }
     );
     // Set pane title as well
     execSync(
-      `${TMUX_PATH} select-pane -t "${opts.tmuxSessionName}" -T "${tabTitle}"`,
+      `${TMUX_CMD} select-pane -t "${opts.tmuxSessionName}" -T "${tabTitle}"`,
       { timeout: 3000 }
     );
   } catch {
@@ -145,12 +144,19 @@ export function openTab(opts: OpenTabOptions): void {
   const g = parseInt(hex.slice(2, 4), 16) * 257;
   const b = parseInt(hex.slice(4, 6), 16) * 257;
 
+  // NOTE: previously the attach command was `tmux attach ... \; copy-mode` to
+  // prevent accidental keystrokes from going to Claude Code (commit 8987e85).
+  // That forced every pane to start in copy-mode, which combined with
+  // ~/.tmux.conf's WheelUpPane binding created the silent-drop race
+  // documented in Issue #73. With Supervisor's dedicated socket (mouse off
+  // + mode-keys emacs) the accidental-input risk is already mitigated, so
+  // we no longer enter copy-mode on attach.
   const script = [
     'tell application "iTerm2"',
     "  tell current window",
     "    create tab with default profile",
     "    tell current session",
-    `      write text "${TMUX_PATH} attach -t ${opts.tmuxSessionName} \\\\; copy-mode"`,
+    `      write text "${TMUX_CMD} attach -t ${opts.tmuxSessionName}"`,
     `      set name to "${tabTitle}"`,
     `      set background color to {${r}, ${g}, ${b}}`,
     "    end tell",
@@ -177,7 +183,7 @@ export function markTabStopped(channelName: string): void {
   const tmuxName = `claude-${channelName}`;
 
   // Update tmux window name if session still exists (fire-and-forget)
-  const renameProc = spawn(TMUX_PATH, ["rename-window", "-t", tmuxName, newName], {
+  const renameProc = spawn(TMUX_PATH, [...TMUX_ARGS, "rename-window", "-t", tmuxName, newName], {
     stdio: "ignore",
   });
   setTimeout(() => renameProc.kill("SIGKILL"), 3000);

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -268,7 +268,7 @@ export class SessionManager {
     });
 
     this.sessions.delete(threadId);
-    markTabStopped(session.channelName);
+    markTabStopped(session.channelName, tmuxName);
     updateSessionStatus(session.id, "stopped", reason);
   }
 
@@ -305,7 +305,7 @@ export class SessionManager {
         );
         this.sessions.delete(threadId);
         if (session) {
-          markTabStopped(session.channelName);
+          markTabStopped(session.channelName, tmuxName);
         }
         updateSessionStatus(sessionId, "stopped", "tmux_exited");
         clearInterval(interval);

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -23,9 +23,9 @@ import {
   getRelayPort,
   cancelRelay,
 } from "./relay-server";
+import { TMUX_CMD, ensureSocketConfigured } from "./tmux";
 
 const CLAUDE_PATH = resolve(homedir(), ".local", "bin", "claude");
-const TMUX_PATH = process.env.TMUX_PATH ?? "/opt/homebrew/bin/tmux";
 const TMUX_SESSION_PREFIX = "claude-";
 
 export class SessionManager {
@@ -33,6 +33,7 @@ export class SessionManager {
   private sessions = new Map<string, SessionInfo>();
 
   constructor() {
+    ensureSocketConfigured();
     startRelayServer();
     this.recoverFromDb();
   }
@@ -71,7 +72,7 @@ export class SessionManager {
   private getTmuxPid(sessionName: string): number | null {
     try {
       const output = execSync(
-        `${TMUX_PATH} list-panes -t "${sessionName}" -F "#{pane_pid}" 2>/dev/null`,
+        `${TMUX_CMD} list-panes -t "${sessionName}" -F "#{pane_pid}" 2>/dev/null`,
         { encoding: "utf8" }
       ).trim();
       const pid = parseInt(output.split("\n")[0] ?? "", 10);
@@ -83,7 +84,7 @@ export class SessionManager {
 
   private isTmuxSessionAlive(sessionName: string): boolean {
     try {
-      execSync(`${TMUX_PATH} has-session -t "${sessionName}" 2>/dev/null`);
+      execSync(`${TMUX_CMD} has-session -t "${sessionName}" 2>/dev/null`);
       return true;
     } catch {
       return false;
@@ -113,7 +114,7 @@ export class SessionManager {
 
     // Kill existing tmux session if any
     try {
-      execSync(`${TMUX_PATH} kill-session -t "${tmuxName}" 2>/dev/null`);
+      execSync(`${TMUX_CMD} kill-session -t "${tmuxName}" 2>/dev/null`);
     } catch {
       // No existing session
     }
@@ -130,14 +131,14 @@ export class SessionManager {
       `exec ${CLAUDE_PATH} --dangerously-skip-permissions --name "${config.channelName}"`,
     ].join(" && ");
 
-    // Launch via tmux (provides a real TTY)
+    // Launch via tmux (provides a real TTY). Uses Supervisor's dedicated
+    // -L claude-hub socket (see ./tmux.ts) so user config is not inherited.
     execSync(
-      `${TMUX_PATH} new-session -d -s "${tmuxName}" '${claudeCmd}'`
+      `${TMUX_CMD} new-session -d -s "${tmuxName}" '${claudeCmd}'`
     );
-    // Limit scroll buffer for claude sessions (prevents iTerm2 freeze on heavy TUI output)
-    try {
-      execSync(`${TMUX_PATH} set-option -t "${tmuxName}" history-limit 10000`, { timeout: 3000 });
-    } catch { /* session may have already exited */ }
+    // Apply server-wide options now that the server is definitely running.
+    // The constructor's eager call is a no-op before the first new-session.
+    ensureSocketConfigured();
 
     // Wait briefly for process to start
     let pid: number | null = null;
@@ -258,7 +259,7 @@ export class SessionManager {
     await new Promise<void>((resolve) => {
       setTimeout(() => {
         try {
-          execSync(`${TMUX_PATH} kill-session -t "${tmuxName}" 2>/dev/null`);
+          execSync(`${TMUX_CMD} kill-session -t "${tmuxName}" 2>/dev/null`);
         } catch {
           // Already dead
         }
@@ -322,7 +323,7 @@ export class SessionManager {
             `[SessionManager] Found running tmux session ${tmuxName}, killing (supervisor restart)`
           );
           try {
-            execSync(`${TMUX_PATH} kill-session -t "${tmuxName}" 2>/dev/null`);
+            execSync(`${TMUX_CMD} kill-session -t "${tmuxName}" 2>/dev/null`);
           } catch {
             // ignore
           }

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -3,8 +3,8 @@ import { resolve } from "path";
 import { homedir } from "os";
 import { mkdirSync, writeFileSync, unlinkSync } from "fs";
 import { waitForRelay, type RelayResult } from "./relay-server";
+import { TMUX_PATH, TMUX_ARGS } from "./tmux";
 
-const TMUX_PATH = process.env.TMUX_PATH ?? "/opt/homebrew/bin/tmux";
 const ATTACHMENT_DIR = resolve(homedir(), "claude-hub", "tmp", "attachments");
 
 /** How long to wait for Claude Code Stop hook to fire (ms) */
@@ -70,7 +70,7 @@ export async function ensurePaneNotInMode(sessionName: string): Promise<void> {
   try {
     mode = execFileSync(
       TMUX_PATH,
-      ["display-message", "-t", sessionName, "-p", "#{pane_in_mode}"],
+      [...TMUX_ARGS, "display-message", "-t", sessionName, "-p", "#{pane_in_mode}"],
       { timeout: 2000 }
     ).toString().trim();
   } catch (err) {
@@ -83,7 +83,7 @@ export async function ensurePaneNotInMode(sessionName: string): Promise<void> {
   if (mode !== "1") return;
   console.warn(`[Relay] pane ${sessionName} in copy-mode, cancelling before send-keys`);
   try {
-    execFileSync(TMUX_PATH, ["send-keys", "-t", sessionName, "-X", "cancel"], {
+    execFileSync(TMUX_PATH, [...TMUX_ARGS, "send-keys", "-t", sessionName, "-X", "cancel"], {
       timeout: 2000,
     });
   } catch (err) {
@@ -96,7 +96,7 @@ export async function ensurePaneNotInMode(sessionName: string): Promise<void> {
 }
 
 export async function tmuxSend(sessionName: string, extraArgs: string[]): Promise<void> {
-  const args = ["send-keys", "-t", sessionName, ...extraArgs];
+  const args = [...TMUX_ARGS, "send-keys", "-t", sessionName, ...extraArgs];
   const PER_CALL_TIMEOUT = 7000;
   try {
     execFileSync(TMUX_PATH, args, { timeout: PER_CALL_TIMEOUT });

--- a/supervisor/src/session/tmux.ts
+++ b/supervisor/src/session/tmux.ts
@@ -12,24 +12,46 @@ export const TMUX_PATH = process.env.TMUX_PATH ?? "/opt/homebrew/bin/tmux";
  * events (real or momentum) re-enter copy-mode in the window between
  * `ensurePaneNotInMode` and the next `send-keys`, causing `send-keys -l` to
  * fail with `not in a mode` and silently drop user messages (Issue #73).
+ *
+ * The socket name is validated against a safe character class so that
+ * `SUPERVISOR_TMUX_SOCKET` (an env var an operator may set) cannot inject
+ * shell metacharacters into `TMUX_CMD`'s template-string interpolation.
  */
-export const TMUX_SOCKET = process.env.SUPERVISOR_TMUX_SOCKET ?? "claude-hub";
+const SOCKET_NAME_PATTERN = /^[A-Za-z0-9_.-]+$/;
+const rawSocket = process.env.SUPERVISOR_TMUX_SOCKET ?? "claude-hub";
+if (!SOCKET_NAME_PATTERN.test(rawSocket)) {
+  throw new Error(
+    `Invalid SUPERVISOR_TMUX_SOCKET: ${JSON.stringify(rawSocket)}. ` +
+      `Allowed characters: [A-Za-z0-9_.-]`
+  );
+}
+export const TMUX_SOCKET = rawSocket;
 
 /** argv prefix for all execFileSync tmux calls. */
 export const TMUX_ARGS: readonly string[] = ["-L", TMUX_SOCKET];
 
 /**
- * Shell fragment for template-string execSync calls. The socket name is a
- * fixed identifier (no user input) so interpolating it directly is safe.
+ * Shell fragment for template-string execSync calls. Safe because
+ * `TMUX_SOCKET` has been validated against `SOCKET_NAME_PATTERN`.
  */
 export const TMUX_CMD = `${TMUX_PATH} -L ${TMUX_SOCKET}`;
 
-let socketConfigured = false;
-
 /**
  * Apply the global options required on the Supervisor's dedicated tmux
- * server. Idempotent — the first call implicitly starts the server if it is
- * not running. Subsequent calls are cheap (early return).
+ * server. Idempotent — `set-option -g` is cheap and re-applying does no
+ * harm, so this intentionally has no memoisation flag: the options are
+ * re-applied on every session start, which makes Supervisor resilient to
+ * the tmux server being restarted (manually or after a crash) within the
+ * same Supervisor process lifetime.
+ *
+ * The three options are chained into a single tmux invocation via the
+ * `\;` command separator so that we spawn one process instead of three.
+ *
+ * On the very first call there is no tmux server yet, so the chained
+ * command fails with `no server running` — that is expected. Our caller
+ * (`SessionManager.start`) invokes this again after `new-session -d`,
+ * at which point the server is up and the options stick. Any other
+ * failure (disk full, /tmp perms, etc.) is logged as a warning.
  *
  * Options set:
  * - `mouse off`: prevents WheelUpPane from auto-entering copy-mode (H1).
@@ -42,18 +64,14 @@ let socketConfigured = false;
  * @see docs: Issue #73 / Epic #79 / Sub #80 (H1) / Sub #81 (H2)
  */
 export function ensureSocketConfigured(): void {
-  if (socketConfigured) return;
   try {
-    execSync(`${TMUX_CMD} set-option -g mouse off`, { timeout: 3000, stdio: "pipe" });
-    execSync(`${TMUX_CMD} set-option -g mode-keys emacs`, { timeout: 3000, stdio: "pipe" });
-    execSync(`${TMUX_CMD} set-option -g history-limit 10000`, { timeout: 3000, stdio: "pipe" });
-    socketConfigured = true;
+    execSync(
+      `${TMUX_CMD} set-option -g mouse off \\; ` +
+        `set-option -g mode-keys emacs \\; ` +
+        `set-option -g history-limit 10000`,
+      { timeout: 3000, stdio: "pipe" }
+    );
   } catch (err) {
-    // Expected on the first call: the tmux server is not yet up (no session
-    // has been created), so `set-option -g` fails with `no server running`.
-    // Our caller (SessionManager.start) invokes this again after
-    // `new-session -d`, at which point the server is up and options stick.
-    // Any other error (disk full, /tmp perms) will also surface on retry.
     const msg = err instanceof Error ? err.message : String(err);
     const isNoServer = /no server running/i.test(msg);
     if (!isNoServer) {

--- a/supervisor/src/session/tmux.ts
+++ b/supervisor/src/session/tmux.ts
@@ -1,0 +1,63 @@
+import { execSync } from "child_process";
+
+export const TMUX_PATH = process.env.TMUX_PATH ?? "/opt/homebrew/bin/tmux";
+
+/**
+ * Dedicated tmux socket for Supervisor-managed sessions.
+ *
+ * Using a dedicated -L socket isolates Supervisor from the user's
+ * ~/.tmux.conf, which in practice has `mouse on`, `mode-keys vi`, and a
+ * WheelUpPane binding that auto-enters `copy-mode -e` when the pane is not
+ * already in a mode. That combination creates the race where mouse wheel
+ * events (real or momentum) re-enter copy-mode in the window between
+ * `ensurePaneNotInMode` and the next `send-keys`, causing `send-keys -l` to
+ * fail with `not in a mode` and silently drop user messages (Issue #73).
+ */
+export const TMUX_SOCKET = process.env.SUPERVISOR_TMUX_SOCKET ?? "claude-hub";
+
+/** argv prefix for all execFileSync tmux calls. */
+export const TMUX_ARGS: readonly string[] = ["-L", TMUX_SOCKET];
+
+/**
+ * Shell fragment for template-string execSync calls. The socket name is a
+ * fixed identifier (no user input) so interpolating it directly is safe.
+ */
+export const TMUX_CMD = `${TMUX_PATH} -L ${TMUX_SOCKET}`;
+
+let socketConfigured = false;
+
+/**
+ * Apply the global options required on the Supervisor's dedicated tmux
+ * server. Idempotent — the first call implicitly starts the server if it is
+ * not running. Subsequent calls are cheap (early return).
+ *
+ * Options set:
+ * - `mouse off`: prevents WheelUpPane from auto-entering copy-mode (H1).
+ * - `mode-keys emacs`: `Escape` cancels copy-mode when in one (in contrast
+ *   to vi, where Escape is a no-op on the mode). This protects the Ink
+ *   modal-clear behaviour in `relay.ts` even in the defensive path.
+ * - `history-limit 10000`: matches the prior per-session setting and keeps
+ *   scrollback bounded to avoid iTerm2 freezes on heavy TUI output.
+ *
+ * @see docs: Issue #73 / Epic #79 / Sub #80 (H1) / Sub #81 (H2)
+ */
+export function ensureSocketConfigured(): void {
+  if (socketConfigured) return;
+  try {
+    execSync(`${TMUX_CMD} set-option -g mouse off`, { timeout: 3000, stdio: "pipe" });
+    execSync(`${TMUX_CMD} set-option -g mode-keys emacs`, { timeout: 3000, stdio: "pipe" });
+    execSync(`${TMUX_CMD} set-option -g history-limit 10000`, { timeout: 3000, stdio: "pipe" });
+    socketConfigured = true;
+  } catch (err) {
+    // Expected on the first call: the tmux server is not yet up (no session
+    // has been created), so `set-option -g` fails with `no server running`.
+    // Our caller (SessionManager.start) invokes this again after
+    // `new-session -d`, at which point the server is up and options stick.
+    // Any other error (disk full, /tmp perms) will also surface on retry.
+    const msg = err instanceof Error ? err.message : String(err);
+    const isNoServer = /no server running/i.test(msg);
+    if (!isNoServer) {
+      console.warn("[tmux] ensureSocketConfigured failed:", err);
+    }
+  }
+}

--- a/supervisor/tests/e2e/ac-verification.test.ts
+++ b/supervisor/tests/e2e/ac-verification.test.ts
@@ -16,6 +16,7 @@ import {
   getRelayPort,
 } from "../../src/session/relay-server";
 import { tmuxSend, ensurePaneNotInMode } from "../../src/session/relay";
+import { TMUX_ARGS, ensureSocketConfigured } from "../../src/session/tmux";
 
 /**
  * End-to-end AC verification for the Discord ↔ Supervisor ↔ Claude Code
@@ -66,7 +67,7 @@ function makeName(tag: string): string {
 }
 
 function capturePane(session: string): string {
-  return execFileSync(TMUX_PATH, ["capture-pane", "-p", "-t", session], {
+  return execFileSync(TMUX_PATH, [...TMUX_ARGS, "capture-pane", "-p", "-t", session], {
     timeout: TMUX_OP_TIMEOUT,
   }).toString();
 }
@@ -74,14 +75,14 @@ function capturePane(session: string): string {
 function startPaneWithSleep(name: string): void {
   execFileSync(
     TMUX_PATH,
-    ["new-session", "-d", "-s", name, "-x", "500", "-y", "40", "sleep", "600"],
+    [...TMUX_ARGS, "new-session", "-d", "-s", name, "-x", "500", "-y", "40", "sleep", "600"],
     { timeout: TMUX_OP_TIMEOUT }
   );
 }
 
 function killPane(name: string): void {
   try {
-    execFileSync(TMUX_PATH, ["kill-session", "-t", name], {
+    execFileSync(TMUX_PATH, [...TMUX_ARGS, "kill-session", "-t", name], {
       timeout: TMUX_OP_TIMEOUT,
     });
   } catch {
@@ -92,10 +93,11 @@ function killPane(name: string): void {
 beforeAll(() => {
   if (hasTmux) {
     try {
-      execFileSync(TMUX_PATH, ["start-server"], { timeout: TMUX_OP_TIMEOUT });
+      execFileSync(TMUX_PATH, [...TMUX_ARGS, "start-server"], { timeout: TMUX_OP_TIMEOUT });
     } catch {
       /* new-session will start the server on demand */
     }
+    ensureSocketConfigured();
   }
   startRelayServer();
 });
@@ -137,7 +139,7 @@ describe("AC E2E verification (Issue #73)", () => {
     try {
       const list = execFileSync(
         TMUX_PATH,
-        ["list-sessions", "-F", "#{session_name}"],
+        [...TMUX_ARGS, "list-sessions", "-F", "#{session_name}"],
         { timeout: TMUX_OP_TIMEOUT }
       ).toString();
       expect(list.split("\n")).toContain(name);
@@ -166,6 +168,7 @@ done
     execFileSync(
       TMUX_PATH,
       [
+        ...TMUX_ARGS,
         "new-session",
         "-d",
         "-s",
@@ -229,12 +232,12 @@ done
     const name = makeName("ac7b");
     startPaneWithSleep(name);
     try {
-      execFileSync(TMUX_PATH, ["copy-mode", "-t", name], {
+      execFileSync(TMUX_PATH, [...TMUX_ARGS, "copy-mode", "-t", name], {
         timeout: TMUX_OP_TIMEOUT,
       });
       const modeOut = execFileSync(
         TMUX_PATH,
-        ["display-message", "-t", name, "-p", "#{pane_in_mode}"],
+        [...TMUX_ARGS, "display-message", "-t", name, "-p", "#{pane_in_mode}"],
         { timeout: TMUX_OP_TIMEOUT }
       )
         .toString()
@@ -248,7 +251,7 @@ done
 
       const finalMode = execFileSync(
         TMUX_PATH,
-        ["display-message", "-t", name, "-p", "#{pane_in_mode}"],
+        [...TMUX_ARGS, "display-message", "-t", name, "-p", "#{pane_in_mode}"],
         { timeout: TMUX_OP_TIMEOUT }
       )
         .toString()

--- a/supervisor/tests/session/relay.test.ts
+++ b/supervisor/tests/session/relay.test.ts
@@ -5,6 +5,7 @@ import {
   stopRelayServer,
 } from "../../src/session/relay-server";
 import { tmuxSend, ensurePaneNotInMode } from "../../src/session/relay";
+import { TMUX_ARGS, ensureSocketConfigured } from "../../src/session/tmux";
 
 describe("relayMessage", () => {
   beforeAll(() => {
@@ -60,14 +61,14 @@ function startSession(name: string): void {
   // in the captured output and break substring comparison).
   execFileSync(
     TMUX_PATH,
-    ["new-session", "-d", "-s", name, "-x", "500", "-y", "40", "sleep", "600"],
+    [...TMUX_ARGS, "new-session", "-d", "-s", name, "-x", "500", "-y", "40", "sleep", "600"],
     { timeout: TMUX_OP_TIMEOUT }
   );
 }
 
 function killSession(name: string): void {
   try {
-    execFileSync(TMUX_PATH, ["kill-session", "-t", name], {
+    execFileSync(TMUX_PATH, [...TMUX_ARGS, "kill-session", "-t", name], {
       timeout: TMUX_OP_TIMEOUT,
     });
   } catch {
@@ -76,7 +77,7 @@ function killSession(name: string): void {
 }
 
 function capturePane(session: string): string {
-  return execFileSync(TMUX_PATH, ["capture-pane", "-p", "-t", session], {
+  return execFileSync(TMUX_PATH, [...TMUX_ARGS, "capture-pane", "-p", "-t", session], {
     timeout: TMUX_OP_TIMEOUT,
   }).toString();
 }
@@ -84,7 +85,7 @@ function capturePane(session: string): string {
 function paneInMode(session: string): boolean {
   const out = execFileSync(
     TMUX_PATH,
-    ["display-message", "-t", session, "-p", "#{pane_in_mode}"],
+    [...TMUX_ARGS, "display-message", "-t", session, "-p", "#{pane_in_mode}"],
     { timeout: TMUX_OP_TIMEOUT }
   )
     .toString()
@@ -93,14 +94,17 @@ function paneInMode(session: string): boolean {
 }
 
 // Warm up the tmux server once so per-test new-session calls do not include
-// server-startup latency (which can blow through short timeouts on CI).
+// server-startup latency (which can blow through short timeouts on CI). Also
+// applies the Supervisor socket's global options (mouse off / mode-keys
+// emacs) so tests exercise the production configuration.
 beforeAll(() => {
   if (!hasTmux) return;
   try {
-    execFileSync(TMUX_PATH, ["start-server"], { timeout: TMUX_OP_TIMEOUT });
+    execFileSync(TMUX_PATH, [...TMUX_ARGS, "start-server"], { timeout: TMUX_OP_TIMEOUT });
   } catch {
     // non-fatal; new-session will start the server on demand
   }
+  ensureSocketConfigured();
 });
 
 describe("tmuxSend integration (Issue #73 / AC-7)", () => {
@@ -126,7 +130,7 @@ describe("tmuxSend integration (Issue #73 / AC-7)", () => {
     const name = makeSessionName("mode");
     startSession(name);
     try {
-      execFileSync(TMUX_PATH, ["copy-mode", "-t", name], {
+      execFileSync(TMUX_PATH, [...TMUX_ARGS, "copy-mode", "-t", name], {
         timeout: TMUX_OP_TIMEOUT,
       });
       expect(paneInMode(name)).toBe(true);
@@ -143,7 +147,7 @@ describe("tmuxSend integration (Issue #73 / AC-7)", () => {
     const name = makeSessionName("recovery");
     startSession(name);
     try {
-      execFileSync(TMUX_PATH, ["copy-mode", "-t", name], {
+      execFileSync(TMUX_PATH, [...TMUX_ARGS, "copy-mode", "-t", name], {
         timeout: TMUX_OP_TIMEOUT,
       });
       expect(paneInMode(name)).toBe(true);
@@ -156,6 +160,34 @@ describe("tmuxSend integration (Issue #73 / AC-7)", () => {
       expect(paneInMode(name)).toBe(false);
       const captured = capturePane(name);
       expect(captured).toContain(payload);
+    } finally {
+      killSession(name);
+    }
+  });
+
+  // AC-6 for Issue #83: the original H2 reproducer. A pane stuck in
+  // copy-mode + `send-keys -l <long_text>` with special characters used to
+  // emit `not in a mode` × N and exit 1. After the fix (ensurePaneNotInMode
+  // runs first via relay.ts / the socket-scoped `mouse off` prevents auto
+  // re-entry), the send must succeed and deliver the payload verbatim.
+  itmux("AC-6: long mixed text does not produce 'not in a mode'", async () => {
+    const name = makeSessionName("ac6");
+    startSession(name);
+    try {
+      execFileSync(TMUX_PATH, [...TMUX_ARGS, "copy-mode", "-t", name], {
+        timeout: TMUX_OP_TIMEOUT,
+      });
+      // Reproduces the exact production payload class from the Issue #73
+      // comment: Japanese + URL with &?= + trailing Japanese.
+      const payload =
+        "Skillを自動最適化するskill https://x.com/mizchi/status/2045501078574350450?s=46&t=5PQ3oSn6maqPw この記事を読んでagent-baseに組み込むべきか調査してAgentTeams召集";
+      await ensurePaneNotInMode(name);
+      await tmuxSend(name, ["-l", payload]);
+      await new Promise((r) => setTimeout(r, 150));
+      expect(paneInMode(name)).toBe(false);
+      const captured = capturePane(name);
+      expect(captured).toContain("Skillを自動最適化するskill");
+      expect(captured).toContain("AgentTeams召集");
     } finally {
       killSession(name);
     }


### PR DESCRIPTION
## Summary

PR #77 で修正したはずの tmux pane copy-mode stuck が merge 翌日に再発（Issue #73 reopened）。Epic #79 で 4 連鎖のバグ構造を特定し、本 PR で構造的に解消する。

Closes #83. Fixes #73 (再発分).

## 根本原因の連鎖（Epic #79 で確定）

```
iterm2.ts:153 で全 pane が copy-mode で生まれる ──┐
                                                  ├─ relay 失敗 ─→ silent drop
~/.tmux.conf WheelUpPane → copy-mode -e ──────────┘
                                                  
relay.ts:186 Escape は mode-keys vi で NO-OP
tmux 3.6a: send-keys -l <長文> on copy-mode → not in a mode × N + exit 1
```

詳細は Epic [#79](https://github.com/miyashita337/claude-hub/issues/79) と:
- Sub [#80 H1 PASS](https://github.com/miyashita337/claude-hub/issues/80#issuecomment-4306083088): race condition
- Sub [#81 H2 PASS](https://github.com/miyashita337/claude-hub/issues/81#issuecomment-4306428258): tmux 3.6a send-keys -l バグ
- Sub [#82 H3 FAIL](https://github.com/miyashita337/claude-hub/issues/82#issuecomment-4305937557): bypass なし + iterm2.ts copy-mode 二次発見

## 修正内容

### 1. `supervisor/src/session/tmux.ts` (新規)
- `TMUX_PATH` / `TMUX_SOCKET` (`claude-hub`) / `TMUX_ARGS` / `TMUX_CMD` を集約
- `ensureSocketConfigured()`: socket 起動時に `mouse off` / `mode-keys emacs` / `history-limit 10000` を idempotent に適用
- env override: `SUPERVISOR_TMUX_SOCKET` で socket 名を変更可能（test 用）

### 2. `supervisor/src/session/manager.ts`
- 全 `tmux` 呼び出しを `TMUX_CMD` 経由に変更
- `new-session` 後に `ensureSocketConfigured()` を再呼び出し（server 起動済み確定後に option 適用）
- 従来の per-session `set-option history-limit` は global で代替（削除）

### 3. `supervisor/src/session/relay.ts`
- 全 `execFileSync(TMUX_PATH, ...)` に `[...TMUX_ARGS]` を prepend
- 既存の `ensurePaneNotInMode` ロジックは defensive layer として維持

### 4. `supervisor/src/session/iterm2.ts`
- 全 `tmux` 呼び出しに `TMUX_CMD` / `TMUX_ARGS` 適用
- osascript の `tmux attach` から **`\; copy-mode` を削除**（H3 二次発見対応）
- 誤入力防止は socket 分離 (`mouse off`) で代替

### 5. `supervisor/tests/session/relay.test.ts`
- **AC-6 新規追加**: copy-mode pane + 長文 (H2 production payload を再現) で `not in a mode` が出ないことを実機 tmux で検証
- 既存 helper も `TMUX_ARGS` 経由に統一
- `beforeAll` で `ensureSocketConfigured()` 呼び出し

### 6. `supervisor/tests/e2e/ac-verification.test.ts`
- 全 helper / `new-session` / `copy-mode` 呼び出しを `TMUX_ARGS` 経由に変更

## Test plan

- [x] `bun x tsc --noEmit` PASS
- [x] `bun test tests/session/relay.test.ts` 7/7 PASS（AC-6 含む）
- [x] `bun test tests/e2e/` 全 PASS
- [x] manual: `tmux -L claude-hub kill-server && bun test tests/session/ tests/e2e/` で再実行 → 23/23 PASS（pre-existing flake 2 件除く）
- [ ] manual after merge: Supervisor 再起動 → Discord で日本語+URL 長文を team-salary thread に送信 → 応答が返ってくることを実機確認
- [ ] manual after merge: `tmux -L claude-hub show-options -g mouse` が `mouse off` を返すこと確認
- [ ] manual after merge: `tmux ls | grep '^claude-'` が空（default socket に session が残らない）

## 既知の事項

**pre-existing flake 2 件**（main でも同じ条件で fail、本 PR の責務外）:
- `tests/session/iterm2-async.test.ts > markTabStopped non-blocking` — `isItermRunning()` の `execSync('pgrep')` が 100ms+ 取る
- `tests/session/manager.test.ts > stop() removes session by threadId` — `GRACEFUL_KILL_TIMEOUT_MS=15s` + 5s buffer = 20s が現代 macOS で時々超過

## マイグレーション

merge 後、Supervisor を再起動するだけで自動的に新 socket に移行:
1. 既存の default socket 上の `claude-*` session は arrived-naturally で kill される（DB の `recoverFromDb` が新 socket でセッション無しと判断 → stopped 扱い）
2. 新規 session は `-L claude-hub` socket 上で起動

ただし default socket 上の orphan tmux session が残るので、最初の Supervisor 再起動時にユーザーが手動で `tmux ls | grep '^claude-' | cut -d: -f1 | xargs -n1 tmux kill-session -t` を実行することを推奨（issue body にも記載予定）。

## 関連

- Epic #79（全仮説検証完了）
- Sub #80 H1 PASS / #81 H2 PASS / #82 H3 FAIL+二次発見
- Issue #73（原イシュー、reopened）
- PR #77（前回修正、不完全）
- RW-019（agent-base/rules/general/rework-patterns.md に記録）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ターミナル制御の共有設定を導入し、外部ターミナル連携とソケット設定を確実に適用します。

* **バグ修正**
  * iTerm2でタブを開く際に強制的なコピーモード移行を回避し、接続動作を改善しました。
  * セッション開始・終了時の通知とウィンドウ名更新の精度を向上しました。
  * ターミナル初期化時の安定性とスクロール履歴設定の適用を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->