### PR TITLE
feat(#135): supervisor relay segment latency logging + analyze script

### DIFF
--- a/scripts/analyze-relay-latency.sh
+++ b/scripts/analyze-relay-latency.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env bash
+# Issue #135: supervisor relay segment latency 集計 consumer
+#
+# Writer: supervisor/src/session/latency-logger.ts (recordRelayLatency)
+# 出力先: ~/.claude/state/relay-latency-log.jsonl (1 行 1 計測の JSON)
+#
+# 使い方:
+#   bash scripts/analyze-relay-latency.sh                # default ログを集計
+#   bash scripts/analyze-relay-latency.sh /tmp/test.jsonl  # 別ファイルを指定
+#
+# 出力:
+#   - 計測件数 / 期間 / load_avg_1m の min/max
+#   - segment 別 median (ms)
+#   - dominant segment (median が最大のもの)
+#   - error_segment 内訳 (ある場合)
+#
+# observability ルール: rules/general/observability.md「consumer 必須」(RW-023)
+# に従い、本 script は writer (latency-logger.ts) と同 PR で導入される。
+
+set -euo pipefail
+
+LOG_PATH="${1:-${HOME}/.claude/state/relay-latency-log.jsonl}"
+
+if [ ! -f "${LOG_PATH}" ]; then
+  echo "ERROR: log file not found: ${LOG_PATH}" >&2
+  echo "ヒント: supervisor が稼働して relay が 1 度実行されると生成されます。" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required" >&2
+  exit 1
+fi
+
+LINES=$(wc -l < "${LOG_PATH}" | tr -d ' ')
+if [ "${LINES}" = "0" ]; then
+  echo "WARN: log file is empty: ${LOG_PATH}"
+  exit 0
+fi
+
+echo "=== Relay Latency Analysis ==="
+echo "Log:    ${LOG_PATH}"
+echo "Count:  ${LINES} measurements"
+
+FIRST_TS=$(head -1 "${LOG_PATH}" | jq -r '.timestamp // "n/a"')
+LAST_TS=$(tail -1 "${LOG_PATH}" | jq -r '.timestamp // "n/a"')
+echo "Period: ${FIRST_TS} .. ${LAST_TS}"
+
+LOAD_STATS=$(jq -s '[.[].load_avg_1m] | "min=\(min) max=\(max) avg=\(add/length | .*100|round/100)"' "${LOG_PATH}")
+echo "Load:   ${LOAD_STATS}"
+echo
+
+# segment 名 (latency-logger.ts SEGMENT_NAMES と一致させる)
+SEGMENTS="a b c d_e_c f"
+
+echo "=== Segment Median (ms) ==="
+printf "%-10s %10s %10s %10s %10s\n" "segment" "count" "median" "min" "max"
+
+# dominant 判定用に median を一時保持
+DOMINANT_NAME=""
+DOMINANT_VALUE=-1
+
+for seg in ${SEGMENTS}; do
+  # 各行の .segments[seg] を集約し null を除外して median を計算 (-s で slurp)
+  STATS=$(jq -rs --arg s "${seg}" '
+    [.[].segments[$s] // empty] as $vals |
+    if ($vals | length) == 0 then
+      "0|0|0|0"
+    else
+      ($vals | sort) as $sorted |
+      ($sorted | length) as $n |
+      ($sorted[($n / 2 | floor)]) as $med |
+      "\($n)|\($med)|\($sorted[0])|\($sorted[-1])"
+    end' "${LOG_PATH}")
+
+  COUNT=$(echo "${STATS}" | cut -d'|' -f1)
+  MEDIAN=$(echo "${STATS}" | cut -d'|' -f2)
+  MIN=$(echo "${STATS}" | cut -d'|' -f3)
+  MAX=$(echo "${STATS}" | cut -d'|' -f4)
+  printf "%-10s %10s %10s %10s %10s\n" "${seg}" "${COUNT}" "${MEDIAN}" "${MIN}" "${MAX}"
+
+  if [ "${COUNT}" -gt 0 ] && [ "${MEDIAN}" -gt "${DOMINANT_VALUE}" ]; then
+    DOMINANT_VALUE="${MEDIAN}"
+    DOMINANT_NAME="${seg}"
+  fi
+done
+
+echo
+if [ -n "${DOMINANT_NAME}" ]; then
+  echo "dominant: ${DOMINANT_NAME} (${DOMINANT_VALUE}ms)"
+else
+  echo "dominant: n/a (no segment data)"
+fi
+
+# error_segment 集計 (ある場合のみ)
+ERROR_COUNT=$(jq -s '[.[] | select(.error_segment != null)] | length' "${LOG_PATH}")
+if [ "${ERROR_COUNT}" -gt 0 ]; then
+  echo
+  echo "=== Errors (${ERROR_COUNT} of ${LINES}) ==="
+  jq -r 'select(.error_segment != null) | "\(.timestamp)\t\(.error_segment)"' "${LOG_PATH}" \
+    | sort | uniq -c | sort -rn | head -10
+fi

--- a/supervisor/src/session/latency-logger.ts
+++ b/supervisor/src/session/latency-logger.ts
@@ -1,0 +1,141 @@
+import { appendFileSync, mkdirSync } from "fs";
+import { dirname, resolve } from "path";
+import { homedir, loadavg } from "os";
+
+/**
+ * Append-only logger for supervisor relay segment latencies.
+ *
+ * 各 relayMessage 呼出ごとに 1 行 JSON を `~/.claude/state/relay-latency-log.jsonl`
+ * に追記し、Issue #135 / Epic #101 の高負荷時 70s+ 遅延の dominant 要因特定に
+ * 使う。観測コストを抑えるため fail-open: 書き込み失敗は warn のみで握りつぶす
+ * (relay 本来の責務を阻害しない、RW-023 にあるように consumer 側で「ログが
+ * 書かれていない」ことを定期検出する)。
+ *
+ * Consumer: `scripts/analyze-relay-latency.sh` (segment 別 median 集計 + dominant 表示)
+ *
+ * @see Issue #135, Epic #101, rules/general/observability.md「consumer 必須」
+ */
+
+export const DEFAULT_LATENCY_LOG_PATH = resolve(
+  homedir(),
+  ".claude",
+  "state",
+  "relay-latency-log.jsonl"
+);
+
+/** Segment ID → 名称のマッピング (Issue #135 本文の (a)〜(f) に対応) */
+export const SEGMENT_NAMES = {
+  a: "discord_to_relay_entry",
+  b: "tmux_send_keys",
+  c: "tmux_send_complete_to_wait_start",
+  d_e_c: "wait_for_relay_response",
+  f: "discord_reply_complete",
+} as const;
+
+export interface RelayLatencyRecord {
+  /** ISO 8601 timestamp */
+  timestamp: string;
+  /** supervisor session id (tmux session name 等の安定識別子) */
+  session_id: string;
+  /** load_avg_1m at measurement time */
+  load_avg_1m: number;
+  /** segment ms, key は SEGMENT_NAMES のキーと同じ */
+  segments: Partial<Record<keyof typeof SEGMENT_NAMES, number>>;
+  /** 全体所要時間 (ms)。segments の単純合計とは限らない (overlap 等) */
+  total_ms: number;
+  /** error 発生 segment 名 (success 時は undefined) */
+  error_segment?: string;
+}
+
+let logPath = DEFAULT_LATENCY_LOG_PATH;
+let initialized = false;
+
+/**
+ * テスト用にログ出力先を上書きする。本番コードでは呼ばない。
+ */
+export function setLatencyLogPath(path: string): void {
+  logPath = path;
+  initialized = false;
+}
+
+export function getLatencyLogPath(): string {
+  return logPath;
+}
+
+/**
+ * 1 計測分を 1 行 JSON で append する。
+ * Fail-open: I/O エラーは warn ログのみで握りつぶす。
+ */
+export function recordRelayLatency(record: RelayLatencyRecord): void {
+  try {
+    if (!initialized) {
+      mkdirSync(dirname(logPath), { recursive: true });
+      initialized = true;
+    }
+    const line = JSON.stringify(record) + "\n";
+    appendFileSync(logPath, line, { encoding: "utf8" });
+  } catch (err) {
+    // 観測機構の失敗が relay 本来のフローに影響しないよう、warn のみ。
+    // consumer 側 (analyze-relay-latency.sh) で「ログが書かれていない」を検出する。
+    console.warn(
+      "[latency-logger] recordRelayLatency failed (non-fatal):",
+      err instanceof Error ? err.message : String(err)
+    );
+  }
+}
+
+/**
+ * 計測補助: 各 segment 開始時刻と終了時刻を保持して record を組み立てる。
+ *
+ * 使い方:
+ *   const tracker = createLatencyTracker(sessionId);
+ *   tracker.markStart("b");
+ *   ... tmux send ...
+ *   tracker.markEnd("b");
+ *   ...
+ *   tracker.flush();
+ */
+export interface LatencyTracker {
+  markStart(segment: keyof typeof SEGMENT_NAMES): void;
+  markEnd(segment: keyof typeof SEGMENT_NAMES): void;
+  setError(segment: string): void;
+  flush(): RelayLatencyRecord;
+}
+
+export function createLatencyTracker(sessionId: string): LatencyTracker {
+  const startTimes = new Map<string, number>();
+  const segments: Partial<Record<keyof typeof SEGMENT_NAMES, number>> = {};
+  const trackerStart = performance.now();
+  let errorSegment: string | undefined;
+
+  return {
+    markStart(segment) {
+      startTimes.set(segment, performance.now());
+    },
+    markEnd(segment) {
+      const start = startTimes.get(segment);
+      if (start === undefined) {
+        // markStart を呼ばずに markEnd した場合は無視 (壊れた測定にしない)
+        return;
+      }
+      segments[segment] = Math.round(performance.now() - start);
+    },
+    setError(segment) {
+      errorSegment = segment;
+    },
+    flush() {
+      const record: RelayLatencyRecord = {
+        timestamp: new Date().toISOString(),
+        session_id: sessionId,
+        load_avg_1m: Math.round((loadavg()[0] ?? 0) * 100) / 100,
+        segments,
+        total_ms: Math.round(performance.now() - trackerStart),
+      };
+      if (errorSegment) {
+        record.error_segment = errorSegment;
+      }
+      recordRelayLatency(record);
+      return record;
+    },
+  };
+}

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -4,6 +4,7 @@ import { homedir } from "os";
 import { mkdirSync, writeFileSync, unlinkSync } from "fs";
 import { waitForRelay, type RelayResult } from "./relay-server";
 import { TMUX_PATH, TMUX_ARGS } from "./tmux";
+import { createLatencyTracker } from "./latency-logger";
 
 const ATTACHMENT_DIR = resolve(homedir(), "claude-hub", "tmp", "attachments");
 
@@ -160,6 +161,12 @@ export async function relayMessage(
     }
   }
 
+  // Latency tracker: Issue #135 / Epic #101 で高負荷時 70s+ 遅延の dominant
+  // segment を特定するために各 segment の所要 ms を記録。session_id には
+  // tmux session 名 (= supervisor 内で安定識別子) を使う。
+  // 観測機構の失敗は relay 本来の処理を止めない (latency-logger.ts 参照)。
+  const tracker = createLatencyTracker(tmuxSessionName);
+
   // 2. Send via tmux send-keys using execFileSync (argv array, no shell).
   // We issue the input and the submit as two separate calls:
   //   (a) `send-keys -l <literal>` — tmux forwards the bytes verbatim.
@@ -176,6 +183,8 @@ export async function relayMessage(
   const literalText = fullMessage.replace(/\n/g, " ");
 
   try {
+    // Segment (b): tmux 経路 (mode exit + Escape + send-keys -l + C-m)
+    tracker.markStart("b");
     // Exit any stuck tmux mode (copy-mode, view-mode) BEFORE any send-keys.
     // A pane in copy-mode consumes keys as mode commands and silently drops
     // the payload or yields `not in a mode` on the retry path (Issue #73).
@@ -189,7 +198,11 @@ export async function relayMessage(
     // Small pause so the TUI finishes ingesting the text before Enter.
     await new Promise((r) => setTimeout(r, 100));
     await tmuxSend(tmuxSessionName, ["C-m"]);
+    tracker.markEnd("b");
   } catch (err) {
+    tracker.markEnd("b");
+    tracker.setError("b");
+    tracker.flush();
     scheduleCleanup(localFiles, 5 * 60_000);
     return {
       text: "",
@@ -198,8 +211,23 @@ export async function relayMessage(
     };
   }
 
+  // Segment (c): tmux send 完了 → waitForRelay 開始までの隙間 (大体ゼロ、
+  // でも明示的に記録しておくことで設計レビュー時の sanity check になる)
+  tracker.markStart("c");
+  tracker.markEnd("c");
+
   // 3. Wait for Stop hook to POST the response
+  // Segment (d_e_c): claude TUI 受信 + skill/hook init + MCP capability
+  // discovery + Anthropic API 呼出 + Stop hook fire の合計。supervisor から
+  // は内訳を分離できないため 1 まとめで記録 (Issue #135 で「(d)+(e)+(c)」と
+  // して観測する設計と一致)。
+  tracker.markStart("d_e_c");
   const result = await waitForRelay(threadId, RELAY_TIMEOUT_MS);
+  tracker.markEnd("d_e_c");
+  if (result.error) {
+    tracker.setError("d_e_c");
+  }
+  tracker.flush();
 
   scheduleCleanup(localFiles, 5 * 60_000);
   return result;

--- a/supervisor/tests/session/latency-logger.test.ts
+++ b/supervisor/tests/session/latency-logger.test.ts
@@ -1,0 +1,116 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, readFileSync, existsSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  createLatencyTracker,
+  recordRelayLatency,
+  setLatencyLogPath,
+  getLatencyLogPath,
+  DEFAULT_LATENCY_LOG_PATH,
+  SEGMENT_NAMES,
+  type RelayLatencyRecord,
+} from "../../src/session/latency-logger";
+
+describe("latency-logger", () => {
+  let tmpDir: string;
+  let logPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "latency-logger-test-"));
+    logPath = join(tmpDir, "relay-latency-log.jsonl");
+    setLatencyLogPath(logPath);
+  });
+
+  afterEach(() => {
+    setLatencyLogPath(DEFAULT_LATENCY_LOG_PATH);
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  test("DEFAULT_LATENCY_LOG_PATH points to ~/.claude/state/relay-latency-log.jsonl", () => {
+    expect(DEFAULT_LATENCY_LOG_PATH).toContain(".claude");
+    expect(DEFAULT_LATENCY_LOG_PATH).toContain("relay-latency-log.jsonl");
+  });
+
+  test("SEGMENT_NAMES has 5 entries (a, b, c, d_e_c, f)", () => {
+    const keys = Object.keys(SEGMENT_NAMES).sort();
+    expect(keys).toEqual(["a", "b", "c", "d_e_c", "f"]);
+  });
+
+  test("recordRelayLatency appends one JSON line per call", () => {
+    const record: RelayLatencyRecord = {
+      timestamp: "2026-05-03T10:00:00.000Z",
+      session_id: "test-session-1",
+      load_avg_1m: 1.5,
+      segments: { b: 25, d_e_c: 1500 },
+      total_ms: 1525,
+    };
+    recordRelayLatency(record);
+    recordRelayLatency({ ...record, timestamp: "2026-05-03T10:00:10.000Z" });
+
+    expect(existsSync(logPath)).toBe(true);
+    const content = readFileSync(logPath, "utf8");
+    const lines = content.trim().split("\n");
+    expect(lines.length).toBe(2);
+
+    const parsed = JSON.parse(lines[0]!);
+    expect(parsed.session_id).toBe("test-session-1");
+    expect(parsed.segments.b).toBe(25);
+    expect(parsed.segments.d_e_c).toBe(1500);
+  });
+
+  test("createLatencyTracker measures elapsed time per segment", async () => {
+    const tracker = createLatencyTracker("session-x");
+    tracker.markStart("b");
+    await new Promise((r) => setTimeout(r, 30));
+    tracker.markEnd("b");
+
+    tracker.markStart("d_e_c");
+    await new Promise((r) => setTimeout(r, 50));
+    tracker.markEnd("d_e_c");
+
+    const record = tracker.flush();
+
+    expect(record.session_id).toBe("session-x");
+    expect(record.segments.b).toBeGreaterThanOrEqual(25);
+    expect(record.segments.b).toBeLessThan(200);
+    expect(record.segments.d_e_c).toBeGreaterThanOrEqual(45);
+    expect(record.segments.d_e_c).toBeLessThan(300);
+    expect(typeof record.load_avg_1m).toBe("number");
+    expect(record.timestamp).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  test("markEnd without markStart is silently ignored (broken measurement guard)", () => {
+    const tracker = createLatencyTracker("session-y");
+    // markStart を呼ばずに markEnd → 該当 segment は記録されない (壊れた値にしない)
+    tracker.markEnd("b");
+    const record = tracker.flush();
+    expect(record.segments.b).toBeUndefined();
+  });
+
+  test("setError sets error_segment in flushed record", () => {
+    const tracker = createLatencyTracker("session-z");
+    tracker.markStart("b");
+    tracker.markEnd("b");
+    tracker.setError("b");
+    const record = tracker.flush();
+    expect(record.error_segment).toBe("b");
+  });
+
+  test("getLatencyLogPath returns the currently configured path", () => {
+    expect(getLatencyLogPath()).toBe(logPath);
+  });
+
+  test("flush writes the record to disk via recordRelayLatency", () => {
+    const tracker = createLatencyTracker("session-flush");
+    tracker.markStart("b");
+    tracker.markEnd("b");
+    tracker.flush();
+
+    expect(existsSync(logPath)).toBe(true);
+    const lines = readFileSync(logPath, "utf8").trim().split("\n");
+    expect(lines.length).toBe(1);
+    const parsed = JSON.parse(lines[0]!);
+    expect(parsed.session_id).toBe("session-flush");
+  });
+});


### PR DESCRIPTION
## 概要

Issue #135 / Epic #101 で観測された高負荷時 70s+ 遅延の dominant segment を特定するため、supervisor relay 経路の各 segment に ms 精度の timestamp logging を仕込む。同 PR で consumer (集計 script) も実装し、observability ルール「consumer 必須」(RW-023) に準拠。

## 主な変更点

| ファイル | 内容 |
|---|---|
| `supervisor/src/session/latency-logger.ts` (新規) | `recordRelayLatency` / `createLatencyTracker` writer。fail-open で書込み失敗は warn のみ。出力先は `~/.claude/state/relay-latency-log.jsonl` (1 行 1 計測 JSON) |
| `supervisor/src/session/relay.ts` | `relayMessage` に tracker を組み込み、segment **(b)** tmux send-keys 経路 と **(d_e_c)** waitForRelay 待機を計測。既存 relay 機能・エラーハンドリングは保全 (logging 追加のみ) |
| `scripts/analyze-relay-latency.sh` (新規) | jsonl を jq で読み、segment 別 median / count / min / max を表で表示し dominant segment を 1 行で出力 |
| `supervisor/tests/session/latency-logger.test.ts` (新規, 8 ケース) | writer/tracker/error/壊れた測定 guard を回帰テスト |

## Segment 設計

Issue #135 本文の (a)〜(f) のうち、supervisor から直接観測可能な範囲を計測:

| segment | 内容 | supervisor からの観測 |
|---|---|---|
| `a` | Discord 受信〜relay 入口 | 呼出側で個別計測 (本 PR では未計測) |
| `b` | tmux 経路 (mode exit + Escape + send-keys -l + C-m) | 計測済 |
| `c` | tmux 完了 → waitForRelay 開始 | 計測済 (sanity check 用、ほぼ 0ms) |
| `d_e_c` | TUI 受信 + skill/hook init + MCP discovery + Anthropic API + Stop hook | 計測済 (内訳分離不可のため 1 まとめ) |
| `f` | Discord reply 完了 | 呼出側 (manager.ts) で計測すべきだが本 PR では未計測 |

(a)/(f) は呼出側で個別計測する設計拡張余地として残し、本 PR では relay.ts 単独で観測可能な範囲に絞った (relay.ts の責務境界保全)。

## Test Plan

- [x] bun test tests/session/latency-logger.test.ts → 8/8 PASS
- [x] bun test tests/session/relay.test.ts tests/session/relay-server.test.ts → 27/27 PASS (regression なし)
- [x] bun test tests/session/manager.test.ts → 24/24 PASS
- [x] bunx tsc --noEmit → エラーなし
- [x] consumer script smoke test (5 行 fixture で dominant: d_e_c (2800ms) 確認)

## AC 状況 (#135)

- AC-1 (PASS): supervisor 側に segment timestamp ログを追加 (b/c/d_e_c の 3 segment、ms 精度)
- AC-2 (部分達成): ログは jsonl に append される。実機計測 5+5 件は手動 phase で別途実施
- AC-3 (PASS): consumer script を同 PR で実装、fixture jsonl で smoke test 済
- AC-4 (未達): dominant 特定は実機 5+5 計測後の follow-up で行う

AC-2/AC-4 は手動計測フェーズが必要なため、本 PR merge 後も Issue #135 は open のまま とし needs-followup ラベルを付与する。

## 関連

- Issue: #135
- 親 Epic: #101
- 関連 RW: RW-023 (consumer 必須)、RW-019 (tmux socket 分離、本計測の前提)