### PR TITLE
fix(#147): supervisor newSession の単引用符ラップ崩壊で claude セッションが即 exit する障害

### DIFF
--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync, execSync } from "child_process";
 import {
   openTab as realOpenTab,
   markTabStopped as realMarkTabStopped,
@@ -11,7 +11,9 @@ import {
   cancelRelay as realCancelRelay,
 } from "./relay-server";
 import {
+  TMUX_ARGS,
   TMUX_CMD,
+  TMUX_PATH,
   ensureSocketConfigured as realEnsureSocketConfigured,
 } from "./tmux";
 
@@ -55,7 +57,15 @@ export interface SessionEffects {
 
 export const realTmuxAdapter: TmuxAdapter = {
   newSession(name, command) {
-    execSync(`${TMUX_CMD} new-session -d -s "${name}" '${command}'`);
+    // Issue #147: previous `execSync(\`tmux new-session ... '${command}'\`)`
+    // wrapped the entire command in single quotes. When `command` itself
+    // contained single quotes (e.g. `--mcp-config '{"mcpServers":{}}'` added
+    // in #104), the outer quotes closed prematurely, exposing the inner JSON
+    // to bash word-splitting and quote stripping — claude received malformed
+    // arguments and exited immediately. Using execFileSync with an argv array
+    // avoids shell parsing entirely: tmux receives `command` as a single
+    // argument and invokes /bin/sh -c on it once, inside the new session.
+    execFileSync(TMUX_PATH, [...TMUX_ARGS, "new-session", "-d", "-s", name, command]);
   },
   killSession(name) {
     try {

--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -1,4 +1,4 @@
-import { execFileSync, execSync } from "child_process";
+import { execFileSync } from "child_process";
 import {
   openTab as realOpenTab,
   markTabStopped as realMarkTabStopped,
@@ -12,7 +12,6 @@ import {
 } from "./relay-server";
 import {
   TMUX_ARGS,
-  TMUX_CMD,
   TMUX_PATH,
   ensureSocketConfigured as realEnsureSocketConfigured,
 } from "./tmux";
@@ -68,25 +67,36 @@ export const realTmuxAdapter: TmuxAdapter = {
     execFileSync(TMUX_PATH, [...TMUX_ARGS, "new-session", "-d", "-s", name, command]);
   },
   killSession(name) {
+    // PR #148 review (gemini critical): use execFileSync + argv array so an
+    // attacker-controlled `name` cannot inject shell metacharacters via the
+    // template literal. `stdio: "ignore"` matches the previous `2>/dev/null`
+    // (silence the expected "no session" error).
     try {
-      execSync(`${TMUX_CMD} kill-session -t "${name}" 2>/dev/null`);
+      execFileSync(TMUX_PATH, [...TMUX_ARGS, "kill-session", "-t", name], {
+        stdio: "ignore",
+      });
     } catch {
       // No existing session
     }
   },
   hasSession(name) {
     try {
-      execSync(`${TMUX_CMD} has-session -t "${name}" 2>/dev/null`);
+      execFileSync(TMUX_PATH, [...TMUX_ARGS, "has-session", "-t", name], {
+        stdio: "ignore",
+      });
       return true;
     } catch {
       return false;
     }
   },
   getPid(name) {
+    // stdio: ["ignore", "pipe", "ignore"] — we need stdout to read the pid,
+    // but stderr is discarded just like the previous `2>/dev/null`.
     try {
-      const output = execSync(
-        `${TMUX_CMD} list-panes -t "${name}" -F "#{pane_pid}" 2>/dev/null`,
-        { encoding: "utf8" }
+      const output = execFileSync(
+        TMUX_PATH,
+        [...TMUX_ARGS, "list-panes", "-t", name, "-F", "#{pane_pid}"],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
       ).trim();
       const pid = parseInt(output.split("\n")[0] ?? "", 10);
       return isNaN(pid) ? null : pid;

--- a/supervisor/tests/session/adapters.test.ts
+++ b/supervisor/tests/session/adapters.test.ts
@@ -1,0 +1,97 @@
+import {
+  describe,
+  test,
+  expect,
+  mock,
+  beforeEach,
+} from "bun:test";
+
+/**
+ * Issue #147 regression test: realTmuxAdapter.newSession must pass `command`
+ * to tmux as a single argv element, so any shell metacharacters inside
+ * (single quotes, $-expansions, brace expansion seeds) survive intact until
+ * tmux's own /bin/sh -c invocation inside the new session.
+ *
+ * Pre-fix: `execSync(\`tmux new-session ... '${command}'\`)` re-parsed
+ * `command` through the calling shell. A command containing
+ * `--mcp-config '{"mcpServers":{}}'` would have its outer single quote
+ * pair closed by the inner one, leaking the JSON into bash word-splitting
+ * and bricking the claude session immediately on spawn.
+ *
+ * Post-fix: `execFileSync(TMUX_PATH, [..., name, command])` bypasses the
+ * shell entirely, so `command` is one argv element verbatim.
+ */
+
+let execFileCalls: Array<{ file: string; args: readonly string[] }> = [];
+const mockExecFileSync = mock(
+  (file: unknown, args: unknown): Buffer => {
+    execFileCalls.push({
+      file: file as string,
+      args: args as readonly string[],
+    });
+    return Buffer.from("");
+  }
+);
+
+// execSync is still used by killSession/hasSession/getPid; keep it mockable
+// so tests don't accidentally shell out.
+const mockExecSync = mock((..._args: unknown[]) => "");
+
+// We re-export the rest of node:child_process untouched so other modules
+// loaded in this test process (e.g. anything importing `spawn`) keep working.
+const realChildProcess = await import("child_process");
+mock.module("child_process", () => ({
+  ...realChildProcess,
+  execFileSync: mockExecFileSync,
+  execSync: mockExecSync,
+}));
+
+const { realTmuxAdapter } = await import("../../src/session/adapters");
+const { TMUX_PATH, TMUX_ARGS } = await import("../../src/session/tmux");
+
+beforeEach(() => {
+  execFileCalls = [];
+  mockExecFileSync.mockClear();
+  mockExecSync.mockClear();
+});
+
+describe("realTmuxAdapter.newSession (#147)", () => {
+  test("uses execFileSync with argv array (no shell parsing)", () => {
+    realTmuxAdapter.newSession("claude-test", "echo hi");
+
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    expect(execFileCalls[0]?.file).toBe(TMUX_PATH);
+    expect(execFileCalls[0]?.args).toEqual([
+      ...TMUX_ARGS,
+      "new-session",
+      "-d",
+      "-s",
+      "claude-test",
+      "echo hi",
+    ]);
+  });
+
+  test("preserves single quotes in command (the #147 regression)", () => {
+    // This is the exact pattern that broke Supervisor in #104:
+    // --mcp-config '{"mcpServers":{}}' embedded in a longer chain.
+    const command =
+      `cd /tmp && exec claude --mcp-config '{"mcpServers":{}}'`;
+
+    realTmuxAdapter.newSession("claude-x", command);
+
+    // The command must appear in argv VERBATIM — no quote balancing,
+    // no escape-mangling, no truncation at the inner single quote.
+    expect(execFileCalls[0]?.args.at(-1)).toBe(command);
+  });
+
+  test("preserves $-expansions, backticks, and brace seeds", () => {
+    // None of these should expand client-side. tmux is responsible for
+    // running /bin/sh -c on this string inside the new session.
+    const tricky =
+      `export X=$HOME && echo \`date\` && touch {a,b,c}.txt && exec claude`;
+
+    realTmuxAdapter.newSession("claude-tricky", tricky);
+
+    expect(execFileCalls[0]?.args.at(-1)).toBe(tricky);
+  });
+});

--- a/supervisor/tests/session/adapters.test.ts
+++ b/supervisor/tests/session/adapters.test.ts
@@ -7,35 +7,34 @@ import {
 } from "bun:test";
 
 /**
- * Issue #147 regression test: realTmuxAdapter.newSession must pass `command`
- * to tmux as a single argv element, so any shell metacharacters inside
- * (single quotes, $-expansions, brace expansion seeds) survive intact until
- * tmux's own /bin/sh -c invocation inside the new session.
+ * Issue #147 regression tests: every realTmuxAdapter method must reach tmux
+ * via execFileSync + argv array so neither `command` nor `name` flow through
+ * the calling shell.
  *
  * Pre-fix: `execSync(\`tmux new-session ... '${command}'\`)` re-parsed
  * `command` through the calling shell. A command containing
  * `--mcp-config '{"mcpServers":{}}'` would have its outer single quote
  * pair closed by the inner one, leaking the JSON into bash word-splitting
- * and bricking the claude session immediately on spawn.
+ * and bricking the claude session immediately on spawn (#147).
  *
- * Post-fix: `execFileSync(TMUX_PATH, [..., name, command])` bypasses the
- * shell entirely, so `command` is one argv element verbatim.
+ * killSession / hasSession / getPid also accepted `name` via string
+ * interpolation. PR #148 review (gemini critical) flagged that pattern as
+ * a latent shell-injection vector even though current callers pass numeric
+ * thread-IDs — defence-in-depth, not a current exploit.
+ *
+ * Post-fix: every method uses execFileSync(TMUX_PATH, [..., name, ...])
+ * so user input cannot reach the shell at all.
  */
 
 let execFileCalls: Array<{ file: string; args: readonly string[] }> = [];
+// PR #148 review (gemini medium): mock signature typed directly to avoid
+// `unknown` + type assertion in the body.
 const mockExecFileSync = mock(
-  (file: unknown, args: unknown): Buffer => {
-    execFileCalls.push({
-      file: file as string,
-      args: args as readonly string[],
-    });
+  (file: string, args: readonly string[]): Buffer => {
+    execFileCalls.push({ file, args });
     return Buffer.from("");
   }
 );
-
-// execSync is still used by killSession/hasSession/getPid; keep it mockable
-// so tests don't accidentally shell out.
-const mockExecSync = mock((..._args: unknown[]) => "");
 
 // We re-export the rest of node:child_process untouched so other modules
 // loaded in this test process (e.g. anything importing `spawn`) keep working.
@@ -43,7 +42,6 @@ const realChildProcess = await import("child_process");
 mock.module("child_process", () => ({
   ...realChildProcess,
   execFileSync: mockExecFileSync,
-  execSync: mockExecSync,
 }));
 
 const { realTmuxAdapter } = await import("../../src/session/adapters");
@@ -52,7 +50,6 @@ const { TMUX_PATH, TMUX_ARGS } = await import("../../src/session/tmux");
 beforeEach(() => {
   execFileCalls = [];
   mockExecFileSync.mockClear();
-  mockExecSync.mockClear();
 });
 
 describe("realTmuxAdapter.newSession (#147)", () => {
@@ -93,5 +90,100 @@ describe("realTmuxAdapter.newSession (#147)", () => {
     realTmuxAdapter.newSession("claude-tricky", tricky);
 
     expect(execFileCalls[0]?.args.at(-1)).toBe(tricky);
+  });
+});
+
+describe("realTmuxAdapter.killSession (#148 review)", () => {
+  test("uses execFileSync with name as argv element (no shell)", () => {
+    realTmuxAdapter.killSession("claude-test");
+
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    expect(execFileCalls[0]?.file).toBe(TMUX_PATH);
+    expect(execFileCalls[0]?.args).toEqual([
+      ...TMUX_ARGS,
+      "kill-session",
+      "-t",
+      "claude-test",
+    ]);
+  });
+
+  test("neutralises shell-metacharacter injection via name", () => {
+    // The gemini review example. With the old execSync template literal
+    // this would have run `reboot` on the host. argv array passing makes
+    // the whole string a single argument to tmux's -t flag.
+    const malicious = `x"; reboot; #`;
+
+    realTmuxAdapter.killSession(malicious);
+
+    expect(execFileCalls[0]?.args.at(-1)).toBe(malicious);
+  });
+});
+
+describe("realTmuxAdapter.hasSession (#148 review)", () => {
+  test("returns true when execFileSync succeeds", () => {
+    expect(realTmuxAdapter.hasSession("claude-test")).toBe(true);
+    expect(execFileCalls[0]?.args).toEqual([
+      ...TMUX_ARGS,
+      "has-session",
+      "-t",
+      "claude-test",
+    ]);
+  });
+
+  test("returns false when execFileSync throws", () => {
+    const throwingMock = mock(
+      (_file: string, _args: readonly string[]): Buffer => {
+        throw new Error("no server running");
+      }
+    );
+    mock.module("child_process", () => ({
+      ...realChildProcess,
+      execFileSync: throwingMock,
+    }));
+
+    // Re-import so the adapter picks up the throwing mock for this test
+    // only; the mock.module call above is scoped to this test's lifetime.
+    return import("../../src/session/adapters").then(({ realTmuxAdapter: a }) => {
+      expect(a.hasSession("missing")).toBe(false);
+
+      // Restore the normal non-throwing mock for subsequent tests.
+      mock.module("child_process", () => ({
+        ...realChildProcess,
+        execFileSync: mockExecFileSync,
+      }));
+    });
+  });
+});
+
+describe("realTmuxAdapter.getPid (#148 review)", () => {
+  test("uses execFileSync and parses pane_pid", () => {
+    const pidMock = mock(
+      (_file: string, _args: readonly string[]): string => "12345\n"
+    );
+    mock.module("child_process", () => ({
+      ...realChildProcess,
+      execFileSync: pidMock,
+    }));
+
+    return import("../../src/session/adapters").then(({ realTmuxAdapter: a }) => {
+      expect(a.getPid("claude-test")).toBe(12345);
+      expect(pidMock).toHaveBeenCalledTimes(1);
+      const [file, args] = pidMock.mock.calls[0] ?? [];
+      expect(file).toBe(TMUX_PATH);
+      expect(args).toEqual([
+        ...TMUX_ARGS,
+        "list-panes",
+        "-t",
+        "claude-test",
+        "-F",
+        "#{pane_pid}",
+      ]);
+
+      // Restore normal mock for the rest of the file.
+      mock.module("child_process", () => ({
+        ...realChildProcess,
+        execFileSync: mockExecFileSync,
+      }));
+    });
   });
 });


### PR DESCRIPTION
## Summary

- `adapters.ts:58` の `execSync(\`tmux new-session ... '${command}'\`)` が `command` 内の単引用符 (`--mcp-config '{"mcpServers":{}}'`) と衝突して claude セッションが即 exit していた問題を修正
- `execFileSync(TMUX_PATH, [...TMUX_ARGS, "new-session", "-d", "-s", name, command])` に変更し argv 配列渡しで shell parse を回避
- 回帰テスト 3 件追加 (`supervisor/tests/session/adapters.test.ts`)

Closes #147

## 根本原因

`supervisor/src/session/adapters.ts:58` (pre-fix):
```typescript
execSync(`${TMUX_CMD} new-session -d -s "${name}" '${command}'`);
//                                                ^^^^^^^^^^^^^
//                                                単引用符で全体を包む
```

`command` は `manager.ts:233-244` で組み立てられ、末尾に `--mcp-config '{"mcpServers":{}}'` を含む。
内側の `'` が外側 `'...'` を早期に閉じてしまい、JSON が unquoted になり bash が中の `"` を剥がす。結果 claude には壊れた JSON が渡り parse 失敗で即 exit していた。

## デグレ起点

`fba48e5 feat(#104): supervisor session の cold-start を MCP / chrome の lazy disable で短縮 (#128)` で `--strict-mcp-config --mcp-config '{...}'` が追加されたタイミング。`adapters.ts:58` 側の単引用符ラップとの相互作用が見落とされた。

## 修正

`execSync` の shell パス → `execFileSync` の argv 配列パスに変更。`command` は tmux に**単一の argv 要素**として渡り、shell 解析は tmux が新セッション内で `/bin/sh -c` を呼ぶ時の 1 回だけになる。`adapters.ts` による二重 wrap が消える。

```typescript
execFileSync(TMUX_PATH, [...TMUX_ARGS, "new-session", "-d", "-s", name, command]);
```

## 統合ジャーニーAC

1. **操作**: Discord のスレッドにメッセージを投稿
   - **期待結果**: Supervisor が tmux で claude セッションを spawn → TUI 起動 → 維持 → Discord に応答が返る
   - **検証手段**: `tmux -L claude-hub ls` で session 存在確認 + Discord 上で claude のレスポンス受信
2. **操作**: `/session stop` でスレッド終了
   - **期待結果**: tmux セッションが正常終了
   - **検証手段**: `tmux -L claude-hub ls` で該当 session 不在

## Test plan

- [x] `bun test tests/session/adapters.test.ts` (3/3 PASS)
- [x] `bunx tsc --noEmit -p .` (0 errors)
- [x] 既存 `tests/session/tmux.test.ts` 回帰確認 (`bun test tests/session/tmux.test.ts` PASS)
- [x] 統合テスト: `realTmuxAdapter.newSession()` を直接呼んで `--mcp-config '{"mcpServers":{}}'` 含む完全 command で session 生存確認 (pre-fix: exit:1 即死 / post-fix: exit:0 維持)
- [ ] **マージ後**: Supervisor restart → Discord スレッドにメッセージ投稿 → claude レスポンスを受信できることをユーザーが手動確認

## 関連RW

- RW-024 (GitHub Actions backtick command substitution) と同型: 「外部入力を shell に直接埋め込む罠」
- RW-019 (Supervisor 専用 tmux socket) は健全、本症状は別経路

## 影響範囲

- `supervisor/src/session/adapters.ts`: 1 関数 (`realTmuxAdapter.newSession`) の実装変更、+ import 追加
- `supervisor/tests/session/adapters.test.ts`: 新規 (97 行、回帰テスト 3 件)
- killSession / hasSession / getPid は `2>/dev/null` のシェル redirect を使うため execSync のまま (引数が `name` のみで shell injection リスクなし)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * tmux呼び出しをシェル文字列依存から安全な引数方式に変更し、クォートや特殊文字（'$'、バックティック、波括弧展開など）を含むコマンドが正しく扱われるよう改善しました。

* **Tests**
  * tmux関連処理の網羅的なリグレッションテストを追加し、セッション作成・終了・存在確認・PID取得の振る舞いを検証するように拡充しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miyashita337/claude-hub/pull/148)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->