### PR TITLE
feat(#7): 処理中インジケーター (⏳ react + typing 継続更新)

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -333,7 +333,8 @@ export async function startBot(token: string): Promise<void> {
 
         // File-attach failures don't downgrade relay success — the chunks
         // were already delivered and the user has the substantive response.
-        relaySucceeded = true;
+        relaySucceeded = !result.error;
+
       } catch (err) {
         console.error(`[Bot] Relay error in thread ${threadId}:`, err);
         try {

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -238,12 +238,32 @@ export async function startBot(token: string): Promise<void> {
     // Without this, the second message overwrites the first's pending request
     // in relay-server and the first response is lost.
     enqueueForThread(threadId, async () => {
-      // Show typing indicator
+      // Processing indicator (Issue #7): react ⏳ + refresh sendTyping every 5s.
+      // Discord's typing indicator times out after ~10s so a single call masks
+      // long-running relays as "idle" — refresh it on an interval until the
+      // relay completes, then swap ⏳ for ✅ (success) or ⚠️ (failure).
+      let reactedHourglass = false;
+      try {
+        await message.react("⏳");
+        reactedHourglass = true;
+      } catch (err) {
+        console.warn(
+          `[Bot] Failed to react ⏳ in thread ${threadId}:`,
+          err
+        );
+      }
       try {
         await thread.sendTyping();
       } catch {
         // Ignore typing errors
       }
+      const typingInterval = setInterval(() => {
+        thread.sendTyping().catch(() => {
+          // Best-effort during long relay; transient API errors are non-fatal.
+        });
+      }, 5000);
+
+      let relaySucceeded = false;
 
       // Relay to Claude Code
       console.log(
@@ -310,6 +330,10 @@ export async function startBot(token: string): Promise<void> {
             attachErr
           );
         }
+
+        // File-attach failures don't downgrade relay success — the chunks
+        // were already delivered and the user has the substantive response.
+        relaySucceeded = true;
       } catch (err) {
         console.error(`[Bot] Relay error in thread ${threadId}:`, err);
         try {
@@ -318,6 +342,31 @@ export async function startBot(token: string): Promise<void> {
           );
         } catch (sendErr) {
           console.error(`[Bot] Failed to send error notification to thread ${threadId}:`, sendErr);
+        }
+      } finally {
+        clearInterval(typingInterval);
+        if (reactedHourglass) {
+          try {
+            const me = client.user;
+            if (me) {
+              await message.reactions.cache
+                .get("⏳")
+                ?.users.remove(me.id);
+            }
+          } catch (err) {
+            console.warn(
+              `[Bot] Failed to remove ⏳ reaction in thread ${threadId}:`,
+              err
+            );
+          }
+        }
+        try {
+          await message.react(relaySucceeded ? "✅" : "⚠️");
+        } catch (err) {
+          console.warn(
+            `[Bot] Failed to react ${relaySucceeded ? "✅" : "⚠️"} in thread ${threadId}:`,
+            err
+          );
         }
       }
     });


### PR DESCRIPTION
## Summary

Issue #7 (P1) 対応。Discord スレッドで Claude Code への relay 中、応答が来ないとユーザー側からは「処理中か無応答か」判別できない問題に対応。

- メッセージに `⏳` リアクションを付与
- 5秒ごとに `thread.sendTyping()` を継続発火 (Discord typing indicator は ~10s で消えるため)
- relay 完了/失敗時に `try/finally` で必ず typing interval を停止
- 成功時 `⏳` を削除し `✅` を付与
- 失敗時 `⚠️` を付与 (`⏳` も best-effort で削除)
- ファイル添付の失敗は relay 成功扱い (chunks は配信済のため)
- Discord API エラーは全 best-effort、本体 relay を阻害しない

## 統合ジャーニーAC

1. **操作**: Discord スレッドで長時間タスク (例: `Bash(sleep 30)`) をメッセージ投稿
   - **期待結果**: 投稿直後にメッセージに `⏳` が付き、`Claude is typing...` が 30 秒間継続表示される
   - **検証手段**: Discord 実機で確認 (typing インジケーターが 30 秒消えないこと、`⏳` が見えること)
2. **操作**: 上記タスクが完了する
   - **期待結果**: `⏳` が消え `✅` に切り替わる、typing 表示も停止
   - **検証手段**: Discord 実機で確認 (`⏳` 削除 + `✅` 表示 + typing 消失)
3. **操作**: relay でエラーが発生するメッセージを投稿 (例: 存在しない /command 経由でハング → タイムアウト)
   - **期待結果**: `⏳` が消え `⚠️` に切り替わる、エラーメッセージが thread に送られる
   - **検証手段**: Discord 実機で確認 (`⚠️` 表示 + エラーメッセージ受信)

## Test plan

- [ ] CI: TypeCheck / Unit / E2E / CodeRabbit / Routing / codecov 全 6 緑
- [ ] 実機 (follow-up): 統合ジャーニーAC 3 件を Discord で確認

## 関連

- Closes #7
- 関連 Issue: #119 (progress-relay レート制限/バッファリング — 本 PR merge 後に着手予定、bot.ts 同箇所に手を入れるためコンフリクト見込み)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * リレー操作中のプログレスフィードバックが向上しました。⏳、✅、⚠️の絵文字で処理状態を視覚的に表示します。
  * 長時間の処理中、Discordのタイピングインジケータが5秒ごとに更新され、接続が維持されます。
  * 処理終了時にインジケータと絵文字のクリーンアップが行われます。
  * ファイル添付の失敗はリレー全体の失敗として扱われなくなりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->