### PR TITLE
feat(#167): claude_session_id を --session-id 注入で start 時に確定捕捉

### DIFF
--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -258,6 +258,12 @@ export class SessionManager {
     }
 
     const sessionId = randomUUID();
+    // Pre-generate the Claude session id and pin it via `claude --session-id`
+    // so the DB row captures it deterministically at start (Issue #167).
+    // The previous opportunistic capture (relay round-trip in bot.ts) left
+    // ~90% of rows NULL because relays time out before reporting the id; that
+    // path is now an idempotent fallback (only sets when still NULL).
+    const claudeSessionId = randomUUID();
     const tmuxName = this.tmuxSessionName(threadId);
 
     // Kill existing tmux session if any
@@ -289,7 +295,10 @@ export class SessionManager {
       `mkdir -p "${relayUrlDir}"`,
       `printf "%s" "${relayUrl}" > "${relayUrlFile}"`,
       `cd "${projectDir}"`,
-      `exec ${CLAUDE_PATH} ${buildClaudeFlags(config).join(" ")}`,
+      // `--session-id <uuid>` only on fresh start; resume uses `--resume <id>`
+      // (the two are mutually exclusive). claudeSessionId is a randomUUID() so
+      // it is shell-safe to embed here.
+      `exec ${CLAUDE_PATH} --session-id ${claudeSessionId} ${buildClaudeFlags(config).join(" ")}`,
     ].join(" && ");
 
     // Launch via tmux (provides a real TTY). Uses Supervisor's dedicated
@@ -326,6 +335,7 @@ export class SessionManager {
       threadId,
       projectDir,
       pid,
+      claudeSessionId,
       process: null as unknown as any, // tmux manages the process
       startedAt: now,
       lastActivityAt: now,
@@ -341,7 +351,7 @@ export class SessionManager {
       thread_id: threadId,
       project_dir: projectDir,
       pid,
-      claude_session_id: null,
+      claude_session_id: claudeSessionId,
       started_at: now.toISOString(),
       last_activity_at: now.toISOString(),
       status: "running",

--- a/supervisor/tests/session/manager.test.ts
+++ b/supervisor/tests/session/manager.test.ts
@@ -71,6 +71,25 @@ describe("SessionManager (thread-based)", () => {
     expect(session.status).toBe("running");
   });
 
+  test("start injects --session-id and captures claudeSessionId deterministically (Issue #167)", () => {
+    const threadId = "thread-csid";
+    const session = manager.start(primaryConfig, threadId);
+
+    // The id is captured on start, not via a relay round-trip (which times out
+    // ~90% of the time and left the DB column NULL).
+    expect(session.claudeSessionId).toMatch(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+    );
+
+    // The spawned claude command pins that id with --session-id, and a fresh
+    // start must NOT use --resume (the two flags are mutually exclusive).
+    // tmux name is deterministic: "claude-" + first 12 chars of threadId.
+    const tmuxName = `claude-${threadId.slice(0, 12)}`;
+    const cmd = effects.tmux.getCommand(tmuxName)!;
+    expect(cmd).toContain(`--session-id ${session.claudeSessionId}`);
+    expect(cmd).not.toContain("--resume");
+  });
+
   test("has() checks by threadId", () => {
     const threadId = "thread-456";
     manager.start(primaryConfig, threadId);


### PR DESCRIPTION
## 概要
Issue #167 — `claude_session_id` を起動時に確定捕捉する。

## 問題
`claude_session_id` の捕捉が relay 成功時のみの opportunistic 方式（`bot.ts:319`）で、relay タイムアウト多発により sessions.db の **約90%（1018 件中 101 件のみ取得）** が NULL。running でも MISSING が混在し、resume に必要な ID が取れない。

## 変更
- `start()` で `crypto.randomUUID()` を生成し `claude --session-id <uuid>` で起動 → DB 行へ即保存（100% 捕捉）
- `SessionInfo.claudeSessionId` も start 時に設定
- resume 経路は既存どおり `--resume <id>` を使い `--session-id` は付けない（排他）
- relay 経由の捕捉（`bot.ts:321` の `!session.claudeSessionId` ガード）は NULL 時のみ set する idempotent fallback として残置

## テスト
- `start injects --session-id and captures claudeSessionId deterministically` を追加（コマンドに `--session-id <uuid>` を含み `--resume` を含まないこと、`claudeSessionId` が UUID 形式）
- manager 34/0、manager-resume 7/0 PASS、typecheck 通過

## AC（Issue #167 統合ジャーニー）
1. `/session start` 直後に sessions.db の当該 thread 行の `claude_session_id` が即時に非 NULL（UUID）→ 本変更で成立
2. resume 経路も同 ID 保存（既存実装で成立）

## 関連
- Epic #166 / 設計 PR #173
