### PR TITLE
test(#159): execSync/exec のシェル文字列補間に // shell-safe 注釈を必須化する guard

### DIFF
--- a/supervisor/src/session/iterm2.ts
+++ b/supervisor/src/session/iterm2.ts
@@ -110,26 +110,32 @@ export function openTab(opts: OpenTabOptions): void {
 
   // Set tmux window name so it persists after attach
   const tabTitle = `${opts.channelName} (running)`;
+  // shell-safe: every interpolation below is non-free-text — TMUX_CMD is a
+  // module constant, tmuxSessionName is `claude-<numeric Discord threadId>`,
+  // and tabTitle is built from channelName (a static CHANNEL_MAP key). No
+  // Discord message content reaches these strings (RW-045 guard, #159).
   try {
+    // shell-safe: TMUX_CMD const + internal session id / static channel name
     execSync(
       `${TMUX_CMD} rename-window -t "${opts.tmuxSessionName}" "${tabTitle}"`,
       { timeout: 3000 }
     );
-    // Disable automatic-rename so tmux doesn't overwrite our title
+    // shell-safe: TMUX_CMD const + internal session id (no free text)
     execSync(
       `${TMUX_CMD} set-option -t "${opts.tmuxSessionName}" automatic-rename off`,
       { timeout: 3000 }
     );
-    // Enable set-titles so tmux pushes the window name to iTerm2's tab title
+    // shell-safe: TMUX_CMD const + internal session id (no free text)
     execSync(
       `${TMUX_CMD} set-option -t "${opts.tmuxSessionName}" set-titles on`,
       { timeout: 3000 }
     );
+    // shell-safe: TMUX_CMD const + internal session id (no free text)
     execSync(
       `${TMUX_CMD} set-option -t "${opts.tmuxSessionName}" set-titles-string "#{window_name}"`,
       { timeout: 3000 }
     );
-    // Set pane title as well
+    // shell-safe: TMUX_CMD const + internal session id / static channel name
     execSync(
       `${TMUX_CMD} select-pane -t "${opts.tmuxSessionName}" -T "${tabTitle}"`,
       { timeout: 3000 }
@@ -165,6 +171,8 @@ export function openTab(opts: OpenTabOptions): void {
   ].join("\n");
 
   try {
+    // shell-safe: the AppleScript is single-quote-escaped (every `'` → `'\''`)
+    // before being wrapped in the outer single-quoted `osascript -e '...'`.
     execSync(`osascript -e '${script.replace(/'/g, "'\\''")}'`, {
       timeout: 5000,
     });

--- a/supervisor/src/session/tmux.ts
+++ b/supervisor/src/session/tmux.ts
@@ -65,6 +65,8 @@ export const TMUX_CMD = `${TMUX_PATH} -L ${TMUX_SOCKET}`;
  */
 export function ensureSocketConfigured(): void {
   try {
+    // shell-safe: TMUX_CMD is a module constant and every other token is a
+    // hard-coded literal — no external input is interpolated (RW-045 guard).
     execSync(
       `${TMUX_CMD} set-option -g mouse off \\; ` +
         `set-option -g mode-keys emacs \\; ` +

--- a/supervisor/tests/guards/shell-exec-safety.test.ts
+++ b/supervisor/tests/guards/shell-exec-safety.test.ts
@@ -1,0 +1,121 @@
+import { test, expect, describe } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "fs";
+import { join } from "path";
+
+/**
+ * Shell-exec injection guard (Issue #159, RW-045).
+ *
+ * `execSync` / `exec` / `Bun.$` run their argument through a shell, so a
+ * template literal that interpolates a value (`${...}`) into one of them is a
+ * potential command-injection site if the value is ever attacker-influenced.
+ * claude-hub has hit this class repeatedly (RW-019 tmux send-keys, PR #147
+ * single-quote wrap collapse, PR #157 branch → `cd "<path>"`).
+ *
+ * This guard scans supervisor/src and fails if such a call lacks a nearby
+ * `// shell-safe: <reason>` justification, forcing the author to argue why the
+ * interpolated value cannot inject (constant, internal id, escaped, validated
+ * at a choke point). `execFileSync` is intentionally NOT flagged — it passes an
+ * argv array with no shell, which is the safe alternative.
+ */
+
+const SRC_DIR = join(import.meta.dir, "..", "..", "src");
+const JUSTIFICATION = "shell-safe:";
+
+/** Shell-executing calls whose first arg is a (possibly multi-line) template literal. */
+const SHELL_EXEC_RE = /(?<!execFileSync\s*\()\b(?:execSync|exec)\s*\(\s*`([^`]*)`/gs;
+const BUN_SHELL_RE = /\bBun\.\$\s*`([^`]*)`/gs;
+
+function listTsFiles(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    const st = statSync(full);
+    if (st.isDirectory()) {
+      out.push(...listTsFiles(full));
+    } else if (entry.endsWith(".ts") && !entry.endsWith(".test.ts")) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+interface Violation {
+  file: string;
+  line: number;
+  snippet: string;
+}
+
+/** Was a `// shell-safe:` comment placed on or within 3 lines above `charIndex`? */
+function hasJustificationBefore(content: string, charIndex: number): boolean {
+  const before = content.slice(0, charIndex);
+  const lines = before.split("\n");
+  // Look at the line containing the call plus the 3 preceding lines.
+  const window = lines.slice(Math.max(0, lines.length - 4));
+  return window.some((l) => l.includes(JUSTIFICATION));
+}
+
+function scanFile(file: string): Violation[] {
+  const content = readFileSync(file, "utf8");
+  const violations: Violation[] = [];
+
+  for (const re of [SHELL_EXEC_RE, BUN_SHELL_RE]) {
+    re.lastIndex = 0;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(content)) !== null) {
+      const arg = m[1] ?? "";
+      if (!arg.includes("${")) continue; // no interpolation → not a concern
+      if (hasJustificationBefore(content, m.index)) continue;
+      const line = content.slice(0, m.index).split("\n").length;
+      violations.push({
+        file: file.replace(`${SRC_DIR}/`, "src/"),
+        line,
+        snippet: arg.slice(0, 60).replace(/\n/g, " "),
+      });
+    }
+  }
+  return violations;
+}
+
+describe("shell-exec injection guard (#159 / RW-045)", () => {
+  test("every interpolated execSync/exec/Bun.$ in src has a // shell-safe justification", () => {
+    const violations = listTsFiles(SRC_DIR).flatMap(scanFile);
+    if (violations.length > 0) {
+      const report = violations
+        .map((v) => `  ${v.file}:${v.line}  \`${v.snippet}...\``)
+        .join("\n");
+      throw new Error(
+        `Unjustified interpolated shell-exec call(s) found. Pass untrusted ` +
+          `input via execFileSync (argv) or validate at a choke point, then add ` +
+          `a "// shell-safe: <reason>" comment on/above the call:\n${report}`,
+      );
+    }
+    expect(violations).toHaveLength(0);
+  });
+
+  // Self-check: the scanner must actually catch an unjustified interpolation
+  // (guards against the regex silently matching nothing — RW-021 空振り).
+  test("scanner flags an unjustified interpolated execSync (planted)", () => {
+    const planted = 'const x = "a";\nexecSync(`echo ${x}`);\n';
+    const tmp = join(import.meta.dir, ".planted-violation.tmp.ts");
+    require("fs").writeFileSync(tmp, planted);
+    try {
+      expect(scanFile(tmp).length).toBe(1);
+    } finally {
+      require("fs").unlinkSync(tmp);
+    }
+  });
+
+  test("scanner ignores a justified interpolation and execFileSync", () => {
+    const ok =
+      '// shell-safe: x is a constant\nexecSync(`echo ${x}`);\n' +
+      "execFileSync(`${bin}`, [arg]);\n" +
+      "execSync(`echo literal`);\n";
+    const tmp = join(import.meta.dir, ".justified.tmp.ts");
+    require("fs").writeFileSync(tmp, ok);
+    try {
+      expect(scanFile(tmp).length).toBe(0);
+    } finally {
+      require("fs").unlinkSync(tmp);
+    }
+  });
+});


### PR DESCRIPTION
## 概要

PR #157 (#154) のレビュー must（シェル injection）→ agent-base RW-045 の **class hardening**。Closes #159。

`supervisor/src/**/*.ts` を走査し、`execSync` / `exec` / `Bun.$` がテンプレートリテラル補間（`${...}`）を含むのに `// shell-safe: <理由>` 注釈が無い場合に test を fail させる guard を追加。新規コードがシェル文字列補間で injection を再導入するのを機械的に防ぐ。

> #157 の具体ベクタ（branch → `cd "<path>"`）自体は `resolveWorktreePath` の metachar 拒否（PR #157 で CI 済）で塞ぎ済み。本 PR はクラスとしての再発防止。

## 変更

- `supervisor/tests/guards/shell-exec-safety.test.ts`（新規）
  - src 走査 + 本体検査
  - **planted violation の自己検証**（regex の空振り防止 — RW-021）
  - justified 注釈 / `execFileSync`(argv) を無視することの検証
- `iterm2.ts` / `tmux.ts` の既存補間 `execSync` 全 7 箇所に `// shell-safe:` 注釈
  - いずれも `TMUX_CMD`（定数）/ 内部 session id / 静的 channel 名 / osascript エスケープで、Discord の自由入力は到達しない

## AC

| AC | 判定 |
|---|---|
| guard test が現 tree で PASS（注釈付与後） | ✅ 3/3 PASS |
| 注釈なし補間 execSync を仕込むと FAIL | ✅ planted violation テストで検証 |
| `execFileSync`(argv) は対象外 | ✅ 検証済 |
| tsc / 全体テスト regression なし | ✅ tsc clean、336 pass（既存 tmux AC-7 flaky 4 件は main 再現） |

関連: #154, PR #157, RW-045（agent-base）
