### PR TITLE
fix(#90): .claude/settings.json deny を project-scoped 化 (RW-014)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -69,8 +69,8 @@
       "Read(//Users/*/.ssh/**)",
       "Read(//Users/*/.config/gh/**)",
       "Read(//Users/*/Library/Keychains/**)",
-      "Read(//Users/*/claude-hub/**/.env)",
-      "Read(//Users/*/claude-hub/**/.env.*)",
+      "Read(**/.env)",
+      "Read(**/.env.*)",
       "Read(//**/credentials*)",
       "Read(//**/id_rsa*)",
       "Read(//**/id_ed25519*)"

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -60,7 +60,6 @@
       "Bash(npx:*)",
       "Bash(node:*)",
       "Bash(python:*)",
-      "Bash(python3:*)",
       "Bash(sh:*)",
       "Bash(bash:*)",
       "Bash(zsh:*)",
@@ -70,8 +69,8 @@
       "Read(//Users/*/.ssh/**)",
       "Read(//Users/*/.config/gh/**)",
       "Read(//Users/*/Library/Keychains/**)",
-      "Read(//**/.env)",
-      "Read(//**/.env.*)",
+      "Read(//Users/*/claude-hub/**/.env)",
+      "Read(//Users/*/claude-hub/**/.env.*)",
       "Read(//**/credentials*)",
       "Read(//**/id_rsa*)",
       "Read(//**/id_ed25519*)"


### PR DESCRIPTION
## 概要

claude-hub の `.claude/settings.json` に書かれていた広域 deny パターンが agent-base 共通資産（`~/.claude/.env`、`python3` 依存スクリプト）を巻き込んでいた問題を解消する。agent-base RW-014 既知パターン。

Closes #90

## 変更点

`.claude/settings.json`:

```diff
-      "Bash(python3:*)",
       ...
-      "Read(//**/.env)",
-      "Read(//**/.env.*)",
+      "Read(//Users/*/claude-hub/**/.env)",
+      "Read(//Users/*/claude-hub/**/.env.*)",
```

合計: 1 ファイル、+2 -3。

## 設計判断

Claude Code 仕様で `deny > allow` かつ Project deny は User global allow を覆せないため、global allow を追加する案では救済不可。`Read` rule は negative pattern 非対応のため deny 側を狭める/削除するしかない（agent-base RW-014 で確定済み）。

- `Bash(python3:*)` は agent-base 側で `python3 scripts/videodb-check.py` 等の python3 依存スクリプトが存在するため削除。`Bash(python:*)` は #90 のスコープ外として温存。
- `Read(//**/.env*)` は絶対 glob で `~/.claude/.env` を巻き込むため、claude-hub プロジェクト境界に絞った glob に置換。

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | python3 deny 削除 | `jq -r '.permissions.deny[]' .claude/settings.json \| grep -c 'Bash(python3:\*)'` | 0 | 0 | ✅ PASS |
| AC-2 | 絶対 glob env deny 削除 | `jq -r '.permissions.deny[]' .claude/settings.json \| grep -E '^Read\(//\*\*/\.env'` | 空 | 空 | ✅ PASS |
| AC-3 | agent-base verify HEALTHY | `bash /Users/harieshokunin/agent-base/install.sh --verify` | claude-hub issue 0 件 | **agent-base 側で別途検証**（claude-hub セッション内では agent-base スクリプトの実行権限なし） | ⏭️ 手動 |

加えて `jq empty .claude/settings.json` で JSON 妥当性も PASS 確認。

## 統合ジャーニーAC（不要・理由）

設定ファイルの deny パターン修正のみ、外部から観測可能な振る舞いは変わらない（permissions が静かに広がる方向）ため不要。

## 影響範囲

- claude-hub は現在 Phase 1（`CLAUDE_HUB_UNSAFE_SKIP_PERMISSIONS=1`）で permissions skip 状態のため**実害なし**。Phase 2 で flip された時点で agent-base 共通資産が一斉に停止する**時限爆弾**を解除する。
- agent-base の `install.sh --verify` で claude-hub に関する 2 件の ISSUE が消えるはず（agent-base 側で要確認）。

## 関連

- agent-base RW-014: `rules/general/rework-patterns.md`
- 関連 issue: 本リポ #53 (Phase 3 S7 — CLOSED)
- agent-base 既存 issue: `#124` (Keychain 移行 follow-up)