### PR TITLE
fix(#88): .supervisor-relay-url を XDG_RUNTIME_DIR 配下に集約 (cwd 汚染解消)

### DIFF
--- a/supervisor/hooks/progress-relay.sh
+++ b/supervisor/hooks/progress-relay.sh
@@ -7,10 +7,12 @@
 # relayUrlFilePath). Claude Code hooks don't inherit custom env vars, so we
 # fall back to the filesystem. Layout (Issue #88):
 #
-#   ${XDG_RUNTIME_DIR:-/tmp}/claude-hub-supervisor/<sanitised-cwd>.relay-url
+#   $XDG_RUNTIME_DIR set: ${XDG_RUNTIME_DIR}/claude-hub-supervisor/<sanitised-cwd>.relay-url
+#   $XDG_RUNTIME_DIR unset (typical macOS): /tmp/claude-hub-supervisor-<USER>/<sanitised-cwd>.relay-url
 #
-# where <sanitised-cwd> is the absolute cwd with the leading `/` stripped and
-# the remaining `/` replaced by `_` (matches the TS helper exactly).
+# <sanitised-cwd> is the absolute cwd with all leading `/` stripped and any
+# non-`[A-Za-z0-9._-]` character replaced by `_`. The sanitisation must match
+# `relayUrlFilePath()` in manager.ts exactly.
 #
 # Sends: { tool, message } where message is a short human-readable target
 # extracted from tool_input (e.g., "pgrep -fl claude" for Bash).
@@ -25,10 +27,15 @@ if [ -z "$CWD" ]; then
 fi
 
 # Sanitise the cwd to match relayUrlFilePath() in manager.ts
-SANITISED="${CWD#/}"
-SANITISED="${SANITISED//\//_}"
-RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp}"
-RELAY_URL_FILE="${RUNTIME_DIR}/claude-hub-supervisor/${SANITISED}.relay-url"
+# - strip ALL leading slashes (TS: replace(/^\/+/, ""))
+# - replace any non-[A-Za-z0-9._-] with `_` (TS: replace(/[^A-Za-z0-9._-]/g, "_"))
+SANITISED=$(printf '%s' "$CWD" | sed -e 's|^/*||' -e 's|[^A-Za-z0-9._-]|_|g')
+if [ -n "$XDG_RUNTIME_DIR" ]; then
+  RUNTIME_DIR="${XDG_RUNTIME_DIR}/claude-hub-supervisor"
+else
+  RUNTIME_DIR="/tmp/claude-hub-supervisor-${USER:-default}"
+fi
+RELAY_URL_FILE="${RUNTIME_DIR}/${SANITISED}.relay-url"
 if [ ! -f "$RELAY_URL_FILE" ]; then
   exit 0
 fi

--- a/supervisor/hooks/progress-relay.sh
+++ b/supervisor/hooks/progress-relay.sh
@@ -2,8 +2,15 @@
 # Claude Code PostToolUse hook: sends tool progress to Supervisor's HTTP relay.
 # Called with JSON on stdin containing tool_name, tool_input, cwd, etc.
 #
-# Relay URL is read from $CWD/.supervisor-relay-url (written by SessionManager).
-# Claude Code hooks don't inherit custom env vars, so we use filesystem.
+# Relay URL is read from a runtime-dir file keyed by the sanitised cwd, written
+# by SessionManager.start (see supervisor/src/session/manager.ts
+# relayUrlFilePath). Claude Code hooks don't inherit custom env vars, so we
+# fall back to the filesystem. Layout (Issue #88):
+#
+#   ${XDG_RUNTIME_DIR:-/tmp}/claude-hub-supervisor/<sanitised-cwd>.relay-url
+#
+# where <sanitised-cwd> is the absolute cwd with the leading `/` stripped and
+# the remaining `/` replaced by `_` (matches the TS helper exactly).
 #
 # Sends: { tool, message } where message is a short human-readable target
 # extracted from tool_input (e.g., "pgrep -fl claude" for Bash).
@@ -17,7 +24,11 @@ if [ -z "$CWD" ]; then
   exit 0
 fi
 
-RELAY_URL_FILE="${CWD}/.supervisor-relay-url"
+# Sanitise the cwd to match relayUrlFilePath() in manager.ts
+SANITISED="${CWD#/}"
+SANITISED="${SANITISED//\//_}"
+RUNTIME_DIR="${XDG_RUNTIME_DIR:-/tmp}"
+RELAY_URL_FILE="${RUNTIME_DIR}/claude-hub-supervisor/${SANITISED}.relay-url"
 if [ ! -f "$RELAY_URL_FILE" ]; then
   exit 0
 fi

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -24,6 +24,24 @@ import {
 const CLAUDE_PATH = resolve(homedir(), ".local", "bin", "claude");
 const TMUX_SESSION_PREFIX = "claude-";
 
+/**
+ * Compute the runtime-dir path that holds the relay URL for a given project
+ * cwd. Sanitises by stripping the leading `/` and replacing the remaining
+ * slashes with underscores so each session's URL lives in its own file:
+ *
+ *   /Users/x/team_salary  →  ${RUNTIME_DIR}/claude-hub-supervisor/Users_x_team_salary.relay-url
+ *
+ * The same scheme is mirrored in `supervisor/hooks/progress-relay.sh`. If you
+ * change the layout here, update the hook and its tests as well.
+ *
+ * Issue #88: keeps the file out of every project repo.
+ */
+export function relayUrlFilePath(projectDir: string): string {
+  const runtimeDir = process.env.XDG_RUNTIME_DIR || "/tmp";
+  const sanitised = projectDir.replace(/^\/+/, "").replace(/\//g, "_");
+  return `${runtimeDir}/claude-hub-supervisor/${sanitised}.relay-url`;
+}
+
 export interface SessionManagerOptions {
   /**
    * Inject side-effect adapters for tmux / iTerm2 / relay-server / process
@@ -121,11 +139,19 @@ export class SessionManager {
     // Build the claude command — unset ANTHROPIC_API_KEY to use Claude Max subscription
     const relayUrl = `http://localhost:${this.effects.relayServer.getPort()}/relay/${threadId}`;
 
+    // Relay URL is written to a runtime-dir file keyed by the project cwd so
+    // that progress-relay.sh (PostToolUse hook) can locate it from $CWD without
+    // dropping `.supervisor-relay-url` into every project repo (Issue #88).
+    // The hook applies the same sanitisation logic to its `$CWD` payload.
+    const relayUrlFile = relayUrlFilePath(config.dir);
+    const relayUrlDir = relayUrlFile.replace(/\/[^/]+$/, "");
+
     const claudeCmd = [
       "unset ANTHROPIC_API_KEY",
       `export PATH="${resolve(homedir(), ".local/bin")}:${resolve(homedir(), ".bun/bin")}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"`,
       `export SUPERVISOR_RELAY_URL="${relayUrl}"`,
-      `printf "%s" "${relayUrl}" > "${config.dir}/.supervisor-relay-url"`,
+      `mkdir -p "${relayUrlDir}"`,
+      `printf "%s" "${relayUrl}" > "${relayUrlFile}"`,
       `cd "${config.dir}"`,
       `exec ${CLAUDE_PATH} --dangerously-skip-permissions --name "${config.channelName}"`,
     ].join(" && ");

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -26,10 +26,16 @@ const TMUX_SESSION_PREFIX = "claude-";
 
 /**
  * Compute the runtime-dir path that holds the relay URL for a given project
- * cwd. Sanitises by stripping the leading `/` and replacing the remaining
- * slashes with underscores so each session's URL lives in its own file:
+ * cwd. Sanitises by stripping every leading `/` and replacing any character
+ * outside `[A-Za-z0-9._-]` with `_`, so each session's URL lives in its own
+ * file and the path is shell-safe even if `projectDir` contains quotes:
  *
- *   /Users/x/team_salary  →  ${RUNTIME_DIR}/claude-hub-supervisor/Users_x_team_salary.relay-url
+ *   /Users/x/team_salary  →  ${RUNTIME_DIR}/Users_x_team_salary.relay-url
+ *
+ * `XDG_RUNTIME_DIR` is per-user by spec (`/run/user/$UID`), so when present
+ * we just append `claude-hub-supervisor`. When absent (typical macOS) we fall
+ * back to `/tmp/claude-hub-supervisor-<USER>` to avoid multi-user mkdir
+ * collisions on shared `/tmp`.
  *
  * The same scheme is mirrored in `supervisor/hooks/progress-relay.sh`. If you
  * change the layout here, update the hook and its tests as well.
@@ -37,9 +43,15 @@ const TMUX_SESSION_PREFIX = "claude-";
  * Issue #88: keeps the file out of every project repo.
  */
 export function relayUrlFilePath(projectDir: string): string {
-  const runtimeDir = process.env.XDG_RUNTIME_DIR || "/tmp";
-  const sanitised = projectDir.replace(/^\/+/, "").replace(/\//g, "_");
-  return `${runtimeDir}/claude-hub-supervisor/${sanitised}.relay-url`;
+  const fromXdg = process.env.XDG_RUNTIME_DIR;
+  const user = process.env.USER || "default";
+  const runtimeDir = fromXdg
+    ? `${fromXdg}/claude-hub-supervisor`
+    : `/tmp/claude-hub-supervisor-${user}`;
+  const sanitised = projectDir
+    .replace(/^\/+/, "")
+    .replace(/[^A-Za-z0-9._-]/g, "_");
+  return `${runtimeDir}/${sanitised}.relay-url`;
 }
 
 export interface SessionManagerOptions {

--- a/supervisor/tests/hooks/progress-relay.test.ts
+++ b/supervisor/tests/hooks/progress-relay.test.ts
@@ -13,7 +13,18 @@ const HOOK_PATH = resolve(import.meta.dir, "../../hooks/progress-relay.sh");
  */
 function setupTestEnv(relayUrl: string) {
   const dir = mkdtempSync(resolve(tmpdir(), "progress-relay-test-"));
-  writeFileSync(resolve(dir, ".supervisor-relay-url"), relayUrl, "utf8");
+
+  // Issue #88: relay URL file lives in $XDG_RUNTIME_DIR/claude-hub-supervisor/
+  // keyed by sanitised cwd, NOT inside the project dir.
+  const runtimeDir = mkdtempSync(resolve(tmpdir(), "progress-relay-runtime-"));
+  const sanitisedCwd = dir.replace(/^\/+/, "").replace(/\//g, "_");
+  const relayDir = resolve(runtimeDir, "claude-hub-supervisor");
+  mkdirSync(relayDir, { recursive: true });
+  writeFileSync(
+    resolve(relayDir, `${sanitisedCwd}.relay-url`),
+    relayUrl,
+    "utf8",
+  );
 
   // Mock curl: writes all args to a file, reads stdin -d @- and writes it too
   const mockBinDir = resolve(dir, "mock-bin");
@@ -36,11 +47,12 @@ done
   const mockCurlPath = resolve(mockBinDir, "curl");
   writeFileSync(mockCurlPath, mockCurl, { mode: 0o755 });
 
-  return { dir, curlArgsFile, curlStdinFile, mockBinDir };
+  return { dir, curlArgsFile, curlStdinFile, mockBinDir, runtimeDir };
 }
 
-function cleanup(dir: string) {
-  rmSync(dir, { recursive: true, force: true });
+function cleanup(env: ReturnType<typeof setupTestEnv>) {
+  rmSync(env.dir, { recursive: true, force: true });
+  rmSync(env.runtimeDir, { recursive: true, force: true });
 }
 
 function makeInput(toolName: string, toolInput: Record<string, unknown>, cwd: string): string {
@@ -58,13 +70,13 @@ describe("progress-relay.sh URL replacement", () => {
   });
 
   afterEach(() => {
-    cleanup(env.dir);
+    cleanup(env);
   });
 
   test("PROGRESS_URL has no backslash-escaped slashes", async () => {
     const input = makeInput("Bash", { command: "echo test" }, env.dir);
 
-    await $`echo ${input} | PATH=${env.mockBinDir}:$PATH bash ${HOOK_PATH}`
+    await $`echo ${input} | PATH=${env.mockBinDir}:$PATH XDG_RUNTIME_DIR=${env.runtimeDir} bash ${HOOK_PATH}`
       .quiet()
       .nothrow();
 
@@ -77,21 +89,25 @@ describe("progress-relay.sh URL replacement", () => {
 });
 
 // ---------------------------------------------------------------------------
-// Test 2: Static analysis — manager.ts writes .supervisor-relay-url
+// Test 2: Static analysis — manager.ts writes the relay URL file via
+// relayUrlFilePath() helper (Issue #88: file lives in $XDG_RUNTIME_DIR, not
+// in the project repo).
 // ---------------------------------------------------------------------------
-describe("manager.ts .supervisor-relay-url write", () => {
-  test("start() contains printf to .supervisor-relay-url in tmux command", () => {
+describe("manager.ts relay URL write", () => {
+  test("start() contains printf to the relayUrlFilePath result in tmux command", () => {
     const managerSource = readFileSync(
       resolve(import.meta.dir, "../../src/session/manager.ts"),
       "utf8"
     );
 
-    // The tmux command string should include writing the relay URL file
-    expect(managerSource).toMatch(/\.supervisor-relay-url/);
+    // The tmux command string should reference the helper-derived file path
+    expect(managerSource).toMatch(/relayUrlFile/);
     // Check for the printf pattern that writes the relay URL (double-quoted for tmux safety)
     expect(managerSource).toMatch(
-      /printf\s+"%s"\s+.*\.supervisor-relay-url/
+      /printf\s+"%s"\s+"\$\{relayUrl\}"\s+>\s+"\$\{relayUrlFile\}"/
     );
+    // mkdir -p must precede the printf so the runtime dir exists
+    expect(managerSource).toMatch(/mkdir\s+-p\s+"\$\{relayUrlDir\}"/);
   });
 
   test("start() does NOT use writeFileSync (printf in tmux is sufficient)", () => {
@@ -102,6 +118,33 @@ describe("manager.ts .supervisor-relay-url write", () => {
 
     // writeFileSync for relay URL should have been removed
     expect(managerSource).not.toMatch(/writeFileSync\(relayUrlFile/);
+  });
+
+  test("relayUrlFilePath sanitises cwd into $XDG_RUNTIME_DIR/claude-hub-supervisor/<sanitised>.relay-url", async () => {
+    const { relayUrlFilePath } = await import("../../src/session/manager");
+    const result = relayUrlFilePath("/Users/x/team_salary");
+    // Default to /tmp when XDG_RUNTIME_DIR is unset
+    expect(result).toMatch(
+      /\/claude-hub-supervisor\/Users_x_team_salary\.relay-url$/
+    );
+  });
+
+  test("relayUrlFilePath honours XDG_RUNTIME_DIR when set", async () => {
+    const original = process.env.XDG_RUNTIME_DIR;
+    process.env.XDG_RUNTIME_DIR = "/run/user/501";
+    try {
+      const { relayUrlFilePath } = await import("../../src/session/manager");
+      const result = relayUrlFilePath("/Users/x/agent-base");
+      expect(result).toBe(
+        "/run/user/501/claude-hub-supervisor/Users_x_agent-base.relay-url"
+      );
+    } finally {
+      if (original !== undefined) {
+        process.env.XDG_RUNTIME_DIR = original;
+      } else {
+        delete process.env.XDG_RUNTIME_DIR;
+      }
+    }
   });
 });
 
@@ -116,7 +159,7 @@ describe("progress-relay.sh tool message extraction", () => {
   });
 
   afterEach(() => {
-    cleanup(env.dir);
+    cleanup(env);
   });
 
   async function runHookAndGetMessage(
@@ -125,7 +168,7 @@ describe("progress-relay.sh tool message extraction", () => {
   ): Promise<{ tool: string; message: string } | null> {
     const input = makeInput(toolName, toolInput, env.dir);
 
-    await $`echo ${input} | PATH=${env.mockBinDir}:$PATH bash ${HOOK_PATH}`
+    await $`echo ${input} | PATH=${env.mockBinDir}:$PATH XDG_RUNTIME_DIR=${env.runtimeDir} bash ${HOOK_PATH}`
       .quiet()
       .nothrow();
 
@@ -195,7 +238,8 @@ describe("manager.ts tmux command syntax", () => {
       "unset ANTHROPIC_API_KEY",
       'export PATH="/tmp/.local/bin:/tmp/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"',
       'export SUPERVISOR_RELAY_URL="http://localhost:12345/relay/thread-abc"',
-      'printf "%s" "http://localhost:12345/relay/thread-abc" > "/tmp/project/.supervisor-relay-url"',
+      'mkdir -p "/tmp/claude-hub-supervisor"',
+      'printf "%s" "http://localhost:12345/relay/thread-abc" > "/tmp/claude-hub-supervisor/tmp_project.relay-url"',
       'cd "/tmp/project"',
       'exec /tmp/claude --dangerously-skip-permissions --name "my-channel"',
     ].join(" && ");

--- a/supervisor/tests/hooks/progress-relay.test.ts
+++ b/supervisor/tests/hooks/progress-relay.test.ts
@@ -120,16 +120,24 @@ describe("manager.ts relay URL write", () => {
     expect(managerSource).not.toMatch(/writeFileSync\(relayUrlFile/);
   });
 
-  test("relayUrlFilePath sanitises cwd into $XDG_RUNTIME_DIR/claude-hub-supervisor/<sanitised>.relay-url", async () => {
-    const { relayUrlFilePath } = await import("../../src/session/manager");
-    const result = relayUrlFilePath("/Users/x/team_salary");
-    // Default to /tmp when XDG_RUNTIME_DIR is unset
-    expect(result).toMatch(
-      /\/claude-hub-supervisor\/Users_x_team_salary\.relay-url$/
-    );
+  test("relayUrlFilePath sanitises cwd and falls back to /tmp/claude-hub-supervisor-<USER> when XDG unset", async () => {
+    const originalXdg = process.env.XDG_RUNTIME_DIR;
+    const originalUser = process.env.USER;
+    delete process.env.XDG_RUNTIME_DIR;
+    process.env.USER = "alice";
+    try {
+      const { relayUrlFilePath } = await import("../../src/session/manager");
+      expect(relayUrlFilePath("/Users/x/team_salary")).toBe(
+        "/tmp/claude-hub-supervisor-alice/Users_x_team_salary.relay-url"
+      );
+    } finally {
+      if (originalXdg !== undefined) process.env.XDG_RUNTIME_DIR = originalXdg;
+      if (originalUser !== undefined) process.env.USER = originalUser;
+      else delete process.env.USER;
+    }
   });
 
-  test("relayUrlFilePath honours XDG_RUNTIME_DIR when set", async () => {
+  test("relayUrlFilePath honours XDG_RUNTIME_DIR when set (per-user dir by spec)", async () => {
     const original = process.env.XDG_RUNTIME_DIR;
     process.env.XDG_RUNTIME_DIR = "/run/user/501";
     try {
@@ -145,6 +153,24 @@ describe("manager.ts relay URL write", () => {
         delete process.env.XDG_RUNTIME_DIR;
       }
     }
+  });
+
+  test("relayUrlFilePath sanitises shell-unsafe characters (defensive)", async () => {
+    const { relayUrlFilePath } = await import("../../src/session/manager");
+    // double-quotes / spaces / backticks must become `_` so the resulting path
+    // cannot break the printf > "${file}" tmux command
+    const result = relayUrlFilePath('/Users/x/dir"with spaces`');
+    expect(result).toMatch(/Users_x_dir_with_spaces_\.relay-url$/);
+    expect(result).not.toContain('"');
+    expect(result).not.toContain("`");
+    expect(result).not.toContain(" ");
+  });
+
+  test("relayUrlFilePath strips multiple leading slashes (matches TS regex /^\\/+/)", async () => {
+    const { relayUrlFilePath } = await import("../../src/session/manager");
+    expect(relayUrlFilePath("///Users/x/foo")).toMatch(
+      /\/Users_x_foo\.relay-url$/
+    );
   });
 });
 
@@ -238,8 +264,8 @@ describe("manager.ts tmux command syntax", () => {
       "unset ANTHROPIC_API_KEY",
       'export PATH="/tmp/.local/bin:/tmp/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"',
       'export SUPERVISOR_RELAY_URL="http://localhost:12345/relay/thread-abc"',
-      'mkdir -p "/tmp/claude-hub-supervisor"',
-      'printf "%s" "http://localhost:12345/relay/thread-abc" > "/tmp/claude-hub-supervisor/tmp_project.relay-url"',
+      'mkdir -p "/tmp/claude-hub-supervisor-alice"',
+      'printf "%s" "http://localhost:12345/relay/thread-abc" > "/tmp/claude-hub-supervisor-alice/tmp_project.relay-url"',
       'cd "/tmp/project"',
       'exec /tmp/claude --dangerously-skip-permissions --name "my-channel"',
     ].join(" && ");


### PR DESCRIPTION
## 概要

Supervisor が起動時に書き出していた `.supervisor-relay-url` が **各プロジェクトの cwd に固定** されており、claude-hub 以外で起動したセッション（agent-base / team_salary / kicad / convert-service 等）の repo に未追跡ファイルが落ちる問題を解消。

agent-base PR #143 (closed) で「他リポの `.gitignore` に `.supervisor-relay-url` を書く」案が**責務違反**として却下されており、本 PR は claude-hub 側の根本対処に該当。Issue #88 の **推奨案 A** を実装。

Closes #88

## 設計

```
旧: ${config.dir}/.supervisor-relay-url               ← 各プロジェクト repo を汚染
新: ${XDG_RUNTIME_DIR:-/tmp}/claude-hub-supervisor/
    Users_harieshokunin_team_salary.relay-url        ← 1箇所に集約
    Users_harieshokunin_agent-base.relay-url
    ...
```

- ファイル名は cwd の sanitisation 結果（`/Users/x/team_salary` → `Users_x_team_salary.relay-url`）
- TS 側 `relayUrlFilePath(projectDir)` と bash 側 sanitisation logic は厳密に同じルール
- `mkdir -p` を tmux command 内に追加してディレクトリ存在を保証
- macOS は `XDG_RUNTIME_DIR` が typically unset なので `/tmp` フォールバック

## 変更ファイル (3)

| ファイル | 変更内容 |
|---|---|
| `supervisor/src/session/manager.ts` | `relayUrlFilePath()` helper を export 追加。tmux command で `mkdir -p && printf > <relayUrlFile>` |
| `supervisor/hooks/progress-relay.sh` | bash 側で同じ sanitisation を行い `${XDG_RUNTIME_DIR:-/tmp}/claude-hub-supervisor/<sanitised>.relay-url` から読み込み |
| `supervisor/tests/hooks/progress-relay.test.ts` | setupTestEnv が runtimeDir を別途 mkdtemp、cleanup シグネチャ変更、hook 起動に `XDG_RUNTIME_DIR=` 注入、Test 2 を 4 ケースに再構成、Test 4 の claudeCmd 再構築を新仕様に更新 |

合計 +100 / -19 行。

## AC 検証結果

| AC | 検証内容 | コマンド | 結果 | 判定 |
|---|---|---|---|---|
| AC-1 | cwd 非依存に出力 | `relayUrlFilePath("/Users/x/team_salary")` | `…/claude-hub-supervisor/Users_x_team_salary.relay-url` | ✅ PASS |
| AC-2 | XDG_RUNTIME_DIR 尊重 | `XDG_RUNTIME_DIR=/run/user/501` 設定で再実行 | `/run/user/501/claude-hub-supervisor/…` | ✅ PASS |
| AC-3 | hook が新 path から読める | `XDG_RUNTIME_DIR=tmpdir bash progress-relay.sh` | 11 pass / 0 fail | ✅ PASS |
| AC-4 | manager 既存テスト regression なし | `bun test supervisor/tests/session/manager.test.ts` | 17 pass / 0 fail | ✅ PASS |
| AC-5 | 全体 regression なし | `bun test supervisor/tests` | 101 pass / 3 skip / 2 fail | ⚠️ 既存 fail のみ |

⚠️ 既存 fail 2 件 (`tests/commands/session-interaction.test.ts` の `ENOENT: src/commands/session.ts`) は **本 PR と無関係**。CWD 依存の relative path で `bun test` をリポ root から走らせると ENOENT になる既存問題（`bun test --cwd supervisor` なら通る）。後続 Issue が必要なら別途起票。

## 統合ジャーニーAC

| 操作 | 期待結果 | 検証手段 |
|---|---|---|
| Discord で `/session start agent-base` | agent-base スレッドが作成され、~/agent-base に **`.supervisor-relay-url` ファイルが落ちない** | `cd ~/agent-base && ls -la .supervisor-relay-url` → No such file |
| 同じスレッドで何かのコマンドを実行 | PostToolUse hook 経由で進捗が Discord スレッドに表示される | Discord 上で `🔧 <tool>: ...` が表示される |
| `/session stop` 後、もう一度 `/session start` | 再起動後も同様に動作（runtime dir のファイルは上書き） | 上 2 ケースが再現 |

実機検証は merge 後の Supervisor 再起動時に行う想定（マージ可決定的な決定的検証は AC-1〜AC-5 で完了）。

## 影響範囲

- **後方互換性**: なし（旧 `.supervisor-relay-url` ファイルが各 repo に残っていても無害だが手動削除が必要）。merge 後、ユーザーが各 repo で `find ~ -name '.supervisor-relay-url' -delete` 推奨。
- **Supervisor 再起動が必要**: launchd 配下の Supervisor は plist reload で再起動推奨。
- **Linux portability**: `XDG_RUNTIME_DIR` 標準準拠なので Linux でも自然に動作。

## 関連

- 起点 Issue: #88
- 経緯: agent-base PR #143 (closed) — 責務違反で却下
- 既存 fail に関する別 Issue 候補: `tests/commands/session-interaction.test.ts` の CWD 依存 ENOENT (本 PR 範囲外)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正

* リレーURLの管理方式を改善しました。ファイルの保存先がプロジェクトディレクトリからシステムのランタイムディレクトリへ変更されました。設定がより標準的で安全な場所に保存されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->