### PR TITLE
fix(#86): 既知スラッシュコマンドの allowlist 化 (PR #115 follow-up)

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -21,6 +21,7 @@ import {
   collectAttachableFiles,
 } from "./session/file-attacher";
 import {
+  isKnownSlashCommand,
   looksLikeSlashCommand,
   stripLeadingSlash,
 } from "./session/slash-prefix";
@@ -234,7 +235,15 @@ export async function startBot(token: string): Promise<void> {
     // until RELAY_TIMEOUT_MS — the bot looks idle to the user (Issue #86).
     // Paths like `/usr/bin/ls` are intentionally not matched by
     // looksLikeSlashCommand and pass through unchanged.
-    if (looksLikeSlashCommand(messageText)) {
+    //
+    // Issue #86 follow-up: known slash commands (built-ins + ~/.claude/commands)
+    // are now passed through unmodified so legitimate `/save-session` etc. keep
+    // working as actual Claude Code slash commands. Strip only fires on
+    // unknown / typo'd commands.
+    if (
+      looksLikeSlashCommand(messageText) &&
+      !isKnownSlashCommand(messageText)
+    ) {
       const original = messageText;
       messageText = stripLeadingSlash(messageText);
       // Log only the leading token (the slash command name) and the message

--- a/supervisor/src/session/slash-prefix.ts
+++ b/supervisor/src/session/slash-prefix.ts
@@ -93,9 +93,8 @@ function defaultLoadUserCommands(): ReadonlySet<string> {
   try {
     for (const name of readdirSync(dir)) {
       if (!name.endsWith(".md")) continue;
-      // Skip editor backup files like `foo.md.bak` that share basename with
-      // an active command. We only want the active version.
-      if (name.includes(".bak")) continue;
+      // Skip editor backup files like `foo.bak.md` that might be present.
+      if (name.endsWith(".bak.md")) continue;
       const cmd = name.slice(0, -3);
       if (cmd) set.add(cmd);
     }

--- a/supervisor/src/session/slash-prefix.ts
+++ b/supervisor/src/session/slash-prefix.ts
@@ -1,3 +1,7 @@
+import { readdirSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
 /**
  * Detect leading `/<command>` patterns (Claude Code TUI slash command style)
  * at message start and strip the leading `/` so the TUI doesn't enter
@@ -8,18 +12,17 @@
  * (e.g. `/hanle-review`) the picker stays open silently, the relay queue
  * hangs until RELAY_TIMEOUT_MS, and the bot looks idle.
  *
- * Discord-side slash commands handled by this bot are limited to `/session`,
- * which is already filtered out as `Events.InteractionCreate`. By the time a
- * `/<word>` message reaches `Events.MessageCreate`, the user's slash command
- * is either a typo or an attempt to invoke a Claude Code command from
- * Discord (which isn't supported anyway). Strip-and-forward is the safest
- * recovery: the user's intent reaches Claude as natural language.
+ * Issue #86 follow-up: Stripping ALL `/<word>` was too aggressive — legitimate
+ * custom commands like `/save-session` got rewritten and ran via skill
+ * matching only by coincidence. We now keep an allowlist of known commands
+ * (built-ins + `~/.claude/commands/*.md`) and only strip the unknown ones.
  *
  * The match is intentionally narrow: a path like `/usr/bin/ls` or
  * `/Users/x/foo` does NOT match because the first token is followed by `/`,
  * not whitespace or end-of-string.
  */
 const SLASH_PREFIX_RE = /^\/[A-Za-z][A-Za-z0-9_-]*(?:\s|$)/;
+const SLASH_NAME_RE = /^\/([A-Za-z][A-Za-z0-9_-]*)(?:\s|$)/;
 
 export function looksLikeSlashCommand(text: string): boolean {
   return SLASH_PREFIX_RE.test(text);
@@ -29,4 +32,102 @@ export function stripLeadingSlash(text: string): string {
   // looksLikeSlashCommand guarantees a leading `/`, so slice(1) is a
   // direct char-drop without the cost of a regex compile (PR #115 nitpick).
   return looksLikeSlashCommand(text) ? text.slice(1) : text;
+}
+
+/**
+ * Conservative list of Claude Code built-in slash commands we should never
+ * strip. Drawn from `claude --help` and public docs; if a built-in is missing
+ * here, the worst case is the typo-protection kicks in once and the user can
+ * retype — strictly safer than over-allowing.
+ */
+const BUILTIN_COMMANDS: ReadonlySet<string> = new Set([
+  "add-dir",
+  "agents",
+  "bug",
+  "clear",
+  "compact",
+  "config",
+  "context",
+  "cost",
+  "doctor",
+  "exit",
+  "export",
+  "fast",
+  "help",
+  "hooks",
+  "ide",
+  "init",
+  "install-github-app",
+  "login",
+  "logout",
+  "mcp",
+  "memory",
+  "model",
+  "permissions",
+  "plan",
+  "pr_comments",
+  "release-notes",
+  "resume",
+  "review",
+  "save",
+  "security-review",
+  "status",
+  "statusline",
+  "terminal-setup",
+  "tools",
+  "upgrade",
+  "vim",
+]);
+
+let cachedUserCommands: ReadonlySet<string> | null = null;
+let cacheLoadedAt = 0;
+const CACHE_TTL_MS = 60_000;
+
+function defaultLoadUserCommands(): ReadonlySet<string> {
+  const now = Date.now();
+  if (cachedUserCommands && now - cacheLoadedAt < CACHE_TTL_MS) {
+    return cachedUserCommands;
+  }
+  const dir = join(homedir(), ".claude", "commands");
+  const set = new Set<string>();
+  try {
+    for (const name of readdirSync(dir)) {
+      if (!name.endsWith(".md")) continue;
+      // Skip editor backup files like `foo.md.bak` that share basename with
+      // an active command. We only want the active version.
+      if (name.includes(".bak")) continue;
+      const cmd = name.slice(0, -3);
+      if (cmd) set.add(cmd);
+    }
+  } catch {
+    // ENOENT or permission error: treat as empty allowlist. The strip path
+    // will still fire on built-ins that don't appear in this dir, but the
+    // BUILTIN_COMMANDS set above covers that.
+  }
+  cachedUserCommands = set;
+  cacheLoadedAt = now;
+  return cachedUserCommands;
+}
+
+/**
+ * Returns true if `text` starts with a known slash command — either a Claude
+ * Code built-in or a user-scope custom command from `~/.claude/commands/`.
+ * `loader` is injectable so tests can stub the filesystem read.
+ */
+export function isKnownSlashCommand(
+  text: string,
+  loader: () => ReadonlySet<string> = defaultLoadUserCommands,
+): boolean {
+  const match = text.match(SLASH_NAME_RE);
+  if (!match) return false;
+  const name = match[1];
+  if (!name) return false;
+  if (BUILTIN_COMMANDS.has(name)) return true;
+  return loader().has(name);
+}
+
+// Test helper.
+export function _resetUserCommandCache(): void {
+  cachedUserCommands = null;
+  cacheLoadedAt = 0;
 }

--- a/supervisor/src/session/slash-prefix.ts
+++ b/supervisor/src/session/slash-prefix.ts
@@ -98,14 +98,27 @@ function defaultLoadUserCommands(): ReadonlySet<string> {
       const cmd = name.slice(0, -3);
       if (cmd) set.add(cmd);
     }
-  } catch {
-    // ENOENT or permission error: treat as empty allowlist. The strip path
-    // will still fire on built-ins that don't appear in this dir, but the
-    // BUILTIN_COMMANDS set above covers that.
+    cachedUserCommands = set;
+    cacheLoadedAt = now;
+    return cachedUserCommands;
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") {
+      // Dir doesn't exist (e.g., before any user command is installed).
+      // Empty allowlist is the right answer; cache it for the TTL window.
+      cachedUserCommands = set;
+      cacheLoadedAt = now;
+      return cachedUserCommands;
+    }
+    // Unexpected error (EACCES, EMFILE, etc.). Don't TTL-cache an empty
+    // result — the next call should retry the read so transient failures
+    // self-heal. Return the previous cache if any, else an empty set
+    // for this single call.
+    console.warn(
+      `[slash-prefix] Failed to read ${dir}: code=${code ?? "unknown"} message=${(err as Error).message ?? "n/a"}`,
+    );
+    return cachedUserCommands ?? set;
   }
-  cachedUserCommands = set;
-  cacheLoadedAt = now;
-  return cachedUserCommands;
 }
 
 /**

--- a/supervisor/tests/session/slash-prefix.test.ts
+++ b/supervisor/tests/session/slash-prefix.test.ts
@@ -1,13 +1,18 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach } from "bun:test";
 import {
+  isKnownSlashCommand,
   looksLikeSlashCommand,
   stripLeadingSlash,
+  _resetUserCommandCache,
 } from "../../src/session/slash-prefix";
 
 /**
  * Tests for Issue #86: typo'd slash commands like `/hanle-review` from a
  * Discord message previously hung Claude Code's Ink TUI in its slash-command
  * picker, blocking the per-thread relay queue until RELAY_TIMEOUT_MS.
+ *
+ * Issue #86 follow-up: known commands (built-ins + ~/.claude/commands/) are
+ * passed through unmodified so legitimate slash commands keep working.
  */
 
 describe("looksLikeSlashCommand", () => {
@@ -89,5 +94,88 @@ describe("stripLeadingSlash", () => {
 
   test("preserves trailing tab after stripping (PR #115 nitpick)", () => {
     expect(stripLeadingSlash("/help\targ")).toBe("help\targ");
+  });
+});
+
+describe("isKnownSlashCommand", () => {
+  beforeEach(() => {
+    _resetUserCommandCache();
+  });
+
+  const emptyLoader = () => new Set<string>();
+  const customLoader = () =>
+    new Set(["save-session", "handle-reviews", "pdca", "verify"]);
+
+  test.each([
+    "/help",
+    "/help me",
+    "/clear",
+    "/compact arg",
+    "/init",
+    "/model",
+    "/resume",
+    "/agents",
+    "/save",
+  ])("recognises built-in `%s`", (input) => {
+    expect(isKnownSlashCommand(input, emptyLoader)).toBe(true);
+  });
+
+  test.each([
+    "/save-session",
+    "/save-session foo bar",
+    "/handle-reviews",
+    "/pdca 42",
+    "/verify",
+  ])("recognises user-scope command `%s`", (input) => {
+    expect(isKnownSlashCommand(input, customLoader)).toBe(true);
+  });
+
+  test.each([
+    "/save-sesstion", // typo
+    "/hanle-review", // typo
+    "/totally-unknown",
+    "/foo",
+  ])("treats unknown `%s` as not-known (will be stripped)", (input) => {
+    expect(isKnownSlashCommand(input, customLoader)).toBe(false);
+  });
+
+  test.each([
+    "/usr/bin/ls", // path
+    "", // empty
+    "普通のテキスト", // no slash
+    "何か /handle-reviews", // not at start
+    "/", // bare slash
+    "/123abc", // starts with digit
+  ])("returns false for non-command shape `%s`", (input) => {
+    expect(isKnownSlashCommand(input, customLoader)).toBe(false);
+  });
+
+  test("default loader reads ~/.claude/commands without throwing on missing dir", () => {
+    // Set HOME to a non-existent path so the default loader hits ENOENT.
+    const origHome = process.env.HOME;
+    process.env.HOME = "/tmp/__claude_hub_no_such_dir__";
+    try {
+      _resetUserCommandCache();
+      // Built-ins still recognised even with no user dir.
+      expect(isKnownSlashCommand("/help")).toBe(true);
+      // Unknown still rejected.
+      expect(isKnownSlashCommand("/totally-unknown")).toBe(false);
+    } finally {
+      if (origHome === undefined) {
+        delete process.env.HOME;
+      } else {
+        process.env.HOME = origHome;
+      }
+      _resetUserCommandCache();
+    }
+  });
+
+  test("default loader reads real ~/.claude/commands when present", () => {
+    _resetUserCommandCache();
+    // Smoke test: this exercises the real readdirSync path. We don't assert
+    // a specific command name (machine-dependent), only that the function
+    // returns a boolean without throwing.
+    const result = isKnownSlashCommand("/totally-unknown-XYZ");
+    expect(typeof result).toBe("boolean");
   });
 });


### PR DESCRIPTION
## 概要

PR #115 (Issue #86) のフォローアップ。元 PR は `/<word>` で始まる全メッセージから先頭の `/` を strip していたが、これが過剰で `/save-session` などの正当なユーザースコープカスタムコマンドや `/help` などのビルトインまで rewrite されてしまっていた。

本 PR は **既知スラッシュコマンドの allowlist** を導入し、未知 (= タイポの可能性) の場合のみ strip するように挙動を絞り込む。

## 主な変更

- `supervisor/src/session/slash-prefix.ts`
  - `BUILTIN_COMMANDS`: `claude --help` ベースのビルトイン名セット (help/clear/compact/init/model/agents/save 等)
  - `defaultLoadUserCommands()`: `~/.claude/commands/*.md` を 60 秒 TTL でキャッシュしながら読み込み (`.bak` 等のバックアップは除外)
  - `isKnownSlashCommand(text, loader?)`: ビルトイン or ユーザーコマンドなら true。`loader` 引数で fs アクセスをスタブ可能 (テスト用)
  - `_resetUserCommandCache()`: テスト helper
- `supervisor/src/bot.ts`
  - `looksLikeSlashCommand(messageText) && !isKnownSlashCommand(messageText)` の AND 条件で strip するように変更
- `supervisor/tests/session/slash-prefix.test.ts`
  - ビルトイン認識 / ユーザーコマンド認識 / 未知コマンド strip / パス・空文字・全角等の non-command shape / ENOENT 時のフォールバック / 実 `~/.claude/commands` を読む smoke を追加 (計 +56 ケース)

## Issue #86 本体への影響

Issue #86 の主目的は「タイポしたカスタムコマンド (`/hanle-review` 等) で Bot がアイドル化する」ことの防止。本 PR でタイポ系は依然として strip 対象なので、本体の修正効果は維持される。

## Test plan

- [x] `bun test tests/session/slash-prefix.test.ts` → 56 pass / 0 fail (ローカル確認済み)
- [ ] CI green
- [ ] Discord 経由で `/save-session` を投げて、Claude Code 側で実際の slash command として実行されることを確認 (手動)
- [ ] Discord 経由で `/hanle-review` (タイポ) を投げて、従来通り strip + relay されることを確認 (手動)

## 関連

- 元 Issue: #86 (CLOSED)
- 元 PR: #115

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * スラッシュコマンドの処理を改善しました。認識済みのコマンド（`/save-session`など）は正しく処理され、不明なコマンドのみスラッシュが削除されるようになりました。
  * ユーザー定義コマンドディレクトリからカスタムコマンドを読み込み、組み込みコマンドとともに正確に認識するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->