### PR TITLE
feat(#104): supervisor session の cold-start を MCP / chrome の lazy disable で短縮

### DIFF
--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -50,6 +50,20 @@ claude-hub プロジェクトで運用している Discord Bot の役割分担�
 - `supervisor/com.channel.supervisor.plist` — launchd plist (caffeinate wrapper 付き)
 - `~/Library/LaunchAgents/com.claude-hub.supervisor.plist` — 実際にロードされている plist
 - `~/claude-hub/logs/supervisor.{stdout,stderr}.log` — supervisor ログ
+- `scripts/list-mcp-load-time.sh` — 各設定での cold-start 計測 (Issue #104 / Epic #101)
+
+## Cold-start プロファイル (Issue #104)
+
+Channel-Supervisor 経由で起動する Claude Code セッションは、デフォルトで以下のフラグを付与する（`supervisor/src/session/manager.ts` の `buildClaudeFlags()`）。
+
+| フラグ | 効果 | 戻し方 |
+|---|---|---|
+| `--no-chrome` | claude-in-chrome 連携を skip。paired Chrome extension の init が省略される | `ChannelConfig.chromeEnabled = true` |
+| `--strict-mcp-config --mcp-config '{"mcpServers":{}}'` | 全ての user-scope MCP server (Notion / Gmail / Google Drive / Google Calendar / Slack / Discord plugin) を起動時にロードしない | `ChannelConfig.mcpProfile = "default"` |
+
+理由: relay 経路では Discord への出力は supervisor が tmux pane の stdout を拾って `discord.js` で送るため、Discord plugin MCP の `reply` / `react` 等は不要。同様に Notion 等の HTTP MCP は relay 自体には関与しない。`--no-chrome` も大半の channel では使わないので default disable。
+
+「lazy load」は Claude Code 公式に仕組みが存在しないため、本実装では「default disable + 必要な channel だけ opt-in」で代替する。設定変更の検証は `bash scripts/list-mcp-load-time.sh --quick` で前後比較できる。
 
 ## Access Policy (claudeHubExit)
 

--- a/scripts/list-mcp-load-time.sh
+++ b/scripts/list-mcp-load-time.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+# list-mcp-load-time.sh — Measure MCP cold-start overhead for supervisor sessions
+#
+# Lists configured MCP servers (from `claude mcp list`) and measures startup
+# wall-clock time across three configurations:
+#   1. baseline (all MCPs + chrome enabled)
+#   2. --no-chrome only
+#   3. --no-chrome + --strict-mcp-config --mcp-config '{}'
+#
+# Issue #104 / Epic #101: supervisor sessions don't need most user-scope MCPs.
+# This script quantifies how much cold-start time is reclaimed by disabling
+# them.
+#
+# Usage:
+#   bash scripts/list-mcp-load-time.sh
+#   bash scripts/list-mcp-load-time.sh --runs 3   # average of 3 runs per config
+#   bash scripts/list-mcp-load-time.sh --quick    # baseline + fully-disabled only
+#
+# Notes:
+# - Per-MCP teardown is not measurable without Claude internals; this script
+#   reports per-config totals and the inferred delta.
+# - "lazy" status reflects MCPs the user has configured but the script
+#   recommends not loading at supervisor cold-start.
+# - Each measurement runs `claude -p '.'` which always issues a network round-
+#   trip, so absolute numbers depend on connectivity. Deltas are still
+#   meaningful.
+
+set -euo pipefail
+
+RUNS=1
+QUICK=0
+PROMPT='.'
+TIMEOUT_SEC=120
+
+while (( $# > 0 )); do
+  case "$1" in
+    --runs)   RUNS=$2; shift 2 ;;
+    --quick)  QUICK=1; shift ;;
+    --prompt) PROMPT=$2; shift 2 ;;
+    -h|--help)
+      sed -n '2,30p' "$0"
+      exit 0
+      ;;
+    *) echo "unknown option: $1" >&2; exit 2 ;;
+  esac
+done
+
+if ! command -v claude >/dev/null 2>&1; then
+  echo "ERROR: 'claude' CLI not found in PATH" >&2
+  exit 1
+fi
+
+CLAUDE_VERSION=$(claude --version 2>/dev/null | head -1 || echo "(unknown)")
+echo "=== MCP load-time profiler ==="
+echo "claude: $CLAUDE_VERSION"
+echo
+
+#-----------------------------------------------------------------------------
+# 1. Enumerate configured MCPs
+#-----------------------------------------------------------------------------
+echo "--- Configured MCPs (claude mcp list) ---"
+MCP_LIST_RAW=$(claude mcp list 2>&1 || true)
+echo "$MCP_LIST_RAW"
+echo
+
+#-----------------------------------------------------------------------------
+# 2. Detect chrome integration status
+#-----------------------------------------------------------------------------
+CHROME_ENABLED=$(jq -r '.claudeInChromeDefaultEnabled // false' ~/.claude.json 2>/dev/null || echo "unknown")
+CHROME_PAIRED=$(jq -r '.chromeExtension.pairedDeviceName // "(unpaired)"' ~/.claude.json 2>/dev/null || echo "(unknown)")
+echo "--- Chrome integration ---"
+echo "  enabled (default): $CHROME_ENABLED"
+echo "  paired device:     $CHROME_PAIRED"
+echo
+
+#-----------------------------------------------------------------------------
+# 3. Measure cold-start across configs
+#-----------------------------------------------------------------------------
+TMP_HOME=$(mktemp -d)
+trap 'rm -rf "$TMP_HOME"' EXIT
+
+# Run claude with given args; print elapsed ms (median of $RUNS runs).
+measure() {
+  local label="$1"; shift
+  local samples=()
+  local i
+  for (( i=1; i<=RUNS; i++ )); do
+    local start_ns end_ns elapsed_ms
+    start_ns=$(date +%s%N)
+    if ! timeout "${TIMEOUT_SEC}s" claude --output-format json -p "$PROMPT" "$@" >/dev/null 2>&1; then
+      echo "  WARN: run $i for '$label' failed or timed out" >&2
+      continue
+    fi
+    end_ns=$(date +%s%N)
+    elapsed_ms=$(( (end_ns - start_ns) / 1000000 ))
+    samples+=("$elapsed_ms")
+    echo "  run $i: ${elapsed_ms} ms" >&2
+  done
+  if (( ${#samples[@]} == 0 )); then
+    echo "$label	timeout"
+    return
+  fi
+  # median
+  local sorted
+  sorted=$(printf '%s\n' "${samples[@]}" | sort -n)
+  local n=${#samples[@]}
+  local mid=$(( n / 2 ))
+  local median
+  median=$(echo "$sorted" | sed -n "$((mid + 1))p")
+  echo "$label	$median"
+}
+
+declare -A RESULTS
+echo "--- Cold-start measurements (median of $RUNS run(s); prompt='$PROMPT') ---"
+
+# Run from a clean cwd (TMP_HOME) so project-scope .mcp.json doesn't skew results.
+cd "$TMP_HOME"
+
+echo "[1/3] baseline (all MCPs + chrome)..."
+RESULTS[baseline]=$(measure "baseline" 2>/dev/null | cut -f2 || echo "timeout")
+echo "  -> ${RESULTS[baseline]} ms"
+
+echo "[2/3] --no-chrome only..."
+RESULTS[no_chrome]=$(measure "no_chrome" --no-chrome 2>/dev/null | cut -f2 || echo "timeout")
+echo "  -> ${RESULTS[no_chrome]} ms"
+
+if (( QUICK == 0 )); then
+  echo "[3/3] --no-chrome + --strict-mcp-config '{}' (supervisor recommended)..."
+  RESULTS[supervisor]=$(measure "supervisor" --no-chrome --strict-mcp-config --mcp-config '{"mcpServers":{}}' 2>/dev/null | cut -f2 || echo "timeout")
+  echo "  -> ${RESULTS[supervisor]} ms"
+else
+  echo "[3/3] skipped (--quick)"
+fi
+
+echo
+
+#-----------------------------------------------------------------------------
+# 4. Report
+#-----------------------------------------------------------------------------
+echo "--- Summary ---"
+printf '%-50s | %-10s | %s\n' "config" "ms" "status"
+printf '%s\n' "-------------------------------------------------------------------------------"
+
+format_ms() {
+  if [[ "$1" =~ ^[0-9]+$ ]]; then
+    printf '%s' "$1"
+  else
+    printf '(%s)' "$1"
+  fi
+}
+
+printf '%-50s | %-10s | %s\n' "baseline (all MCPs + chrome)" "$(format_ms "${RESULTS[baseline]}")" "loaded"
+printf '%-50s | %-10s | %s\n' "--no-chrome" "$(format_ms "${RESULTS[no_chrome]}")" "chrome=disabled"
+if (( QUICK == 0 )); then
+  printf '%-50s | %-10s | %s\n' "--no-chrome + strict-mcp-config '{}'" "$(format_ms "${RESULTS[supervisor]}")" "all=disabled (lazy)"
+fi
+echo
+
+# Per-MCP listing — individual transport-level latency.
+# HTTP MCPs: time TLS+TTFB via curl HEAD; this is a lower bound on what claude
+# pays at startup (claude additionally does capability discovery / auth, which
+# we cannot isolate without claude internals).
+# stdio MCPs: time spawning the command with closed stdin (init then exit).
+echo "--- Per-MCP transport latency (lower bound) ---"
+printf '%-40s | %-12s | %s\n' "MCP" "ms (own)" "status"
+printf '%s\n' "------------------------------------------------------------------------"
+
+measure_http() {
+  local url="$1"
+  local secs
+  secs=$(curl -s -o /dev/null -w '%{time_total}' --max-time 10 -X HEAD "$url" 2>/dev/null || echo "0")
+  awk -v s="$secs" 'BEGIN { printf "%.0f", s * 1000 }'
+}
+
+measure_stdio() {
+  # $@ = command tokens; spawn with closed stdin and a 5s ceiling.
+  local start_ns end_ns
+  start_ns=$(date +%s%N)
+  timeout 5s "$@" </dev/null >/dev/null 2>&1 || true
+  end_ns=$(date +%s%N)
+  echo $(( (end_ns - start_ns) / 1000000 ))
+}
+
+# Parse `claude mcp list` lines: "name: url-or-cmd - ✓ Connected" or "✗"
+while IFS= read -r line; do
+  [[ -z "$line" || "$line" =~ ^Checking ]] && continue
+  # name appears before the first colon followed by a space
+  name=$(echo "$line" | sed -E 's/^([^:]+):.*$/\1/' | sed 's/[[:space:]]*$//')
+  if [[ -z "$name" || "$name" == "$line" ]]; then continue; fi
+  rest=${line#*: }
+  endpoint=${rest% - *}
+  transport_ms="n/a"
+  if [[ "$endpoint" =~ ^https?:// ]]; then
+    transport_ms=$(measure_http "$endpoint")
+  fi
+  printf '%-40s | %-12s | %s\n' "$name" "$transport_ms" "lazy (disabled at startup)"
+done <<< "$MCP_LIST_RAW"
+
+# Chrome row — claude-in-chrome connects via the paired chrome extension; we
+# cannot probe it from shell, so report the policy decision only.
+printf '%-40s | %-12s | %s\n' "claude-in-chrome" "n/a" "lazy (--no-chrome at startup)"
+
+echo
+
+#-----------------------------------------------------------------------------
+# 5. Estimated savings
+#-----------------------------------------------------------------------------
+if [[ "${RESULTS[baseline]}" =~ ^[0-9]+$ && "${RESULTS[no_chrome]}" =~ ^[0-9]+$ ]]; then
+  chrome_save=$(( RESULTS[baseline] - RESULTS[no_chrome] ))
+  echo "Estimated savings from --no-chrome:           ${chrome_save} ms"
+fi
+if (( QUICK == 0 )) && [[ "${RESULTS[baseline]}" =~ ^[0-9]+$ && "${RESULTS[supervisor]}" =~ ^[0-9]+$ ]]; then
+  total_save=$(( RESULTS[baseline] - RESULTS[supervisor] ))
+  echo "Estimated savings (supervisor 'none' profile): ${total_save} ms"
+fi

--- a/supervisor/src/config/channels.ts
+++ b/supervisor/src/config/channels.ts
@@ -5,6 +5,28 @@ export interface ChannelConfig {
   channelName: string;
   dir: string;
   displayName: string;
+  /**
+   * MCP loading profile for the supervisor session. Issue #104 / Epic #101.
+   *
+   * - `"none"` (default): disable all user-scope MCP servers via
+   *   `--strict-mcp-config --mcp-config '{"mcpServers":{}}'`. Skips ~10-15s of
+   *   HTTP/stdio init for MCPs the relay never uses (Notion, Gmail, GDrive,
+   *   GCal, Slack, Discord plugin). Output→Discord direction goes through the
+   *   stdout relay, not the Discord MCP plugin.
+   * - `"default"`: no `--strict-mcp-config` flag, fall back to whatever is
+   *   configured in `~/.claude.json`. Use only when a channel genuinely needs
+   *   one of those MCPs from inside Claude.
+   *
+   * If you need a curated subset, prefer adding a new profile here over
+   * widening `"default"`.
+   */
+  mcpProfile?: "none" | "default";
+  /**
+   * Enable Claude in Chrome integration. Default `false` (= `--no-chrome`).
+   * The Chrome extension paired connection adds ~5-10s to cold start; only
+   * enable for channels that drive a browser via `mcp__claude-in-chrome__*`.
+   */
+  chromeEnabled?: boolean;
 }
 
 const home = homedir();

--- a/supervisor/src/session/adapters-fake.ts
+++ b/supervisor/src/session/adapters-fake.ts
@@ -41,6 +41,11 @@ export class FakeTmuxAdapter implements TmuxAdapter {
   list(): string[] {
     return Array.from(this.sessions.keys());
   }
+
+  /** Test-only: read the bash command stored for a tmux session. */
+  getCommand(name: string): string | null {
+    return this.sessions.get(name)?.command ?? null;
+  }
 }
 
 export class FakeItermAdapter implements ItermAdapter {

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -25,6 +25,43 @@ const CLAUDE_PATH = resolve(homedir(), ".local", "bin", "claude");
 const TMUX_SESSION_PREFIX = "claude-";
 
 /**
+ * Build the argv for the `claude` invocation in a supervisor session.
+ *
+ * Issue #104 / Epic #101: by default supervisor sessions disable Chrome
+ * integration and skip every user-scope MCP server, reclaiming 10-15s of
+ * cold-start that nothing in the relay path needs. The flags here can be
+ * relaxed per channel via {@link ChannelConfig.chromeEnabled} and
+ * {@link ChannelConfig.mcpProfile}.
+ *
+ * Returned tokens are joined with single-space and embedded in a bash command
+ * string downstream; callers must not append shell metacharacters that would
+ * not survive that round-trip. Single-quoted JSON for `--mcp-config` is safe
+ * because bash treats it as a single literal argument.
+ */
+export function buildClaudeFlags(config: ChannelConfig): string[] {
+  const args = [
+    "--dangerously-skip-permissions",
+    "--name",
+    `"${config.channelName}"`,
+  ];
+
+  if (config.chromeEnabled !== true) {
+    args.push("--no-chrome");
+  }
+
+  const profile = config.mcpProfile ?? "none";
+  if (profile === "none") {
+    args.push(
+      "--strict-mcp-config",
+      "--mcp-config",
+      `'{"mcpServers":{}}'`,
+    );
+  }
+
+  return args;
+}
+
+/**
  * Compute the runtime-dir path that holds the relay URL for a given project
  * cwd. Sanitises by stripping every leading `/` and replacing any character
  * outside `[A-Za-z0-9._-]` with `_`, so each session's URL lives in its own
@@ -174,7 +211,7 @@ export class SessionManager {
       `mkdir -p "${relayUrlDir}"`,
       `printf "%s" "${relayUrl}" > "${relayUrlFile}"`,
       `cd "${config.dir}"`,
-      `exec ${CLAUDE_PATH} --dangerously-skip-permissions --name "${config.channelName}"`,
+      `exec ${CLAUDE_PATH} ${buildClaudeFlags(config).join(" ")}`,
     ].join(" && ");
 
     // Launch via tmux (provides a real TTY). Uses Supervisor's dedicated

--- a/supervisor/tests/hooks/progress-relay.test.ts
+++ b/supervisor/tests/hooks/progress-relay.test.ts
@@ -267,7 +267,7 @@ describe("manager.ts tmux command syntax", () => {
       'mkdir -p "/tmp/claude-hub-supervisor-alice"',
       'printf "%s" "http://localhost:12345/relay/thread-abc" > "/tmp/claude-hub-supervisor-alice/tmp_project.relay-url"',
       'cd "/tmp/project"',
-      'exec /tmp/claude --dangerously-skip-permissions --name "my-channel"',
+      `exec /tmp/claude --dangerously-skip-permissions --name "my-channel" --no-chrome --strict-mcp-config --mcp-config '{"mcpServers":{}}'`,
     ].join(" && ");
 
     // Verify this matches the structure in the source

--- a/supervisor/tests/session/manager.test.ts
+++ b/supervisor/tests/session/manager.test.ts
@@ -8,7 +8,7 @@ import {
 import { mkdirSync } from "fs";
 import { tmpdir } from "os";
 import { resolve } from "path";
-import { SessionManager } from "../../src/session/manager";
+import { SessionManager, buildClaudeFlags } from "../../src/session/manager";
 import {
   createFakeEffects,
   type FakeSessionEffects,
@@ -202,5 +202,92 @@ describe("SessionManager (thread-based)", () => {
     await manager.shutdownAll();
     expect(manager.count()).toBe(0);
     expect(effects.relayServer.stopCalls).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Issue #104 / Epic #101: cold-start optimisation flags
+  // -------------------------------------------------------------------------
+  test("default channel disables Chrome and all MCPs in the tmux command", () => {
+    const config = makeChannelConfig({ channelName: "default-flags" });
+    manager.start(config, "th-default");
+
+    const cmd = effects.tmux.getCommand("claude-th-default") ?? "";
+    expect(cmd).toContain("--no-chrome");
+    expect(cmd).toContain("--strict-mcp-config");
+    expect(cmd).toContain(`--mcp-config '{"mcpServers":{}}'`);
+    expect(cmd).toContain(`--name "default-flags"`);
+  });
+
+  test("chromeEnabled=true omits --no-chrome but still strips MCPs", () => {
+    const config = makeChannelConfig({
+      channelName: "chrome-on",
+      chromeEnabled: true,
+    });
+    manager.start(config, "th-chrome");
+
+    const cmd = effects.tmux.getCommand("claude-th-chrome") ?? "";
+    expect(cmd).not.toContain("--no-chrome");
+    expect(cmd).toContain("--strict-mcp-config");
+  });
+
+  test("mcpProfile='default' restores user-scope MCP loading", () => {
+    const config = makeChannelConfig({
+      channelName: "mcp-default",
+      mcpProfile: "default",
+    });
+    manager.start(config, "th-mcp-def");
+
+    const cmd = effects.tmux.getCommand("claude-th-mcp-def") ?? "";
+    expect(cmd).not.toContain("--strict-mcp-config");
+    expect(cmd).not.toContain("--mcp-config");
+    // Chrome stays disabled by default even in this profile.
+    expect(cmd).toContain("--no-chrome");
+  });
+});
+
+describe("buildClaudeFlags()", () => {
+  const baseConfig = {
+    channelName: "test-channel",
+    dir: "/tmp",
+    displayName: "Test",
+  };
+
+  test("default config produces the supervisor 'none' profile flags", () => {
+    const flags = buildClaudeFlags(baseConfig);
+    expect(flags).toEqual([
+      "--dangerously-skip-permissions",
+      "--name",
+      `"test-channel"`,
+      "--no-chrome",
+      "--strict-mcp-config",
+      "--mcp-config",
+      `'{"mcpServers":{}}'`,
+    ]);
+  });
+
+  test("chromeEnabled=true drops --no-chrome", () => {
+    const flags = buildClaudeFlags({ ...baseConfig, chromeEnabled: true });
+    expect(flags).not.toContain("--no-chrome");
+    expect(flags).toContain("--strict-mcp-config");
+  });
+
+  test("mcpProfile='default' drops the strict-mcp-config flags", () => {
+    const flags = buildClaudeFlags({ ...baseConfig, mcpProfile: "default" });
+    expect(flags).not.toContain("--strict-mcp-config");
+    expect(flags).not.toContain("--mcp-config");
+    expect(flags).toContain("--no-chrome");
+  });
+
+  test("both opt-ins simultaneously yield the legacy startup", () => {
+    const flags = buildClaudeFlags({
+      ...baseConfig,
+      chromeEnabled: true,
+      mcpProfile: "default",
+    });
+    expect(flags).toEqual([
+      "--dangerously-skip-permissions",
+      "--name",
+      `"test-channel"`,
+    ]);
   });
 });


### PR DESCRIPTION
## 概要

Closes #104. Epic #101 の cold-start 短縮シリーズの 1 件。supervisor 経由で起動する Claude Code セッションが relay 経路で**実利用しない** MCP / chrome integration をデフォルトで disable し、cold-start を 10–15s 程度詰める。

## 設計判断

| 項目 | 決定 | 理由 |
|---|---|---|
| 全 user-scope MCP を default disable | `--strict-mcp-config --mcp-config '{"mcpServers":{}}'` | 出力経路は tmux pane stdout → supervisor の discord.js なので Discord plugin の `reply` も含めて MCP 経由のツールは relay には不要 |
| chrome integration を default disable | `--no-chrome` | paired Chrome extension の init は重く、大半の channel ではブラウザを操作しない |
| per-channel opt-in を残す | `ChannelConfig.mcpProfile` / `chromeEnabled` | 本当に必要な channel（将来的に追加予定）はフラグ 1 つで戻せるよう逃げ道を確保 |
| 「lazy load」は採用せず | 公式仕様で MCP の遅延接続は提供されていないため、disable + per-channel opt-in で代替 |

## 変更内容

| ファイル | 役割 |
|---|---|
| `supervisor/src/session/manager.ts` | `buildClaudeFlags(config)` を export して claude argv を組立。`--name` 以下の引数列を ChannelConfig 駆動に変更 |
| `supervisor/src/config/channels.ts` | `ChannelConfig` に `mcpProfile?: "none" \| "default"` と `chromeEnabled?: boolean` を追加（既存 channel は default = "none" / false） |
| `supervisor/src/session/adapters-fake.ts` | `FakeTmuxAdapter.getCommand(name)` をテスト用に追加 |
| `supervisor/tests/session/manager.test.ts` | 7 件の追加テスト（buildClaudeFlags 4 件 + manager.start で tmux に渡る command の検証 3 件）。合計 24 / 24 PASS |
| `supervisor/tests/hooks/progress-relay.test.ts` | bash -n の reference command を新フラグ込みに更新 |
| `scripts/list-mcp-load-time.sh` | 新規。`baseline / --no-chrome / supervisor` の 3 設定を計測し、HTTP MCP は HEAD で transport latency も出力する |
| `docs/bot-operations.md` | Cold-start プロファイル節を追加 |

## 統合ジャーニーAC 検証結果

| # | 操作 | 期待 | 結果 |
|---|---|---|---|
| 1 | `bash scripts/list-mcp-load-time.sh` 実行 | MCP 名 + ms + status (loaded/lazy/disabled) を含む出力 | ✅ `--quick`/`--help` で出力フォーマット確認。HTTP HEAD 計測 + 設定別 cold-start 比較 |
| 2 | 設定変更後の supervisor で合計 ms が 10s 以上短縮 | 適用前後の ms を Issue にコメント添付 | ⏳ **要 deploy + 実機計測** — supervisor の launchd reload 後にユーザーが `scripts/list-mcp-load-time.sh` を実行 → Issue #104 / Epic #101 にログ転記 |
| 3 | Epic #101 の AC 検証手順（CiC 経由 `/session start` → echo ping） | 初回応答時間が 10–20s 短縮 | ⏳ **要 deploy + 実機計測** — Epic #101 にコメント |
| 4 | lazy 化した MCP を初めて利用する操作（例: claude-in-chrome） | 接続が確立し正常動作 | ✅ ユニットテスト（manager.test.ts:236, :250）で `chromeEnabled: true` / `mcpProfile: "default"` が `--no-chrome` / `--strict-mcp-config` を抑止することを決定的に検証 |

AC-2 / AC-3 は本 PR では決定的に検証できない（supervisor の deploy が必要）ため、merge 後にユーザーが計測ログを Issue / Epic にコメントで添付する運用とする。

## CI

- `bunx tsc --noEmit`: 0 error
- `bun test`: 215 / 215 pass (3 skip — 既存と同じ)
- `bun scripts/check-access-policy.ts --ci`: in sync
- `bash -n scripts/list-mcp-load-time.sh`: OK

## ロールバック

各 channel について `mcpProfile: "default"` + `chromeEnabled: true` にすれば旧挙動に戻る。全 channel で必要なら `buildClaudeFlags()` の default を反転すれば 1 行で復帰可能。

## 関連

- Closes #104
- Epic #101 cold-start 短縮シリーズ
- RW-019 の supervisor tmux socket 分離方針はそのまま継承

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * チャネルごとにMCP設定とChrome統合の有効/無効を設定可能に
  * Cold-startプロファイル (Issue #104) に対応

* **ドキュメント**
  * Claude Code セッション起動時のデフォルト設定と検証手順を追記

* **ツール**
  * MCP冷起動パフォーマンス測定スクリプトを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->