### PR TITLE
fix(#86): タイポしたスラッシュコマンドで Bot がアイドル化する問題を slash-prefix strip で防止

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -20,6 +20,10 @@ import {
   extractFilePaths,
   collectAttachableFiles,
 } from "./session/file-attacher";
+import {
+  looksLikeSlashCommand,
+  stripLeadingSlash,
+} from "./session/slash-prefix";
 
 export async function startBot(token: string): Promise<void> {
   const client = new Client({
@@ -195,6 +199,27 @@ export async function startBot(token: string): Promise<void> {
       messageText = "添付ファイルを確認してください。";
     }
     if (!messageText) return;
+
+    // Slash-prefix stripping: `/hanle-review XXX` → `hanle-review XXX`. Without
+    // this, Claude Code's Ink TUI enters its slash-command picker on `/`, and
+    // for a typo it stays open silently, hanging the per-thread relay queue
+    // until RELAY_TIMEOUT_MS — the bot looks idle to the user (Issue #86).
+    // Paths like `/usr/bin/ls` are intentionally not matched by
+    // looksLikeSlashCommand and pass through unchanged.
+    if (looksLikeSlashCommand(messageText)) {
+      const original = messageText;
+      messageText = stripLeadingSlash(messageText);
+      console.log(
+        `[Bot] Stripped slash prefix in thread ${threadId}: "${original.slice(0, 80)}" → "${messageText.slice(0, 80)}"`
+      );
+      try {
+        await thread.send(
+          `ℹ️ \`/\` 始まりの入力は Claude Code TUI のスラッシュピッカーで詰まる現象を避けるため \`/\` を除去して送信します（自然言語として処理されます。Issue #86）。`
+        );
+      } catch {
+        // Don't let the heads-up notification block the actual relay
+      }
+    }
 
     // Enqueue to prevent concurrent relay for the same thread.
     // Without this, the second message overwrites the first's pending request

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -212,13 +212,22 @@ export async function startBot(token: string): Promise<void> {
       console.log(
         `[Bot] Stripped slash prefix in thread ${threadId}: "${original.slice(0, 80)}" → "${messageText.slice(0, 80)}"`
       );
-      try {
-        await thread.send(
+      // Fire-and-forget: do NOT await. Awaiting Discord's send ACK before the
+      // enqueueForThread call below would let a later message in the same
+      // thread race past this notification's latency and enter the queue
+      // first, breaking message ordering (gemini-code-assist review on PR
+      // #115). The notification is purely informational; the queue must
+      // observe the original arrival order.
+      thread
+        .send(
           `ℹ️ \`/\` 始まりの入力は Claude Code TUI のスラッシュピッカーで詰まる現象を避けるため \`/\` を除去して送信します（自然言語として処理されます。Issue #86）。`
-        );
-      } catch {
-        // Don't let the heads-up notification block the actual relay
-      }
+        )
+        .catch((err: unknown) => {
+          console.warn(
+            `[Bot] Failed to post slash-strip notice to thread ${threadId}:`,
+            err
+          );
+        });
     }
 
     // Enqueue to prevent concurrent relay for the same thread.

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -209,8 +209,12 @@ export async function startBot(token: string): Promise<void> {
     if (looksLikeSlashCommand(messageText)) {
       const original = messageText;
       messageText = stripLeadingSlash(messageText);
+      // Log only the leading token (the slash command name) and the message
+      // length to mirror other relay logs (L246) and avoid leaking the
+      // user-supplied argument body through stdout (PR #115 nitpick — PII).
+      const firstToken = original.split(/\s/, 1)[0] ?? "";
       console.log(
-        `[Bot] Stripped slash prefix in thread ${threadId}: "${original.slice(0, 80)}" → "${messageText.slice(0, 80)}"`
+        `[Bot] Stripped slash prefix in thread ${threadId} (token="${firstToken.slice(0, 32)}", len=${original.length})`
       );
       // Fire-and-forget: do NOT await. Awaiting Discord's send ACK before the
       // enqueueForThread call below would let a later message in the same

--- a/supervisor/src/session/slash-prefix.ts
+++ b/supervisor/src/session/slash-prefix.ts
@@ -1,0 +1,30 @@
+/**
+ * Detect leading `/<command>` patterns (Claude Code TUI slash command style)
+ * at message start and strip the leading `/` so the TUI doesn't enter
+ * slash-picker mode.
+ *
+ * Issue #86: Forwarding `/<typo>` via tmux send-keys puts Claude Code's Ink
+ * TUI into the slash-command picker. If the command is a typo
+ * (e.g. `/hanle-review`) the picker stays open silently, the relay queue
+ * hangs until RELAY_TIMEOUT_MS, and the bot looks idle.
+ *
+ * Discord-side slash commands handled by this bot are limited to `/session`,
+ * which is already filtered out as `Events.InteractionCreate`. By the time a
+ * `/<word>` message reaches `Events.MessageCreate`, the user's slash command
+ * is either a typo or an attempt to invoke a Claude Code command from
+ * Discord (which isn't supported anyway). Strip-and-forward is the safest
+ * recovery: the user's intent reaches Claude as natural language.
+ *
+ * The match is intentionally narrow: a path like `/usr/bin/ls` or
+ * `/Users/x/foo` does NOT match because the first token is followed by `/`,
+ * not whitespace or end-of-string.
+ */
+const SLASH_PREFIX_RE = /^\/[A-Za-z][A-Za-z0-9_-]*(?:\s|$)/;
+
+export function looksLikeSlashCommand(text: string): boolean {
+  return SLASH_PREFIX_RE.test(text);
+}
+
+export function stripLeadingSlash(text: string): string {
+  return looksLikeSlashCommand(text) ? text.replace(/^\//, "") : text;
+}

--- a/supervisor/src/session/slash-prefix.ts
+++ b/supervisor/src/session/slash-prefix.ts
@@ -26,5 +26,7 @@ export function looksLikeSlashCommand(text: string): boolean {
 }
 
 export function stripLeadingSlash(text: string): string {
-  return looksLikeSlashCommand(text) ? text.replace(/^\//, "") : text;
+  // looksLikeSlashCommand guarantees a leading `/`, so slice(1) is a
+  // direct char-drop without the cost of a regex compile (PR #115 nitpick).
+  return looksLikeSlashCommand(text) ? text.slice(1) : text;
 }

--- a/supervisor/tests/session/slash-prefix.test.ts
+++ b/supervisor/tests/session/slash-prefix.test.ts
@@ -20,6 +20,8 @@ describe("looksLikeSlashCommand", () => {
     ["/help me", true],
     ["/h", true], // single letter command
     ["/abc_under-score123", true],
+    ["/help\n続き", true], // \s newline boundary (PR #115 nitpick)
+    ["/help\targ", true], // \s tab boundary (PR #115 nitpick)
   ])("matches `%s` → %s (slash-command shape)", (input, expected) => {
     expect(looksLikeSlashCommand(input)).toBe(expected);
   });
@@ -79,5 +81,13 @@ describe("stripLeadingSlash", () => {
     expect(stripLeadingSlash("/handle-reviews and /foo")).toBe(
       "handle-reviews and /foo",
     );
+  });
+
+  test("preserves trailing newline after stripping (PR #115 nitpick)", () => {
+    expect(stripLeadingSlash("/help\n続き")).toBe("help\n続き");
+  });
+
+  test("preserves trailing tab after stripping (PR #115 nitpick)", () => {
+    expect(stripLeadingSlash("/help\targ")).toBe("help\targ");
   });
 });

--- a/supervisor/tests/session/slash-prefix.test.ts
+++ b/supervisor/tests/session/slash-prefix.test.ts
@@ -1,0 +1,83 @@
+import { describe, test, expect } from "bun:test";
+import {
+  looksLikeSlashCommand,
+  stripLeadingSlash,
+} from "../../src/session/slash-prefix";
+
+/**
+ * Tests for Issue #86: typo'd slash commands like `/hanle-review` from a
+ * Discord message previously hung Claude Code's Ink TUI in its slash-command
+ * picker, blocking the per-thread relay queue until RELAY_TIMEOUT_MS.
+ */
+
+describe("looksLikeSlashCommand", () => {
+  test.each([
+    ["/handle-reviews", true],
+    ["/handle-reviews 109", true],
+    ["/hanle-review XXX", true],
+    ["/sesssion-resume", true],
+    ["/help", true],
+    ["/help me", true],
+    ["/h", true], // single letter command
+    ["/abc_under-score123", true],
+  ])("matches `%s` → %s (slash-command shape)", (input, expected) => {
+    expect(looksLikeSlashCommand(input)).toBe(expected);
+  });
+
+  test.each([
+    ["/usr/bin/ls", false], // path: first token followed by `/`, not space
+    ["/Users/x/foo", false], // path
+    ["/", false], // bare slash, no letter
+    ["//comment", false], // not letter after first `/`
+    ["/123abc", false], // starts with digit
+    ["", false], // empty
+    ["普通のテキスト", false], // no slash
+    ["何か /handle-reviews", false], // not at start
+    ["/-leading-dash", false], // not letter immediately after slash
+  ])("rejects `%s` → %s", (input, expected) => {
+    expect(looksLikeSlashCommand(input)).toBe(expected);
+  });
+});
+
+describe("stripLeadingSlash", () => {
+  test("strips a slash-command prefix (the typo case)", () => {
+    expect(stripLeadingSlash("/hanle-review XXX")).toBe("hanle-review XXX");
+  });
+
+  test("strips a slash-command prefix with no args", () => {
+    expect(stripLeadingSlash("/handle-reviews")).toBe("handle-reviews");
+  });
+
+  test("preserves a path-like leading slash (`/usr/bin/ls`)", () => {
+    expect(stripLeadingSlash("/usr/bin/ls")).toBe("/usr/bin/ls");
+  });
+
+  test("preserves a path-like leading slash (`/Users/x/foo`)", () => {
+    expect(stripLeadingSlash("/Users/x/foo")).toBe("/Users/x/foo");
+  });
+
+  test("preserves arbitrary natural language", () => {
+    expect(stripLeadingSlash("普通のテキスト")).toBe("普通のテキスト");
+  });
+
+  test("preserves a slash that is not at the very start", () => {
+    expect(stripLeadingSlash("何か /handle-reviews")).toBe(
+      "何か /handle-reviews"
+    );
+  });
+
+  test("preserves bare slash (no letter follows)", () => {
+    expect(stripLeadingSlash("/")).toBe("/");
+  });
+
+  test("preserves empty string", () => {
+    expect(stripLeadingSlash("")).toBe("");
+  });
+
+  test("only strips a single leading slash, not deeper structure", () => {
+    // The narrow regex ensures we don't strip into a path
+    expect(stripLeadingSlash("/handle-reviews and /foo")).toBe(
+      "handle-reviews and /foo",
+    );
+  });
+});


### PR DESCRIPTION
## 概要

Discord スレッドで `/hanle-review`（`/handle-reviews` のタイポ）など typo の slash command を投稿すると、Claude Code の Ink TUI がスラッシュコマンドピッカーに入って閉じる入力が来ないまま固まり、`enqueueForThread` の per-thread relay queue が `RELAY_TIMEOUT_MS` (5分) まで block される。これが「Bot がアイドル化」の正体だった。

修正: `MessageCreate` handler で `^/<word>(?:\s|$)` パターン（path 系を除く）を検知した場合、先頭の `/` を除去して自然言語として Claude Code に渡す。

Closes #86

## 設計判断

| 案 | Pros | Cons | 採用 |
|---|---|---|---|
| (a) `/<word>` を検知してエラー応答だけ返し relay しない | bug 完全防止 | `/help` 等の正当な Claude Code slash command も殺す | ❌ |
| (b) `/` を strip して自然言語として forward | 正当 command も自然言語として通る | TUI 経由の slash command 機能が Discord から呼べない（元から呼べていなかった） | ✅ |
| (c) Escape × N + send-keys で picker を抜ける | 既存仕様維持 | picker 抜け方が UI モードで挙動異なる、不安定 | ❌ |

→ 統合ジャーニーAC「`/` で始まる文字列をそのまま自然言語入力として Claude Code に転送する」を満たすため (b) を採用。

`/usr/bin/ls` や `/Users/x/foo` は narrow regex で **path として除外**（先頭 token の後が `/` で続くため `(?:\s|$)` に引っかからない）。

## 変更ファイル (3)

| ファイル | 内容 |
|---|---|
| `supervisor/src/session/slash-prefix.ts` (新規) | `looksLikeSlashCommand()` / `stripLeadingSlash()` の pure utility |
| `supervisor/src/bot.ts` | MessageCreate で `looksLikeSlashCommand` チェック、検知時は thread に警告送信 + stripped を relay |
| `supervisor/tests/session/slash-prefix.test.ts` (新規) | 26 テスト（slash-command shape / path / 自然言語 / edge cases） |

## AC 検証結果

### コンポーネントAC
| AC | 内容 | コマンド | 結果 | 判定 |
|---|---|---|---|---|
| AC-1 | 未知 slash command の fallback 処理がコード上で確認可能 | `grep stripLeadingSlash supervisor/src/bot.ts` | hit | ✅ PASS |
| AC-2 | 再現手順を 3 回連続で Bot がアイドル化しない | (実機 E2E) | merge 後 Supervisor 再起動で確認 | ⏭️ 手動 |
| AC-3 | ユニットテスト追加 + green | `bun test supervisor/tests/session/slash-prefix.test.ts` | 26 pass / 0 fail | ✅ PASS |

加えて `bun build supervisor/index.ts` で 524 modules ビルド成功。

### 統合ジャーニーAC
| 操作 | 期待結果 | 検証手段 |
|---|---|---|
| Discord で `/hanle-review` 投稿 | Bot が即座に「`/` 除去して送信」warning + Claude が自然言語 `hanle-review` として処理 | Discord 上の応答メッセージ確認 |
| 続けて `@Bot こんにちは` | 通常応答（queue は block されない） | 30 秒以内応答 |
| `/sesssion-resume` 別 typo | 同上 | 同上 |

→ 実機 E2E は merge 後 Supervisor 再起動 + Discord 操作で確認。

## 影響範囲

- **後方互換性**: あり。`/help` 等の Claude Code slash command を Discord メッセージ経由で**呼べていた場合**、それは natural language として処理されるようになる。ただし元から TUI picker は典型的に hang していたので実質的な機能差はない。
- **Discord-side `/session` slash command**: 影響なし。`Events.InteractionCreate` で別途処理されるため `MessageCreate` には来ない。

## 関連

- 起点 Issue: #86
- 親 Epic: #72 (silent fail / 通信詰まり)
- 関連 fix: PR #84 (tmux socket), PR #77 (copy-mode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ボットがスラッシュコマンド形式のメッセージを自動検出し、先頭のスラッシュを削除するようになりました
  * コマンド形式が検出された場合、スレッドに日本語の情報通知を自動投稿します
  * メッセージ処理前の前処理機能により、より正確なメッセージフォワーディングが実現されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->