### PR TITLE
feat(#119): progress-relay にバッファリング追加 (2秒間隔で thread 単位コアレス)

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -79,7 +79,12 @@ export async function startBot(token: string): Promise<void> {
         const lines = entries.map((e) => `🔧 \`${e.tool}\`: ${e.message}`);
         const body =
           lines.length === 1 ? lines[0]! : `🔧 進捗:\n${lines.join("\n")}`;
-        await channel.send(body);
+        // Coalesced bodies can exceed Discord's 2000-char limit when many
+        // tools fire within the window — chunk via formatForDiscord before
+        // sending so channel.send() doesn't 400.
+        for (const chunk of formatForDiscord(body)) {
+          await channel.send(chunk);
+        }
       } catch (err) {
         console.error(
           `[Bot] Progress flush error for thread ${threadId}:`,

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -24,6 +24,7 @@ import {
   looksLikeSlashCommand,
   stripLeadingSlash,
 } from "./session/slash-prefix";
+import { ProgressBuffer } from "./session/progress-buffer";
 
 export async function startBot(token: string): Promise<void> {
   const client = new Client({
@@ -64,6 +65,29 @@ export async function startBot(token: string): Promise<void> {
   const resourceMonitor = new ResourceMonitor(sessionManager);
   const sessionHandler = createSessionHandler(sessionManager);
 
+  // Per-thread progress buffer (Issue #119): coalesce PostToolUse events
+  // within a 2-second window so tool-heavy turns don't trip Discord's
+  // 5-msg/5-sec rate limit. The buffer fetches the channel and sends the
+  // batched body at flush time.
+  const progressBuffer = new ProgressBuffer({
+    intervalMs: 2000,
+    onFlush: async (threadId, entries) => {
+      try {
+        const channel = await client.channels.fetch(threadId);
+        if (!channel?.isThread()) return;
+        const lines = entries.map((e) => `🔧 \`${e.tool}\`: ${e.message}`);
+        const body =
+          lines.length === 1 ? lines[0]! : `🔧 進捗:\n${lines.join("\n")}`;
+        await channel.send(body);
+      } catch (err) {
+        console.error(
+          `[Bot] Progress flush error for thread ${threadId}:`,
+          err
+        );
+      }
+    },
+  });
+
   // Register slash commands
   client.once(Events.ClientReady, async (readyClient) => {
     console.log(`[Bot] Logged in as ${readyClient.user.tag}`);
@@ -90,16 +114,14 @@ export async function startBot(token: string): Promise<void> {
     reaper.start();
     resourceMonitor.start();
 
-    // Register progress callback to send tool progress to Discord threads
-    onProgress(async (event) => {
-      try {
-        const channel = await client.channels.fetch(event.threadId);
-        if (channel?.isThread()) {
-          await channel.send(`🔧 \`${event.tool}\`: ${event.message}`);
-        }
-      } catch (err) {
-        console.error(`[Bot] Progress send error for thread ${event.threadId}:`, err);
-      }
+    // Register progress callback to send tool progress to Discord threads.
+    // Events are buffered (Issue #119) and flushed every 2s as a single
+    // message per thread to stay under Discord's 5-msg/5-sec rate limit.
+    onProgress((event) => {
+      progressBuffer.add(event.threadId, {
+        tool: event.tool,
+        message: event.message,
+      });
     });
 
     // Register late-response callback: when a Stop hook POST arrives after
@@ -378,6 +400,14 @@ export async function startBot(token: string): Promise<void> {
     console.log("[Bot] Shutdown signal received");
     reaper.stop();
     resourceMonitor.stop();
+    // Drain pending progress buffers before tearing down the Discord client
+    // so in-flight tool events still reach the user (Issue #119).
+    try {
+      await progressBuffer.flushAll();
+    } catch (err) {
+      console.error("[Bot] Progress flushAll error during shutdown:", err);
+    }
+    progressBuffer.close();
     await sessionManager.shutdownAll();
     client.destroy();
     process.exit(0);

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -25,6 +25,7 @@ import {
   stripLeadingSlash,
 } from "./session/slash-prefix";
 import { ProgressBuffer } from "./session/progress-buffer";
+import { formatForDiscord } from "./session/output-formatter";
 
 export async function startBot(token: string): Promise<void> {
   const client = new Client({

--- a/supervisor/src/session/progress-buffer.ts
+++ b/supervisor/src/session/progress-buffer.ts
@@ -47,7 +47,14 @@ export class ProgressBuffer {
     }
     this.buffers.set(threadId, [entry]);
     const t = setTimeout(() => {
-      void this.flush(threadId);
+      // Catch background rejections so a throwing onFlush can't surface as
+      // an unhandledRejection and destabilize the process.
+      this.flush(threadId).catch((err) => {
+        console.error(
+          `[ProgressBuffer] Background flush failed for thread ${threadId}:`,
+          err
+        );
+      });
     }, this.intervalMs);
     this.timers.set(threadId, t);
   }

--- a/supervisor/src/session/progress-buffer.ts
+++ b/supervisor/src/session/progress-buffer.ts
@@ -1,0 +1,84 @@
+export interface ProgressEntry {
+  tool: string;
+  message: string;
+}
+
+export interface ProgressBufferOptions {
+  intervalMs?: number;
+  onFlush: (threadId: string, entries: ProgressEntry[]) => Promise<void> | void;
+}
+
+const DEFAULT_INTERVAL_MS = 2000;
+
+/**
+ * Per-thread progress buffer (Issue #119).
+ *
+ * Coalesces PostToolUse progress events per thread for `intervalMs` (default
+ * 2000ms), then emits one onFlush call with all queued entries. Without this,
+ * tool-heavy turns (grep + N reads + edits) burst N messages and trip
+ * Discord's 5-msg/5-sec rate limit.
+ *
+ * Behavior: the first add() per thread arms a setTimeout. Subsequent add()
+ * within the window append to the same buffer. After flush the buffer + timer
+ * are cleared so the next add() opens a fresh window — i.e. fixed-interval
+ * coalesce, no leading-edge debounce.
+ */
+export class ProgressBuffer {
+  private buffers = new Map<string, ProgressEntry[]>();
+  private timers = new Map<string, ReturnType<typeof setTimeout>>();
+  private readonly intervalMs: number;
+  private readonly onFlush: (
+    threadId: string,
+    entries: ProgressEntry[]
+  ) => Promise<void> | void;
+  private closed = false;
+
+  constructor(opts: ProgressBufferOptions) {
+    this.intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+    this.onFlush = opts.onFlush;
+  }
+
+  add(threadId: string, entry: ProgressEntry): void {
+    if (this.closed) return;
+    const buf = this.buffers.get(threadId);
+    if (buf) {
+      buf.push(entry);
+      return;
+    }
+    this.buffers.set(threadId, [entry]);
+    const t = setTimeout(() => {
+      void this.flush(threadId);
+    }, this.intervalMs);
+    this.timers.set(threadId, t);
+  }
+
+  async flush(threadId: string): Promise<void> {
+    const t = this.timers.get(threadId);
+    if (t) {
+      clearTimeout(t);
+      this.timers.delete(threadId);
+    }
+    const entries = this.buffers.get(threadId);
+    this.buffers.delete(threadId);
+    if (!entries || entries.length === 0) return;
+    await this.onFlush(threadId, entries);
+  }
+
+  async flushAll(): Promise<void> {
+    const threadIds = Array.from(this.buffers.keys());
+    await Promise.all(threadIds.map((id) => this.flush(id)));
+  }
+
+  close(): void {
+    this.closed = true;
+    for (const t of this.timers.values()) {
+      clearTimeout(t);
+    }
+    this.timers.clear();
+    this.buffers.clear();
+  }
+
+  pendingThreadIds(): string[] {
+    return Array.from(this.buffers.keys());
+  }
+}

--- a/supervisor/tests/session/progress-buffer.test.ts
+++ b/supervisor/tests/session/progress-buffer.test.ts
@@ -1,0 +1,131 @@
+import { describe, expect, test } from "bun:test";
+import {
+  ProgressBuffer,
+  type ProgressEntry,
+} from "../../src/session/progress-buffer";
+
+interface FlushCall {
+  threadId: string;
+  entries: ProgressEntry[];
+}
+
+describe("ProgressBuffer (#119)", () => {
+  test("coalesces multiple entries within interval into a single onFlush call", async () => {
+    const flushes: FlushCall[] = [];
+    const buf = new ProgressBuffer({
+      intervalMs: 50,
+      onFlush: (threadId, entries) => {
+        flushes.push({ threadId, entries });
+      },
+    });
+
+    buf.add("t1", { tool: "Read", message: "src/a.ts" });
+    buf.add("t1", { tool: "Bash", message: "bun test (exit: 0)" });
+    buf.add("t1", { tool: "Edit", message: "src/b.ts" });
+
+    await new Promise((r) => setTimeout(r, 80));
+
+    expect(flushes).toHaveLength(1);
+    expect(flushes[0]?.threadId).toBe("t1");
+    expect(flushes[0]?.entries.map((e) => e.tool)).toEqual([
+      "Read",
+      "Bash",
+      "Edit",
+    ]);
+  });
+
+  test("emits separate onFlush calls when entries straddle two windows", async () => {
+    const flushes: FlushCall[] = [];
+    const buf = new ProgressBuffer({
+      intervalMs: 30,
+      onFlush: (threadId, entries) => {
+        flushes.push({ threadId, entries });
+      },
+    });
+
+    buf.add("t1", { tool: "Read", message: "a" });
+    await new Promise((r) => setTimeout(r, 60));
+    buf.add("t1", { tool: "Write", message: "b" });
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(flushes).toHaveLength(2);
+    expect(flushes[0]?.entries[0]?.tool).toBe("Read");
+    expect(flushes[1]?.entries[0]?.tool).toBe("Write");
+  });
+
+  test("isolates buffers per thread", async () => {
+    const flushes: FlushCall[] = [];
+    const buf = new ProgressBuffer({
+      intervalMs: 30,
+      onFlush: (threadId, entries) => {
+        flushes.push({ threadId, entries });
+      },
+    });
+
+    buf.add("t1", { tool: "Read", message: "a" });
+    buf.add("t2", { tool: "Bash", message: "ls" });
+
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(flushes).toHaveLength(2);
+    const t1Flush = flushes.find((f) => f.threadId === "t1");
+    const t2Flush = flushes.find((f) => f.threadId === "t2");
+    expect(t1Flush?.entries.map((e) => e.tool)).toEqual(["Read"]);
+    expect(t2Flush?.entries.map((e) => e.tool)).toEqual(["Bash"]);
+  });
+
+  test("flush() on empty buffer is a no-op", async () => {
+    let calls = 0;
+    const buf = new ProgressBuffer({
+      intervalMs: 100,
+      onFlush: () => {
+        calls++;
+      },
+    });
+
+    await buf.flush("nonexistent");
+    expect(calls).toBe(0);
+  });
+
+  test("flushAll() drains all pending threads immediately (before interval fires)", async () => {
+    const flushes: FlushCall[] = [];
+    const buf = new ProgressBuffer({
+      intervalMs: 60_000, // long enough that the interval timer would not fire on its own
+      onFlush: (threadId, entries) => {
+        flushes.push({ threadId, entries });
+      },
+    });
+
+    buf.add("t1", { tool: "Read", message: "a" });
+    buf.add("t2", { tool: "Bash", message: "ls" });
+    buf.add("t1", { tool: "Edit", message: "b" });
+
+    await buf.flushAll();
+
+    expect(flushes).toHaveLength(2);
+    expect(buf.pendingThreadIds()).toEqual([]);
+    const t1Flush = flushes.find((f) => f.threadId === "t1");
+    expect(t1Flush?.entries).toHaveLength(2);
+  });
+
+  test("close() cancels timers, drops buffered entries, and silently rejects further add()", async () => {
+    const flushes: FlushCall[] = [];
+    const buf = new ProgressBuffer({
+      intervalMs: 30,
+      onFlush: (threadId, entries) => {
+        flushes.push({ threadId, entries });
+      },
+    });
+
+    buf.add("t1", { tool: "Read", message: "a" });
+    buf.close();
+    await new Promise((r) => setTimeout(r, 60));
+    expect(flushes).toHaveLength(0);
+
+    // add() after close is silently dropped (no flush emitted, no buffered state)
+    buf.add("t1", { tool: "Bash", message: "should not flush" });
+    await new Promise((r) => setTimeout(r, 60));
+    expect(flushes).toHaveLength(0);
+    expect(buf.pendingThreadIds()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Issue #119 (P2) 対応。PostToolUse 進捗イベントを thread 単位で 2 秒間バッファに積み、まとめて 1 メッセージで送信する `ProgressBuffer` を追加。ツール乱発時 (grep + N reads + edits) に Discord の 5 msg/5 sec レート制限に抵触するリスクを解消する。

## 変更点

| ファイル | 内容 |
|---|---|
| `supervisor/src/session/progress-buffer.ts` (新規) | `ProgressBuffer` クラス。初回 `add()` で `setTimeout` を arm、以降の `add()` は同 buffer に append、interval 経過で `onFlush(threadId, entries)` を一括呼び出し。flush 後に buffer/timer をクリアし次の add() で新ウィンドウ (固定間隔コアレス、leading-edge debounce ではない)。`flushAll()` + `close()` でシャットダウン時の draining も提供 |
| `supervisor/src/bot.ts` | `onProgress` callback を `progressBuffer.add()` 経由に切替、shutdown 時に `flushAll` + `close`。エントリ 1 件は従来書式 / 複数件は `🔧 進捗:\n...` 形式に整形 |
| `supervisor/tests/session/progress-buffer.test.ts` (新規) | 6 ケース全 PASS (コアレス・連続ウィンドウ分離・thread 隔離・空 flush no-op・flushAll 即時排水・close 挙動) |

## 統合ジャーニーAC

1. **操作**: Discord thread で Claude にツール連続実行依頼を出す (例: 「`src/` を grep して 3 ファイルを read して」)
   - **期待結果**: thread に 1 メッセージで 3 ツール分まとめて投稿される (個別 3 メッセージにならない)
   - **検証手段**: Discord thread のメッセージ件数が 1 件、本文に 3 ツール全てが `🔧 \`<tool>\`: <message>` 形式で含まれる
2. **操作**: 2 秒以上の間隔を空けて 2 回ツール実行
   - **期待結果**: メッセージは 2 件に分かれる (バッファ flush タイミングに従う)
   - **検証手段**: Discord 上の 2 メッセージの timestamp 差が 2 秒以上
3. **操作**: 単発ツール 1 件のみ実行
   - **期待結果**: バッファ flush までに ~2 秒待ってから 1 メッセージで投稿される (従来の即時送信ではない)
   - **検証手段**: ツール完了から Discord 投稿までの遅延が ~2 秒

## Test plan

- [x] Unit: `bun test tests/session/progress-buffer.test.ts` → 6 pass / 0 fail (local)
- [ ] CI: TypeCheck / Unit / E2E / CodeRabbit / Routing / codecov 全 6 緑
- [ ] 実機 (follow-up): 統合ジャーニーAC 3 件を Discord で確認

## 関連

- Closes #119
- 親 (close 済): #10 (PostToolUse 中間進捗中継)
- 直前 PR: #121 (Issue #7 typing インジケーター、bot.ts 同箇所を編集)