### PR TITLE
fix(#61): SessionManager の単体テストで実 tmux/iTerm2 を生成しない (DI 化)

### DIFF
--- a/supervisor/src/session/adapters-fake.ts
+++ b/supervisor/src/session/adapters-fake.ts
@@ -1,0 +1,109 @@
+import type {
+  ItermAdapter,
+  ProcessAdapter,
+  RelayServerAdapter,
+  SessionEffects,
+  TmuxAdapter,
+} from "./adapters";
+import type { OpenTabOptions } from "./iterm2";
+
+/**
+ * In-memory fakes for the {@link SessionEffects} interfaces. Used by unit
+ * tests to avoid spawning real tmux sessions, iTerm2 tabs, HTTP servers, or
+ * sending real OS signals. See Issue #61.
+ */
+
+export class FakeTmuxAdapter implements TmuxAdapter {
+  private sessions = new Map<string, { command: string; pid: number }>();
+  private pidCounter = 10_000;
+  ensureSocketConfiguredCalls = 0;
+
+  newSession(name: string, command: string): void {
+    this.sessions.set(name, { command, pid: this.pidCounter++ });
+  }
+
+  killSession(name: string): void {
+    this.sessions.delete(name);
+  }
+
+  hasSession(name: string): boolean {
+    return this.sessions.has(name);
+  }
+
+  getPid(name: string): number | null {
+    return this.sessions.get(name)?.pid ?? null;
+  }
+
+  ensureSocketConfigured(): void {
+    this.ensureSocketConfiguredCalls += 1;
+  }
+
+  list(): string[] {
+    return Array.from(this.sessions.keys());
+  }
+}
+
+export class FakeItermAdapter implements ItermAdapter {
+  openTabCalls: OpenTabOptions[] = [];
+  markTabStoppedCalls: { channelName: string; tmuxSessionName?: string }[] =
+    [];
+
+  openTab(opts: OpenTabOptions): void {
+    this.openTabCalls.push(opts);
+  }
+
+  markTabStopped(channelName: string, tmuxSessionName?: string): void {
+    this.markTabStoppedCalls.push({ channelName, tmuxSessionName });
+  }
+}
+
+export class FakeRelayServerAdapter implements RelayServerAdapter {
+  startCalls = 0;
+  stopCalls = 0;
+  cancelCalls: string[] = [];
+  port = 12_345;
+
+  start(): void {
+    this.startCalls += 1;
+  }
+
+  stop(): void {
+    this.stopCalls += 1;
+  }
+
+  getPort(): number {
+    return this.port;
+  }
+
+  cancel(threadId: string): void {
+    this.cancelCalls.push(threadId);
+  }
+}
+
+export class FakeProcessAdapter implements ProcessAdapter {
+  killCalls: { pid: number; signal: NodeJS.Signals | number }[] = [];
+  failOnKill = false;
+
+  kill(pid: number, signal: NodeJS.Signals | number): void {
+    this.killCalls.push({ pid, signal });
+    if (this.failOnKill) {
+      throw new Error("process not found");
+    }
+  }
+}
+
+export interface FakeSessionEffects extends SessionEffects {
+  tmux: FakeTmuxAdapter;
+  iterm2: FakeItermAdapter;
+  relayServer: FakeRelayServerAdapter;
+  process: FakeProcessAdapter;
+}
+
+export function createFakeEffects(): FakeSessionEffects {
+  return {
+    tmux: new FakeTmuxAdapter(),
+    iterm2: new FakeItermAdapter(),
+    relayServer: new FakeRelayServerAdapter(),
+    process: new FakeProcessAdapter(),
+  };
+}

--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -1,0 +1,119 @@
+import { execSync } from "child_process";
+import {
+  openTab as realOpenTab,
+  markTabStopped as realMarkTabStopped,
+  type OpenTabOptions,
+} from "./iterm2";
+import {
+  startRelayServer as realStartRelayServer,
+  stopRelayServer as realStopRelayServer,
+  getRelayPort as realGetRelayPort,
+  cancelRelay as realCancelRelay,
+} from "./relay-server";
+import {
+  TMUX_CMD,
+  ensureSocketConfigured as realEnsureSocketConfigured,
+} from "./tmux";
+
+/**
+ * Adapters that wrap external side effects (tmux, iTerm2, relay HTTP server,
+ * OS process signals). The {@link SessionManager} uses this indirection so
+ * unit tests can inject in-memory fakes and avoid spawning real tmux sessions
+ * or iTerm2 tabs (Issue #61).
+ */
+
+export interface TmuxAdapter {
+  newSession(name: string, command: string): void;
+  killSession(name: string): void;
+  hasSession(name: string): boolean;
+  getPid(name: string): number | null;
+  ensureSocketConfigured(): void;
+}
+
+export interface ItermAdapter {
+  openTab(opts: OpenTabOptions): void;
+  markTabStopped(channelName: string, tmuxSessionName?: string): void;
+}
+
+export interface RelayServerAdapter {
+  start(): void;
+  stop(): void;
+  getPort(): number;
+  cancel(threadId: string): void;
+}
+
+export interface ProcessAdapter {
+  kill(pid: number, signal: NodeJS.Signals | number): void;
+}
+
+export interface SessionEffects {
+  tmux: TmuxAdapter;
+  iterm2: ItermAdapter;
+  relayServer: RelayServerAdapter;
+  process: ProcessAdapter;
+}
+
+export const realTmuxAdapter: TmuxAdapter = {
+  newSession(name, command) {
+    execSync(`${TMUX_CMD} new-session -d -s "${name}" '${command}'`);
+  },
+  killSession(name) {
+    try {
+      execSync(`${TMUX_CMD} kill-session -t "${name}" 2>/dev/null`);
+    } catch {
+      // No existing session
+    }
+  },
+  hasSession(name) {
+    try {
+      execSync(`${TMUX_CMD} has-session -t "${name}" 2>/dev/null`);
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  getPid(name) {
+    try {
+      const output = execSync(
+        `${TMUX_CMD} list-panes -t "${name}" -F "#{pane_pid}" 2>/dev/null`,
+        { encoding: "utf8" }
+      ).trim();
+      const pid = parseInt(output.split("\n")[0] ?? "", 10);
+      return isNaN(pid) ? null : pid;
+    } catch {
+      return null;
+    }
+  },
+  ensureSocketConfigured() {
+    realEnsureSocketConfigured();
+  },
+};
+
+export const realItermAdapter: ItermAdapter = {
+  openTab(opts) {
+    realOpenTab(opts);
+  },
+  markTabStopped(channelName, tmuxSessionName) {
+    realMarkTabStopped(channelName, tmuxSessionName);
+  },
+};
+
+export const realRelayServerAdapter: RelayServerAdapter = {
+  start: realStartRelayServer,
+  stop: realStopRelayServer,
+  getPort: realGetRelayPort,
+  cancel: realCancelRelay,
+};
+
+export const realProcessAdapter: ProcessAdapter = {
+  kill(pid, signal) {
+    process.kill(pid, signal);
+  },
+};
+
+export const realSessionEffects: SessionEffects = {
+  tmux: realTmuxAdapter,
+  iterm2: realItermAdapter,
+  relayServer: realRelayServerAdapter,
+  process: realProcessAdapter,
+};

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -1,6 +1,6 @@
 import { execSync } from "child_process";
 import { randomUUID } from "crypto";
-import { existsSync, mkdirSync } from "fs";
+import { existsSync } from "fs";
 import { resolve } from "path";
 import { homedir } from "os";
 import type { SessionInfo, StopReason } from "./types";
@@ -15,26 +15,51 @@ import {
   updateSessionActivity,
   getRunningSessions,
 } from "../infra/db";
-import { openTab, markTabStopped } from "./iterm2";
 import { relayMessage, type AttachmentInfo, type RelayResult } from "./relay";
 import {
-  startRelayServer,
-  stopRelayServer,
-  getRelayPort,
-  cancelRelay,
-} from "./relay-server";
-import { TMUX_CMD, ensureSocketConfigured } from "./tmux";
+  realSessionEffects,
+  type SessionEffects,
+} from "./adapters";
 
 const CLAUDE_PATH = resolve(homedir(), ".local", "bin", "claude");
 const TMUX_SESSION_PREFIX = "claude-";
 
+export interface SessionManagerOptions {
+  /**
+   * Inject side-effect adapters for tmux / iTerm2 / relay-server / process
+   * signals. Tests pass fakes from {@link ./adapters-fake} so unit tests do
+   * not spawn real tmux sessions or iTerm2 tabs (Issue #61). Production
+   * leaves this undefined to use {@link realSessionEffects}.
+   */
+  effects?: Partial<SessionEffects>;
+  /**
+   * Override the graceful-kill wait so tests don't pay the production 15s
+   * delay before kill-session. Defaults to {@link GRACEFUL_KILL_TIMEOUT_MS}.
+   */
+  gracefulKillTimeoutMs?: number;
+}
+
 export class SessionManager {
   /** Map<threadId, SessionInfo> — one session per thread */
   private sessions = new Map<string, SessionInfo>();
+  /** Map<threadId, intervalHandle> — watchdogs to clear on stop/shutdown */
+  private watchers = new Map<string, ReturnType<typeof setInterval>>();
+  private readonly effects: SessionEffects;
+  private readonly gracefulKillTimeoutMs: number;
 
-  constructor() {
-    ensureSocketConfigured();
-    startRelayServer();
+  constructor(options: SessionManagerOptions = {}) {
+    this.effects = {
+      tmux: options.effects?.tmux ?? realSessionEffects.tmux,
+      iterm2: options.effects?.iterm2 ?? realSessionEffects.iterm2,
+      relayServer:
+        options.effects?.relayServer ?? realSessionEffects.relayServer,
+      process: options.effects?.process ?? realSessionEffects.process,
+    };
+    this.gracefulKillTimeoutMs =
+      options.gracefulKillTimeoutMs ?? GRACEFUL_KILL_TIMEOUT_MS;
+
+    this.effects.tmux.ensureSocketConfigured();
+    this.effects.relayServer.start();
     this.recoverFromDb();
   }
 
@@ -69,28 +94,6 @@ export class SessionManager {
     return `${TMUX_SESSION_PREFIX}${threadId.slice(0, 12)}`;
   }
 
-  private getTmuxPid(sessionName: string): number | null {
-    try {
-      const output = execSync(
-        `${TMUX_CMD} list-panes -t "${sessionName}" -F "#{pane_pid}" 2>/dev/null`,
-        { encoding: "utf8" }
-      ).trim();
-      const pid = parseInt(output.split("\n")[0] ?? "", 10);
-      return isNaN(pid) ? null : pid;
-    } catch {
-      return null;
-    }
-  }
-
-  private isTmuxSessionAlive(sessionName: string): boolean {
-    try {
-      execSync(`${TMUX_CMD} has-session -t "${sessionName}" 2>/dev/null`);
-      return true;
-    } catch {
-      return false;
-    }
-  }
-
   /**
    * Start a new session with tmux + iTerm2 + thread.
    */
@@ -113,14 +116,10 @@ export class SessionManager {
     const tmuxName = this.tmuxSessionName(threadId);
 
     // Kill existing tmux session if any
-    try {
-      execSync(`${TMUX_CMD} kill-session -t "${tmuxName}" 2>/dev/null`);
-    } catch {
-      // No existing session
-    }
+    this.effects.tmux.killSession(tmuxName);
 
     // Build the claude command — unset ANTHROPIC_API_KEY to use Claude Max subscription
-    const relayUrl = `http://localhost:${getRelayPort()}/relay/${threadId}`;
+    const relayUrl = `http://localhost:${this.effects.relayServer.getPort()}/relay/${threadId}`;
 
     const claudeCmd = [
       "unset ANTHROPIC_API_KEY",
@@ -133,17 +132,15 @@ export class SessionManager {
 
     // Launch via tmux (provides a real TTY). Uses Supervisor's dedicated
     // -L claude-hub socket (see ./tmux.ts) so user config is not inherited.
-    execSync(
-      `${TMUX_CMD} new-session -d -s "${tmuxName}" '${claudeCmd}'`
-    );
+    this.effects.tmux.newSession(tmuxName, claudeCmd);
     // Apply server-wide options now that the server is definitely running.
     // The constructor's eager call is a no-op before the first new-session.
-    ensureSocketConfigured();
+    this.effects.tmux.ensureSocketConfigured();
 
     // Wait briefly for process to start
     let pid: number | null = null;
     for (let i = 0; i < 5; i++) {
-      pid = this.getTmuxPid(tmuxName);
+      pid = this.effects.tmux.getPid(tmuxName);
       if (pid) break;
       execSync("sleep 0.5");
     }
@@ -190,7 +187,7 @@ export class SessionManager {
 
     // Open iTerm2 tab asynchronously (non-blocking, failure is safe)
     setTimeout(() => {
-      openTab({
+      this.effects.iterm2.openTab({
         tmuxSessionName: tmuxName,
         channelName: config.channelName,
         projectDir: config.dir,
@@ -220,7 +217,7 @@ export class SessionManager {
     const tmuxName = this.tmuxSessionName(threadId);
 
     // Check tmux session is alive
-    if (!this.isTmuxSessionAlive(tmuxName)) {
+    if (!this.effects.tmux.hasSession(tmuxName)) {
       return {
         text: "",
         chunks: ["⚠️ Claude Code セッションが終了しています。`/session start` で再起動してください。"],
@@ -241,7 +238,7 @@ export class SessionManager {
     }
 
     session.status = "stopping";
-    cancelRelay(threadId);
+    this.effects.relayServer.cancel(threadId);
     const tmuxName = this.tmuxSessionName(threadId);
 
     console.log(
@@ -250,7 +247,7 @@ export class SessionManager {
 
     // Send SIGTERM to the claude process
     try {
-      process.kill(session.pid, "SIGTERM");
+      this.effects.process.kill(session.pid, "SIGTERM");
     } catch {
       // Process already dead
     }
@@ -258,17 +255,14 @@ export class SessionManager {
     // Wait for graceful shutdown, then force kill tmux session
     await new Promise<void>((resolve) => {
       setTimeout(() => {
-        try {
-          execSync(`${TMUX_CMD} kill-session -t "${tmuxName}" 2>/dev/null`);
-        } catch {
-          // Already dead
-        }
+        this.effects.tmux.killSession(tmuxName);
         resolve();
-      }, GRACEFUL_KILL_TIMEOUT_MS);
+      }, this.gracefulKillTimeoutMs);
     });
 
+    this.clearWatcher(threadId);
     this.sessions.delete(threadId);
-    markTabStopped(session.channelName, tmuxName);
+    this.effects.iterm2.markTabStopped(session.channelName, tmuxName);
     updateSessionStatus(session.id, "stopped", reason);
   }
 
@@ -288,8 +282,21 @@ export class SessionManager {
       )
     );
     await Promise.allSettled(promises);
-    stopRelayServer();
+    // Clear any remaining watchers (defensive — stop() already clears them).
+    for (const handle of this.watchers.values()) {
+      clearInterval(handle);
+    }
+    this.watchers.clear();
+    this.effects.relayServer.stop();
     console.log("[SessionManager] All sessions stopped.");
+  }
+
+  private clearWatcher(threadId: string): void {
+    const handle = this.watchers.get(threadId);
+    if (handle) {
+      clearInterval(handle);
+      this.watchers.delete(threadId);
+    }
   }
 
   private watchTmuxSession(
@@ -298,19 +305,20 @@ export class SessionManager {
     sessionId: string
   ): void {
     const interval = setInterval(() => {
-      if (!this.isTmuxSessionAlive(tmuxName)) {
+      if (!this.effects.tmux.hasSession(tmuxName)) {
         const session = this.sessions.get(threadId);
         console.log(
           `[SessionManager] tmux session ${tmuxName} exited`
         );
         this.sessions.delete(threadId);
         if (session) {
-          markTabStopped(session.channelName, tmuxName);
+          this.effects.iterm2.markTabStopped(session.channelName, tmuxName);
         }
         updateSessionStatus(sessionId, "stopped", "tmux_exited");
-        clearInterval(interval);
+        this.clearWatcher(threadId);
       }
     }, 10_000); // Check every 10 seconds
+    this.watchers.set(threadId, interval);
   }
 
   private recoverFromDb(): void {
@@ -318,15 +326,11 @@ export class SessionManager {
     for (const row of rows) {
       if (row.thread_id) {
         const tmuxName = this.tmuxSessionName(row.thread_id);
-        if (this.isTmuxSessionAlive(tmuxName)) {
+        if (this.effects.tmux.hasSession(tmuxName)) {
           console.log(
             `[SessionManager] Found running tmux session ${tmuxName}, killing (supervisor restart)`
           );
-          try {
-            execSync(`${TMUX_CMD} kill-session -t "${tmuxName}" 2>/dev/null`);
-          } catch {
-            // ignore
-          }
+          this.effects.tmux.killSession(tmuxName);
         }
       }
       updateSessionStatus(row.id, "stopped", "supervisor_restart");

--- a/supervisor/tests/session/manager.test.ts
+++ b/supervisor/tests/session/manager.test.ts
@@ -1,39 +1,88 @@
-import { test, expect, describe, beforeEach } from "bun:test";
+import {
+  test,
+  expect,
+  describe,
+  beforeEach,
+  afterEach,
+} from "bun:test";
+import { mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { resolve } from "path";
 import { SessionManager } from "../../src/session/manager";
-import { CHANNEL_MAP } from "../../src/config/channels";
+import {
+  createFakeEffects,
+  type FakeSessionEffects,
+} from "../../src/session/adapters-fake";
+import type { ChannelConfig } from "../../src/config/channels";
+
+/**
+ * These tests inject fake adapters via {@link SessionManager}'s DI hooks so
+ * the unit tests do NOT spawn real tmux sessions or iTerm2 tabs.
+ *
+ * See Issue #61 — running these tests previously left ~10 zombie iTerm2 tabs
+ * and 9+ tmux sessions every time `/verify` was executed.
+ */
+
+function makeChannelConfig(overrides: Partial<ChannelConfig> = {}): ChannelConfig {
+  // Use a real temp dir so the fs.existsSync gate in start() passes without
+  // depending on the developer's home directory.
+  const dir = resolve(tmpdir(), `supervisor-test-${process.pid}`);
+  mkdirSync(dir, { recursive: true });
+  return {
+    channelName: "test-channel",
+    dir,
+    displayName: "Test Channel",
+    botTokenEnvKey: "TEST_BOT_TOKEN",
+    ...overrides,
+  };
+}
 
 describe("SessionManager (thread-based)", () => {
   let manager: SessionManager;
+  let effects: FakeSessionEffects;
+  let primaryConfig: ChannelConfig;
+  let secondaryConfig: ChannelConfig;
 
   beforeEach(() => {
-    manager = new SessionManager();
+    effects = createFakeEffects();
+    manager = new SessionManager({
+      effects,
+      // Skip the production 15s graceful-kill wait so stop() resolves
+      // immediately in tests.
+      gracefulKillTimeoutMs: 0,
+    });
+    primaryConfig = makeChannelConfig({ channelName: "channel-primary" });
+    secondaryConfig = makeChannelConfig({ channelName: "channel-secondary" });
+  });
+
+  afterEach(async () => {
+    // Defensive cleanup so a failing test doesn't leak watchers across
+    // test cases.
+    await manager.shutdownAll();
   });
 
   test("starts a session with threadId", () => {
-    const config = CHANNEL_MAP.get("oci-develop")!;
     const threadId = "thread-123";
-    const session = manager.start(config, threadId);
+    const session = manager.start(primaryConfig, threadId);
 
     expect(session.id).toBeTruthy();
-    expect(session.channelName).toBe("oci-develop");
+    expect(session.channelName).toBe("channel-primary");
     expect(session.threadId).toBe(threadId);
-    expect(session.projectDir).toBe(config.dir);
+    expect(session.projectDir).toBe(primaryConfig.dir);
     expect(session.status).toBe("running");
   });
 
   test("has() checks by threadId", () => {
-    const config = CHANNEL_MAP.get("oci-develop")!;
     const threadId = "thread-456";
-    manager.start(config, threadId);
+    manager.start(primaryConfig, threadId);
 
     expect(manager.has(threadId)).toBe(true);
     expect(manager.has("thread-nonexistent")).toBe(false);
   });
 
   test("allows multiple sessions in the same channel", () => {
-    const config = CHANNEL_MAP.get("oci-develop")!;
-    manager.start(config, "thread-1");
-    manager.start(config, "thread-2");
+    manager.start(primaryConfig, "thread-1");
+    manager.start(primaryConfig, "thread-2");
 
     expect(manager.count()).toBe(2);
     expect(manager.has("thread-1")).toBe(true);
@@ -41,28 +90,21 @@ describe("SessionManager (thread-based)", () => {
   });
 
   test("listRunningByChannel returns sessions for a specific channel", () => {
-    const ociConfig = CHANNEL_MAP.get("oci-develop")!;
-    const devConfig = CHANNEL_MAP.get("dev-tool")!;
-    manager.start(ociConfig, "thread-oci-1");
-    manager.start(ociConfig, "thread-oci-2");
-    manager.start(devConfig, "thread-dev-1");
+    manager.start(primaryConfig, "thread-pri-1");
+    manager.start(primaryConfig, "thread-pri-2");
+    manager.start(secondaryConfig, "thread-sec-1");
 
-    const ociSessions = manager.listRunningByChannel("oci-develop");
-    expect(ociSessions).toHaveLength(2);
-
-    const devSessions = manager.listRunningByChannel("dev-tool");
-    expect(devSessions).toHaveLength(1);
+    expect(manager.listRunningByChannel("channel-primary")).toHaveLength(2);
+    expect(manager.listRunningByChannel("channel-secondary")).toHaveLength(1);
   });
 
   test("stop() removes session by threadId", async () => {
-    const config = CHANNEL_MAP.get("oci-develop")!;
-    manager.start(config, "thread-to-stop");
+    manager.start(primaryConfig, "thread-to-stop");
 
     expect(manager.has("thread-to-stop")).toBe(true);
-    // stop() waits GRACEFUL_KILL_TIMEOUT_MS (15s), so increase test timeout
     await manager.stop("thread-to-stop", "manual");
     expect(manager.has("thread-to-stop")).toBe(false);
-  }, 20_000);
+  });
 
   test("stop() throws for nonexistent thread", async () => {
     await expect(
@@ -71,31 +113,25 @@ describe("SessionManager (thread-based)", () => {
   });
 
   test("throws when max sessions exceeded", () => {
-    const config = CHANNEL_MAP.get("oci-develop")!;
-    // Start MAX_SESSIONS sessions
     for (let i = 0; i < 10; i++) {
-      manager.start(config, `thread-${i}`);
+      manager.start(primaryConfig, `thread-${i}`);
     }
-    expect(() => manager.start(config, "thread-overflow")).toThrow(
+    expect(() => manager.start(primaryConfig, "thread-overflow")).toThrow(
       "最大セッション数"
     );
   });
 
   test("throws for duplicate threadId", () => {
-    const config = CHANNEL_MAP.get("oci-develop")!;
-    manager.start(config, "thread-dup");
-    expect(() => manager.start(config, "thread-dup")).toThrow(
+    manager.start(primaryConfig, "thread-dup");
+    expect(() => manager.start(primaryConfig, "thread-dup")).toThrow(
       "既に稼働中です"
     );
   });
 
   test("touchActivity updates lastActivityAt", () => {
-    const config = CHANNEL_MAP.get("oci-develop")!;
-    const session = manager.start(config, "thread-touch");
+    const session = manager.start(primaryConfig, "thread-touch");
     const initialTime = session.lastActivityAt.getTime();
 
-    // Small delay to ensure time difference
-    const later = new Date(initialTime + 1000);
     manager.touchActivity("thread-touch");
 
     const updated = manager.get("thread-touch");
@@ -105,6 +141,67 @@ describe("SessionManager (thread-based)", () => {
   });
 
   test("listRunningByChannel returns empty when no sessions for channel", () => {
-    expect(manager.listRunningByChannel("oci-develop")).toHaveLength(0);
+    expect(manager.listRunningByChannel("channel-primary")).toHaveLength(0);
+  });
+
+  /**
+   * Below: AC-1 / AC-2 verification — confirm fakes are used and no real
+   * external side effects are triggered.
+   */
+
+  test("AC-1: start() does not call real tmux — only the fake adapter sees it", () => {
+    manager.start(primaryConfig, "thread-ac1");
+    expect(effects.tmux.list()).toContain("claude-thread-ac1");
+  });
+
+  test("AC-2: start() defers iTerm2 tab opening through the fake adapter (no osascript)", async () => {
+    manager.start(primaryConfig, "thread-ac2");
+    // openTab is dispatched via setTimeout(0); flush the macrotask queue.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(effects.iterm2.openTabCalls).toHaveLength(1);
+    expect(effects.iterm2.openTabCalls[0]?.channelName).toBe(
+      "channel-primary"
+    );
+  });
+
+  test("AC-4 surface: real adapters are wired by default when no effects passed", () => {
+    // We don't actually instantiate this — we only assert the type contract:
+    // SessionManager() with no args must compile and use realSessionEffects.
+    // (Compile-time check; runtime would spawn real tmux which is exactly
+    // what Issue #61 forbids in tests.)
+    const ctor: new () => SessionManager = SessionManager;
+    expect(typeof ctor).toBe("function");
+  });
+
+  test("relay-server start/stop are routed through the fake adapter", async () => {
+    expect(effects.relayServer.startCalls).toBe(1);
+    await manager.shutdownAll();
+    expect(effects.relayServer.stopCalls).toBe(1);
+  });
+
+  test("stop() sends SIGTERM via the process adapter, not real OS signals", async () => {
+    const session = manager.start(primaryConfig, "thread-sigterm");
+    await manager.stop("thread-sigterm", "manual");
+    expect(effects.process.killCalls).toEqual([
+      { pid: session.pid, signal: "SIGTERM" },
+    ]);
+  });
+
+  test("stop() routes kill-session through the fake tmux adapter", async () => {
+    manager.start(primaryConfig, "thread-killsess");
+    // tmuxSessionName takes the first 12 chars of threadId (see manager.ts).
+    expect(effects.tmux.list()).toContain("claude-thread-kills");
+    await manager.stop("thread-killsess", "manual");
+    expect(effects.tmux.list()).not.toContain("claude-thread-kills");
+  });
+
+  test("shutdownAll() clears all sessions and stops the relay server", async () => {
+    manager.start(primaryConfig, "thread-a");
+    manager.start(primaryConfig, "thread-b");
+    expect(manager.count()).toBe(2);
+
+    await manager.shutdownAll();
+    expect(manager.count()).toBe(0);
+    expect(effects.relayServer.stopCalls).toBe(1);
   });
 });


### PR DESCRIPTION
## 概要

Closes #61

`SessionManager` を DI 化し、tmux / iTerm2 / relay-server / process kill を adapter 経由で実行する。テストは fake adapter を注入することで、実 tmux セッションや iTerm2 タブを一切生成せずにユニットテストを完了できるようにする。

## 背景

`/verify` (= `bun test`) を走らせるたびに `manager.test.ts` がモックなしで `manager.start()` を呼んでいたため:

- `tmux new-session -d -s claude-thread-*` が 9+ 件
- iTerm2 タブが対応する数だけ開きゾンビ化
- `can't find session: claude-thread-*` を表示するゴミタブが残る

## 変更点

| ファイル | 変更 |
|---|---|
| `supervisor/src/session/adapters.ts` | 新設。`TmuxAdapter` / `ItermAdapter` / `RelayServerAdapter` / `ProcessAdapter` のインターフェースと real 実装 (既存関数のラッパー) |
| `supervisor/src/session/adapters-fake.ts` | 新設。テスト用の in-memory fake 実装 (`createFakeEffects()`) |
| `supervisor/src/session/manager.ts` | コンストラクタに `{ effects?, gracefulKillTimeoutMs? }` を追加。`execSync`/`openTab`/`process.kill` 等を全て `this.effects.*` 経由へ。`watchTmuxSession` の interval を Map で追跡し `stop()` / `shutdownAll()` で clear |
| `supervisor/tests/session/manager.test.ts` | 既存 10 ケースを fake adapter 注入に書き換え、`gracefulKillTimeoutMs: 0` で stop() を即座に解決。AC-1/AC-2/AC-4 の追加検証ケースを追加 |

`supervisor/src/bot.ts` は **無変更** — `new SessionManager()` のデフォルトでは `realSessionEffects` が注入され従来動作のまま。

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | bun test 実行後の新規 tmux session 数 | `tmux ls \| grep ^claude-thread- \| wc -l` (default + `-L claude-hub` 双方) | 0 | 0 / 0 | PASS |
| AC-2 | iTerm2 タブが増えない | `osascript -e 'count tabs of windows'` 前後 diff | 0 | 3→3 (diff 0) | PASS |
| AC-3 | テスト本体が PASS | `bun test tests/session/manager.test.ts` | all PASS | 17/17 PASS | PASS |
| AC-4 | 本番パスは adapter 未指定で従来動作 | bot.ts 差分なし + デフォルト引数で `realSessionEffects` 注入 | 動作 | 未変更 | PASS |

全体テスト: **110 pass / 3 skip / 0 fail** (16 ファイル, 4.35s)

## 統合ジャーニーAC 検証結果

1. **操作**: `bun test supervisor/tests/session/` を実行
   - **期待結果**: 全テスト PASS、かつ実行中に iTerm2 タブ/tmux セッションが新規生成されない
   - **検証手段**: 実行前後で `tmux ls` (default + `-L claude-hub` 双方) と iTerm2 タブ数を比較し差分 0
   - **実測**: 実行前 0 / 0 / 3 → 実行後 0 / 0 / 3 (差分 0)、110 件 PASS ✓

2. **操作**: Supervisor を本番起動して Discord 経由でスレッド作成
   - **期待結果**: 従来どおり iTerm2 タブが開き tmux セッションが立ち上がる
   - **検証手段**: Discord 側でスレッド発言 → 対応する iTerm2 タブが 1 件開く
   - **実測 (コードレベル)**: `bot.ts` 未変更、`new SessionManager()` で `realSessionEffects` が注入されるため `realTmuxAdapter` / `realItermAdapter` 経由で従来どおり tmux/iTerm2 を起動する。実機 Supervisor での動作確認は merge 後に実施推奨

## レビュー観点

- DI 境界として 4 つのインターフェース (`tmux` / `iterm2` / `relayServer` / `process`) を切り出しているが、過剰抽象化になっていないか
- `gracefulKillTimeoutMs` を public option として露出していること (テストでのみ 0 に上書き)
- `watchTmuxSession` の interval が stop/shutdown で clear されるようになり、テストでの leak が解消されている