### PR TITLE
fix(#132): list-mcp-load-time.sh を bash 3.2 互換化

### DIFF
--- a/scripts/list-mcp-load-time.sh
+++ b/scripts/list-mcp-load-time.sh
@@ -110,24 +110,28 @@ measure() {
   echo "$label	$median"
 }
 
-declare -A RESULTS
+# bash 3.2 compat (macOS default): scalar vars instead of associative array.
+# Issue #132 / RW-028 同型: declare -A は bash 4.0+ 専用なので使わない。
+RESULTS_baseline=""
+RESULTS_no_chrome=""
+RESULTS_supervisor=""
 echo "--- Cold-start measurements (median of $RUNS run(s); prompt='$PROMPT') ---"
 
 # Run from a clean cwd (TMP_HOME) so project-scope .mcp.json doesn't skew results.
 cd "$TMP_HOME"
 
 echo "[1/3] baseline (all MCPs + chrome)..."
-RESULTS[baseline]=$(measure "baseline" 2>/dev/null | cut -f2 || echo "timeout")
-echo "  -> ${RESULTS[baseline]} ms"
+RESULTS_baseline=$(measure "baseline" 2>/dev/null | cut -f2 || echo "timeout")
+echo "  -> ${RESULTS_baseline} ms"
 
 echo "[2/3] --no-chrome only..."
-RESULTS[no_chrome]=$(measure "no_chrome" --no-chrome 2>/dev/null | cut -f2 || echo "timeout")
-echo "  -> ${RESULTS[no_chrome]} ms"
+RESULTS_no_chrome=$(measure "no_chrome" --no-chrome 2>/dev/null | cut -f2 || echo "timeout")
+echo "  -> ${RESULTS_no_chrome} ms"
 
 if (( QUICK == 0 )); then
   echo "[3/3] --no-chrome + --strict-mcp-config '{}' (supervisor recommended)..."
-  RESULTS[supervisor]=$(measure "supervisor" --no-chrome --strict-mcp-config --mcp-config '{"mcpServers":{}}' 2>/dev/null | cut -f2 || echo "timeout")
-  echo "  -> ${RESULTS[supervisor]} ms"
+  RESULTS_supervisor=$(measure "supervisor" --no-chrome --strict-mcp-config --mcp-config '{"mcpServers":{}}' 2>/dev/null | cut -f2 || echo "timeout")
+  echo "  -> ${RESULTS_supervisor} ms"
 else
   echo "[3/3] skipped (--quick)"
 fi
@@ -149,10 +153,10 @@ format_ms() {
   fi
 }
 
-printf '%-50s | %-10s | %s\n' "baseline (all MCPs + chrome)" "$(format_ms "${RESULTS[baseline]}")" "loaded"
-printf '%-50s | %-10s | %s\n' "--no-chrome" "$(format_ms "${RESULTS[no_chrome]}")" "chrome=disabled"
+printf '%-50s | %-10s | %s\n' "baseline (all MCPs + chrome)" "$(format_ms "${RESULTS_baseline}")" "loaded"
+printf '%-50s | %-10s | %s\n' "--no-chrome" "$(format_ms "${RESULTS_no_chrome}")" "chrome=disabled"
 if (( QUICK == 0 )); then
-  printf '%-50s | %-10s | %s\n' "--no-chrome + strict-mcp-config '{}'" "$(format_ms "${RESULTS[supervisor]}")" "all=disabled (lazy)"
+  printf '%-50s | %-10s | %s\n' "--no-chrome + strict-mcp-config '{}'" "$(format_ms "${RESULTS_supervisor}")" "all=disabled (lazy)"
 fi
 echo
 
@@ -205,11 +209,11 @@ echo
 #-----------------------------------------------------------------------------
 # 5. Estimated savings
 #-----------------------------------------------------------------------------
-if [[ "${RESULTS[baseline]}" =~ ^[0-9]+$ && "${RESULTS[no_chrome]}" =~ ^[0-9]+$ ]]; then
-  chrome_save=$(( RESULTS[baseline] - RESULTS[no_chrome] ))
+if [[ "${RESULTS_baseline}" =~ ^[0-9]+$ && "${RESULTS_no_chrome}" =~ ^[0-9]+$ ]]; then
+  chrome_save=$(( RESULTS_baseline - RESULTS_no_chrome ))
   echo "Estimated savings from --no-chrome:           ${chrome_save} ms"
 fi
-if (( QUICK == 0 )) && [[ "${RESULTS[baseline]}" =~ ^[0-9]+$ && "${RESULTS[supervisor]}" =~ ^[0-9]+$ ]]; then
-  total_save=$(( RESULTS[baseline] - RESULTS[supervisor] ))
+if (( QUICK == 0 )) && [[ "${RESULTS_baseline}" =~ ^[0-9]+$ && "${RESULTS_supervisor}" =~ ^[0-9]+$ ]]; then
+  total_save=$(( RESULTS_baseline - RESULTS_supervisor ))
   echo "Estimated savings (supervisor 'none' profile): ${total_save} ms"
 fi


### PR DESCRIPTION
## 概要

`scripts/list-mcp-load-time.sh` が macOS 既定 bash 3.2 で `declare -A: invalid option` (line 113) で停止していた問題を修正。RW-028 同型のリグレッション。

連想配列 `RESULTS` を 3 つのスカラー変数 (`RESULTS_baseline` / `RESULTS_no_chrome` / `RESULTS_supervisor`) に置換し、Summary 出力 / 集計 / Estimated savings 部の参照もすべて書き換えた。

Closes #132

## 関連

- 親: Epic #101 (cold-start 30s) / Sub #104 (MCP lazy disable)
- 同型: agent-base RW-028 (`scripts/cic-smoke.sh` で readarray を bash 3.2 互換化)
- 検証 evidence: #107 のコメント (Phase 1.3 結果)

## 変更内容

```diff
-declare -A RESULTS
+# bash 3.2 compat (macOS default): scalar vars instead of associative array.
+# Issue #132 / RW-028 同型: declare -A は bash 4.0+ 専用なので使わない。
+RESULTS_baseline=""
+RESULTS_no_chrome=""
+RESULTS_supervisor=""
```

集計参照部も `${RESULTS[baseline]}` → `${RESULTS_baseline}` のようにすべて置換。

## 統合ジャーニーAC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | macOS bash 3.2 で `declare` エラーなく完走 + `--- Summary ---` 表示 | `/bin/bash scripts/list-mcp-load-time.sh --quick` | exit 0 + Summary section | exit 0 + Summary 出力確認 | PASS |
| AC-2 | baseline / no_chrome / supervisor の値が記録 (timeout 文字列許容) | 同上 | 3 値 (or `--quick` で 2 値) 出力 | baseline/no_chrome 行に `(timeout)` 表示 | PASS |
| AC-3 | bash 4.x (Linux 等) でも互換動作 | CI Linux runner | 同フォーマット出力 | CI で確認 (本 PR の checks) | PENDING (CI) |

実機ログ抜粋 (macOS bash 3.2.57):
```
=== MCP load-time profiler ===
claude: 2.1.126 (Claude Code)
...
--- Summary ---
config                                             | ms         | status
-------------------------------------------------------------------------------
baseline (all MCPs + chrome)                       | (timeout)  | loaded
--no-chrome                                        | (timeout)  | chrome=disabled
EXIT_CODE=0
```

## テスト手順

1. macOS で `/bin/bash --version` が 3.2.x であることを確認
2. `/bin/bash scripts/list-mcp-load-time.sh --quick` を実行
3. `declare: -A: invalid option` エラーが出ず、`--- Summary ---` セクションが表示されることを確認
4. `echo $?` で exit code 0 を確認

## チェックリスト

- [x] bash 3.2 構文 valid (`/bin/bash -n` で確認)
- [x] `declare -A` / `RESULTS[KEY]` 残存なし (grep で確認)
- [x] 実機 macOS bash 3.2 で完走確認
- [ ] CI green (Linux runner で AC-3 確認)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **メンテナンス**
  * 開発用の内部ツールの実装を最適化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->