### PR TITLE
feat(#161): /session resume <session_id> で停止済みセッションを会話履歴付きで復帰

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,9 @@ jobs:
                    tests/session/relay.test.ts \
                    tests/session/relay-server.test.ts \
                    tests/session/queue-resilience.test.ts \
+                   tests/session/manager-resume.test.ts \
                    tests/commands/session-interaction.test.ts \
+                   tests/commands/session-resume.test.ts \
                    tests/hooks/stop-relay.test.ts \
                    tests/infra/db.test.ts \
                    tests/hijoguchi-routing/p0.test.ts \

--- a/supervisor/src/commands/session.ts
+++ b/supervisor/src/commands/session.ts
@@ -33,6 +33,19 @@ export function createSessionCommand() {
     )
     .addSubcommand((sub) =>
       sub.setName("list").setDescription("稼働中セッション一覧")
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName("resume")
+        .setDescription("停止済みセッションを会話履歴付きで復帰（新スレッドで起動）")
+        // Issue #161: session_id is required. Declared optional at the Discord
+        // layer so a missing arg reaches the handler, which returns a usage hint.
+        .addStringOption((opt) =>
+          opt
+            .setName("session_id")
+            .setDescription("復帰する claude session id（/session list で確認できる UUID）")
+            .setRequired(false)
+        )
     );
 }
 
@@ -49,6 +62,9 @@ export function createSessionHandler(sessionManager: SessionManager) {
         break;
       case "list":
         await handleList(interaction, sessionManager);
+        break;
+      case "resume":
+        await handleResume(interaction, sessionManager);
         break;
     }
   };
@@ -173,6 +189,144 @@ async function handleStart(
       }
     }
     const msg = `❌ セッション起動に失敗: ${err instanceof Error ? err.message : String(err)}`;
+    if (interaction.deferred || interaction.replied) {
+      await interaction.editReply({ content: msg });
+    } else {
+      await interaction.reply({ content: msg, flags: 64 });
+    }
+  }
+}
+
+async function handleResume(
+  interaction: ChatInputCommandInteraction,
+  sessionManager: SessionManager
+): Promise<void> {
+  // Issue #161: resume a stopped session by its claude session id, in a new
+  // thread, with full relay wiring. Invoked from the project's channel (same
+  // channel-scoping rule as `start`).
+  const channel = interaction.channel;
+  if (!channel) {
+    await interaction.reply({
+      content: "❌ チャンネル情報を取得できません。",
+      flags: 64,
+    });
+    return;
+  }
+
+  let channelName: string = "";
+  if (channel.isThread() && channel.parent) {
+    channelName = channel.parent.name ?? "";
+  } else if ("name" in channel && typeof channel.name === "string") {
+    channelName = channel.name;
+  }
+
+  const config = CHANNEL_MAP.get(channelName);
+  if (!config) {
+    await interaction.reply({
+      content: `❌ このチャンネル (${channelName}) は未登録です。\n登録済みチャンネル: ${Array.from(CHANNEL_MAP.keys()).join(", ")}`,
+      flags: 64,
+    });
+    return;
+  }
+
+  const sessionId = interaction.options.getString("session_id")?.trim() ?? "";
+  if (!sessionId) {
+    await interaction.reply({
+      content:
+        "❌ session_id が必須です。`/session resume <session_id>` で実行してください（`/session list` で UUID を確認できます）。",
+      flags: 64,
+    });
+    return;
+  }
+
+  const row = sessionManager.findResumableSession(sessionId);
+  if (!row) {
+    await interaction.reply({
+      content: `❌ session_id が見つかりません: \`${sessionId}\``,
+      flags: 64,
+    });
+    return;
+  }
+  if (row.channel_name !== channelName) {
+    await interaction.reply({
+      content: `❌ この session は別チャンネル (\`${row.channel_name}\`) のものです。そのチャンネルで実行してください。`,
+      flags: 64,
+    });
+    return;
+  }
+  if (row.status === "running") {
+    await interaction.reply({
+      content: "⚠️ この session は既に稼働中です。`/session list` で確認してください。",
+      flags: 64,
+    });
+    return;
+  }
+
+  if (sessionManager.count() >= MAX_SESSIONS) {
+    await interaction.reply({
+      content: `⚠️ 最大セッション数 (${MAX_SESSIONS}) に達しています。\n古いセッションのスレッドで \`/session stop\` を実行してください。`,
+      flags: 64,
+    });
+    return;
+  }
+
+  await interaction.deferReply();
+
+  let createdThread: ThreadChannel | null = null;
+  try {
+    const existingSessions = sessionManager.listRunningByChannel(channelName);
+    const sessionNum = existingSessions.length + 1;
+    const threadName =
+      sessionNum > 1
+        ? `♻️ Resume: ${config.displayName} (${sessionNum})`
+        : `♻️ Resume: ${config.displayName}`;
+
+    const parentChannel =
+      channel.isThread() && channel.parent ? channel.parent : channel;
+
+    if (
+      !parentChannel.isTextBased() ||
+      parentChannel.isDMBased() ||
+      !("threads" in parentChannel)
+    ) {
+      await interaction.editReply({
+        content: "❌ このチャンネルではスレッドを作成できません。",
+      });
+      return;
+    }
+
+    const textChannel = parentChannel as import("discord.js").TextChannel;
+    const thread = await textChannel.threads.create({
+      name: threadName,
+      autoArchiveDuration: 10080, // 7 days
+    });
+    createdThread = thread;
+
+    // Resume in the directory the original session ran in (row.project_dir),
+    // not a worktree — `claude --resume` keys the transcript by cwd.
+    sessionManager.resumeSession(config, thread.id, sessionId, row.project_dir);
+
+    await thread.send(
+      `♻️ **${config.displayName}** のセッションを復帰しました（resume）\n\n` +
+        `📁 ディレクトリ: \`${row.project_dir}\`\n` +
+        `🔑 Claude session: \`${sessionId}\`\n` +
+        `📊 稼働中セッション: ${sessionManager.count()}/${MAX_SESSIONS}\n\n` +
+        `前回の会話を引き継いで再開します。このスレッドにメッセージを送信すると中継されます。\n` +
+        `終了するには \`/session stop\` をこのスレッド内で実行してください。`
+    );
+
+    await interaction.editReply({
+      content: `✅ セッションを復帰しました → ${thread}`,
+    });
+  } catch (err) {
+    if (createdThread) {
+      try {
+        await createdThread.delete();
+      } catch {
+        // Thread already gone or delete not permitted — nothing to recover.
+      }
+    }
+    const msg = `❌ セッション復帰に失敗: ${err instanceof Error ? err.message : String(err)}`;
     if (interaction.deferred || interaction.replied) {
       await interaction.editReply({ content: msg });
     } else {

--- a/supervisor/src/commands/session.ts
+++ b/supervisor/src/commands/session.ts
@@ -303,8 +303,14 @@ async function handleResume(
     createdThread = thread;
 
     // Resume in the directory the original session ran in (row.project_dir),
-    // not a worktree — `claude --resume` keys the transcript by cwd.
-    sessionManager.resumeSession(config, thread.id, sessionId, row.project_dir);
+    // not a worktree — `claude --resume` keys the transcript by cwd. Awaited so
+    // the resume prompt is confirmed before the welcome message is posted.
+    await sessionManager.resumeSession(
+      config,
+      thread.id,
+      sessionId,
+      row.project_dir
+    );
 
     await thread.send(
       `♻️ **${config.displayName}** のセッションを復帰しました（resume）\n\n` +

--- a/supervisor/src/commands/session.ts
+++ b/supervisor/src/commands/session.ts
@@ -273,6 +273,7 @@ async function handleResume(
   await interaction.deferReply();
 
   let createdThread: ThreadChannel | null = null;
+  let resumed = false;
   try {
     const existingSessions = sessionManager.listRunningByChannel(channelName);
     const sessionNum = existingSessions.length + 1;
@@ -311,6 +312,7 @@ async function handleResume(
       sessionId,
       row.project_dir
     );
+    resumed = true;
 
     await thread.send(
       `♻️ **${config.displayName}** のセッションを復帰しました（resume）\n\n` +
@@ -325,6 +327,17 @@ async function handleResume(
       content: `✅ セッションを復帰しました → ${thread}`,
     });
   } catch (err) {
+    // If resumeSession already succeeded, the session is live; a failure in the
+    // follow-up notification (welcome message or interaction acknowledgement)
+    // must not leave a running session unreachable from Discord. Stop it before
+    // discarding the thread (PR #162 review: CodeRabbit Major).
+    if (resumed && createdThread) {
+      try {
+        await sessionManager.stop(createdThread.id, "manual");
+      } catch {
+        // Best-effort: nothing more to recover if the stop itself fails.
+      }
+    }
     if (createdThread) {
       try {
         await createdThread.delete();
@@ -377,10 +390,12 @@ async function handleStop(
   try {
     await sessionManager.stop(threadId, "manual");
 
-    // Update thread name to show stopped
+    // Update thread name to show stopped. Start threads lead with "🟢",
+    // resume threads with "♻️" — replace whichever prefix is present so resume
+    // threads also reflect the stopped state (PR #162 review: CodeRabbit).
     const thread = channel as ThreadChannel;
     const currentName = thread.name;
-    const stoppedName = currentName.replace("🟢", "🔴");
+    const stoppedName = currentName.replace("🟢", "🔴").replace("♻️", "🔴");
     await thread.setName(stoppedName);
 
     // Archive and lock the thread

--- a/supervisor/src/infra/db.ts
+++ b/supervisor/src/infra/db.ts
@@ -121,6 +121,17 @@ export function getRunningSessionByThread(
     .get(threadId) as SessionRow | undefined;
 }
 
+export function getSessionByClaudeSessionId(
+  claudeSessionId: string
+): SessionRow | undefined {
+  const db = getDb();
+  return db
+    .prepare(
+      `SELECT * FROM sessions WHERE claude_session_id = ? ORDER BY started_at DESC LIMIT 1`
+    )
+    .get(claudeSessionId) as SessionRow | undefined;
+}
+
 export function getRunningSessions(): SessionRow[] {
   const db = getDb();
   return db

--- a/supervisor/src/session/adapters-fake.ts
+++ b/supervisor/src/session/adapters-fake.ts
@@ -23,6 +23,8 @@ export class FakeTmuxAdapter implements TmuxAdapter {
   private paneContent = new Map<string, string>();
   /** Records every sendKeys() call so tests can assert prompt confirmation. */
   sendKeysCalls: { name: string; keys: string[] }[] = [];
+  /** When set, sendKeys() throws to simulate a failure during prompt confirm. */
+  failOnSendKeys = false;
 
   newSession(name: string, command: string): void {
     this.sessions.set(name, { command, pid: this.pidCounter++ });
@@ -50,6 +52,9 @@ export class FakeTmuxAdapter implements TmuxAdapter {
 
   sendKeys(name: string, keys: string[]): void {
     this.sendKeysCalls.push({ name, keys });
+    if (this.failOnSendKeys) {
+      throw new Error("sendKeys failed");
+    }
   }
 
   list(): string[] {

--- a/supervisor/src/session/adapters-fake.ts
+++ b/supervisor/src/session/adapters-fake.ts
@@ -19,6 +19,10 @@ export class FakeTmuxAdapter implements TmuxAdapter {
   private sessions = new Map<string, { command: string; pid: number }>();
   private pidCounter = 10_000;
   ensureSocketConfiguredCalls = 0;
+  /** Programmable pane buffers returned by capturePane(). */
+  private paneContent = new Map<string, string>();
+  /** Records every sendKeys() call so tests can assert prompt confirmation. */
+  sendKeysCalls: { name: string; keys: string[] }[] = [];
 
   newSession(name: string, command: string): void {
     this.sessions.set(name, { command, pid: this.pidCounter++ });
@@ -40,6 +44,14 @@ export class FakeTmuxAdapter implements TmuxAdapter {
     this.ensureSocketConfiguredCalls += 1;
   }
 
+  capturePane(name: string): string {
+    return this.paneContent.get(name) ?? "";
+  }
+
+  sendKeys(name: string, keys: string[]): void {
+    this.sendKeysCalls.push({ name, keys });
+  }
+
   list(): string[] {
     return Array.from(this.sessions.keys());
   }
@@ -47,6 +59,11 @@ export class FakeTmuxAdapter implements TmuxAdapter {
   /** Test-only: read the bash command stored for a tmux session. */
   getCommand(name: string): string | null {
     return this.sessions.get(name)?.command ?? null;
+  }
+
+  /** Test-only: set what capturePane() returns for a session. */
+  setPaneContent(name: string, content: string): void {
+    this.paneContent.set(name, content);
   }
 }
 

--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -35,6 +35,18 @@ export interface TmuxAdapter {
   hasSession(name: string): boolean;
   getPid(name: string): number | null;
   ensureSocketConfigured(): void;
+  /**
+   * Capture the visible pane content (`tmux capture-pane -p`). Returns "" on
+   * error. Used by the resume flow (Issue #161) to detect Claude Code's
+   * interactive "Resume from summary" prompt so it can be auto-confirmed.
+   */
+  capturePane(name: string): string;
+  /**
+   * Send raw keys to the pane (`tmux send-keys -t <name> <keys...>`).
+   * Best-effort: a transient failure is swallowed (the caller's poll loop
+   * retries or proceeds). Used to confirm the resume prompt with `C-m` (Enter).
+   */
+  sendKeys(name: string, keys: string[]): void;
 }
 
 export interface ItermAdapter {
@@ -125,6 +137,30 @@ export const realTmuxAdapter: TmuxAdapter = {
   },
   ensureSocketConfigured() {
     realEnsureSocketConfigured();
+  },
+  capturePane(name) {
+    // stdio: ["ignore", "pipe", "ignore"] — read stdout, discard stderr (the
+    // "can't find pane" case is handled by the catch returning "").
+    try {
+      return execFileSync(
+        TMUX_PATH,
+        [...TMUX_ARGS, "capture-pane", "-p", "-t", name],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
+      );
+    } catch {
+      return "";
+    }
+  },
+  sendKeys(name, keys) {
+    // execFileSync + argv array: no shell, so `keys` cannot inject
+    // metacharacters. Best-effort — swallow transient tmux errors.
+    try {
+      execFileSync(TMUX_PATH, [...TMUX_ARGS, "send-keys", "-t", name, ...keys], {
+        stdio: "ignore",
+      });
+    } catch {
+      // Caller's poll loop retries or proceeds.
+    }
   },
 };
 

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -14,6 +14,8 @@ import {
   updateSessionStatus,
   updateSessionActivity,
   getRunningSessions,
+  getSessionByClaudeSessionId,
+  type SessionRow,
 } from "../infra/db";
 import {
   relayMessage,
@@ -28,6 +30,25 @@ import {
 
 const CLAUDE_PATH = resolve(homedir(), ".local", "bin", "claude");
 const TMUX_SESSION_PREFIX = "claude-";
+
+/**
+ * Claude session IDs are UUIDs. The resume flow embeds the id in the bash
+ * command string passed to tmux, so restrict it to the UUID shape — a value
+ * that fails this cannot carry shell metacharacters (Issue #161).
+ */
+const CLAUDE_SESSION_ID_RE =
+  /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+
+/**
+ * Marker for Claude Code's interactive resume prompt
+ * (`Resume from summary (recommended)` / `Resume the full conversation`),
+ * shown when `claude --resume <id>` targets a compacted session. There is no
+ * CLI flag to pre-select it (`claude --help`), so the resume flow polls the
+ * pane for this marker and sends Enter (Issue #161).
+ */
+const RESUME_PROMPT_RE = /Resume (from summary|the full conversation)/i;
+/** Poll attempts (×0.5s) to detect the resume prompt before giving up. */
+const RESUME_PROMPT_POLL_ATTEMPTS = 12;
 
 /**
  * Build the argv for the `claude` invocation in a supervisor session.
@@ -109,6 +130,13 @@ export interface SessionManagerOptions {
    * delay before kill-session. Defaults to {@link GRACEFUL_KILL_TIMEOUT_MS}.
    */
   gracefulKillTimeoutMs?: number;
+  /**
+   * Resume-prompt poll tuning (Issue #161). Tests shrink these so the
+   * "no prompt" path doesn't pay the production ~6s wait. Defaults:
+   * {@link RESUME_PROMPT_POLL_ATTEMPTS} attempts × 500ms.
+   */
+  resumePromptPollAttempts?: number;
+  resumePromptPollIntervalMs?: number;
 }
 
 export class SessionManager {
@@ -118,6 +146,8 @@ export class SessionManager {
   private watchers = new Map<string, ReturnType<typeof setInterval>>();
   private readonly effects: SessionEffects;
   private readonly gracefulKillTimeoutMs: number;
+  private readonly resumePromptPollAttempts: number;
+  private readonly resumePromptPollIntervalMs: number;
 
   constructor(options: SessionManagerOptions = {}) {
     this.effects = {
@@ -130,6 +160,10 @@ export class SessionManager {
     };
     this.gracefulKillTimeoutMs =
       options.gracefulKillTimeoutMs ?? GRACEFUL_KILL_TIMEOUT_MS;
+    this.resumePromptPollAttempts =
+      options.resumePromptPollAttempts ?? RESUME_PROMPT_POLL_ATTEMPTS;
+    this.resumePromptPollIntervalMs =
+      options.resumePromptPollIntervalMs ?? 500;
 
     this.effects.tmux.ensureSocketConfigured();
     this.effects.relayServer.start();
@@ -316,6 +350,165 @@ export class SessionManager {
     }, 0);
 
     return info;
+  }
+
+  /**
+   * Look up a stopped (or any) session by its Claude session id so the caller
+   * can validate it before resuming. Returns the most recent matching row, or
+   * undefined when the id is unknown (Issue #161).
+   */
+  findResumableSession(claudeSessionId: string): SessionRow | undefined {
+    return getSessionByClaudeSessionId(claudeSessionId);
+  }
+
+  /**
+   * Resume a previously-stopped Claude session in a fresh thread with full
+   * relay wiring (Issue #161). Unlike {@link start}, this passes
+   * `claude --resume <id>` so the conversation history is preserved.
+   *
+   * `projectDir` MUST be the directory the original session ran in (recorded in
+   * sessions.db): `claude --resume` keys the transcript by cwd, so resuming
+   * from any other directory — including a `-w` worktree — fails to find the
+   * jsonl. Worktree re-creation is intentionally out of scope; a missing
+   * `projectDir` throws so the caller can report it instead of silently
+   * starting a fresh conversation.
+   */
+  resumeSession(
+    config: ChannelConfig,
+    threadId: string,
+    claudeSessionId: string,
+    projectDir: string
+  ): SessionInfo {
+    if (this.sessions.size >= MAX_SESSIONS) {
+      throw new Error(`最大セッション数 (${MAX_SESSIONS}) に達しています`);
+    }
+    if (this.sessions.has(threadId)) {
+      throw new Error(`このスレッドのセッションは既に稼働中です`);
+    }
+    if (!CLAUDE_SESSION_ID_RE.test(claudeSessionId)) {
+      throw new Error(
+        `claude session id の形式が不正です: ${claudeSessionId}`
+      );
+    }
+    if (!existsSync(projectDir)) {
+      throw new Error(
+        `プロジェクトディレクトリが見つかりません: ${projectDir}（worktree が削除された可能性があります）`
+      );
+    }
+
+    const sessionId = randomUUID();
+    const tmuxName = this.tmuxSessionName(threadId);
+    this.effects.tmux.killSession(tmuxName);
+
+    const relayUrl = `http://localhost:${this.effects.relayServer.getPort()}/relay/${encodeURIComponent(threadId)}`;
+    const relayUrlFile = relayUrlFilePath(projectDir);
+    const relayUrlDir = dirname(relayUrlFile);
+    this.cleanupRelayUrlFile(projectDir);
+
+    // `--resume <id>` continues the prior conversation in-place (no
+    // --fork-session, so the same claude session id keeps accumulating).
+    // claudeSessionId is validated as a UUID above, so embedding it in the
+    // bash string is shell-safe. The command is passed to tmux via execFileSync
+    // (argv) in the adapter, so it is not subject to outer-shell parsing.
+    const resumeFlags = [
+      "--resume",
+      claudeSessionId,
+      ...buildClaudeFlags(config),
+    ];
+    const claudeCmd = [
+      "unset ANTHROPIC_API_KEY",
+      `export PATH="${resolve(homedir(), ".local/bin")}:${resolve(homedir(), ".bun/bin")}:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin"`,
+      `export SUPERVISOR_RELAY_URL="${relayUrl}"`,
+      `mkdir -p "${relayUrlDir}"`,
+      `printf "%s" "${relayUrl}" > "${relayUrlFile}"`,
+      `cd "${projectDir}"`,
+      `exec ${CLAUDE_PATH} ${resumeFlags.join(" ")}`,
+    ].join(" && ");
+
+    this.effects.tmux.newSession(tmuxName, claudeCmd);
+    this.effects.tmux.ensureSocketConfigured();
+
+    let pid: number | null = null;
+    for (let i = 0; i < 5; i++) {
+      pid = this.effects.tmux.getPid(tmuxName);
+      if (pid) break;
+      // shell-safe: literal constant, no interpolation.
+      execSync("sleep 0.5");
+    }
+
+    if (!pid) {
+      this.cleanupRelayUrlFile(projectDir);
+      throw new Error(
+        "Claude Code の起動に失敗しました（tmuxセッションのPID取得失敗）"
+      );
+    }
+
+    // Auto-confirm the interactive "Resume from summary" prompt if it appears.
+    this.confirmResumePromptIfPresent(tmuxName);
+
+    const now = new Date();
+    const info: SessionInfo = {
+      id: sessionId,
+      channelName: config.channelName,
+      threadId,
+      projectDir,
+      pid,
+      process: null as unknown as any, // tmux manages the process
+      claudeSessionId,
+      startedAt: now,
+      lastActivityAt: now,
+      status: "running",
+    };
+
+    this.sessions.set(threadId, info);
+
+    insertSession({
+      id: sessionId,
+      channel_name: config.channelName,
+      thread_id: threadId,
+      project_dir: projectDir,
+      pid,
+      claude_session_id: claudeSessionId,
+      started_at: now.toISOString(),
+      last_activity_at: now.toISOString(),
+      status: "running",
+    });
+
+    this.watchTmuxSession(threadId, tmuxName, sessionId);
+
+    console.log(
+      `[SessionManager] Resumed ${config.channelName} (claude session ${claudeSessionId}) via tmux (PID: ${pid}, tmux: ${tmuxName}, thread: ${threadId})`
+    );
+
+    setTimeout(() => {
+      this.effects.iterm2.openTab({
+        tmuxSessionName: tmuxName,
+        channelName: config.channelName,
+        projectDir,
+      });
+    }, 0);
+
+    return info;
+  }
+
+  /**
+   * Poll the pane for Claude Code's "Resume from summary" prompt and accept the
+   * default highlighted option with Enter. Marker-based rather than a fixed
+   * sleep (RW-025/027): if the marker never appears the session resumed without
+   * a prompt and we proceed without sending stray keys.
+   */
+  private confirmResumePromptIfPresent(tmuxName: string): void {
+    const seconds = this.resumePromptPollIntervalMs / 1000;
+    for (let i = 0; i < this.resumePromptPollAttempts; i++) {
+      const pane = this.effects.tmux.capturePane(tmuxName);
+      if (RESUME_PROMPT_RE.test(pane)) {
+        this.effects.tmux.sendKeys(tmuxName, ["C-m"]);
+        return;
+      }
+      // shell-safe: `seconds` is an internal number (intervalMs / 1000), never
+      // user input, so it cannot carry shell metacharacters.
+      execSync(`sleep ${seconds}`);
+    }
   }
 
   /**

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -432,8 +432,10 @@ export class SessionManager {
     for (let i = 0; i < 5; i++) {
       pid = this.effects.tmux.getPid(tmuxName);
       if (pid) break;
-      // shell-safe: literal constant, no interpolation.
-      execSync("sleep 0.5");
+      // Async wait — resumeSession is async, so unlike start()'s synchronous
+      // execSync("sleep") this does not block the single-process Discord bot's
+      // event loop while the tmux pane spins up (PR #162 review: gemini medium).
+      await new Promise((resolve) => setTimeout(resolve, 500));
     }
 
     if (!pid) {

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -445,11 +445,6 @@ export class SessionManager {
       );
     }
 
-    // Auto-confirm the interactive "Resume from summary" prompt if it appears.
-    // Awaited (not fire-and-forget) so the session is registered only AFTER the
-    // TUI reaches its normal input prompt — see the ordering note below.
-    await this.confirmResumePromptIfPresent(tmuxName);
-
     const now = new Date();
     const info: SessionInfo = {
       id: sessionId,
@@ -464,19 +459,35 @@ export class SessionManager {
       status: "running",
     };
 
-    this.sessions.set(threadId, info);
+    // Post-launch init (prompt confirm + state registration) can throw. tmux is
+    // already running by now, so on failure we must kill it and drop the
+    // relay-url file — otherwise Discord reports failure while a Claude/tmux
+    // process is left orphaned (PR #162 review: CodeRabbit Major).
+    try {
+      // Auto-confirm the interactive "Resume from summary" prompt if it appears.
+      // Awaited (not fire-and-forget) so the session is registered only AFTER the
+      // TUI reaches its normal input prompt — see the ordering note below.
+      await this.confirmResumePromptIfPresent(tmuxName);
 
-    insertSession({
-      id: sessionId,
-      channel_name: config.channelName,
-      thread_id: threadId,
-      project_dir: projectDir,
-      pid,
-      claude_session_id: claudeSessionId,
-      started_at: now.toISOString(),
-      last_activity_at: now.toISOString(),
-      status: "running",
-    });
+      this.sessions.set(threadId, info);
+
+      insertSession({
+        id: sessionId,
+        channel_name: config.channelName,
+        thread_id: threadId,
+        project_dir: projectDir,
+        pid,
+        claude_session_id: claudeSessionId,
+        started_at: now.toISOString(),
+        last_activity_at: now.toISOString(),
+        status: "running",
+      });
+    } catch (err) {
+      this.sessions.delete(threadId);
+      this.effects.tmux.killSession(tmuxName);
+      this.cleanupRelayUrlFile(projectDir);
+      throw err;
+    }
 
     this.watchTmuxSession(threadId, tmuxName, sessionId);
 

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -373,12 +373,12 @@ export class SessionManager {
    * `projectDir` throws so the caller can report it instead of silently
    * starting a fresh conversation.
    */
-  resumeSession(
+  async resumeSession(
     config: ChannelConfig,
     threadId: string,
     claudeSessionId: string,
     projectDir: string
-  ): SessionInfo {
+  ): Promise<SessionInfo> {
     if (this.sessions.size >= MAX_SESSIONS) {
       throw new Error(`最大セッション数 (${MAX_SESSIONS}) に達しています`);
     }
@@ -444,7 +444,9 @@ export class SessionManager {
     }
 
     // Auto-confirm the interactive "Resume from summary" prompt if it appears.
-    this.confirmResumePromptIfPresent(tmuxName);
+    // Awaited (not fire-and-forget) so the session is registered only AFTER the
+    // TUI reaches its normal input prompt — see the ordering note below.
+    await this.confirmResumePromptIfPresent(tmuxName);
 
     const now = new Date();
     const info: SessionInfo = {
@@ -496,18 +498,25 @@ export class SessionManager {
    * default highlighted option with Enter. Marker-based rather than a fixed
    * sleep (RW-025/027): if the marker never appears the session resumed without
    * a prompt and we proceed without sending stray keys.
+   *
+   * The wait between polls uses an awaited `setTimeout`, not a synchronous
+   * `execSync("sleep")`, so the single-process Discord bot's event loop stays
+   * free while polling (PR #162 review: a synchronous sleep would block all
+   * other channels' relays for up to ~6s). The caller awaits this method, so
+   * the non-blocking change does NOT weaken the ordering guarantee — the
+   * session is still registered only after the prompt is confirmed, so a
+   * relayed message can never race the prompt picker (#86 / RW-019 class bug).
    */
-  private confirmResumePromptIfPresent(tmuxName: string): void {
-    const seconds = this.resumePromptPollIntervalMs / 1000;
+  private async confirmResumePromptIfPresent(tmuxName: string): Promise<void> {
     for (let i = 0; i < this.resumePromptPollAttempts; i++) {
       const pane = this.effects.tmux.capturePane(tmuxName);
       if (RESUME_PROMPT_RE.test(pane)) {
         this.effects.tmux.sendKeys(tmuxName, ["C-m"]);
         return;
       }
-      // shell-safe: `seconds` is an internal number (intervalMs / 1000), never
-      // user input, so it cannot carry shell metacharacters.
-      execSync(`sleep ${seconds}`);
+      await new Promise((resolve) =>
+        setTimeout(resolve, this.resumePromptPollIntervalMs)
+      );
     }
   }
 

--- a/supervisor/tests/commands/session-resume.test.ts
+++ b/supervisor/tests/commands/session-resume.test.ts
@@ -32,16 +32,20 @@ function makeInteraction(opts: {
   channelName?: string;
   resumableRow?: ResumableRow | undefined;
   resumeImpl?: (...args: unknown[]) => unknown;
+  sendImpl?: () => unknown;
 }) {
   const replies: ReplyRecord[] = [];
   const resumeCalls: unknown[][] = [];
   const findCalls: string[] = [];
+  const stopCalls: unknown[][] = [];
   let threadCreated = false;
   let threadDeleted = false;
 
   const thread = {
     id: "thread-resume-1",
-    send: async () => {},
+    send: async () => {
+      opts.sendImpl?.();
+    },
     delete: async () => {
       threadDeleted = true;
     },
@@ -92,6 +96,9 @@ function makeInteraction(opts: {
       resumeCalls.push(args);
       return opts.resumeImpl?.(...args) ?? { id: "sess-1" };
     },
+    stop: async (...args: unknown[]) => {
+      stopCalls.push(args);
+    },
   };
 
   return {
@@ -100,6 +107,7 @@ function makeInteraction(opts: {
     replies,
     resumeCalls,
     findCalls,
+    stopCalls,
     get threadCreated() {
       return threadCreated;
     },
@@ -218,6 +226,36 @@ describe("/session resume validation (#161)", () => {
     await h.run();
 
     expect(h.threadCreated).toBe(true);
+    expect(h.threadDeleted).toBe(true);
+    // resumeSession never completed → no live session to stop.
+    expect(h.stopCalls).toHaveLength(0);
+    const editReplies = h.replies.filter((r) => r.kind === "editReply");
+    expect(editReplies[editReplies.length - 1]!.content).toContain(
+      "セッション復帰に失敗"
+    );
+  });
+
+  test("notify failure after resume → session stopped, then thread deleted (PR #162: CodeRabbit Major)", async () => {
+    const h = makeInteraction({
+      sessionId: VALID_ID,
+      channelName: "team-salary",
+      resumableRow: {
+        channel_name: "team-salary",
+        project_dir: "/Users/x/team_salary",
+        status: "stopped",
+      },
+      // resumeSession succeeds (default impl), but the welcome message fails.
+      sendImpl: () => {
+        throw new Error("Discord API 5xx");
+      },
+    });
+    await h.run();
+
+    expect(h.threadCreated).toBe(true);
+    // The live session must be stopped so it is not orphaned (unreachable).
+    expect(h.stopCalls).toHaveLength(1);
+    expect(h.stopCalls[0]![0]).toBe("thread-resume-1");
+    // The thread is then discarded and the error is surfaced.
     expect(h.threadDeleted).toBe(true);
     const editReplies = h.replies.filter((r) => r.kind === "editReply");
     expect(editReplies[editReplies.length - 1]!.content).toContain(

--- a/supervisor/tests/commands/session-resume.test.ts
+++ b/supervisor/tests/commands/session-resume.test.ts
@@ -1,0 +1,227 @@
+import { test, expect, describe } from "bun:test";
+import { createSessionHandler } from "../../src/commands/session";
+
+/**
+ * Handler-level tests for `/session resume <session_id>` (Issue #161).
+ *
+ * Mirrors session-start-branch.test.ts: a minimal fake
+ * ChatInputCommandInteraction exercises the real handler without a Discord
+ * gateway. `findResumableSession` is stubbed on the fake SessionManager so the
+ * handler's validation branches are covered without a real DB.
+ *
+ * "team-salary" is a real CHANNEL_MAP key, so the channel-registration gate
+ * passes; "claude-hub-hijoguchi" is intentionally NOT in CHANNEL_MAP.
+ */
+
+const VALID_ID = "3139aa23-fe2a-485a-831a-2209081f9935";
+
+interface ReplyRecord {
+  kind: "reply" | "editReply";
+  content?: string;
+  flags?: number;
+}
+
+interface ResumableRow {
+  channel_name: string;
+  project_dir: string;
+  status: string;
+}
+
+function makeInteraction(opts: {
+  sessionId?: string | null;
+  channelName?: string;
+  resumableRow?: ResumableRow | undefined;
+  resumeImpl?: (...args: unknown[]) => unknown;
+}) {
+  const replies: ReplyRecord[] = [];
+  const resumeCalls: unknown[][] = [];
+  const findCalls: string[] = [];
+  let threadCreated = false;
+  let threadDeleted = false;
+
+  const thread = {
+    id: "thread-resume-1",
+    send: async () => {},
+    delete: async () => {
+      threadDeleted = true;
+    },
+  };
+
+  const channel = {
+    isThread: () => false,
+    isTextBased: () => true,
+    isDMBased: () => false,
+    name: opts.channelName ?? "team-salary",
+    threads: {
+      create: async () => {
+        threadCreated = true;
+        return thread;
+      },
+    },
+  };
+
+  const interaction = {
+    options: {
+      getSubcommand: () => "resume",
+      getString: (name: string) =>
+        name === "session_id" ? opts.sessionId ?? null : null,
+    },
+    channel,
+    deferred: false,
+    replied: false,
+    async reply(msg: { content?: string; flags?: number }) {
+      this.replied = true;
+      replies.push({ kind: "reply", content: msg.content, flags: msg.flags });
+    },
+    async deferReply() {
+      this.deferred = true;
+    },
+    async editReply(msg: { content?: string }) {
+      replies.push({ kind: "editReply", content: msg.content });
+    },
+  };
+
+  const sessionManager = {
+    count: () => 0,
+    listRunningByChannel: () => [],
+    findResumableSession: (id: string) => {
+      findCalls.push(id);
+      return opts.resumableRow;
+    },
+    resumeSession: (...args: unknown[]) => {
+      resumeCalls.push(args);
+      return opts.resumeImpl?.(...args) ?? { id: "sess-1" };
+    },
+  };
+
+  return {
+    run: () =>
+      createSessionHandler(sessionManager as never)(interaction as never),
+    replies,
+    resumeCalls,
+    findCalls,
+    get threadCreated() {
+      return threadCreated;
+    },
+    get threadDeleted() {
+      return threadDeleted;
+    },
+  };
+}
+
+describe("/session resume validation (#161)", () => {
+  test("no session_id → ephemeral usage error, no resume, no thread", async () => {
+    const h = makeInteraction({ sessionId: null });
+    await h.run();
+
+    expect(h.resumeCalls).toHaveLength(0);
+    expect(h.threadCreated).toBe(false);
+    expect(h.replies).toHaveLength(1);
+    expect(h.replies[0]!.flags).toBe(64);
+    expect(h.replies[0]!.content).toContain("session_id が必須");
+  });
+
+  test("whitespace-only session_id is also rejected", async () => {
+    const h = makeInteraction({ sessionId: "   " });
+    await h.run();
+    expect(h.resumeCalls).toHaveLength(0);
+    expect(h.threadCreated).toBe(false);
+  });
+
+  test("unregistered channel → 未登録 error, no DB lookup", async () => {
+    const h = makeInteraction({
+      sessionId: VALID_ID,
+      channelName: "claude-hub-hijoguchi",
+    });
+    await h.run();
+    expect(h.findCalls).toHaveLength(0);
+    expect(h.resumeCalls).toHaveLength(0);
+    expect(h.replies[0]!.content).toContain("未登録");
+  });
+
+  test("session_id not found → error, no thread", async () => {
+    const h = makeInteraction({ sessionId: VALID_ID, resumableRow: undefined });
+    await h.run();
+    expect(h.findCalls).toEqual([VALID_ID]);
+    expect(h.resumeCalls).toHaveLength(0);
+    expect(h.threadCreated).toBe(false);
+    expect(h.replies[0]!.content).toContain("見つかりません");
+  });
+
+  test("session from a different channel → error", async () => {
+    const h = makeInteraction({
+      sessionId: VALID_ID,
+      channelName: "team-salary",
+      resumableRow: {
+        channel_name: "agent-base",
+        project_dir: "/Users/x/agent-base",
+        status: "stopped",
+      },
+    });
+    await h.run();
+    expect(h.resumeCalls).toHaveLength(0);
+    expect(h.replies[0]!.content).toContain("別チャンネル");
+    expect(h.replies[0]!.content).toContain("agent-base");
+  });
+
+  test("session already running → warns, no resume", async () => {
+    const h = makeInteraction({
+      sessionId: VALID_ID,
+      channelName: "team-salary",
+      resumableRow: {
+        channel_name: "team-salary",
+        project_dir: "/Users/x/team_salary",
+        status: "running",
+      },
+    });
+    await h.run();
+    expect(h.resumeCalls).toHaveLength(0);
+    expect(h.replies[0]!.content).toContain("既に稼働中");
+  });
+
+  test("valid stopped session → resumeSession called with project_dir, thread created", async () => {
+    const h = makeInteraction({
+      sessionId: VALID_ID,
+      channelName: "team-salary",
+      resumableRow: {
+        channel_name: "team-salary",
+        project_dir: "/Users/x/team_salary",
+        status: "stopped",
+      },
+    });
+    await h.run();
+
+    expect(h.threadCreated).toBe(true);
+    expect(h.resumeCalls).toHaveLength(1);
+    // resumeSession(config, threadId, sessionId, projectDir)
+    expect(h.resumeCalls[0]![1]).toBe("thread-resume-1");
+    expect(h.resumeCalls[0]![2]).toBe(VALID_ID);
+    expect(h.resumeCalls[0]![3]).toBe("/Users/x/team_salary");
+
+    const editReplies = h.replies.filter((r) => r.kind === "editReply");
+    expect(editReplies[editReplies.length - 1]!.content).toContain("復帰しました");
+  });
+
+  test("resume failure → orphan thread deleted + error surfaced", async () => {
+    const h = makeInteraction({
+      sessionId: VALID_ID,
+      channelName: "team-salary",
+      resumableRow: {
+        channel_name: "team-salary",
+        project_dir: "/Users/x/team_salary",
+        status: "stopped",
+      },
+      resumeImpl: () => {
+        throw new Error("プロジェクトディレクトリが見つかりません");
+      },
+    });
+    await h.run();
+
+    expect(h.threadCreated).toBe(true);
+    expect(h.threadDeleted).toBe(true);
+    const editReplies = h.replies.filter((r) => r.kind === "editReply");
+    expect(editReplies[editReplies.length - 1]!.content).toContain(
+      "セッション復帰に失敗"
+    );
+  });
+});

--- a/supervisor/tests/infra/db.test.ts
+++ b/supervisor/tests/infra/db.test.ts
@@ -5,7 +5,7 @@ process.env.SUPERVISOR_DB_PATH = ":memory:";
 
 // Reset module cache to pick up the env var
 // Import after setting env
-const { getDb, insertSession, updateSessionStatus, updateSessionActivity, getRunningSessions, getRunningSessionByThread, getRunningSessionsByChannel, getLastSessionByChannel } = await import("../../src/infra/db");
+const { getDb, insertSession, updateSessionStatus, updateSessionActivity, getRunningSessions, getRunningSessionByThread, getRunningSessionsByChannel, getLastSessionByChannel, getSessionByClaudeSessionId } = await import("../../src/infra/db");
 
 describe("infra/db (in-memory)", () => {
   beforeEach(() => {
@@ -35,6 +35,42 @@ describe("infra/db (in-memory)", () => {
     expect(rows[0]!.id).toBe("test-1");
     expect(rows[0]!.channel_name).toBe("team-salary");
     expect(rows[0]!.thread_id).toBe("thread-1");
+  });
+
+  test("getSessionByClaudeSessionId returns the most recent matching row (#161)", () => {
+    const claudeId = "3139aa23-fe2a-485a-831a-2209081f9935";
+    // Older row with the same claude session id.
+    insertSession({
+      id: "resume-old",
+      channel_name: "team-salary",
+      thread_id: "thread-old",
+      project_dir: "/Users/x/team_salary",
+      pid: 100,
+      claude_session_id: claudeId,
+      started_at: "2026-05-24T10:00:00.000Z",
+      last_activity_at: "2026-05-24T10:00:00.000Z",
+      status: "stopped",
+    });
+    // Newer row with the same claude session id (e.g. a prior resume).
+    insertSession({
+      id: "resume-new",
+      channel_name: "team-salary",
+      thread_id: "thread-new",
+      project_dir: "/Users/x/team_salary",
+      pid: 200,
+      claude_session_id: claudeId,
+      started_at: "2026-05-25T10:00:00.000Z",
+      last_activity_at: "2026-05-25T10:00:00.000Z",
+      status: "stopped",
+    });
+
+    const found = getSessionByClaudeSessionId(claudeId);
+    expect(found?.id).toBe("resume-new"); // ORDER BY started_at DESC
+    expect(found?.project_dir).toBe("/Users/x/team_salary");
+
+    // bun:sqlite .get() returns null (not undefined) for no match; the handler
+    // treats both as "not found" via `if (!row)`.
+    expect(getSessionByClaudeSessionId("00000000-0000-0000-0000-000000000000")).toBeNull();
   });
 
   test("updateSessionStatus changes status and reason", () => {

--- a/supervisor/tests/session/manager-resume.test.ts
+++ b/supervisor/tests/session/manager-resume.test.ts
@@ -1,0 +1,130 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { resolve } from "path";
+
+// Isolate DB writes from the real sessions.db (mirrors tests/infra/db.test.ts).
+process.env.SUPERVISOR_DB_PATH = ":memory:";
+
+const { SessionManager } = await import("../../src/session/manager");
+const { createFakeEffects } = await import(
+  "../../src/session/adapters-fake"
+);
+import type { FakeSessionEffects } from "../../src/session/adapters-fake";
+import type { ChannelConfig } from "../../src/config/channels";
+
+/**
+ * Manager-level tests for SessionManager.resumeSession (Issue #161). Fake
+ * adapters keep tmux / iTerm2 / relay out of the test; assertions target the
+ * built claude command and the "Resume from summary" prompt auto-confirm.
+ */
+
+const VALID_ID = "3139aa23-fe2a-485a-831a-2209081f9935";
+const THREAD_ID = "thread-resume-abc";
+const tmuxName = `claude-${THREAD_ID.slice(0, 12)}`;
+
+function makeProjectDir(): string {
+  const dir = resolve(tmpdir(), `supervisor-resume-${process.pid}`);
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+function makeConfig(dir: string): ChannelConfig {
+  return { channelName: "team-salary", dir, displayName: "Team Salary" };
+}
+
+describe("SessionManager.resumeSession (#161)", () => {
+  let manager: InstanceType<typeof SessionManager>;
+  let effects: FakeSessionEffects;
+  let projectDir: string;
+
+  beforeEach(() => {
+    effects = createFakeEffects();
+    projectDir = makeProjectDir();
+  });
+
+  afterEach(async () => {
+    await manager?.shutdownAll();
+  });
+
+  test("builds `claude --resume <id>` with cd into the recorded projectDir", () => {
+    manager = new SessionManager({ effects, gracefulKillTimeoutMs: 0, resumePromptPollAttempts: 0 });
+    const info = manager.resumeSession(
+      makeConfig(projectDir),
+      THREAD_ID,
+      VALID_ID,
+      projectDir
+    );
+
+    const cmd = effects.tmux.getCommand(tmuxName) ?? "";
+    expect(cmd).toContain(`--resume ${VALID_ID}`);
+    expect(cmd).toContain(`cd "${projectDir}"`);
+    expect(cmd).toContain("--dangerously-skip-permissions");
+    // AC-4: relay wiring identical to start() — SUPERVISOR_RELAY_URL is exported
+    // and the per-thread relay endpoint is set so inbound/outbound relay works.
+    expect(cmd).toContain("SUPERVISOR_RELAY_URL=");
+    expect(cmd).toContain("/relay/");
+
+    expect(info.claudeSessionId).toBe(VALID_ID);
+    expect(info.projectDir).toBe(projectDir);
+    expect(info.status).toBe("running");
+    // No worktree for resume (resumes the recorded cwd, Q2).
+    expect(info.worktree).toBeUndefined();
+  });
+
+  test("auto-confirms the resume prompt with Enter when the marker is present", () => {
+    manager = new SessionManager({
+      effects,
+      gracefulKillTimeoutMs: 0,
+      resumePromptPollAttempts: 3,
+    });
+    // The pane shows Claude's interactive resume prompt on first capture.
+    effects.tmux.setPaneContent(
+      tmuxName,
+      "Resume from summary (recommended)\n❯ 1. ...\n  2. Resume the full conversation"
+    );
+
+    manager.resumeSession(makeConfig(projectDir), THREAD_ID, VALID_ID, projectDir);
+
+    const confirm = effects.tmux.sendKeysCalls.find(
+      (c) => c.name === tmuxName
+    );
+    expect(confirm).toBeDefined();
+    expect(confirm!.keys).toEqual(["C-m"]);
+  });
+
+  test("does not send keys when no resume prompt appears", () => {
+    manager = new SessionManager({
+      effects,
+      gracefulKillTimeoutMs: 0,
+      resumePromptPollAttempts: 2,
+      resumePromptPollIntervalMs: 5,
+    });
+    // capturePane returns "" (no marker) for the whole poll window.
+    manager.resumeSession(makeConfig(projectDir), THREAD_ID, VALID_ID, projectDir);
+
+    expect(effects.tmux.sendKeysCalls).toHaveLength(0);
+  });
+
+  test("rejects a malformed (non-UUID) session id before launching", () => {
+    manager = new SessionManager({ effects, gracefulKillTimeoutMs: 0, resumePromptPollAttempts: 0 });
+    expect(() =>
+      manager.resumeSession(
+        makeConfig(projectDir),
+        THREAD_ID,
+        "not-a-uuid; rm -rf /",
+        projectDir
+      )
+    ).toThrow(/形式が不正/);
+    expect(effects.tmux.list()).toHaveLength(0);
+  });
+
+  test("throws when the recorded projectDir no longer exists", () => {
+    manager = new SessionManager({ effects, gracefulKillTimeoutMs: 0, resumePromptPollAttempts: 0 });
+    const gone = resolve(tmpdir(), `supervisor-resume-gone-${process.pid}`);
+    rmSync(gone, { recursive: true, force: true });
+    expect(() =>
+      manager.resumeSession(makeConfig(gone), THREAD_ID, VALID_ID, gone)
+    ).toThrow(/見つかりません/);
+  });
+});

--- a/supervisor/tests/session/manager-resume.test.ts
+++ b/supervisor/tests/session/manager-resume.test.ts
@@ -127,4 +127,28 @@ describe("SessionManager.resumeSession (#161)", () => {
       manager.resumeSession(makeConfig(gone), THREAD_ID, VALID_ID, gone)
     ).rejects.toThrow(/見つかりません/);
   });
+
+  test("rolls back the tmux session if post-launch init throws (PR #162: CodeRabbit Major)", async () => {
+    manager = new SessionManager({
+      effects,
+      gracefulKillTimeoutMs: 0,
+      resumePromptPollAttempts: 3,
+    });
+    // Prompt marker present → confirmResumePromptIfPresent calls sendKeys, which
+    // we force to throw, simulating a failure after tmux has already started.
+    effects.tmux.setPaneContent(
+      tmuxName,
+      "Resume from summary (recommended)\n❯ 1. ..."
+    );
+    effects.tmux.failOnSendKeys = true;
+
+    await expect(
+      manager.resumeSession(makeConfig(projectDir), THREAD_ID, VALID_ID, projectDir)
+    ).rejects.toThrow(/sendKeys failed/);
+
+    // No orphaned tmux session, and no half-registered session state.
+    expect(effects.tmux.list()).toHaveLength(0);
+    expect(manager.has(THREAD_ID)).toBe(false);
+    expect(manager.count()).toBe(0);
+  });
 });

--- a/supervisor/tests/session/manager-resume.test.ts
+++ b/supervisor/tests/session/manager-resume.test.ts
@@ -47,9 +47,9 @@ describe("SessionManager.resumeSession (#161)", () => {
     await manager?.shutdownAll();
   });
 
-  test("builds `claude --resume <id>` with cd into the recorded projectDir", () => {
+  test("builds `claude --resume <id>` with cd into the recorded projectDir", async () => {
     manager = new SessionManager({ effects, gracefulKillTimeoutMs: 0, resumePromptPollAttempts: 0 });
-    const info = manager.resumeSession(
+    const info = await manager.resumeSession(
       makeConfig(projectDir),
       THREAD_ID,
       VALID_ID,
@@ -72,7 +72,7 @@ describe("SessionManager.resumeSession (#161)", () => {
     expect(info.worktree).toBeUndefined();
   });
 
-  test("auto-confirms the resume prompt with Enter when the marker is present", () => {
+  test("auto-confirms the resume prompt with Enter when the marker is present", async () => {
     manager = new SessionManager({
       effects,
       gracefulKillTimeoutMs: 0,
@@ -84,7 +84,7 @@ describe("SessionManager.resumeSession (#161)", () => {
       "Resume from summary (recommended)\n❯ 1. ...\n  2. Resume the full conversation"
     );
 
-    manager.resumeSession(makeConfig(projectDir), THREAD_ID, VALID_ID, projectDir);
+    await manager.resumeSession(makeConfig(projectDir), THREAD_ID, VALID_ID, projectDir);
 
     const confirm = effects.tmux.sendKeysCalls.find(
       (c) => c.name === tmuxName
@@ -93,7 +93,7 @@ describe("SessionManager.resumeSession (#161)", () => {
     expect(confirm!.keys).toEqual(["C-m"]);
   });
 
-  test("does not send keys when no resume prompt appears", () => {
+  test("does not send keys when no resume prompt appears", async () => {
     manager = new SessionManager({
       effects,
       gracefulKillTimeoutMs: 0,
@@ -101,30 +101,30 @@ describe("SessionManager.resumeSession (#161)", () => {
       resumePromptPollIntervalMs: 5,
     });
     // capturePane returns "" (no marker) for the whole poll window.
-    manager.resumeSession(makeConfig(projectDir), THREAD_ID, VALID_ID, projectDir);
+    await manager.resumeSession(makeConfig(projectDir), THREAD_ID, VALID_ID, projectDir);
 
     expect(effects.tmux.sendKeysCalls).toHaveLength(0);
   });
 
-  test("rejects a malformed (non-UUID) session id before launching", () => {
+  test("rejects a malformed (non-UUID) session id before launching", async () => {
     manager = new SessionManager({ effects, gracefulKillTimeoutMs: 0, resumePromptPollAttempts: 0 });
-    expect(() =>
+    await expect(
       manager.resumeSession(
         makeConfig(projectDir),
         THREAD_ID,
         "not-a-uuid; rm -rf /",
         projectDir
       )
-    ).toThrow(/形式が不正/);
+    ).rejects.toThrow(/形式が不正/);
     expect(effects.tmux.list()).toHaveLength(0);
   });
 
-  test("throws when the recorded projectDir no longer exists", () => {
+  test("rejects when the recorded projectDir no longer exists", async () => {
     manager = new SessionManager({ effects, gracefulKillTimeoutMs: 0, resumePromptPollAttempts: 0 });
     const gone = resolve(tmpdir(), `supervisor-resume-gone-${process.pid}`);
     rmSync(gone, { recursive: true, force: true });
-    expect(() =>
+    await expect(
       manager.resumeSession(makeConfig(gone), THREAD_ID, VALID_ID, gone)
-    ).toThrow(/見つかりません/);
+    ).rejects.toThrow(/見つかりません/);
   });
 });


### PR DESCRIPTION
Closes #161

## 概要

停止済みの Claude Code セッションを **会話履歴を保持したまま** Discord の新スレッドに復帰させる `/session resume <session_id>` を追加した。従来 `/session` は start / stop / list のみで、停止後は Supervisor 管理下で会話の続きをやり直せなかった（`/session start` は必ず fresh start）。

## 変更点

- **session.ts**: `resume` サブコマンド + `handleResume` を追加。`session_id` 必須、チャンネル一致 / 未検出 / 既 running を事前バリデーションし、新スレッドを作成して起動。失敗時は orphan スレッドを削除。
- **manager.ts**: `resumeSession()` / `findResumableSession()` を追加。`claude --resume <id>` を **記録済み projectDir** で起動し **`-w` を使わない**（`--resume` は transcript を cwd の project key で引くため、worktree を使うと jsonl が見つからない。実運用で確認済みの落とし穴）。`session_id` は UUID 検証してからシェル文字列へ埋め込む。
- **Resume from summary プロンプト自動確定**: `claude --resume` は compact 済みセッションで対話プロンプトを出すが CLI に skip フラグが無い（`claude --help` 確認済み）。`capturePane` をマーカーでポーリングし Enter を送出して確定（固定 sleep でなくマーカー検出 = RW-025/027 準拠。ポーリング回数/間隔は注入可能）。
- **tmux adapter**: `capturePane` / `sendKeys` を追加（real は `execFileSync` の argv＝シェル非経由）。
- **db.ts**: `getSessionByClaudeSessionId()` を追加。

## 設計判断

- Q1: 復帰先は**新スレッド**（元スレッドは stop 時に archive+lock 済みのため）
- Q2: `sessions.db` の `project_dir` で resume。worktree 復元はスコープ外。projectDir 不在ならエラー
- Q3: 対話プロンプトは marker ポーリング + Enter
- Q4: 未検出 / 別チャンネル / 既 running をエラー分岐
- Q5: MAX_SESSIONS チェック

## テスト

- `tests/commands/session-resume.test.ts`（handler 8 ケース: 引数なし / 未登録チャンネル / 未検出 / 別チャンネル / 既 running / 正常 / 失敗時 orphan 削除 ほか）
- `tests/session/manager-resume.test.ts`（manager 5 ケース: コマンド文字列に --resume + cd projectDir + relay URL / プロンプト自動確定 / プロンプト無時は送出なし / 不正 UUID 拒否 / projectDir 不在で throw）
- `tests/infra/db.test.ts`（getSessionByClaudeSessionId、最新行優先 + 未検出）
- `bunx tsc --noEmit` clean / CI 正規 unit-test ゲート 68 pass・0 fail / shell-exec-safety guard pass

## AC 検証結果

| AC | 検証 | 判定 |
|---|---|---|
| AC-1 resume サブコマンド + session_id 必須 | session-resume.test.ts | PASS |
| AC-2 claude --resume を projectDir で起動・-w 不使用 | manager-resume.test.ts | PASS |
| AC-3 Resume プロンプト自動確定 | manager-resume.test.ts | PASS |
| AC-4 relay 結線（新 thread） | manager-resume.test.ts | PASS |
| AC-5 DB 行に claude_session_id | db.test.ts | PASS |
| AC-6 テスト追加 | 14 新規テスト全 PASS | PASS |

## 統合ジャーニーAC（manual / post-merge）

Discord 実機での往復（resume → 文脈保持応答 → tool 進捗中継）は、**merge + Supervisor 再起動後**でないと新コマンドが有効化されないため post-merge 手動検証とする（リポジトリ既存の AC-1/2/3 manual パターンに準拠）。

## ⚠️ merge 後の手順

Supervisor は repo のコードから動き、`/session` の新サブコマンドは起動時に Discord へ再登録されるため、**merge 後に Supervisor を 1 回再起動**する必要がある（merge 前の再起動は無効）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 停止済みセッションをセッションIDで復帰できる /session resume を追加。前回のプロジェクトディレクトリと会話を再開します。
  * 復帰プロンプトを自動で検出・確認して復帰手順を簡便化。

* **Bug Fixes / Validation**
  * 無効なID・未指定・別チャンネル・既に稼働中・上限超過時に適切なエラーメッセージを返すよう強化。

* **Tests**
  * 復帰動作やエラーケースを網羅するテストを追加。

* **Style / UX**
  * 停止時のスレッド名の接頭辞表示を更新（再開マークを赤表示へ）。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miyashita337/claude-hub/pull/162?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->