### PR TITLE
enhance(#134): list-mcp-load-time.sh の measure 関数で API error 時も cold-start 計測値を採用

### DIFF
--- a/scripts/list-mcp-load-time.sh
+++ b/scripts/list-mcp-load-time.sh
@@ -80,21 +80,39 @@ TMP_HOME=$(mktemp -d)
 trap 'rm -rf "$TMP_HOME"' EXIT
 
 # Run claude with given args; print elapsed ms (median of $RUNS runs).
+#
+# Note: claude exit code is non-zero when the API returns is_error=true
+# (e.g., "Credit balance is too low", auth failures, rate limits). In these
+# cases the MCP discovery + auth + initial API round-trip have completed,
+# which is what we want to measure for cold-start. We therefore distinguish
+# "real timeout" (exit 124 from `timeout` cmd) from "API error" (other
+# non-zero exits) and accept the latter as valid measurements with a tag.
 measure() {
   local label="$1"; shift
   local samples=()
+  local api_error_count=0
   local i
   for (( i=1; i<=RUNS; i++ )); do
-    local start_ns end_ns elapsed_ms
+    local start_ns end_ns elapsed_ms rc
     start_ns=$(date +%s%N)
-    if ! timeout "${TIMEOUT_SEC}s" claude --output-format json -p "$PROMPT" "$@" >/dev/null 2>&1; then
-      echo "  WARN: run $i for '$label' failed or timed out" >&2
-      continue
-    fi
+    timeout "${TIMEOUT_SEC}s" claude --output-format json -p "$PROMPT" "$@" >/dev/null 2>&1
+    rc=$?
     end_ns=$(date +%s%N)
     elapsed_ms=$(( (end_ns - start_ns) / 1000000 ))
+    if (( rc == 124 )); then
+      # Real timeout from `timeout` cmd.
+      echo "  WARN: run $i for '$label' timed out (>${TIMEOUT_SEC}s)" >&2
+      continue
+    fi
+    if (( rc != 0 )); then
+      # claude returned non-zero (typically API error like credit balance);
+      # the cold-start work is still complete by this point.
+      api_error_count=$(( api_error_count + 1 ))
+      echo "  run $i: ${elapsed_ms} ms (claude exit=$rc, API error - cold-start still measured)" >&2
+    else
+      echo "  run $i: ${elapsed_ms} ms" >&2
+    fi
     samples+=("$elapsed_ms")
-    echo "  run $i: ${elapsed_ms} ms" >&2
   done
   if (( ${#samples[@]} == 0 )); then
     echo "$label	timeout"
@@ -107,6 +125,9 @@ measure() {
   local mid=$(( n / 2 ))
   local median
   median=$(echo "$sorted" | sed -n "$((mid + 1))p")
+  if (( api_error_count > 0 )); then
+    echo "  NOTE: $api_error_count/${#samples[@]} runs returned API error (cold-start still valid)" >&2
+  fi
   echo "$label	$median"
 }
 


### PR DESCRIPTION
## 概要

`scripts/list-mcp-load-time.sh` の `measure()` 関数で、`claude` CLI が API エラー (例: `Credit balance is too low` で `is_error: true` 400) で exit non-zero を返したとき、`samples` 配列に何も追加せず「timeout」として誤表示する logic bug があった。

実態は MCP discovery + auth + 初回 API round-trip まで完了している有効な cold-start 計測値であり、本来採用すべきデータを取りこぼしていた。

## 変更内容

- `timeout` cmd の exit code 124 (real timeout) と他の non-zero exit (API error) を区別
- API error 時も `elapsed_ms` を `samples` に追加 + log に `API error - cold-start still measured` を明示表示
- median 計算後に `api_error_count > 0` の場合は NOTE を出力 (測定値の文脈情報)

## 動作確認

修正前 (Issue #134 本文記載):
```
[1/3] baseline (all MCPs + chrome)...
  -> timeout ms
[2/3] --no-chrome only...
  -> timeout ms
```

修正後 (本機 2026-05-03 20:36 JST):
```
[1/3] baseline (all MCPs + chrome)...
  -> 4866 ms
[2/3] --no-chrome only...
  -> 4310 ms
[3/3] --no-chrome + --strict-mcp-config '{}' (supervisor recommended)...
  -> 3305 ms

Estimated savings from --no-chrome:           556 ms
Estimated savings (supervisor 'none' profile): 1561 ms
```

## 統合ジャーニーAC

1. **操作**: `/bin/bash scripts/list-mcp-load-time.sh --runs 3` 実行
   - **期待結果**: API error が発生していても Summary に baseline / no_chrome / supervisor の 3 行とも数値 (ms) が出る
   - **検証手段**: stdout の `--- Summary ---` 直後に 3 行とも `^[0-9]+$` の値が含まれる
2. **操作**: 計測中に `claude` CLI が exit code 1 (API error) を返す
   - **期待結果**: 各 run の log に `(claude exit=N, API error - cold-start still measured)` が表示され、median には採用される
   - **検証手段**: stderr に上記文字列が含まれ、`samples` 配列が空にならない
3. **操作**: real timeout (`timeout` cmd の exit 124) が発生する
   - **期待結果**: 従来通り「WARN: ... timed out」を表示し、samples からは除外
   - **検証手段**: stderr に `timed out` を含む WARN が出る

## 関連

- 親: Issue #134 (verification: MCP capability discovery lazy 化の cold-start 寄与計測)
- 前提: #132 / PR #137 (bash 3.2 互換 fix)
- 検証対象: Sub #104 (MCP lazy disable)
- Epic: #101 (cold-start 30s)
