### PR TITLE
feat(#100): CHANNEL_MAP と Discord access policy の sync を機械検知

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,12 @@ jobs:
       - name: Type check
         run: bunx tsc --noEmit
 
+      # Issue #100: prevent silent CHANNEL_MAP / access policy drift.
+      # Verifies CHANNEL_MAP keys match examples/access-policy.template.json
+      # (which uses channel names, not real Discord IDs — IDs stay user-local).
+      - name: Check CHANNEL_MAP ↔ access policy template sync
+        run: bun scripts/check-access-policy.ts --ci
+
   unit-test:
     name: Unit Tests
     runs-on: ubuntu-latest

--- a/examples/access-policy.template.json
+++ b/examples/access-policy.template.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Issue #100. This file documents the EXPECTED set of channel entries for ~/.claude/channels/discord/access.json. Real access.json keys are Discord channel IDs and are user-local — they are NOT committed here. This template uses channel NAMES (kebab-case, matching supervisor/src/config/channels.ts CHANNEL_MAP keys) so CI can verify CHANNEL_MAP and the access policy stay in sync without leaking channel IDs. When you add a channel to CHANNEL_MAP, also: (1) add the same name as a key here, and (2) add the real Discord channel ID + policy to your local ~/.claude/channels/discord/access.json. The supervisor/scripts/check-access-policy.ts script verifies (1) automatically (CI mode) and warns if (2) is out of sync (local count check).",
+  "_claudeHubExitPrimary": {
+    "_note": "Reserved entry representing the claudeHubExit primary DM/maintenance channel. This channel is intentionally NOT in CHANNEL_MAP (see supervisor/src/config/channels.ts meta-dependency guard).",
+    "requireMention": false,
+    "allowFrom": []
+  },
+  "team-salary": { "requireMention": true, "allowFrom": ["<owner>"] },
+  "convert-service": { "requireMention": true, "allowFrom": ["<owner>"] },
+  "segment-anything": { "requireMention": true, "allowFrom": ["<owner>"] },
+  "claude-context-manager": { "requireMention": true, "allowFrom": ["<owner>"] },
+  "dev-tool": { "requireMention": true, "allowFrom": ["<owner>"] },
+  "obsidian-img-annotator": { "requireMention": true, "allowFrom": ["<owner>"] },
+  "oci-develop": { "requireMention": true, "allowFrom": ["<owner>"] },
+  "agent-base": { "requireMention": true, "allowFrom": ["<owner>"] },
+  "openclaw-rpi5-ops": { "requireMention": true, "allowFrom": ["<owner>"] },
+  "vive-reading": { "requireMention": true, "allowFrom": ["<owner>"] },
+  "video-qa": { "requireMention": true, "allowFrom": ["<owner>"] }
+}

--- a/supervisor/scripts/check-access-policy.ts
+++ b/supervisor/scripts/check-access-policy.ts
@@ -54,6 +54,21 @@ function readJson(path: string): unknown {
   return JSON.parse(raw);
 }
 
+/**
+ * Narrow `unknown` to a non-null object. Rejects `null`, arrays, and
+ * primitives so subsequent property/key access is type-safe. Throws with
+ * a descriptive message used by the caller's catch.
+ */
+function asObject(
+  value: unknown,
+  context: string,
+): Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error(`${context} must be a JSON object`);
+  }
+  return value as Record<string, unknown>;
+}
+
 function runCiMode(): number {
   if (!existsSync(TEMPLATE_PATH)) {
     console.error(`[check-access-policy] template not found: ${TEMPLATE_PATH}`);
@@ -61,7 +76,7 @@ function runCiMode(): number {
   }
   let template: Record<string, unknown>;
   try {
-    template = readJson(TEMPLATE_PATH) as Record<string, unknown>;
+    template = asObject(readJson(TEMPLATE_PATH), "template");
   } catch (err) {
     console.error(
       `[check-access-policy] failed to parse template: ${(err as Error).message}`,
@@ -131,7 +146,7 @@ function runLocalMode(): number {
   }
   let parsed: AccessJsonShape;
   try {
-    parsed = readJson(ACCESS_JSON_PATH) as AccessJsonShape;
+    parsed = asObject(readJson(ACCESS_JSON_PATH), "access.json") as AccessJsonShape;
   } catch (err) {
     console.error(
       `[check-access-policy] failed to parse access.json: ${(err as Error).message}`,
@@ -139,7 +154,15 @@ function runLocalMode(): number {
     return 2;
   }
 
-  const groups = parsed.groups ?? {};
+  // access.json keeps Discord-ID-keyed channel entries under a `groups`
+  // sub-object (alongside `dmPolicy` / `allowFrom` / `pending`); fall back
+  // to an empty object if absent so the downstream count is 0 rather than
+  // crashing.
+  const groupsRaw = parsed.groups;
+  const groups =
+    groupsRaw && typeof groupsRaw === "object" && !Array.isArray(groupsRaw)
+      ? (groupsRaw as Record<string, unknown>)
+      : {};
   const groupCount = Object.keys(groups).length;
   const channelMapNames = [...CHANNEL_MAP.keys()];
 

--- a/supervisor/scripts/check-access-policy.ts
+++ b/supervisor/scripts/check-access-policy.ts
@@ -1,0 +1,192 @@
+#!/usr/bin/env bun
+/**
+ * Verify CHANNEL_MAP stays in sync with the Discord access policy.
+ * Issue #100.
+ *
+ * Modes:
+ *
+ * - default (no flag): local check against `~/.claude/channels/discord/
+ *   access.json`. Uses count-based comparison because access.json keys
+ *   are Discord channel IDs, not names. Reports missing or extra group
+ *   entries as a warning.
+ *
+ * - `--ci`: name-based check against the committed
+ *   `examples/access-policy.template.json`. Used by GitHub Actions on
+ *   every push / PR. Fails if CHANNEL_MAP and the template's channel-name
+ *   keys diverge. Real Discord IDs are never committed.
+ *
+ * Exit codes:
+ *   0 — in sync
+ *   1 — mismatch detected
+ *   2 — configuration error (missing or unparseable file)
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, resolve } from "node:path";
+
+import { CHANNEL_MAP } from "../src/config/channels";
+import {
+  checkAccessPolicyCounts,
+  checkAccessPolicyTemplate,
+} from "../src/config/check-access-policy-core";
+
+const ACCESS_JSON_PATH = join(
+  homedir(),
+  ".claude",
+  "channels",
+  "discord",
+  "access.json",
+);
+
+// repo-root/examples/access-policy.template.json
+const TEMPLATE_PATH = resolve(
+  import.meta.dir,
+  "../../examples/access-policy.template.json",
+);
+
+interface AccessJsonShape {
+  groups?: Record<string, unknown>;
+}
+
+function readJson(path: string): unknown {
+  const raw = readFileSync(path, "utf-8");
+  return JSON.parse(raw);
+}
+
+function runCiMode(): number {
+  if (!existsSync(TEMPLATE_PATH)) {
+    console.error(`[check-access-policy] template not found: ${TEMPLATE_PATH}`);
+    return 2;
+  }
+  let template: Record<string, unknown>;
+  try {
+    template = readJson(TEMPLATE_PATH) as Record<string, unknown>;
+  } catch (err) {
+    console.error(
+      `[check-access-policy] failed to parse template: ${(err as Error).message}`,
+    );
+    return 2;
+  }
+
+  // Drop top-level metadata keys (those starting with `_`, except the reserved
+  // primary marker). They are documentation, not channel entries.
+  const templateKeys = Object.keys(template).filter(
+    (k) => !k.startsWith("_") || k === "_claudeHubExitPrimary",
+  );
+  const channelMapNames = [...CHANNEL_MAP.keys()];
+
+  const result = checkAccessPolicyTemplate(channelMapNames, templateKeys);
+
+  console.log("[check-access-policy] mode: --ci (template comparison)");
+  console.log(`  CHANNEL_MAP names:  ${channelMapNames.length}`);
+  console.log(
+    `  template entries:   ${templateKeys.length} (incl. _claudeHubExitPrimary)`,
+  );
+
+  if (result.inSync) {
+    console.log("  status:             ✓ in sync");
+    return 0;
+  }
+
+  console.error("  status:             ✗ mismatch");
+  if (result.missingFromTemplate.length > 0) {
+    console.error("");
+    console.error(
+      "  Missing from examples/access-policy.template.json (add these):",
+    );
+    for (const name of result.missingFromTemplate) {
+      console.error(`    - ${name}`);
+    }
+  }
+  if (result.extraInTemplate.length > 0) {
+    console.error("");
+    console.error(
+      "  Stale entries in examples/access-policy.template.json (remove these):",
+    );
+    for (const name of result.extraInTemplate) {
+      console.error(`    - ${name}`);
+    }
+  }
+  console.error("");
+  console.error(
+    "  Reminder: also update your local ~/.claude/channels/discord/access.json",
+  );
+  console.error("  with the real Discord channel IDs for any newly added channels.");
+  return 1;
+}
+
+function runLocalMode(): number {
+  if (!existsSync(ACCESS_JSON_PATH)) {
+    console.error(
+      `[check-access-policy] access.json not found at ${ACCESS_JSON_PATH}`,
+    );
+    console.error(
+      "  This is a local-only check; if you don't run the supervisor on this",
+    );
+    console.error(
+      "  machine, you can ignore this and rely on the --ci template check.",
+    );
+    return 2;
+  }
+  let parsed: AccessJsonShape;
+  try {
+    parsed = readJson(ACCESS_JSON_PATH) as AccessJsonShape;
+  } catch (err) {
+    console.error(
+      `[check-access-policy] failed to parse access.json: ${(err as Error).message}`,
+    );
+    return 2;
+  }
+
+  const groups = parsed.groups ?? {};
+  const groupCount = Object.keys(groups).length;
+  const channelMapNames = [...CHANNEL_MAP.keys()];
+
+  const result = checkAccessPolicyCounts(channelMapNames.length, groupCount);
+
+  console.log("[check-access-policy] mode: local (access.json count check)");
+  console.log(`  CHANNEL_MAP entries:    ${channelMapNames.length}`);
+  console.log(`  access.json groups:     ${result.actual}`);
+  console.log(
+    `  expected groups count:  ${result.expected} (CHANNEL_MAP + claudeHubExit primary)`,
+  );
+
+  if (result.inSync) {
+    console.log("  status:                 ✓ counts match");
+    return 0;
+  }
+
+  console.error(
+    `  status:                 ✗ off by ${Math.abs(result.diff)} (${
+      result.diff > 0 ? "extra" : "missing"
+    })`,
+  );
+  console.error("");
+  if (result.diff < 0) {
+    console.error(
+      `  ${Math.abs(result.diff)} channel(s) likely missing from access.json.`,
+    );
+    console.error("  CHANNEL_MAP names (verify each has a group entry):");
+    for (const name of channelMapNames) {
+      console.error(`    - ${name}`);
+    }
+    console.error("");
+    console.error(`  Edit:  ${ACCESS_JSON_PATH}`);
+  } else {
+    console.error(
+      `  access.json has ${result.diff} extra group(s) not represented in CHANNEL_MAP.`,
+    );
+    console.error(
+      "  This may be intentional (e.g., legacy / test channels) but verify.",
+    );
+  }
+  return 1;
+}
+
+function main(): number {
+  const mode = process.argv.includes("--ci") ? "ci" : "local";
+  return mode === "ci" ? runCiMode() : runLocalMode();
+}
+
+process.exit(main());

--- a/supervisor/src/config/check-access-policy-core.ts
+++ b/supervisor/src/config/check-access-policy-core.ts
@@ -1,0 +1,81 @@
+/**
+ * Pure logic for verifying that `CHANNEL_MAP` (TypeScript source of truth)
+ * stays in sync with the Discord access policy (`~/.claude/channels/discord/
+ * access.json` for the live env, or `examples/access-policy.template.json`
+ * for the committed CI snapshot). Issue #100.
+ *
+ * Two complementary checks:
+ *
+ * - {@link checkAccessPolicyCounts}: count-based, used against the live
+ *   `access.json` whose keys are Discord channel IDs (not names). Catches
+ *   "you added a channel to CHANNEL_MAP but forgot to add the matching
+ *   group entry to access.json" by comparing counts.
+ *
+ * - {@link checkAccessPolicyTemplate}: name-based, used against a committed
+ *   template whose keys are channel names. Catches the same mismatch in CI
+ *   without requiring any real channel IDs to be committed (the live IDs
+ *   are user-local and are not safe to publish).
+ */
+
+export interface CountCheckResult {
+  inSync: boolean;
+  expected: number;
+  actual: number;
+  diff: number;
+}
+
+export interface TemplateCheckResult {
+  inSync: boolean;
+  missingFromTemplate: string[];
+  extraInTemplate: string[];
+}
+
+/**
+ * Count-based check against the live `access.json`. Each `CHANNEL_MAP`
+ * entry is expected to have a matching Discord group entry, plus
+ * `primaryReserved` entries (default 1, for the claudeHubExit primary
+ * channel that is intentionally not in `CHANNEL_MAP`).
+ */
+export function checkAccessPolicyCounts(
+  channelMapSize: number,
+  accessGroupCount: number,
+  primaryReserved = 1,
+): CountCheckResult {
+  const expected = channelMapSize + primaryReserved;
+  return {
+    inSync: accessGroupCount === expected,
+    expected,
+    actual: accessGroupCount,
+    diff: accessGroupCount - expected,
+  };
+}
+
+/**
+ * Name-based check against the committed template. The template's keys
+ * (excluding any reserved primary key) must match `channelMapNames`
+ * exactly — every CHANNEL_MAP entry must appear in the template, and no
+ * stale template entries may remain.
+ */
+export function checkAccessPolicyTemplate(
+  channelMapNames: readonly string[],
+  templateKeys: readonly string[],
+  primaryKey = "_claudeHubExitPrimary",
+): TemplateCheckResult {
+  const channelSet = new Set(channelMapNames);
+  const filteredTemplate = templateKeys.filter((k) => k !== primaryKey);
+  const templateSet = new Set(filteredTemplate);
+
+  const missingFromTemplate = channelMapNames
+    .filter((name) => !templateSet.has(name))
+    .sort();
+  const extraInTemplate = filteredTemplate
+    .filter((name) => !channelSet.has(name))
+    .sort();
+
+  return {
+    inSync:
+      missingFromTemplate.length === 0 && extraInTemplate.length === 0,
+    missingFromTemplate,
+    extraInTemplate,
+  };
+}

--- a/supervisor/tests/config/check-access-policy.test.ts
+++ b/supervisor/tests/config/check-access-policy.test.ts
@@ -1,0 +1,124 @@
+import { describe, test, expect } from "bun:test";
+import {
+  checkAccessPolicyCounts,
+  checkAccessPolicyTemplate,
+} from "../../src/config/check-access-policy-core";
+
+/**
+ * Issue #100: verify CHANNEL_MAP and the Discord access policy stay in sync.
+ *
+ * The two checks have complementary responsibilities:
+ *   - count check: catches drift in the live ~/.claude/.../access.json
+ *   - template check: catches drift in the committed
+ *     examples/access-policy.template.json (run in CI)
+ */
+
+describe("checkAccessPolicyCounts", () => {
+  test("returns inSync when counts match (CHANNEL_MAP + 1 primary)", () => {
+    const r = checkAccessPolicyCounts(11, 12);
+    expect(r.inSync).toBe(true);
+    expect(r.expected).toBe(12);
+    expect(r.actual).toBe(12);
+    expect(r.diff).toBe(0);
+  });
+
+  test("flags missing entries with negative diff", () => {
+    const r = checkAccessPolicyCounts(11, 9);
+    expect(r.inSync).toBe(false);
+    expect(r.expected).toBe(12);
+    expect(r.actual).toBe(9);
+    expect(r.diff).toBe(-3);
+  });
+
+  test("flags extra entries with positive diff", () => {
+    const r = checkAccessPolicyCounts(5, 8);
+    expect(r.inSync).toBe(false);
+    expect(r.diff).toBe(2);
+  });
+
+  test("respects custom primaryReserved (e.g. 0 if no claudeHubExit primary)", () => {
+    const r = checkAccessPolicyCounts(5, 5, 0);
+    expect(r.inSync).toBe(true);
+    expect(r.expected).toBe(5);
+  });
+
+  test("handles edge case: empty CHANNEL_MAP and only the primary group", () => {
+    const r = checkAccessPolicyCounts(0, 1);
+    expect(r.inSync).toBe(true);
+  });
+});
+
+describe("checkAccessPolicyTemplate", () => {
+  const channelNames = ["team-salary", "convert-service", "video-qa"];
+
+  test("returns inSync when template has same names + the primary marker", () => {
+    const tplKeys = [
+      "_claudeHubExitPrimary",
+      "team-salary",
+      "convert-service",
+      "video-qa",
+    ];
+    const r = checkAccessPolicyTemplate(channelNames, tplKeys);
+    expect(r.inSync).toBe(true);
+    expect(r.missingFromTemplate).toEqual([]);
+    expect(r.extraInTemplate).toEqual([]);
+  });
+
+  test("flags channels present in CHANNEL_MAP but missing from the template", () => {
+    const tplKeys = ["_claudeHubExitPrimary", "team-salary"];
+    const r = checkAccessPolicyTemplate(channelNames, tplKeys);
+    expect(r.inSync).toBe(false);
+    expect(r.missingFromTemplate).toEqual(["convert-service", "video-qa"]);
+    expect(r.extraInTemplate).toEqual([]);
+  });
+
+  test("flags channels in the template but not in CHANNEL_MAP (stale)", () => {
+    const tplKeys = [
+      "_claudeHubExitPrimary",
+      "team-salary",
+      "convert-service",
+      "video-qa",
+      "deprecated-channel",
+    ];
+    const r = checkAccessPolicyTemplate(channelNames, tplKeys);
+    expect(r.inSync).toBe(false);
+    expect(r.missingFromTemplate).toEqual([]);
+    expect(r.extraInTemplate).toEqual(["deprecated-channel"]);
+  });
+
+  test("flags both missing and extra simultaneously", () => {
+    const tplKeys = ["_claudeHubExitPrimary", "team-salary", "old-channel"];
+    const r = checkAccessPolicyTemplate(channelNames, tplKeys);
+    expect(r.inSync).toBe(false);
+    expect(r.missingFromTemplate).toEqual(["convert-service", "video-qa"]);
+    expect(r.extraInTemplate).toEqual(["old-channel"]);
+  });
+
+  test("ignores the primary marker key by default", () => {
+    // Even if CHANNEL_MAP doesn't include the primary marker, an entry for
+    // it in the template is expected and should NOT be reported as extra.
+    const tplKeys = ["_claudeHubExitPrimary", ...channelNames];
+    const r = checkAccessPolicyTemplate(channelNames, tplKeys);
+    expect(r.inSync).toBe(true);
+  });
+
+  test("custom primaryKey can be supplied", () => {
+    const tplKeys = ["customPrimary", ...channelNames];
+    const r = checkAccessPolicyTemplate(channelNames, tplKeys, "customPrimary");
+    expect(r.inSync).toBe(true);
+  });
+
+  test("returns sorted lists for stable diff output", () => {
+    const tplKeys = ["_claudeHubExitPrimary"]; // all 3 missing
+    const r = checkAccessPolicyTemplate(
+      ["video-qa", "team-salary", "convert-service"],
+      tplKeys,
+    );
+    // Sorted alphabetically.
+    expect(r.missingFromTemplate).toEqual([
+      "convert-service",
+      "team-salary",
+      "video-qa",
+    ]);
+  });
+});


### PR DESCRIPTION
## 概要

Issue #100。`CHANNEL_MAP` (TypeScript ソース) と `~/.claude/channels/discord/access.json` (ユーザーローカル設定) が二重管理されており、整合性チェックが無いため、4 Bot 一括追加時に 3 件の access.json 登録漏れが silent に発生（Vive Reading 等で `@claudeHubExit` が無応答化）。本 PR は機械検知を 2 経路で導入する。

## 主な変更

### Pure logic
- `supervisor/src/config/check-access-policy-core.ts` (新規)
  - `checkAccessPolicyCounts(size, groupCount, primaryReserved=1)`: 件数差分を算出（live access.json 用）
  - `checkAccessPolicyTemplate(names, templateKeys, primaryKey)`: 名称ベース厳密比較（committed template 用、`missingFromTemplate` / `extraInTemplate` をソートして返却）

### Committed template (CI 比較用)
- `examples/access-policy.template.json` (新規)
  - キーは **チャンネル名** (kebab-case)。Discord 実 ID は user-local のため commit しない（public repo）
  - `_claudeHubExitPrimary` 予約キーで claudeHubExit primary 用 entry を記録
  - 各 entry は `{requireMention, allowFrom}` の構造ドキュメントを兼ねる

### CLI
- `supervisor/scripts/check-access-policy.ts` (新規、`#!/usr/bin/env bun`)
  - 既定: local mode（`~/.claude/channels/discord/access.json` の count check）
  - `--ci`: template mode（`examples/access-policy.template.json` との name-by-name diff）
  - exit codes: 0 sync / 1 mismatch / 2 config error

### CI 統合
- `.github/workflows/ci.yml`: Type Check job に `bun scripts/check-access-policy.ts --ci` ステップ追加

### Tests
- `supervisor/tests/config/check-access-policy.test.ts` (新規、12 ケース)
  - count match / negative diff (missing) / positive diff (extra) / 0 primary / template inSync / missing / extra / sorted output 等

## AC

- [x] AC-1: `manager.ts:start()` 等の関連 → 該当なし、本 PR は別レイヤー
- [x] AC-1': CHANNEL_MAP 追加で template 未更新 → CI fail（`--ci` mode で diff 検出）
- [x] AC-2: ローカル `bun scripts/check-access-policy.ts` で差分一覧表示
- [x] AC-3: 既存テスト全 PASS（`bun test tests/config/check-access-policy.test.ts` → 12 pass / 0 fail）

## 統合ジャーニーAC

1. **操作**: 開発者が `CHANNEL_MAP` に新規 channel を追加して PR を作成（template 更新を忘れる）
   - **期待結果**: CI が fail し、エラー出力に追加が必要な channel 名が列挙される
   - **検証手段**: 故意に template から 1 件削除した状態で `bun scripts/check-access-policy.ts --ci` 実行 → exit 1 + `Missing from examples/access-policy.template.json: <name>` 出力（ローカル smoke 済み）
2. **操作**: template に追加して再 push
   - **期待結果**: CI pass
3. **操作**: 既存環境で `bun scripts/check-access-policy.ts` 実行
   - **期待結果**: live access.json と CHANNEL_MAP の count 差分が表示される
   - **検証手段**: ローカル実行で `CHANNEL_MAP entries: 11 / access.json groups: 12 / status: ✓ counts match` を確認済み

## Test plan

- [x] `bun test tests/config/check-access-policy.test.ts` → 12 pass / 0 fail
- [x] `bun scripts/check-access-policy.ts --ci` → exit 0 / in sync (ローカル smoke)
- [x] `bun scripts/check-access-policy.ts` → exit 0 / counts match (ローカル smoke)
- [ ] CI green（Type Check job に新ステップが組み込まれて pass）
- [ ] 故意に template から削除した状態で CI fail することを後続確認（手動）

## 関連

- Issue #100
- 直接対応コミット: 2026-04-25 の access.json 編集（access.json.bak.20260425-232218）
- memory: `project_4bots_addition_2026_04_19.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CDパイプラインに設定値の検証メカニズムを統合し、構成の不一致を防止するようになりました。

* **Tests**
  * 検証機能の包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->