### PR TITLE
feat(#144): IDiscordClient interface + Real/InMemory 実装 + claude-mock.sh (Phase 1)

### DIFF
--- a/supervisor/src/discord/in-memory-client.ts
+++ b/supervisor/src/discord/in-memory-client.ts
@@ -1,0 +1,190 @@
+// InMemoryDiscordClient — in-process fake of IDiscordClient for tests.
+//
+// Phase 1 (Issue #144): supports event injection (injectThreadMessage,
+// injectSlashCommand) and exposes sent message / typing logs so the
+// upcoming lifecycle E2E test can assert the supervisor's outbound side.
+
+import type {
+  DiscordSendOptions,
+  DiscordSlashCommand,
+  DiscordThreadMessage,
+  IDiscordClient,
+  SlashCommandHandler,
+  ThreadMessageHandler,
+} from "./types";
+
+export interface SentMessageRecord {
+  threadId: string;
+  content: string;
+  options: DiscordSendOptions;
+  ts: number;
+}
+
+export interface InjectThreadMessageInput {
+  threadId: string;
+  content: string;
+  messageId?: string;
+  authorId?: string;
+  authorBot?: boolean;
+  attachments?: DiscordThreadMessage["attachments"];
+}
+
+export interface InjectSlashCommandInput {
+  commandName: string;
+  options?: Record<string, string | number | boolean>;
+  channelId?: string;
+  userId?: string;
+  /** Optional capture for reply() invocations. Defaults to a recording function. */
+  onReply?: (content: string, ephemeral: boolean) => void | Promise<void>;
+}
+
+export class InMemoryDiscordClient implements IDiscordClient {
+  private readonly threadHandlers: ThreadMessageHandler[] = [];
+  private readonly slashHandlers: SlashCommandHandler[] = [];
+  private readonly sentMessages: SentMessageRecord[] = [];
+  private readonly typingCalls = new Map<string, number>();
+  private readonly slashReplies: Array<{
+    commandName: string;
+    content: string;
+    ephemeral: boolean;
+  }> = [];
+  private readonly handlerErrors: unknown[] = [];
+  private started = false;
+  private stopped = false;
+  private autoIncrementId = 1;
+
+  async start(): Promise<void> {
+    if (this.stopped) {
+      throw new Error("InMemoryDiscordClient: cannot start after stop()");
+    }
+    this.started = true;
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+  }
+
+  async sendToThread(
+    threadId: string,
+    content: string,
+    options: DiscordSendOptions = {},
+  ): Promise<void> {
+    this.assertRunning();
+    this.sentMessages.push({
+      threadId,
+      content,
+      options: { ...options },
+      ts: Date.now(),
+    });
+  }
+
+  async sendTyping(threadId: string): Promise<void> {
+    this.assertRunning();
+    this.typingCalls.set(threadId, (this.typingCalls.get(threadId) ?? 0) + 1);
+  }
+
+  onThreadMessage(handler: ThreadMessageHandler): void {
+    this.threadHandlers.push(handler);
+  }
+
+  onSlashCommand(handler: SlashCommandHandler): void {
+    this.slashHandlers.push(handler);
+  }
+
+  // ---- Test injection API (not part of IDiscordClient) ----
+
+  /** Fire a thread message event. Bot-authored messages are gated like RealDiscordClient. */
+  injectThreadMessage(input: InjectThreadMessageInput): void {
+    this.assertRunning();
+    const event: DiscordThreadMessage = {
+      threadId: input.threadId,
+      messageId: input.messageId ?? `msg_${this.autoIncrementId++}`,
+      authorId: input.authorId ?? "user_test",
+      authorBot: input.authorBot ?? false,
+      content: input.content,
+      attachments: input.attachments ?? [],
+    };
+    if (event.authorBot) return; // Mirror RealDiscordClient gating.
+    // Mirror RealDiscordClient's per-handler isolation: one throwing handler
+    // shouldn't stop the chain. Errors are recorded so tests can assert on
+    // them via getHandlerErrors().
+    for (const h of this.threadHandlers) {
+      try {
+        h(event);
+      } catch (err) {
+        this.handlerErrors.push(err);
+      }
+    }
+  }
+
+  /** Fire a slash command event. reply() recordings are exposed via getSlashReplies(). */
+  injectSlashCommand(input: InjectSlashCommandInput): void {
+    this.assertRunning();
+    const recordReply = async (content: string, ephemeral?: boolean) => {
+      const eph = ephemeral ?? false;
+      this.slashReplies.push({
+        commandName: input.commandName,
+        content,
+        ephemeral: eph,
+      });
+      if (input.onReply) await input.onReply(content, eph);
+    };
+    const cmd: DiscordSlashCommand = {
+      commandName: input.commandName,
+      options: input.options ?? {},
+      channelId: input.channelId ?? "channel_test",
+      userId: input.userId ?? "user_test",
+      reply: recordReply,
+    };
+    for (const h of this.slashHandlers) {
+      try {
+        h(cmd);
+      } catch (err) {
+        this.handlerErrors.push(err);
+      }
+    }
+  }
+
+  // ---- Inspection API ----
+
+  getSentMessages(threadId?: string): SentMessageRecord[] {
+    return threadId
+      ? this.sentMessages.filter((m) => m.threadId === threadId)
+      : [...this.sentMessages];
+  }
+
+  getTypingCallCount(threadId: string): number {
+    return this.typingCalls.get(threadId) ?? 0;
+  }
+
+  getSlashReplies(): ReadonlyArray<{
+    commandName: string;
+    content: string;
+    ephemeral: boolean;
+  }> {
+    return this.slashReplies;
+  }
+
+  isStarted(): boolean {
+    return this.started && !this.stopped;
+  }
+
+  /** Errors thrown by handlers during inject*. The chain itself is never broken. */
+  getHandlerErrors(): readonly unknown[] {
+    return this.handlerErrors;
+  }
+
+  /** Reset all recorded interactions but keep registered handlers. */
+  clearLogs(): void {
+    this.sentMessages.length = 0;
+    this.typingCalls.clear();
+    this.slashReplies.length = 0;
+    this.handlerErrors.length = 0;
+  }
+
+  private assertRunning(): void {
+    if (!this.started) throw new Error("InMemoryDiscordClient: not started");
+    if (this.stopped) throw new Error("InMemoryDiscordClient: already stopped");
+  }
+}

--- a/supervisor/src/discord/real-client.ts
+++ b/supervisor/src/discord/real-client.ts
@@ -86,8 +86,21 @@ export class RealDiscordClient implements IDiscordClient {
       // BOOLEAN / NUMBER and complex objects (User, Channel, Role, Attachment)
       // for resolved types. The interface only exposes primitives — gate on
       // typeof so a complex option doesn't sneak through as `[object Object]`.
+      // Subcommand support: when /session start is invoked, data[0] has
+      // type=SUB_COMMAND (1) and the actual options nest inside .options.
+      // SUB_COMMAND_GROUP (2) nests one level deeper but no current command
+      // uses it, so we flatten only one level.
       const opts: Record<string, string | number | boolean> = {};
-      for (const opt of interaction.options.data) {
+      let subcommand: string | undefined;
+      // ApplicationCommandOptionType: 1 = SUB_COMMAND, 2 = SUB_COMMAND_GROUP.
+      const top = interaction.options.data;
+      const subEntry =
+        top.length === 1 && (top[0]!.type === 1 || top[0]!.type === 2)
+          ? top[0]!
+          : undefined;
+      const optionList = subEntry?.options ?? top;
+      if (subEntry) subcommand = subEntry.name;
+      for (const opt of optionList) {
         const v = opt.value;
         if (
           v !== undefined &&
@@ -101,6 +114,7 @@ export class RealDiscordClient implements IDiscordClient {
       }
       const cmd: DiscordSlashCommand = {
         commandName: interaction.commandName,
+        ...(subcommand !== undefined ? { subcommand } : {}),
         options: opts,
         channelId: interaction.channelId ?? "",
         userId: interaction.user.id,
@@ -129,8 +143,11 @@ export class RealDiscordClient implements IDiscordClient {
       throw new Error("RealDiscordClient: cannot start after stop()");
     }
     if (this.started) return;
-    this.started = true;
+    // Mark as started AFTER successful login so a transient auth failure
+    // leaves the client in the un-started state and the caller can retry
+    // (CodeRabbit PR #145 review).
     await this.client.login(this.token);
+    this.started = true;
   }
 
   async stop(): Promise<void> {
@@ -147,7 +164,9 @@ export class RealDiscordClient implements IDiscordClient {
     this.assertRunning();
     const channel = await this.client.channels.fetch(threadId);
     if (!channel?.isThread()) {
-      throw new Error(`RealDiscordClient: thread not found: ${threadId}`);
+      throw new Error(
+        `RealDiscordClient: channel is not a thread or not found: ${threadId}`,
+      );
     }
     if (options.files?.length) {
       await channel.send({

--- a/supervisor/src/discord/real-client.ts
+++ b/supervisor/src/discord/real-client.ts
@@ -1,0 +1,194 @@
+// RealDiscordClient — thin wrapper over discord.js Client implementing IDiscordClient.
+//
+// Phase 1 (Issue #144): not yet wired into bot.ts. The wrapper exists so Phase 2's
+// lifecycle E2E test can swap in InMemoryDiscordClient at the same seam.
+// Phase 2 will migrate bot.ts to construct the client through this interface.
+
+import {
+  Client,
+  Events,
+  GatewayIntentBits,
+  type Interaction,
+  type Message,
+  type ThreadChannel,
+} from "discord.js";
+import type {
+  AttachmentInfo,
+  DiscordSendOptions,
+  DiscordSlashCommand,
+  DiscordThreadMessage,
+  IDiscordClient,
+  SlashCommandHandler,
+  ThreadMessageHandler,
+} from "./types";
+
+export interface RealDiscordClientOptions {
+  /** discord.js intents. Defaults match bot.ts for backwards compatibility. */
+  intents?: GatewayIntentBits[];
+  /** Inject a Client for tests; production callers leave this undefined. */
+  client?: Client;
+}
+
+const DEFAULT_INTENTS: GatewayIntentBits[] = [
+  GatewayIntentBits.Guilds,
+  GatewayIntentBits.GuildMessages,
+  GatewayIntentBits.MessageContent,
+];
+
+export class RealDiscordClient implements IDiscordClient {
+  private readonly client: Client;
+  private readonly token: string;
+  private readonly threadHandlers: ThreadMessageHandler[] = [];
+  private readonly slashHandlers: SlashCommandHandler[] = [];
+  private started = false;
+  private stopped = false;
+
+  constructor(token: string, options: RealDiscordClientOptions = {}) {
+    if (!token) throw new Error("RealDiscordClient: token is required");
+    this.token = token;
+    this.client =
+      options.client ??
+      new Client({ intents: options.intents ?? DEFAULT_INTENTS });
+
+    this.client.on(Events.MessageCreate, (message: Message) => {
+      // Mirror bot.ts gating: only thread messages from non-bot users propagate.
+      if (message.author.bot) return;
+      if (!message.channel.isThread()) return;
+      const thread = message.channel as ThreadChannel;
+      const attachments: AttachmentInfo[] = [];
+      for (const [, att] of message.attachments) {
+        attachments.push({
+          url: att.url,
+          filename: att.name ?? "attachment",
+          contentType: att.contentType ?? "application/octet-stream",
+        });
+      }
+      const event: DiscordThreadMessage = {
+        threadId: thread.id,
+        messageId: message.id,
+        authorId: message.author.id,
+        authorBot: message.author.bot,
+        content: message.content,
+        attachments,
+      };
+      for (const h of this.threadHandlers) {
+        try {
+          h(event);
+        } catch (err) {
+          console.error("[RealDiscordClient] thread handler threw:", err);
+        }
+      }
+    });
+
+    this.client.on(Events.InteractionCreate, (interaction: Interaction) => {
+      if (!interaction.isChatInputCommand()) return;
+      // discord.js options.data carries primitives for STRING / INTEGER /
+      // BOOLEAN / NUMBER and complex objects (User, Channel, Role, Attachment)
+      // for resolved types. The interface only exposes primitives — gate on
+      // typeof so a complex option doesn't sneak through as `[object Object]`.
+      const opts: Record<string, string | number | boolean> = {};
+      for (const opt of interaction.options.data) {
+        const v = opt.value;
+        if (
+          v !== undefined &&
+          v !== null &&
+          (typeof v === "string" ||
+            typeof v === "number" ||
+            typeof v === "boolean")
+        ) {
+          opts[opt.name] = v;
+        }
+      }
+      const cmd: DiscordSlashCommand = {
+        commandName: interaction.commandName,
+        options: opts,
+        channelId: interaction.channelId ?? "",
+        userId: interaction.user.id,
+        reply: async (content: string, ephemeral?: boolean) => {
+          if (interaction.deferred || interaction.replied) {
+            await interaction.editReply({ content });
+          } else {
+            await interaction.reply(
+              ephemeral ? { content, flags: 64 } : { content },
+            );
+          }
+        },
+      };
+      for (const h of this.slashHandlers) {
+        try {
+          h(cmd);
+        } catch (err) {
+          console.error("[RealDiscordClient] slash handler threw:", err);
+        }
+      }
+    });
+  }
+
+  async start(): Promise<void> {
+    if (this.stopped) {
+      throw new Error("RealDiscordClient: cannot start after stop()");
+    }
+    if (this.started) return;
+    this.started = true;
+    await this.client.login(this.token);
+  }
+
+  async stop(): Promise<void> {
+    if (this.stopped) return;
+    this.stopped = true;
+    this.client.destroy();
+  }
+
+  async sendToThread(
+    threadId: string,
+    content: string,
+    options: DiscordSendOptions = {},
+  ): Promise<void> {
+    this.assertRunning();
+    const channel = await this.client.channels.fetch(threadId);
+    if (!channel?.isThread()) {
+      throw new Error(`RealDiscordClient: thread not found: ${threadId}`);
+    }
+    if (options.files?.length) {
+      await channel.send({
+        content,
+        files: options.files.map((f) => ({
+          attachment: f.attachment,
+          name: f.name,
+        })),
+      });
+    } else {
+      await channel.send(content);
+    }
+  }
+
+  async sendTyping(threadId: string): Promise<void> {
+    this.assertRunning();
+    try {
+      const channel = await this.client.channels.fetch(threadId);
+      if (channel?.isThread()) await channel.sendTyping();
+    } catch (err) {
+      console.warn(
+        `[RealDiscordClient] sendTyping failed for ${threadId}: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  onThreadMessage(handler: ThreadMessageHandler): void {
+    this.threadHandlers.push(handler);
+  }
+
+  onSlashCommand(handler: SlashCommandHandler): void {
+    this.slashHandlers.push(handler);
+  }
+
+  /** Test-only escape hatch for callers that still need the underlying Client. */
+  getUnderlyingClient(): Client {
+    return this.client;
+  }
+
+  private assertRunning(): void {
+    if (!this.started) throw new Error("RealDiscordClient: not started");
+    if (this.stopped) throw new Error("RealDiscordClient: already stopped");
+  }
+}

--- a/supervisor/src/discord/types.ts
+++ b/supervisor/src/discord/types.ts
@@ -1,0 +1,65 @@
+// Discord client abstraction (Issue #144 Phase 1).
+//
+// The interface captures the minimum surface needed by bot.ts and the
+// upcoming lifecycle E2E test. RealDiscordClient wraps discord.js Client;
+// InMemoryDiscordClient is a queue-based fake that lets tests inject
+// thread messages and slash commands without a real Gateway connection.
+
+import type { AttachmentInfo } from "../session/relay";
+
+export type { AttachmentInfo };
+
+export interface DiscordThreadMessage {
+  threadId: string;
+  messageId: string;
+  authorId: string;
+  authorBot: boolean;
+  content: string;
+  attachments: AttachmentInfo[];
+}
+
+export interface DiscordFileAttachment {
+  name: string;
+  /** Absolute path or in-memory buffer. */
+  attachment: string | Buffer;
+}
+
+export interface DiscordSendOptions {
+  files?: DiscordFileAttachment[];
+}
+
+export interface DiscordSlashCommand {
+  commandName: string;
+  options: Record<string, string | number | boolean>;
+  channelId: string;
+  userId: string;
+  /** Reply to the slash command. ephemeral=true mirrors discord.js flags=64. */
+  reply(content: string, ephemeral?: boolean): Promise<void>;
+}
+
+export type ThreadMessageHandler = (msg: DiscordThreadMessage) => void;
+export type SlashCommandHandler = (cmd: DiscordSlashCommand) => void;
+
+export interface IDiscordClient {
+  /** Connect (Real: client.login). Idempotent: subsequent calls resolve immediately. */
+  start(): Promise<void>;
+
+  /** Disconnect (Real: client.destroy). After stop(), send* must throw. */
+  stop(): Promise<void>;
+
+  /** Send a message to a Discord thread. Throws if not running or thread unknown. */
+  sendToThread(
+    threadId: string,
+    content: string,
+    options?: DiscordSendOptions,
+  ): Promise<void>;
+
+  /** Send typing indicator. Best-effort: never throws on transient API errors. */
+  sendTyping(threadId: string): Promise<void>;
+
+  /** Subscribe to thread message events. Multiple handlers fire in registration order. */
+  onThreadMessage(handler: ThreadMessageHandler): void;
+
+  /** Subscribe to slash command events. */
+  onSlashCommand(handler: SlashCommandHandler): void;
+}

--- a/supervisor/src/discord/types.ts
+++ b/supervisor/src/discord/types.ts
@@ -30,6 +30,12 @@ export interface DiscordSendOptions {
 
 export interface DiscordSlashCommand {
   commandName: string;
+  /** Subcommand name when the slash uses subcommands (e.g. `/session start`). */
+  subcommand?: string;
+  /**
+   * Top-level or subcommand options. When `subcommand` is set, these are the
+   * nested options of the subcommand (the discord.js shape `data[0].options`).
+   */
   options: Record<string, string | number | boolean>;
   channelId: string;
   userId: string;

--- a/supervisor/tests/discord/in-memory-client.test.ts
+++ b/supervisor/tests/discord/in-memory-client.test.ts
@@ -1,0 +1,231 @@
+// Unit tests for InMemoryDiscordClient (Issue #144 Phase 1).
+
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { InMemoryDiscordClient } from "../../src/discord/in-memory-client";
+import type {
+  DiscordSlashCommand,
+  DiscordThreadMessage,
+} from "../../src/discord/types";
+
+describe("InMemoryDiscordClient", () => {
+  let client: InMemoryDiscordClient;
+
+  beforeEach(async () => {
+    client = new InMemoryDiscordClient();
+    await client.start();
+  });
+
+  afterEach(async () => {
+    if (client.isStarted()) await client.stop();
+  });
+
+  test("isStarted reflects start/stop lifecycle", async () => {
+    expect(client.isStarted()).toBe(true);
+    await client.stop();
+    expect(client.isStarted()).toBe(false);
+  });
+
+  test("start after stop throws", async () => {
+    await client.stop();
+    await expect(client.start()).rejects.toThrow(/cannot start after stop/);
+  });
+
+  test("sendToThread before start throws", async () => {
+    const fresh = new InMemoryDiscordClient();
+    await expect(fresh.sendToThread("t1", "hi")).rejects.toThrow(/not started/);
+  });
+
+  test("sendToThread after stop throws", async () => {
+    await client.stop();
+    await expect(client.sendToThread("t1", "hi")).rejects.toThrow(
+      /already stopped/,
+    );
+  });
+
+  test("sendToThread records messages with options", async () => {
+    await client.sendToThread("t1", "hello");
+    await client.sendToThread("t1", "world", {
+      files: [{ name: "out.txt", attachment: "/tmp/out.txt" }],
+    });
+    await client.sendToThread("t2", "other");
+
+    const t1 = client.getSentMessages("t1");
+    expect(t1).toHaveLength(2);
+    expect(t1[0]!.content).toBe("hello");
+    expect(t1[0]!.options.files).toBeUndefined();
+    expect(t1[1]!.content).toBe("world");
+    expect(t1[1]!.options.files?.[0]?.name).toBe("out.txt");
+
+    expect(client.getSentMessages("t2")).toHaveLength(1);
+    expect(client.getSentMessages()).toHaveLength(3);
+  });
+
+  test("sendTyping increments per-thread counter", async () => {
+    await client.sendTyping("t1");
+    await client.sendTyping("t1");
+    await client.sendTyping("t2");
+    expect(client.getTypingCallCount("t1")).toBe(2);
+    expect(client.getTypingCallCount("t2")).toBe(1);
+    expect(client.getTypingCallCount("missing")).toBe(0);
+  });
+
+  test("injectThreadMessage fires registered handlers in order", () => {
+    const events: DiscordThreadMessage[] = [];
+    client.onThreadMessage((m) => events.push({ ...m, content: `H1:${m.content}` }));
+    client.onThreadMessage((m) => events.push({ ...m, content: `H2:${m.content}` }));
+
+    client.injectThreadMessage({ threadId: "t1", content: "ping" });
+
+    expect(events).toHaveLength(2);
+    expect(events[0]!.content).toBe("H1:ping");
+    expect(events[1]!.content).toBe("H2:ping");
+    expect(events[0]!.threadId).toBe("t1");
+    expect(events[0]!.authorBot).toBe(false);
+  });
+
+  test("injectThreadMessage gates bot messages (mirrors RealDiscordClient)", () => {
+    const events: DiscordThreadMessage[] = [];
+    client.onThreadMessage((m) => events.push(m));
+    client.injectThreadMessage({
+      threadId: "t1",
+      content: "bot says hi",
+      authorBot: true,
+    });
+    expect(events).toHaveLength(0);
+  });
+
+  test("injectThreadMessage auto-generates messageId when omitted", () => {
+    const events: DiscordThreadMessage[] = [];
+    client.onThreadMessage((m) => events.push(m));
+    client.injectThreadMessage({ threadId: "t1", content: "a" });
+    client.injectThreadMessage({ threadId: "t1", content: "b" });
+    expect(events[0]!.messageId).toMatch(/^msg_/);
+    expect(events[1]!.messageId).toMatch(/^msg_/);
+    expect(events[0]!.messageId).not.toBe(events[1]!.messageId);
+  });
+
+  test("injectThreadMessage propagates explicit attachments", () => {
+    const events: DiscordThreadMessage[] = [];
+    client.onThreadMessage((m) => events.push(m));
+    client.injectThreadMessage({
+      threadId: "t1",
+      content: "see file",
+      attachments: [
+        { url: "https://x/y.png", filename: "y.png", contentType: "image/png" },
+      ],
+    });
+    expect(events[0]!.attachments).toHaveLength(1);
+    expect(events[0]!.attachments[0]!.filename).toBe("y.png");
+  });
+
+  test("injectSlashCommand fires handlers and reply records into log", async () => {
+    const seen: DiscordSlashCommand[] = [];
+    client.onSlashCommand((c) => seen.push(c));
+
+    client.injectSlashCommand({
+      commandName: "session",
+      options: { action: "start" },
+    });
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.options.action).toBe("start");
+
+    await seen[0]!.reply("started", true);
+    const replies = client.getSlashReplies();
+    expect(replies).toHaveLength(1);
+    expect(replies[0]!.content).toBe("started");
+    expect(replies[0]!.ephemeral).toBe(true);
+    expect(replies[0]!.commandName).toBe("session");
+  });
+
+  test("onReply callback receives reply args before they are recorded", async () => {
+    const captured: Array<{ content: string; ephemeral: boolean }> = [];
+
+    // Plain reply (no callback): records into slashReplies log only.
+    const cmds: DiscordSlashCommand[] = [];
+    client.onSlashCommand((c) => cmds.push(c));
+    client.injectSlashCommand({ commandName: "session" });
+    await cmds[0]!.reply("ack");
+    expect(client.getSlashReplies().some((r) => r.content === "ack")).toBe(true);
+
+    // With onReply callback: callback fires alongside slashReplies log.
+    client.injectSlashCommand({
+      commandName: "session",
+      onReply: (content, ephemeral) => {
+        captured.push({ content, ephemeral });
+      },
+    });
+    await cmds[1]!.reply("with-callback", true);
+    expect(captured).toEqual([{ content: "with-callback", ephemeral: true }]);
+  });
+
+  test("clearLogs resets sent/typing/slashReplies but keeps handlers", async () => {
+    const handlerCalls: string[] = [];
+    client.onThreadMessage((m) => handlerCalls.push(m.content));
+    await client.sendToThread("t1", "before");
+    await client.sendTyping("t1");
+    client.injectSlashCommand({ commandName: "session" });
+
+    client.clearLogs();
+    expect(client.getSentMessages()).toHaveLength(0);
+    expect(client.getTypingCallCount("t1")).toBe(0);
+    expect(client.getSlashReplies()).toHaveLength(0);
+
+    // Handler still wired
+    client.injectThreadMessage({ threadId: "t1", content: "after" });
+    expect(handlerCalls).toEqual(["after"]);
+  });
+
+  test("handler exception in injectThreadMessage is isolated and recorded", () => {
+    // Mirror RealDiscordClient: one throwing handler must not abort the chain.
+    // Errors are captured in getHandlerErrors() so tests can still assert.
+    const seen: string[] = [];
+    client.onThreadMessage(() => {
+      throw new Error("boom-1");
+    });
+    client.onThreadMessage((m) => {
+      seen.push(m.content);
+    });
+    client.injectThreadMessage({ threadId: "t1", content: "still-delivered" });
+    expect(seen).toEqual(["still-delivered"]);
+    const errors = client.getHandlerErrors();
+    expect(errors).toHaveLength(1);
+    expect((errors[0] as Error).message).toBe("boom-1");
+  });
+
+  test("handler exception in injectSlashCommand is isolated and recorded", () => {
+    const seen: string[] = [];
+    client.onSlashCommand(() => {
+      throw new Error("slash-boom");
+    });
+    client.onSlashCommand((c) => {
+      seen.push(c.commandName);
+    });
+    client.injectSlashCommand({ commandName: "session" });
+    expect(seen).toEqual(["session"]);
+    expect(client.getHandlerErrors()).toHaveLength(1);
+  });
+
+  test("clearLogs resets handlerErrors", () => {
+    client.onThreadMessage(() => {
+      throw new Error("x");
+    });
+    client.injectThreadMessage({ threadId: "t1", content: "x" });
+    expect(client.getHandlerErrors()).toHaveLength(1);
+    client.clearLogs();
+    expect(client.getHandlerErrors()).toHaveLength(0);
+  });
+
+  test("injectSlashCommand after stop throws", async () => {
+    await client.stop();
+    expect(() =>
+      client.injectSlashCommand({ commandName: "session" }),
+    ).toThrow(/already stopped/);
+  });
+
+  test("injectThreadMessage after stop throws", async () => {
+    await client.stop();
+    expect(() =>
+      client.injectThreadMessage({ threadId: "t1", content: "x" }),
+    ).toThrow(/already stopped/);
+  });
+});

--- a/supervisor/tests/discord/real-client.test.ts
+++ b/supervisor/tests/discord/real-client.test.ts
@@ -74,6 +74,98 @@ describe("RealDiscordClient", () => {
     await expect(wrapper.start()).rejects.toThrow(/cannot start after stop/);
   });
 
+  test("start() leaves client un-started when login fails (retryable)", async () => {
+    // Stub Client whose login() rejects. Under the fix, started must remain
+    // false so the caller can retry. Before the fix, a second start() would
+    // short-circuit and never re-attempt login.
+    let loginCalls = 0;
+    const stub = new Client({ intents: [GatewayIntentBits.Guilds] });
+    // Override login to count attempts and reject the first.
+    (stub as unknown as { login: (t: string) => Promise<string> }).login =
+      async () => {
+        loginCalls += 1;
+        if (loginCalls === 1) throw new Error("auth-fail");
+        return "token-ok";
+      };
+
+    const wrapper = new RealDiscordClient("fake-token", { client: stub });
+    created.push(wrapper);
+
+    await expect(wrapper.start()).rejects.toThrow(/auth-fail/);
+    // Second attempt must reach login() again, not no-op.
+    await wrapper.start();
+    expect(loginCalls).toBe(2);
+  });
+
+  test("InteractionCreate flattens subcommand options and exposes subcommand name", async () => {
+    const inner = new Client({ intents: [GatewayIntentBits.Guilds] });
+    const wrapper = new RealDiscordClient("fake-token", { client: inner });
+    created.push(wrapper);
+
+    const seen: Array<{
+      commandName: string;
+      subcommand?: string;
+      options: Record<string, string | number | boolean>;
+    }> = [];
+    wrapper.onSlashCommand((c) => {
+      seen.push({
+        commandName: c.commandName,
+        subcommand: c.subcommand,
+        options: c.options,
+      });
+    });
+
+    // Synthesize a /session start subcommand interaction. type=1 is
+    // ApplicationCommandOptionType.Subcommand. Top-level data has a single
+    // entry whose nested .options holds the actual primitives.
+    const baseInteraction = {
+      isChatInputCommand: () => true,
+      commandName: "session",
+      channelId: "channel_1",
+      user: { id: "user_1" },
+      deferred: false,
+      replied: false,
+      options: {
+        data: [
+          {
+            name: "start",
+            type: 1,
+            options: [
+              { name: "channel", value: "team-salary", type: 3 },
+              { name: "ephemeral", value: true, type: 5 },
+              // Complex object should still be filtered out.
+              { name: "user", value: { id: "u1" }, type: 6 },
+            ],
+          },
+        ],
+      },
+      reply: async () => undefined,
+      editReply: async () => undefined,
+    };
+
+    inner.emit("interactionCreate", baseInteraction as never);
+    expect(seen).toHaveLength(1);
+    expect(seen[0]!.commandName).toBe("session");
+    expect(seen[0]!.subcommand).toBe("start");
+    expect(seen[0]!.options).toEqual({
+      channel: "team-salary",
+      ephemeral: true,
+    });
+
+    // No-subcommand path: top-level primitives flow through directly,
+    // subcommand stays undefined.
+    inner.emit("interactionCreate", {
+      ...baseInteraction,
+      commandName: "ping",
+      options: {
+        data: [{ name: "loud", value: false, type: 5 }],
+      },
+    } as never);
+    expect(seen).toHaveLength(2);
+    expect(seen[1]!.subcommand).toBeUndefined();
+    expect(seen[1]!.options).toEqual({ loud: false });
+  });
+
   test("injecting MessageCreate via underlying Client emits to handlers", () => {
     // Use the underlying EventEmitter directly to avoid logging in. The
     // wrapper subscribes to Events.MessageCreate at construction time, so

--- a/supervisor/tests/discord/real-client.test.ts
+++ b/supervisor/tests/discord/real-client.test.ts
@@ -1,0 +1,122 @@
+// Light unit tests for RealDiscordClient (Issue #144 Phase 1).
+//
+// These tests verify construction and lifecycle gating without actually
+// reaching Discord — the discord.js Client is constructed but never logged in.
+// Behavioral E2E coverage lives in Phase 2's lifecycle test, which routes
+// through InMemoryDiscordClient and the real tmux + claude-mock.sh.
+
+import { afterEach, describe, expect, test } from "bun:test";
+import { Client, GatewayIntentBits } from "discord.js";
+import { RealDiscordClient } from "../../src/discord/real-client";
+
+describe("RealDiscordClient", () => {
+  const created: RealDiscordClient[] = [];
+
+  afterEach(async () => {
+    while (created.length) {
+      const c = created.pop()!;
+      try {
+        await c.stop();
+      } catch {
+        // best-effort cleanup
+      }
+    }
+  });
+
+  test("constructor rejects empty token", () => {
+    expect(() => new RealDiscordClient("")).toThrow(/token is required/);
+  });
+
+  test("constructor accepts injected Client", () => {
+    const inner = new Client({
+      intents: [GatewayIntentBits.Guilds],
+    });
+    const wrapper = new RealDiscordClient("fake-token", { client: inner });
+    created.push(wrapper);
+    expect(wrapper.getUnderlyingClient()).toBe(inner);
+  });
+
+  test("sendToThread before start throws", async () => {
+    const inner = new Client({ intents: [GatewayIntentBits.Guilds] });
+    const wrapper = new RealDiscordClient("fake-token", { client: inner });
+    created.push(wrapper);
+    await expect(wrapper.sendToThread("t1", "hi")).rejects.toThrow(/not started/);
+  });
+
+  test("sendTyping before start throws", async () => {
+    const inner = new Client({ intents: [GatewayIntentBits.Guilds] });
+    const wrapper = new RealDiscordClient("fake-token", { client: inner });
+    created.push(wrapper);
+    await expect(wrapper.sendTyping("t1")).rejects.toThrow(/not started/);
+  });
+
+  test("onThreadMessage / onSlashCommand register without throwing", () => {
+    const inner = new Client({ intents: [GatewayIntentBits.Guilds] });
+    const wrapper = new RealDiscordClient("fake-token", { client: inner });
+    created.push(wrapper);
+    expect(() => wrapper.onThreadMessage(() => {})).not.toThrow();
+    expect(() => wrapper.onSlashCommand(() => {})).not.toThrow();
+  });
+
+  test("stop is idempotent", async () => {
+    const inner = new Client({ intents: [GatewayIntentBits.Guilds] });
+    const wrapper = new RealDiscordClient("fake-token", { client: inner });
+    created.push(wrapper);
+    await wrapper.stop();
+    await wrapper.stop(); // second call should be a no-op
+  });
+
+  test("start after stop throws", async () => {
+    const inner = new Client({ intents: [GatewayIntentBits.Guilds] });
+    const wrapper = new RealDiscordClient("fake-token", { client: inner });
+    created.push(wrapper);
+    await wrapper.stop();
+    await expect(wrapper.start()).rejects.toThrow(/cannot start after stop/);
+  });
+
+  test("injecting MessageCreate via underlying Client emits to handlers", () => {
+    // Use the underlying EventEmitter directly to avoid logging in. The
+    // wrapper subscribes to Events.MessageCreate at construction time, so
+    // emitting that event fires the chain. We feed a minimal message-shaped
+    // object to assert the propagation contract end-to-end (gating + payload).
+    const inner = new Client({ intents: [GatewayIntentBits.Guilds] });
+    const wrapper = new RealDiscordClient("fake-token", { client: inner });
+    created.push(wrapper);
+
+    const events: Array<{ threadId: string; content: string; isBot: boolean }> = [];
+    wrapper.onThreadMessage((m) => {
+      events.push({ threadId: m.threadId, content: m.content, isBot: m.authorBot });
+    });
+
+    const baseMessage = {
+      author: { bot: false, id: "user_1" },
+      channel: { isThread: () => true, id: "thread_1" },
+      content: "hi from user",
+      id: "msg_1",
+      attachments: new Map(),
+    };
+
+    inner.emit("messageCreate", baseMessage as never);
+    expect(events).toEqual([
+      { threadId: "thread_1", content: "hi from user", isBot: false },
+    ]);
+
+    // Bot author → gated out
+    inner.emit("messageCreate", {
+      ...baseMessage,
+      author: { bot: true, id: "bot_2" },
+      id: "msg_2",
+      content: "bot says",
+    } as never);
+
+    // Non-thread channel → gated out
+    inner.emit("messageCreate", {
+      ...baseMessage,
+      id: "msg_3",
+      channel: { isThread: () => false, id: "channel_1" },
+      content: "channel msg",
+    } as never);
+
+    expect(events).toHaveLength(1);
+  });
+});

--- a/supervisor/tests/e2e/fixtures/claude-mock.sh
+++ b/supervisor/tests/e2e/fixtures/claude-mock.sh
@@ -22,15 +22,20 @@ SESSION_ID="${CLAUDE_MOCK_SESSION_ID:-mock-session-$$}"
 TEMPLATE="${CLAUDE_MOCK_REPLY_TEMPLATE:-[mock-claude] received: %s}"
 CURL_TIMEOUT="${CLAUDE_MOCK_CURL_TIMEOUT:-5}"
 
+# jq is required: Discord-sourced text can contain arbitrary control
+# characters (tabs, NULs, BEL, etc.). The previous sed-based fallback only
+# escaped backslash / double-quote / newline and produced invalid JSON for
+# anything else (CodeRabbit PR #145 review). We fail loudly instead of
+# emitting broken payloads.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "claude-mock.sh: jq is required for safe JSON encoding (install jq)" >&2
+  exit 127
+fi
+
 # json_escape <text>
-# Emits a JSON-quoted string. Prefers jq when available for correctness;
-# falls back to a minimal sed escaper if jq is missing on the runner.
+# Emits a JSON-quoted string via jq's robust string encoder.
 json_escape() {
-  if command -v jq >/dev/null 2>&1; then
-    printf '%s' "$1" | jq -Rs .
-  else
-    printf '"%s"' "$(printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e ':a;N;$!ba;s/\n/\\n/g')"
-  fi
+  printf '%s' "$1" | jq -Rs .
 }
 
 while IFS= read -r line; do

--- a/supervisor/tests/e2e/fixtures/claude-mock.sh
+++ b/supervisor/tests/e2e/fixtures/claude-mock.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+# claude-mock.sh — fake `claude` CLI for the Discord lifecycle E2E (Issue #144).
+#
+# Reads newline-delimited input from stdin. For each non-empty line:
+#   1. Echoes a reply to stdout (visible to tmux capture-pane).
+#   2. POSTs {text, session_id} to $SUPERVISOR_RELAY_URL to simulate Claude's
+#      Stop hook (mirrors hooks/stop-relay.sh's contract).
+#
+# Env:
+#   SUPERVISOR_RELAY_URL          Relay POST endpoint. Optional; if unset,
+#                                 only stdout echo runs (useful for offline test).
+#   CLAUDE_MOCK_SESSION_ID        Defaults to "mock-session-$$".
+#   CLAUDE_MOCK_REPLY_TEMPLATE    printf format with single %s. Defaults to
+#                                 "[mock-claude] received: %s".
+#   CLAUDE_MOCK_CURL_TIMEOUT      Curl --max-time seconds. Default 5.
+#
+# Exits 0 on EOF (Ctrl-D / pipe close).
+
+set -u
+
+SESSION_ID="${CLAUDE_MOCK_SESSION_ID:-mock-session-$$}"
+TEMPLATE="${CLAUDE_MOCK_REPLY_TEMPLATE:-[mock-claude] received: %s}"
+CURL_TIMEOUT="${CLAUDE_MOCK_CURL_TIMEOUT:-5}"
+
+# json_escape <text>
+# Emits a JSON-quoted string. Prefers jq when available for correctness;
+# falls back to a minimal sed escaper if jq is missing on the runner.
+json_escape() {
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$1" | jq -Rs .
+  else
+    printf '"%s"' "$(printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g' -e ':a;N;$!ba;s/\n/\\n/g')"
+  fi
+}
+
+while IFS= read -r line; do
+  # Skip empty lines but keep loop alive.
+  [ -z "$line" ] && continue
+
+  # Build reply by splitting TEMPLATE on the first %s and concatenating
+  # the literal halves around $line. This avoids passing TEMPLATE to
+  # printf as a format string, sidestepping format-directive injection
+  # if the env var is ever sourced from untrusted input. TEMPLATE
+  # without a %s simply emits its literal contents.
+  if [[ "$TEMPLATE" == *"%s"* ]]; then
+    prefix="${TEMPLATE%%%s*}"
+    suffix="${TEMPLATE#*%s}"
+    reply="${prefix}${line}${suffix}"
+  else
+    reply="$TEMPLATE"
+  fi
+  printf '%s\n' "$reply"
+
+  # Best-effort Stop hook simulation. Failure is non-fatal so test runners
+  # without network access still observe the stdout echo.
+  if [ -n "${SUPERVISOR_RELAY_URL:-}" ]; then
+    text_json=$(json_escape "$reply")
+    sid_json=$(json_escape "$SESSION_ID")
+    payload="{\"text\":${text_json},\"session_id\":${sid_json}}"
+    curl -s -X POST "$SUPERVISOR_RELAY_URL" \
+      -H "Content-Type: application/json" \
+      -d "$payload" \
+      --max-time "$CURL_TIMEOUT" \
+      >/dev/null 2>&1 || true
+  fi
+done
+
+exit 0


### PR DESCRIPTION
Closes #144 (Phase 1)

## 概要

Issue #144 (Discord ↔ Supervisor ↔ tmux セッションライフサイクル E2E を CI に追加) の Phase 1。Phase 2 で書く lifecycle E2E テストの土台として、Discord client を `IDiscordClient` interface に抽象化し、Real (discord.js wrapper) / InMemory (テスト用 fake) の 2 実装と `claude-mock.sh` fixture を追加した。

bot.ts は **Phase 1 では未変更**。Phase 2 で interface 経由に乗せ替える。

## 統合ジャーニーAC との対応

Phase 1 は Issue #144 の AC 1 (bun test 完走) に対する **下準備** で、本 PR 単独では AC 1〜3 全件 PASS にはならない (lifecycle E2E は Phase 2 で書く)。

| Issue #144 AC | 本 PR の関与 |
|---|---|
| AC 1: `bun test discord-lifecycle.test.ts` 全 PASS | Phase 2 で実装 (本 PR は IDiscordClient と fake を提供) |
| AC 2: PR CI に `discord-lifecycle-e2e` ジョブが表示 | Phase 3 で .github/workflows/ci.yml 追加 |
| AC 3: post-merge canary 失敗で Pushover + Issue 起票 | Phase 4 |

本 PR の変更は単体テストレベルで検証 (下記)。

## コンポーネントAC (本 PR で完了する範囲)

- [x] \`IDiscordClient\` interface 定義 (\`supervisor/src/discord/types.ts\`、65 LoC)
- [x] \`RealDiscordClient\` 実装 (discord.js Client wrapper、183 LoC)
- [x] \`InMemoryDiscordClient\` 実装 (queue + event injection + inspection API、168 LoC)
- [x] \`claude-mock.sh\` fixture (stdin echo + curl で Stop hook 模擬、57 LoC)
- [x] 単体テスト (\`tests/discord/in-memory-client.test.ts\` 18 ケース + \`tests/discord/real-client.test.ts\` 8 ケース、合計 26 PASS)

## 設計判断

### IDiscordClient surface

Phase 2 lifecycle E2E に必要な最小限のみ (start/stop/sendToThread/sendTyping/onThreadMessage/onSlashCommand)。file-attacher、guild 操作、member 管理は **含めない** (YAGNI)。

### handler 例外の per-handler 隔離

self-review (must/should/nit/question 全 9 件) で指摘された **handler 例外時の挙動非対称性** を解消。

- 当初: InMemoryDiscordClient は throw を伝播、RealDiscordClient は catch + log
- 修正後: InMemoryDiscordClient も catch しつつ \`getHandlerErrors()\` で収集、テストは loud に書ける

### claude-mock.sh の format-injection 対策

\`CLAUDE_MOCK_REPLY_TEMPLATE\` 環境変数を \`printf\` の format string に直接渡さず、\`%s\` で string-split して連結する形に変更。\`%n\` 等の format directive injection を構造的に不可能にした。

\`\`\`bash
# テスト fixture とはいえ env から format string を取る経路は塞ぐ
if [[ "\$TEMPLATE" == *"%s"* ]]; then
  prefix="\${TEMPLATE%%%s*}"
  suffix="\${TEMPLATE#*%s}"
  reply="\${prefix}\${line}\${suffix}"
else
  reply="\$TEMPLATE"
fi
\`\`\`

## 検証

\`\`\`
bunx tsc --noEmit  # supervisor/, clean (0 errors)
bun test           # 300 pass / 3 skip / 0 fail (既存 277 + 新 26 = 303 中、3 skip)
bun test tests/discord/  # 26 pass / 0 fail / 56 expect()
\`\`\`

claude-mock.sh smoke (4 ケース、format injection 対策確認込み):

\`\`\`
$ echo "hello world" | supervisor/tests/e2e/fixtures/claude-mock.sh
[mock-claude] received: hello world

$ echo "ping" | CLAUDE_MOCK_REPLY_TEMPLATE='%n%x[%s]' supervisor/tests/e2e/fixtures/claude-mock.sh
%n%x[ping]   # %n / %x が literal として扱われる ✓
\`\`\`

## 次の Phase

- **Phase 2**: \`supervisor/tests/e2e/discord-lifecycle.test.ts\` 新規 (3 AC × 各 1+ ケース、bun test green)
- **Phase 3**: \`.github/workflows/ci.yml\` に \`discord-lifecycle-e2e\` ジョブ追加 (PR + push)
- **Phase 4**: post-merge Pushover + Issue 自動起票 + branch protection 登録

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Discord クライアント統合機能を追加。スレッドへのメッセージ送信、入力状態の表示、メッセージおよびスラッシュコマンドの受信が可能に。

* **テスト**
  * テスト環境向けのインメモリクライアント実装を追加。Discord ライブログインなしでボット動作を検証可能に。
  * エンドツーエンドテスト用の Mock CLI ツールを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->