### PR TITLE
fix(#163): resume 時に常に「Resume full session as-is」(選択肢2) を選ぶ

### DIFF
--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -507,10 +507,14 @@ export class SessionManager {
   }
 
   /**
-   * Poll the pane for Claude Code's "Resume from summary" prompt and accept the
-   * default highlighted option with Enter. Marker-based rather than a fixed
+   * Poll the pane for Claude Code's "Resume from summary" prompt and select
+   * option 2 "Resume full session as-is" (Down then Enter). The picker
+   * highlights option 1 "Resume from summary (recommended)" by default, but we
+   * always want the full conversation, not a summary (Issue #163), so we move
+   * the selection down one before confirming. Marker-based rather than a fixed
    * sleep (RW-025/027): if the marker never appears the session resumed without
-   * a prompt and we proceed without sending stray keys.
+   * a prompt (a non-compacted session resumes full directly) and we proceed
+   * without sending stray keys.
    *
    * The wait between polls uses an awaited `setTimeout`, not a synchronous
    * `execSync("sleep")`, so the single-process Discord bot's event loop stays
@@ -524,7 +528,9 @@ export class SessionManager {
     for (let i = 0; i < this.resumePromptPollAttempts; i++) {
       const pane = this.effects.tmux.capturePane(tmuxName);
       if (RESUME_PROMPT_RE.test(pane)) {
-        this.effects.tmux.sendKeys(tmuxName, ["C-m"]);
+        // Down moves from option 1 (summary, highlighted) to option 2 (full
+        // session as-is); C-m confirms. See Issue #163.
+        this.effects.tmux.sendKeys(tmuxName, ["Down", "C-m"]);
         return;
       }
       await new Promise((resolve) =>

--- a/supervisor/tests/session/manager-resume.test.ts
+++ b/supervisor/tests/session/manager-resume.test.ts
@@ -72,7 +72,7 @@ describe("SessionManager.resumeSession (#161)", () => {
     expect(info.worktree).toBeUndefined();
   });
 
-  test("auto-confirms the resume prompt with Enter when the marker is present", async () => {
+  test("selects option 2 'Resume full session as-is' (Down + Enter) when the marker is present (#163)", async () => {
     manager = new SessionManager({
       effects,
       gracefulKillTimeoutMs: 0,
@@ -81,7 +81,7 @@ describe("SessionManager.resumeSession (#161)", () => {
     // The pane shows Claude's interactive resume prompt on first capture.
     effects.tmux.setPaneContent(
       tmuxName,
-      "Resume from summary (recommended)\n❯ 1. ...\n  2. Resume the full conversation"
+      "Resume from summary (recommended)\n❯ 1. ...\n  2. Resume full session as-is"
     );
 
     await manager.resumeSession(makeConfig(projectDir), THREAD_ID, VALID_ID, projectDir);
@@ -90,7 +90,9 @@ describe("SessionManager.resumeSession (#161)", () => {
       (c) => c.name === tmuxName
     );
     expect(confirm).toBeDefined();
-    expect(confirm!.keys).toEqual(["C-m"]);
+    // Down moves from the highlighted option 1 (summary) to option 2 (full),
+    // then Enter confirms — we always want the full session (Issue #163).
+    expect(confirm!.keys).toEqual(["Down", "C-m"]);
   });
 
   test("does not send keys when no resume prompt appears", async () => {


### PR DESCRIPTION
## 目的
Issue #163。`/session resume <id>` で compacted セッションを復帰すると Claude Code が「Resume from summary / Resume full session as-is / Don't ask me again」のピッカーを出す。現状の auto-confirm は `Enter` のみ送出しハイライト中の選択肢1「Resume from summary」を選んでしまう。ユーザー要望に合わせ **常に選択肢2「Resume full session as-is」(full session 復帰)** を選ぶようにする。

## 主な変更
- `confirmResumePromptIfPresent` の送出キーを `["C-m"]` → `["Down", "C-m"]`（↓で選択肢2へ移動 → Enter で確定）
- マーカー未検知時（非 compacted セッション = ピッカー非表示）は従来どおりキー送出なしで full session 直接復帰
- 回帰テスト `manager-resume.test.ts` を `["Down", "C-m"]` 期待に更新

## テスト
- `tsc --noEmit` clean
- `manager-resume` / `session-resume` 15 pass

## 統合ジャーニーAC
1. **操作**: 停止済み team-salary で `/session resume <id>` を実行
   - **期待結果**: 復帰スレッド作成 + tmux 側で選択肢2が自動選択され full session で起動
   - **検証手段**: 再起動デプロイ後に実機で `/session resume` → pane が summary ではなく full conversation で再開 + スレッド中継が動作

## 備考
キー送出 `Down + Enter` が実機の Ink ピッカーで選択肢2を選ぶことはデプロイ後に実機検証する（fake テストは送出キー列のみ検証）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * セッション再開時のプロンプト確認の動作を改善しました。

* **改善**
  * マーカー検出に基づくポーリング処理を最適化し、マーカーが検出されない場合の処理を改善しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miyashita337/claude-hub/pull/164?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->