### PR TITLE
fix(#163): resume の picker 待機を延長＋ready マーカー早期終了（大セッションの固まり対策）

### DIFF
--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -47,8 +47,22 @@ const CLAUDE_SESSION_ID_RE =
  * pane for this marker and sends Enter (Issue #161).
  */
 const RESUME_PROMPT_RE = /Resume (from summary|the full conversation)/i;
-/** Poll attempts (×0.5s) to detect the resume prompt before giving up. */
-const RESUME_PROMPT_POLL_ATTEMPTS = 12;
+/**
+ * Marker that the resumed TUI reached its normal input prompt — either a
+ * non-compacted session that never shows the picker, or the picker has already
+ * been dismissed. Lets the poll loop stop early instead of waiting out the full
+ * window when there is nothing to confirm (Issue #163).
+ */
+const RESUME_READY_RE = /bypass permissions|\? for shortcuts/i;
+/**
+ * Poll attempts (×interval) to detect the resume prompt before giving up.
+ * Large compacted sessions can take minutes to render the picker (observed
+ * ~4min for a 239k-token / 1d21h session), so with the default 1s interval this
+ * is a ~5min budget. The loop exits early as soon as the picker OR the ready
+ * marker appears, so a small/non-compacted resume still returns in ~1s
+ * (Issue #163 — a 12×0.5s=6s window timed out before the picker rendered).
+ */
+const RESUME_PROMPT_POLL_ATTEMPTS = 300;
 
 /**
  * Build the argv for the `claude` invocation in a supervisor session.
@@ -163,7 +177,7 @@ export class SessionManager {
     this.resumePromptPollAttempts =
       options.resumePromptPollAttempts ?? RESUME_PROMPT_POLL_ATTEMPTS;
     this.resumePromptPollIntervalMs =
-      options.resumePromptPollIntervalMs ?? 500;
+      options.resumePromptPollIntervalMs ?? 1000;
 
     this.effects.tmux.ensureSocketConfigured();
     this.effects.relayServer.start();
@@ -531,6 +545,12 @@ export class SessionManager {
         // Down moves from option 1 (summary, highlighted) to option 2 (full
         // session as-is); C-m confirms. See Issue #163.
         this.effects.tmux.sendKeys(tmuxName, ["Down", "C-m"]);
+        return;
+      }
+      // Reached the normal input prompt with no picker — stop polling instead
+      // of waiting out the (multi-minute) window for a picker that won't appear
+      // (Issue #163). Checked after the picker so the picker always wins.
+      if (RESUME_READY_RE.test(pane)) {
         return;
       }
       await new Promise((resolve) =>

--- a/supervisor/tests/session/manager-resume.test.ts
+++ b/supervisor/tests/session/manager-resume.test.ts
@@ -108,6 +108,29 @@ describe("SessionManager.resumeSession (#161)", () => {
     expect(effects.tmux.sendKeysCalls).toHaveLength(0);
   });
 
+  test("exits early without keys when the ready marker appears (no picker, #163)", async () => {
+    // A large poll budget would hang the test if the loop ignored the ready
+    // marker; the early-exit must return on the first capture.
+    manager = new SessionManager({
+      effects,
+      gracefulKillTimeoutMs: 0,
+      resumePromptPollAttempts: 1000,
+      resumePromptPollIntervalMs: 5,
+    });
+    // Non-compacted session: resumes straight to the input prompt (no picker).
+    effects.tmux.setPaneContent(
+      tmuxName,
+      "❯ \n  ⏵⏵ bypass permissions on (shift+tab to cycle)"
+    );
+
+    await manager.resumeSession(makeConfig(projectDir), THREAD_ID, VALID_ID, projectDir);
+
+    // No picker → no keystrokes, and the resume completed (did not exhaust the
+    // 1000-attempt window).
+    expect(effects.tmux.sendKeysCalls).toHaveLength(0);
+    expect(manager.has(THREAD_ID)).toBe(true);
+  });
+
   test("rejects a malformed (non-UUID) session id before launching", async () => {
     manager = new SessionManager({ effects, gracefulKillTimeoutMs: 0, resumePromptPollAttempts: 0 });
     await expect(


### PR DESCRIPTION
## 背景 / 実機で観測した問題
PR #164 で resume 時に「Resume full session as-is」(選択肢2) を選ぶようにしたが、実機 (team-salary, 239.2k tokens / 1d21h) で resume すると **picker のまま固まった**。

原因は**キー選択ではなく待機時間**: `confirmResumePromptIfPresent` の poll が `12 × 0.5s = 6秒` しかなく、大きい compacted セッションは picker 表示まで数分かかるため、**picker が出る前にタイムアウト→自動確定が押されず放置**されていた（pane に `❯ 1. Resume from summary` が残存、"Brewed for 4m"）。手動で `↓+Enter` を送って full session で復帰させ unblock 済み。

## 変更
- poll 既定を `12 × 0.5s` → `300 × 1s`（最大 ~5分）に延長。大セッションでも picker を待てる。
- `RESUME_READY_RE`（`bypass permissions` / `? for shortcuts`）を追加し、**入力プロンプト到達を検知したら早期終了**。非 compacted（picker 無し）resume が5分待機を無駄に消費しない。
- picker 判定を ready 判定より先に評価 → picker が出るケースは常に選択肢2を選ぶ。

## テスト
- `tsc --noEmit` clean
- `manager-resume` 7 pass（ready マーカー早期終了テスト追加）

## 統合ジャーニーAC
1. **操作**: 大きい (>100k token) 停止済みセッションを `/session resume <id>`
   - **期待結果**: 数分かかっても picker 表示時に自動で選択肢2が選ばれ、手動操作なしで full session 起動
   - **検証手段**: 実機で resume → pane が picker で固まらず full conversation で起動 + スレッド中継が動作
2. **操作**: 小さい/非 compacted セッションを resume
   - **期待結果**: picker は出ず、数秒で input prompt に到達しスレッドが中継可能になる
   - **検証手段**: resume 後すぐにスレッドへ送信して応答が返る

## 備考
poll 中は `await setTimeout` で event loop を止めない（PR #162 の方針を維持）。session 登録は picker 確定後（ordering 保証 / RW-019）も維持。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * セッション再開フローの動作を改善し、UI準備状態の検出をより迅速に行うようにしました。ポーリング動作の調整により、不要な待機時間が減少します。

* **テスト**
  * セッション再開時の早期終了シナリオに対するテストケースを追加し、信頼性を向上させました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/miyashita337/claude-hub/pull/165?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->