### PR TITLE
fix(#98): relay URL の threadId を encodeURIComponent / decodeURIComponent で対称化

### DIFF
--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -149,7 +149,10 @@ export class SessionManager {
     this.effects.tmux.killSession(tmuxName);
 
     // Build the claude command — unset ANTHROPIC_API_KEY to use Claude Max subscription
-    const relayUrl = `http://localhost:${this.effects.relayServer.getPort()}/relay/${threadId}`;
+    // encodeURIComponent: Discord thread IDs are numeric today, but encode at
+    // the boundary so any future schema change (or fuzzed input) cannot break
+    // the relay URL parser. relay-server.ts decodes symmetrically on receipt.
+    const relayUrl = `http://localhost:${this.effects.relayServer.getPort()}/relay/${encodeURIComponent(threadId)}`;
 
     // Relay URL is written to a runtime-dir file keyed by the project cwd so
     // that progress-relay.sh (PostToolUse hook) can locate it from $CWD without

--- a/supervisor/src/session/relay-server.ts
+++ b/supervisor/src/session/relay-server.ts
@@ -57,9 +57,19 @@ export function startRelayServer(): void {
       // Progress endpoint: PostToolUse hook sends tool progress here
       const progressMatch = url.pathname.match(/^\/progress\/(.+)$/);
       if (progressMatch && req.method === "POST") {
-        const threadId = progressMatch[1];
-        if (!threadId) {
+        const rawThreadId = progressMatch[1];
+        if (!rawThreadId) {
           return new Response("Invalid thread ID", { status: 400 });
+        }
+        // Symmetric to manager.ts (encodeURIComponent). progress-relay.sh
+        // derives this URL from the same encoded relayUrl, so the threadId
+        // arrives encoded and must be decoded before downstream lookups
+        // (e.g. manager.touchActivity) can find the session.
+        let threadId: string;
+        try {
+          threadId = decodeURIComponent(rawThreadId);
+        } catch {
+          return new Response("Invalid thread ID encoding", { status: 400 });
         }
         try {
           const body = await req.json() as Record<string, unknown>;
@@ -80,7 +90,7 @@ export function startRelayServer(): void {
         if (!rawThreadId) {
           return new Response("Invalid thread ID", { status: 400 });
         }
-        // Symmetric to manager.ts which encodeURIComponents threadId.
+        // Symmetric to manager.ts which encodeURIComponent's threadId.
         // decodeURIComponent throws URIError on malformed escapes (e.g. `%ZZ`);
         // treat that as a 400 instead of a 500.
         let threadId: string;

--- a/supervisor/src/session/relay-server.ts
+++ b/supervisor/src/session/relay-server.ts
@@ -76,9 +76,18 @@ export function startRelayServer(): void {
 
       const relayMatch = url.pathname.match(/^\/relay\/(.+)$/);
       if (relayMatch && req.method === "POST") {
-        const threadId = relayMatch[1];
-        if (!threadId) {
+        const rawThreadId = relayMatch[1];
+        if (!rawThreadId) {
           return new Response("Invalid thread ID", { status: 400 });
+        }
+        // Symmetric to manager.ts which encodeURIComponents threadId.
+        // decodeURIComponent throws URIError on malformed escapes (e.g. `%ZZ`);
+        // treat that as a 400 instead of a 500.
+        let threadId: string;
+        try {
+          threadId = decodeURIComponent(rawThreadId);
+        } catch {
+          return new Response("Invalid thread ID encoding", { status: 400 });
         }
         let body: Record<string, unknown>;
         try {

--- a/supervisor/tests/session/relay-server.test.ts
+++ b/supervisor/tests/session/relay-server.test.ts
@@ -143,4 +143,49 @@ describe("relay-server", () => {
     expect(result1.text).toBe("Response 1");
     expect(result2.text).toBe("Response 2");
   });
+
+  // Issue #98: thread IDs are encoded by manager.ts at URL build time and
+  // must round-trip through relay-server.ts even if they ever contain
+  // characters that would otherwise be ambiguous in a URL path.
+  test.each([
+    ["plain-numeric", "1234567890123456"],
+    ["with-slash", "thread/with/slash"],
+    ["with-question", "thread?with=query"],
+    ["with-hash", "thread#fragment"],
+    ["with-percent", "thread%percent"],
+    ["with-space", "thread with space"],
+    ["with-non-ascii", "スレッドID"],
+  ])("round-trips threadId `%s` through encode/decode", async (_label, threadId) => {
+    startRelayServer();
+    const port = getRelayPort();
+
+    const promise = waitForRelay(threadId, 5000);
+
+    const res = await fetch(
+      `http://localhost:${port}/relay/${encodeURIComponent(threadId)}`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ text: `hello ${threadId}`, session_id: "s" }),
+      },
+    );
+    expect(res.status).toBe(200);
+
+    const result = await promise;
+    expect(result.text).toBe(`hello ${threadId}`);
+  });
+
+  test("returns 400 for malformed percent-encoding in URL", async () => {
+    startRelayServer();
+    const port = getRelayPort();
+
+    // `%ZZ` is not a valid percent-escape sequence and decodeURIComponent
+    // throws URIError on it. The server must respond 400, not 500.
+    const res = await fetch(`http://localhost:${port}/relay/%ZZ`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "hi" }),
+    });
+    expect(res.status).toBe(400);
+  });
 });

--- a/supervisor/tests/session/relay-server.test.ts
+++ b/supervisor/tests/session/relay-server.test.ts
@@ -5,7 +5,9 @@ import {
   waitForRelay,
   getRelayPort,
   onLateResponse,
+  onProgress,
   type LateResponseEvent,
+  type ProgressEvent,
 } from "../../src/session/relay-server";
 
 describe("relay-server", () => {
@@ -185,6 +187,49 @@ describe("relay-server", () => {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ text: "hi" }),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  // Issue #98 / PR #124 review: /progress/ endpoint must apply the same
+  // decodeURIComponent so progress-relay.sh callbacks for special-char
+  // thread IDs reach the right session via manager.touchActivity.
+  test.each([
+    ["plain-numeric", "1234567890123456"],
+    ["with-slash", "thread/with/slash"],
+    ["with-non-ascii", "スレッドID"],
+  ])(
+    "/progress/ round-trips threadId `%s` through encode/decode",
+    async (_label, threadId) => {
+      startRelayServer();
+      const port = getRelayPort();
+
+      const received: ProgressEvent[] = [];
+      onProgress((event) => received.push(event));
+
+      const res = await fetch(
+        `http://localhost:${port}/progress/${encodeURIComponent(threadId)}`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ tool: "Bash", message: `running on ${threadId}` }),
+        },
+      );
+      expect(res.status).toBe(200);
+      expect(received.length).toBe(1);
+      expect(received[0]!.threadId).toBe(threadId);
+      expect(received[0]!.message).toBe(`running on ${threadId}`);
+    },
+  );
+
+  test("/progress/ returns 400 for malformed percent-encoding in URL", async () => {
+    startRelayServer();
+    const port = getRelayPort();
+
+    const res = await fetch(`http://localhost:${port}/progress/%ZZ`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ tool: "Bash", message: "hi" }),
     });
     expect(res.status).toBe(400);
   });


### PR DESCRIPTION
## 概要

Issue #98 / PR #96 review 由来。`supervisor/src/session/manager.ts:start()` の relay URL 構築で `threadId` を URL パスに直接埋め込んでいたため、防御的観点で `encodeURIComponent` 化を実施。受信側 `relay-server.ts` も対称的に `decodeURIComponent` し、不正エスケープは 500 ではなく 400 として返す。

実害は現状ゼロ（Discord の thread ID は数値文字列のみ）だが、境界での厳密チェックを徹底し将来の入力スキーマ変化や fuzz への耐性を確立する。

## 主な変更

- `supervisor/src/session/manager.ts`
  - `relayUrl` 構築時に `encodeURIComponent(threadId)`
- `supervisor/src/session/relay-server.ts`
  - `/relay/:threadId` パーサで `decodeURIComponent`
  - `URIError`（malformed `%ZZ` 等）を捕捉し `400 Invalid thread ID encoding` を返却
- `supervisor/tests/session/relay-server.test.ts`
  - round-trip テスト 7 ケース（plain-numeric / slash / question / hash / percent / space / non-ASCII）
  - malformed encoding `400` テスト 1 ケース

## AC

- [x] AC-1: `manager.ts:start()` で `encodeURIComponent(threadId)` 適用
- [x] AC-2: `relay-server.ts` の URL parser で `decodeURIComponent` 適用
- [x] AC-3: 既存テスト全 PASS（manager.test.ts 17 pass / relay-server.test.ts 16 pass、+7 新規）
- [x] AC-4: round-trip テスト追加（7 ケース parametric + 400 テスト 1 ケース）

## Test plan

- [x] `bun test tests/session/relay-server.test.ts` → 16 pass / 0 fail
- [x] `bun test tests/session/manager.test.ts` → 17 pass / 0 fail
- [ ] CI green
- [ ] Supervisor 再起動後、Discord で実機 relay ラウンドトリップ確認（手動、統合ジャーニーAC）

## 関連

- Issue #98
- PR #96 review [comment 3142031503](https://github.com/miyashita337/claude-hub/pull/96#discussion_r3142031503)
- `~/agent-base/rules/general/defensive-programming.md`「境界での厳密なチェック」