### PR TITLE
test(#85): tmux.ts ensureSocketConfigured の unhappy-path coverage

### DIFF
--- a/supervisor/tests/session/tmux.test.ts
+++ b/supervisor/tests/session/tmux.test.ts
@@ -26,10 +26,9 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
     ensureSocketConfigured();
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][0]).toBe(
-      "[tmux] ensureSocketConfigured failed:",
-    );
-    expect(warnSpy.mock.calls[0][1]).toBeInstanceOf(Error);
+    const firstCall = warnSpy.mock.calls[0]!;
+    expect(firstCall[0]).toBe("[tmux] ensureSocketConfigured failed:");
+    expect(firstCall[1]).toBeInstanceOf(Error);
 
     warnSpy.mockRestore();
   });
@@ -95,7 +94,7 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
 
     ensureSocketConfigured();
 
-    expect(warnSpy.mock.calls[0][1]).toBe(customError);
+    expect(warnSpy.mock.calls[0]![1]).toBe(customError);
 
     warnSpy.mockRestore();
   });
@@ -109,7 +108,7 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
     ensureSocketConfigured();
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0][1]).toBe("permission denied raw string");
+    expect(warnSpy.mock.calls[0]![1]).toBe("permission denied raw string");
 
     warnSpy.mockRestore();
   });

--- a/supervisor/tests/session/tmux.test.ts
+++ b/supervisor/tests/session/tmux.test.ts
@@ -1,4 +1,12 @@
-import { describe, test, expect, mock, spyOn } from "bun:test";
+import {
+  describe,
+  test,
+  expect,
+  mock,
+  spyOn,
+  beforeEach,
+  afterEach,
+} from "bun:test";
 
 /**
  * Tests for Issue #85: ensureSocketConfigured unhappy-path coverage.
@@ -10,18 +18,42 @@ import { describe, test, expect, mock, spyOn } from "bun:test";
 
 let mockExecSyncImpl: () => string = () => "";
 
+// Spy-wrapped mock so we can assert the command/options passed to execSync
+// (#117 follow-up: gemini medium #3142222781).
+const mockExecSync = mock((..._args: unknown[]) => mockExecSyncImpl());
+
 mock.module("child_process", () => ({
-  execSync: () => mockExecSyncImpl(),
+  execSync: mockExecSync,
 }));
 
-const { ensureSocketConfigured } = await import("../../src/session/tmux");
+const { ensureSocketConfigured, TMUX_CMD } = await import(
+  "../../src/session/tmux"
+);
+
+function setupWarnSpy() {
+  return spyOn(console, "warn").mockImplementation(() => {});
+}
 
 describe("ensureSocketConfigured unhappy-path (#85)", () => {
+  // Hoisted to beforeEach/afterEach so a failing assertion never leaves a
+  // stale spy attached to console.warn (#117 follow-up: gemini medium
+  // #3142222783).
+  let warnSpy: ReturnType<typeof setupWarnSpy>;
+
+  beforeEach(() => {
+    mockExecSyncImpl = () => "";
+    mockExecSync.mockClear();
+    warnSpy = setupWarnSpy();
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
   test("warns when execSync throws an error other than 'no server running'", () => {
     mockExecSyncImpl = () => {
       throw new Error("EACCES: permission denied, /tmp/tmux-501");
     };
-    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
 
     ensureSocketConfigured();
 
@@ -29,60 +61,46 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
     const firstCall = warnSpy.mock.calls[0]!;
     expect(firstCall[0]).toBe("[tmux] ensureSocketConfigured failed:");
     expect(firstCall[1]).toBeInstanceOf(Error);
-
-    warnSpy.mockRestore();
   });
 
   test("stays silent when execSync throws 'no server running' (first-call case)", () => {
     mockExecSyncImpl = () => {
       throw new Error("no server running on /tmp/tmux-501/claude-hub");
     };
-    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
 
     ensureSocketConfigured();
 
     expect(warnSpy).not.toHaveBeenCalled();
-
-    warnSpy.mockRestore();
   });
 
   test("stays silent when execSync succeeds", () => {
     mockExecSyncImpl = () => "";
-    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
 
     ensureSocketConfigured();
 
     expect(warnSpy).not.toHaveBeenCalled();
-
-    warnSpy.mockRestore();
   });
 
   test("matches 'no server running' regex case-insensitively", () => {
     mockExecSyncImpl = () => {
       throw new Error("No Server Running");
     };
-    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
 
     ensureSocketConfigured();
 
     expect(warnSpy).not.toHaveBeenCalled();
-
-    warnSpy.mockRestore();
   });
 
   test("re-runs and re-warns on every invocation (no memoisation by design)", () => {
     mockExecSyncImpl = () => {
       throw new Error("EBUSY: tmux socket is locked");
     };
-    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
 
     ensureSocketConfigured();
     ensureSocketConfigured();
     ensureSocketConfigured();
 
     expect(warnSpy).toHaveBeenCalledTimes(3);
-
-    warnSpy.mockRestore();
   });
 
   test("preserves the original Error instance in the warning payload", () => {
@@ -90,26 +108,41 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
     mockExecSyncImpl = () => {
       throw customError;
     };
-    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
 
     ensureSocketConfigured();
 
     expect(warnSpy.mock.calls[0]![1]).toBe(customError);
-
-    warnSpy.mockRestore();
   });
 
-  test("handles non-Error throw values via String(err) coercion", () => {
+  test("passes raw non-Error thrown value through to console.warn", () => {
+    // Plain object: not an Error instance, and String(err) === "[object Object]"
+    // which does NOT match /no server running/i, so the isNoServer guard
+    // correctly falls through to the warn branch (#117 follow-up: coderabbit
+    // minor #3142223332).
+    const thrown = { code: "EPERM", path: "/tmp/tmux-501" };
     mockExecSyncImpl = () => {
-      throw "permission denied raw string";
+      throw thrown;
     };
-    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
 
     ensureSocketConfigured();
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
-    expect(warnSpy.mock.calls[0]![1]).toBe("permission denied raw string");
+    expect(warnSpy.mock.calls[0]![1]).toBe(thrown);
+  });
 
-    warnSpy.mockRestore();
+  test("invokes execSync with the expected tmux command and options", () => {
+    mockExecSyncImpl = () => "";
+
+    ensureSocketConfigured();
+
+    expect(mockExecSync).toHaveBeenCalledTimes(1);
+    const call = mockExecSync.mock.calls[0]!;
+    const cmd = call[0] as string;
+    const opts = call[1] as { timeout?: number; stdio?: string };
+    expect(cmd).toContain(TMUX_CMD);
+    expect(cmd).toContain("set-option -g mouse off");
+    expect(cmd).toContain("set-option -g mode-keys emacs");
+    expect(cmd).toContain("set-option -g history-limit 10000");
+    expect(opts).toMatchObject({ timeout: 3000, stdio: "pipe" });
   });
 });

--- a/supervisor/tests/session/tmux.test.ts
+++ b/supervisor/tests/session/tmux.test.ts
@@ -1,0 +1,116 @@
+import { describe, test, expect, mock, spyOn } from "bun:test";
+
+/**
+ * Tests for Issue #85: ensureSocketConfigured unhappy-path coverage.
+ *
+ * The function in src/session/tmux.ts swallows `no server running` (expected
+ * on the very first call before any tmux server exists) and warns on any
+ * other error. We verify both branches by mocking child_process.execSync.
+ */
+
+let mockExecSyncImpl: () => string = () => "";
+
+mock.module("child_process", () => ({
+  execSync: () => mockExecSyncImpl(),
+}));
+
+const { ensureSocketConfigured } = await import("../../src/session/tmux");
+
+describe("ensureSocketConfigured unhappy-path (#85)", () => {
+  test("warns when execSync throws an error other than 'no server running'", () => {
+    mockExecSyncImpl = () => {
+      throw new Error("EACCES: permission denied, /tmp/tmux-501");
+    };
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+    ensureSocketConfigured();
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][0]).toBe(
+      "[tmux] ensureSocketConfigured failed:",
+    );
+    expect(warnSpy.mock.calls[0][1]).toBeInstanceOf(Error);
+
+    warnSpy.mockRestore();
+  });
+
+  test("stays silent when execSync throws 'no server running' (first-call case)", () => {
+    mockExecSyncImpl = () => {
+      throw new Error("no server running on /tmp/tmux-501/claude-hub");
+    };
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+    ensureSocketConfigured();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  test("stays silent when execSync succeeds", () => {
+    mockExecSyncImpl = () => "";
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+    ensureSocketConfigured();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  test("matches 'no server running' regex case-insensitively", () => {
+    mockExecSyncImpl = () => {
+      throw new Error("No Server Running");
+    };
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+    ensureSocketConfigured();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+
+    warnSpy.mockRestore();
+  });
+
+  test("re-runs and re-warns on every invocation (no memoisation by design)", () => {
+    mockExecSyncImpl = () => {
+      throw new Error("EBUSY: tmux socket is locked");
+    };
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+    ensureSocketConfigured();
+    ensureSocketConfigured();
+    ensureSocketConfigured();
+
+    expect(warnSpy).toHaveBeenCalledTimes(3);
+
+    warnSpy.mockRestore();
+  });
+
+  test("preserves the original Error instance in the warning payload", () => {
+    const customError = new Error("ENOSPC: no space left on device");
+    mockExecSyncImpl = () => {
+      throw customError;
+    };
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+    ensureSocketConfigured();
+
+    expect(warnSpy.mock.calls[0][1]).toBe(customError);
+
+    warnSpy.mockRestore();
+  });
+
+  test("handles non-Error throw values via String(err) coercion", () => {
+    mockExecSyncImpl = () => {
+      throw "permission denied raw string";
+    };
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+
+    ensureSocketConfigured();
+
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(warnSpy.mock.calls[0][1]).toBe("permission denied raw string");
+
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## 概要

PR #84 で導入された `supervisor/src/session/tmux.ts` の `ensureSocketConfigured()` に、`no server running` 以外のエラー時の console.warn 分岐 (line 60) のテストが無く Codecov コメントで patch coverage 95.65% (1 line missing) と警告されていた。本 PR で test を追加し 100% カバーする。

Closes #85

## 変更点

`supervisor/tests/session/tmux.test.ts` を新規追加（7 tests）:

| # | ケース | 検証 |
|---|---|---|
| 1 | execSync が `EACCES: permission denied` を throw | `console.warn("[tmux] ensureSocketConfigured failed:", err)` が 1 回呼ばれる |
| 2 | execSync が `no server running` を throw | warn は呼ばれない (silent: 初回 call の expected case) |
| 3 | execSync が成功 | warn は呼ばれない |
| 4 | execSync が `No Server Running` (case-insensitive) を throw | warn は呼ばれない (regex `/i` フラグ確認) |
| 5 | 連続 3 回呼び出し | 毎回再実行され warn 3 回（no memoisation by design 確認） |
| 6 | カスタム Error instance | warn 第二引数が同一 instance |
| 7 | 文字列 throw (non-Error) | `String(err)` 経路カバー |

`child_process.execSync` は `mock.module("child_process", ...)` で差し替え、`mockExecSyncImpl` 変数で各テストごとに振る舞いを切替。

## AC 検証結果

| AC | 検証内容 | コマンド | 結果 |
|---|---|---|---|
| AC-1 | `bun test tests/session/tmux.test.ts` が PASS | (実行) | ✅ 7 pass / 0 fail |
| AC-2 | `tmux.ts` patch coverage 100% | (CI codecov) | ⏭️ CI で確認 |
| AC-3 | codecov コメントから tmux.ts が消える | (CI codecov) | ⏭️ CI で確認 |

## 統合ジャーニーAC（不要・理由）

テスト追加のみ、production コード変更なし。外部から観測可能な振る舞いは変わらないため不要。

## 補足

Issue #85 「やること 3」の `socketConfigured` flag が `false` のまま再実行... という記述は、実装時点で memoization が意図的に削除されている（tmux.ts:42 docstring「intentionally has no memoisation flag」）ためテストケース 5 の「複数回呼び出しで毎回再実行」で意図を明示的に確認した。

## 関連

- 起点: #85 (PR #84 の codecov patch coverage 警告)
- 親: PR #84 (Issue #83 / Epic #79 / Issue #73)
- RW: agent-base RW-019

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Tests**
  * セッション関連のエラーハンドリングと警告表示の信頼性を高めるテストを追加しました。
  * 警告が正しく発生・抑止されること、重複呼び出し時の動作、投げられた元の例外情報が保持されることを検証しています。
  * コマンド実行時のタイムアウトや出力取り扱いの動作も検証対象に含まれます。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->