### PR TITLE
refactor(#88): manager.ts レビュー nitpick 2 件 (path.dirname + stale relay-url cleanup)

### DIFF
--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -162,16 +162,7 @@ export class SessionManager {
     // this project. Without this, a Supervisor restart can leave a file pointing
     // at a dead relay port; PostToolUse hooks would then POST to a stale URL
     // and silently time out (curl --max-time 3 in progress-relay.sh).
-    try {
-      unlinkSync(relayUrlFile);
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
-        console.warn(
-          `[SessionManager] Failed to unlink stale relay-url ${relayUrlFile}:`,
-          err
-        );
-      }
-    }
+    this.cleanupRelayUrlFile(config.dir);
 
     const claudeCmd = [
       "unset ANTHROPIC_API_KEY",
@@ -317,6 +308,7 @@ export class SessionManager {
     this.sessions.delete(threadId);
     this.effects.iterm2.markTabStopped(session.channelName, tmuxName);
     updateSessionStatus(session.id, "stopped", reason);
+    this.cleanupRelayUrlFile(session.projectDir);
   }
 
   touchActivity(threadId: string): void {
@@ -366,6 +358,7 @@ export class SessionManager {
         this.sessions.delete(threadId);
         if (session) {
           this.effects.iterm2.markTabStopped(session.channelName, tmuxName);
+          this.cleanupRelayUrlFile(session.projectDir);
         }
         updateSessionStatus(sessionId, "stopped", "tmux_exited");
         this.clearWatcher(threadId);
@@ -386,7 +379,29 @@ export class SessionManager {
           this.effects.tmux.killSession(tmuxName);
         }
       }
+      this.cleanupRelayUrlFile(row.project_dir);
       updateSessionStatus(row.id, "stopped", "supervisor_restart");
+    }
+  }
+
+  /**
+   * Best-effort removal of the relay-url file for a project. Idempotent: ENOENT
+   * is treated as success (already cleaned). Called from start (before write),
+   * stop (after sessions.delete), watchTmuxSession (on tmux_exited), and
+   * recoverFromDb (Supervisor restart) so a dead URL never lingers and gets
+   * POSTed to by progress-relay.sh.
+   */
+  private cleanupRelayUrlFile(projectDir: string): void {
+    const relayUrlFile = relayUrlFilePath(projectDir);
+    try {
+      unlinkSync(relayUrlFile);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        console.warn(
+          `[SessionManager] Failed to unlink stale relay-url ${relayUrlFile}:`,
+          err
+        );
+      }
     }
   }
 }

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -1,7 +1,7 @@
 import { execSync } from "child_process";
 import { randomUUID } from "crypto";
-import { existsSync } from "fs";
-import { resolve } from "path";
+import { existsSync, unlinkSync } from "fs";
+import { dirname, resolve } from "path";
 import { homedir } from "os";
 import type { SessionInfo, StopReason } from "./types";
 import type { ChannelConfig } from "../config/channels";
@@ -156,7 +156,22 @@ export class SessionManager {
     // dropping `.supervisor-relay-url` into every project repo (Issue #88).
     // The hook applies the same sanitisation logic to its `$CWD` payload.
     const relayUrlFile = relayUrlFilePath(config.dir);
-    const relayUrlDir = relayUrlFile.replace(/\/[^/]+$/, "");
+    const relayUrlDir = dirname(relayUrlFile);
+
+    // Best-effort cleanup of any stale relay-url file from a prior session for
+    // this project. Without this, a Supervisor restart can leave a file pointing
+    // at a dead relay port; PostToolUse hooks would then POST to a stale URL
+    // and silently time out (curl --max-time 3 in progress-relay.sh).
+    try {
+      unlinkSync(relayUrlFile);
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+        console.warn(
+          `[SessionManager] Failed to unlink stale relay-url ${relayUrlFile}:`,
+          err
+        );
+      }
+    }
 
     const claudeCmd = [
       "unset ANTHROPIC_API_KEY",


### PR DESCRIPTION
## 概要

Issue #118 対応。PR #114 (#88) merge 後の coderabbit PR-level nitpick 2 件を 1 PR で消化。

## 変更内容

### 1. `path.dirname` 採用（任意のリファクタ）

`supervisor/src/session/manager.ts`

\`\`\`diff
-const relayUrlDir = relayUrlFile.replace(/\/[^/]+$/, "");
+const relayUrlDir = dirname(relayUrlFile);
\`\`\`

可読性向上のみ。挙動は同一。

### 2. stale relay-url ファイルの best-effort 掃除

\`\`\`diff
+try {
+  unlinkSync(relayUrlFile);
+} catch (err) {
+  if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+    console.warn(...);
+  }
+}
\`\`\`

Supervisor 再起動後に旧 URL を指したファイルが残ると、PostToolUse hook が dead port に POST → \`curl --max-time 3\` で silent fail するシナリオの対策。

## テスト

- ローカル: `bun test tests/session/` で `relay-server.test.ts` (67 pass) 等は緑だが、`manager.test.ts`/`relay.test.ts`/`iterm2.test.ts` 等で **既存の `node:child_process` import SyntaxError** (`Export named 'spawn'/'execFileSync' not found`) が発生。本 PR の変更行とは無関係 (import 行に触っていないテストが壊れる) で local 環境差の可能性。CI 結果で判定
- regression: 本変更は `relayUrlFile` 計算ロジックを書き換えていない (`replace` → `dirname` 等価) + 追加の `unlinkSync` は ENOENT 無視で初回起動も safe

## AC

- [x] 上記 2 件を 1 PR で対応（同ファイル、小粒）
- [ ] CI で `bun test supervisor/tests/` PASS（local の SyntaxError は環境差調査が必要、本 PR では CI に判定委譲）
- [ ] 既存の relay-url 動作に regression なし（手動 \`/session start\` → file 上書き確認）

## 統合ジャーニーAC（不要・理由: 内部実装の最適化、ユーザー観測動作不変）

## 関連

- Closes #118
- 親: PR #114 (#88)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * セッションの起動・停止や再起動時にプロジェクト固有の古いリレーURLファイルを自動で削除するようにしました。これにより、起動時や終了時、監視・復旧処理での誤検出やエラーが減少し、セッション管理の安定性が向上します。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->