### PR TITLE
feat(#168): 権威ある liveness 判定ユニット + getSessionByThreadId

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,6 +85,7 @@ jobs:
                    tests/session/relay-server.test.ts \
                    tests/session/queue-resilience.test.ts \
                    tests/session/manager-resume.test.ts \
+                   tests/session/manager-liveness.test.ts \
                    tests/commands/session-interaction.test.ts \
                    tests/commands/session-resume.test.ts \
                    tests/hooks/stop-relay.test.ts \

--- a/supervisor/src/infra/db.ts
+++ b/supervisor/src/infra/db.ts
@@ -150,7 +150,17 @@ export function getLastSessionByChannel(
     .get(channelName) as SessionRow | undefined;
 }
 
-export function getLastSessionByThread(
+/**
+ * Most-recent session row for the given thread regardless of status. Used by
+ * the authoritative liveness check (Issue #168) and any caller that needs the
+ * latest run on a thread — including stopped ones. Returns `undefined` when
+ * the thread has never been seen.
+ *
+ * Renamed from `getLastSessionByThread` in Issue #168 to align with the rest
+ * of the file's `getSessionBy<Key>` naming (mirrors
+ * `getSessionByClaudeSessionId`). The old name had zero callers.
+ */
+export function getSessionByThreadId(
   threadId: string
 ): SessionRow | undefined {
   const db = getDb();

--- a/supervisor/src/session/adapters-fake.ts
+++ b/supervisor/src/session/adapters-fake.ts
@@ -112,12 +112,18 @@ export class FakeRelayServerAdapter implements RelayServerAdapter {
 export class FakeProcessAdapter implements ProcessAdapter {
   killCalls: { pid: number; signal: NodeJS.Signals | number }[] = [];
   failOnKill = false;
+  /** Pids that {@link isAlive} should report as alive. Anything else is dead. */
+  alivePids = new Set<number>();
 
   kill(pid: number, signal: NodeJS.Signals | number): void {
     this.killCalls.push({ pid, signal });
     if (this.failOnKill) {
       throw new Error("process not found");
     }
+  }
+
+  isAlive(pid: number): boolean {
+    return this.alivePids.has(pid);
   }
 }
 

--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -63,6 +63,13 @@ export interface RelayServerAdapter {
 
 export interface ProcessAdapter {
   kill(pid: number, signal: NodeJS.Signals | number): void;
+  /**
+   * Best-effort liveness check for a pid. Used by {@link SessionManager} to
+   * cross-check DB `status='running'` against reality (Issue #168). Returns
+   * `true` when the process exists (or exists but we lack signal permission —
+   * EPERM), `false` when it has exited (ESRCH). Never throws.
+   */
+  isAlive(pid: number): boolean;
 }
 
 /**
@@ -183,6 +190,19 @@ export const realRelayServerAdapter: RelayServerAdapter = {
 export const realProcessAdapter: ProcessAdapter = {
   kill(pid, signal) {
     process.kill(pid, signal);
+  },
+  isAlive(pid) {
+    // `kill(pid, 0)` is the POSIX convention for liveness checks: it performs
+    // permission/existence resolution without sending a signal. ESRCH means
+    // the process no longer exists; EPERM means it exists but the calling
+    // process can't signal it — still alive for our purposes (Issue #168).
+    try {
+      process.kill(pid, 0);
+      return true;
+    } catch (err) {
+      const e = err as NodeJS.ErrnoException;
+      return e.code === "EPERM";
+    }
   },
 };
 

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -15,6 +15,7 @@ import {
   updateSessionActivity,
   getRunningSessions,
   getSessionByClaudeSessionId,
+  getSessionByThreadId,
   type SessionRow,
 } from "../infra/db";
 import {
@@ -30,6 +31,16 @@ import {
 
 const CLAUDE_PATH = resolve(homedir(), ".local", "bin", "claude");
 const TMUX_SESSION_PREFIX = "claude-";
+
+/**
+ * Authoritative liveness verdict produced by {@link SessionManager.livenessOf}
+ * (Issue #168). Single source of truth so salvage responses and resume guards
+ * do not drift.
+ *   - `alive`: DB running + pid alive + tmux session exists
+ *   - `dead`: DB stopped, OR DB running but pid dead / tmux missing
+ *   - `unknown`: no DB row for the thread (never observed)
+ */
+export type Liveness = "alive" | "dead" | "unknown";
 
 /**
  * Claude session IDs are UUIDs. The resume flow embeds the id in the bash
@@ -194,6 +205,33 @@ export class SessionManager {
 
   get(threadId: string): SessionInfo | undefined {
     return this.sessions.get(threadId);
+  }
+
+  /**
+   * Authoritative liveness for the given thread (Issue #168 / Epic #166).
+   * Crosses DB `status` with reality — `process.kill(pid, 0)` for the recorded
+   * pid, and tmux session existence — and returns a single `alive | dead |
+   * unknown` verdict. Salvage responses and resume guards share this verdict so
+   * callers cannot drift from each other.
+   *
+   * Behaviour matrix:
+   *   - no DB row for the thread                        → `unknown`
+   *   - row.status !== "running"                        → `dead`
+   *   - row.status === "running" + no pid recorded     → `dead`
+   *   - row.status === "running" + pid alive + tmux alive → `alive`
+   *   - row.status === "running" + (pid dead OR tmux missing) → `dead`
+   *     (DB says running but reality contradicts — answer is the reality)
+   */
+  livenessOf(threadId: string): Liveness {
+    const row = getSessionByThreadId(threadId);
+    if (!row) return "unknown";
+    if (row.status !== "running") return "dead";
+    if (row.pid == null) return "dead";
+    const pidAlive = this.effects.process.isAlive(row.pid);
+    const tmuxAlive = this.effects.tmux.hasSession(
+      this.tmuxSessionName(threadId)
+    );
+    return pidAlive && tmuxAlive ? "alive" : "dead";
   }
 
   entries(): IterableIterator<[string, SessionInfo]> {

--- a/supervisor/tests/infra/db.test.ts
+++ b/supervisor/tests/infra/db.test.ts
@@ -5,7 +5,7 @@ process.env.SUPERVISOR_DB_PATH = ":memory:";
 
 // Reset module cache to pick up the env var
 // Import after setting env
-const { getDb, insertSession, updateSessionStatus, updateSessionActivity, getRunningSessions, getRunningSessionByThread, getRunningSessionsByChannel, getLastSessionByChannel, getSessionByClaudeSessionId } = await import("../../src/infra/db");
+const { getDb, insertSession, updateSessionStatus, updateSessionActivity, getRunningSessions, getRunningSessionByThread, getRunningSessionsByChannel, getLastSessionByChannel, getSessionByClaudeSessionId, getSessionByThreadId } = await import("../../src/infra/db");
 
 describe("infra/db (in-memory)", () => {
   beforeEach(() => {
@@ -71,6 +71,42 @@ describe("infra/db (in-memory)", () => {
     // bun:sqlite .get() returns null (not undefined) for no match; the handler
     // treats both as "not found" via `if (!row)`.
     expect(getSessionByClaudeSessionId("00000000-0000-0000-0000-000000000000")).toBeNull();
+  });
+
+  test("getSessionByThreadId returns the latest row (started_at DESC LIMIT 1) regardless of status (#168)", () => {
+    const threadId = "thread-resumed-twice";
+    // First run on this thread, since stopped.
+    insertSession({
+      id: "first",
+      channel_name: "team-salary",
+      thread_id: threadId,
+      project_dir: "/Users/x/team_salary",
+      pid: 100,
+      claude_session_id: null,
+      started_at: "2026-05-29T10:00:00.000Z",
+      last_activity_at: "2026-05-29T10:00:00.000Z",
+      status: "stopped",
+    });
+    // Second run on the same thread, currently running.
+    insertSession({
+      id: "second",
+      channel_name: "team-salary",
+      thread_id: threadId,
+      project_dir: "/Users/x/team_salary",
+      pid: 200,
+      claude_session_id: null,
+      started_at: "2026-05-31T10:00:00.000Z",
+      last_activity_at: "2026-05-31T10:00:00.000Z",
+      status: "running",
+    });
+
+    // AC: latest by started_at, irrespective of status.
+    const found = getSessionByThreadId(threadId);
+    expect(found?.id).toBe("second");
+    expect(found?.status).toBe("running");
+
+    // No row → null (bun:sqlite convention, treated as "not found" by callers).
+    expect(getSessionByThreadId("thread-never-seen")).toBeNull();
   });
 
   test("updateSessionStatus changes status and reason", () => {

--- a/supervisor/tests/session/manager-liveness.test.ts
+++ b/supervisor/tests/session/manager-liveness.test.ts
@@ -1,0 +1,121 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+
+/**
+ * Manager-level tests for SessionManager.livenessOf (Issue #168). The
+ * authoritative liveness check crosses DB `status='running'` against reality
+ * (pid alive + tmux session present) so salvage responses and resume guards
+ * cannot drift. Uses in-memory SQLite + fake adapters — no real tmux/process.
+ *
+ * AC coverage (issue #168):
+ *   - AC-1: DB running + pid dead     → `dead`         (test: "DB running + pid 死 → dead")
+ *   - AC-2: pid alive + tmux present  → `alive`        (test: "DB running + pid 生 + tmux 有 → alive")
+ *   - AC-3: no DB row                 → `unknown`      (test: "DB 行なし → unknown")
+ *   - AC-4: getSessionByThreadId (latest row) is covered by db.test.ts
+ *           and exercised transitively via livenessOf returning the latest
+ *           row's status (e.g. an older `stopped` row must not mask a newer
+ *           `running` row).
+ */
+
+process.env.SUPERVISOR_DB_PATH = ":memory:";
+
+const { SessionManager } = await import("../../src/session/manager");
+const { createFakeEffects } = await import("../../src/session/adapters-fake");
+const { insertSession, getDb } = await import("../../src/infra/db");
+
+import type { FakeSessionEffects } from "../../src/session/adapters-fake";
+
+// tmuxSessionName(threadId) = `claude-${threadId.slice(0, 12)}` (manager.ts).
+// Kept inline so the tests fail loudly if the prefix or slice changes.
+function tmuxNameFor(threadId: string): string {
+  return `claude-${threadId.slice(0, 12)}`;
+}
+
+function rowFor(
+  id: string,
+  threadId: string,
+  status: "running" | "stopped" | "stopping",
+  pid: number | null,
+  startedAt: string = new Date().toISOString()
+) {
+  return {
+    id,
+    channel_name: "team-salary",
+    thread_id: threadId,
+    project_dir: "/tmp/livenes-test",
+    pid,
+    claude_session_id: null,
+    started_at: startedAt,
+    last_activity_at: startedAt,
+    status,
+  };
+}
+
+describe("SessionManager.livenessOf (#168)", () => {
+  let manager: InstanceType<typeof SessionManager>;
+  let effects: FakeSessionEffects;
+
+  beforeEach(() => {
+    const db = getDb();
+    db.exec("DELETE FROM sessions");
+    effects = createFakeEffects();
+    manager = new SessionManager({ effects, gracefulKillTimeoutMs: 0 });
+  });
+
+  afterEach(async () => {
+    await manager?.shutdownAll();
+  });
+
+  test("AC-3: DB 行なし → unknown", () => {
+    expect(manager.livenessOf("thread-never-existed")).toBe("unknown");
+  });
+
+  test("AC-1: DB running + pid 死 → dead に矯正", () => {
+    const threadId = "thread-zombie";
+    insertSession(rowFor("z1", threadId, "running", 9999));
+    // pid 9999 NOT in alivePids → fake reports dead.
+    // tmux session NOT created → also missing. Either signal alone forces dead.
+    expect(manager.livenessOf(threadId)).toBe("dead");
+  });
+
+  test("AC-2: pid 生存 + tmux 有 → alive", () => {
+    const threadId = "thread-live";
+    insertSession(rowFor("a1", threadId, "running", 4242));
+    effects.process.alivePids.add(4242);
+    effects.tmux.newSession(tmuxNameFor(threadId), "echo ok");
+    expect(manager.livenessOf(threadId)).toBe("alive");
+  });
+
+  test("DB running + pid 生だが tmux 無し → dead (reality wins)", () => {
+    // Defends the matrix: liveness=alive must require BOTH signals.
+    const threadId = "thread-half-alive";
+    insertSession(rowFor("h1", threadId, "running", 7777));
+    effects.process.alivePids.add(7777);
+    // tmux session deliberately NOT created
+    expect(manager.livenessOf(threadId)).toBe("dead");
+  });
+
+  test("DB stopped → dead (DB authoritative when explicitly stopped)", () => {
+    const threadId = "thread-stopped";
+    insertSession(rowFor("s1", threadId, "stopped", 1234));
+    // Even if pid+tmux happened to be reused/alive, an explicitly stopped row
+    // means we should NOT call it alive — answer the stopped status.
+    effects.process.alivePids.add(1234);
+    effects.tmux.newSession(tmuxNameFor(threadId), "echo ok");
+    expect(manager.livenessOf(threadId)).toBe("dead");
+  });
+
+  test("livenessOf reads the latest row (older stopped does not mask newer running)", () => {
+    // Cross-test with AC-4: getSessionByThreadId picks `started_at DESC LIMIT 1`,
+    // so an older stopped row must not flip a newer running row to dead.
+    const threadId = "thread-rerun";
+    insertSession(
+      rowFor("old", threadId, "stopped", 1111, "2026-05-29T10:00:00.000Z")
+    );
+    insertSession(
+      rowFor("new", threadId, "running", 2222, "2026-05-31T10:00:00.000Z")
+    );
+    effects.process.alivePids.add(2222);
+    effects.tmux.newSession(tmuxNameFor(threadId), "echo ok");
+    expect(manager.livenessOf(threadId)).toBe("alive");
+  });
+});


### PR DESCRIPTION
## 目的 (Epic #166 / Phase 1)
セッションの「生死の唯一の真実」となる権威ある liveness 判定ユニットを `SessionManager.livenessOf(threadId)` として新設する。DB `status='running'` を信じきらず、**実 pid 生存（signal 0）** と **tmux セッション存在** を突き合わせて `alive | dead | unknown` を返す。salvage 応答と resume guard が共有することで両者が drift しない単一の source of truth になる。あわせて Issue 仕様どおりの `getSessionByThreadId(threadId)` を db.ts に提供する。

## 主な変更
- **`src/session/manager.ts`**: `Liveness` 型 (alive|dead|unknown) と `livenessOf(threadId): Liveness` メソッドを追加。
- **`src/infra/db.ts`**: 既存の `getLastSessionByThread` を **`getSessionByThreadId`** に rename（grep で 0 callers を確認、命名は `getSessionByClaudeSessionId` と整合）。
- **`src/session/adapters.ts`**: `ProcessAdapter.isAlive(pid)` を追加。real impl は `process.kill(pid, 0)` で `ESRCH` を dead、`EPERM` を alive として扱う（POSIX 慣行）。
- **`src/session/adapters-fake.ts`**: `FakeProcessAdapter.alivePids: Set<number>` を追加してテストから決定的に制御可能化。
- **`tests/session/manager-liveness.test.ts`** (新規): 4 AC + 2 補強ケース（pid 生 + tmux 無 → dead、stopped 既存行が新規 running を mask しないこと）。
- **`tests/infra/db.test.ts`**: `getSessionByThreadId` の「最新行（`started_at DESC LIMIT 1`）」と「未知 thread → null」を検証。
- **`.github/workflows/ci.yml`**: `manager-liveness.test.ts` を unit-test job に結線（CI で回帰を必ず捕捉）。

## 受け入れ基準 (コンポーネントAC)

| AC | 内容 | 結果 |
|---|---|---|
| AC-1 | DB running + pid 死 → `dead` に矯正 | ✅ PASS (`manager-liveness "AC-1"`) |
| AC-2 | pid 生存 + tmux 有 → `alive` | ✅ PASS (`manager-liveness "AC-2"`) |
| AC-3 | DB 行なし → `unknown` | ✅ PASS (`manager-liveness "AC-3"`) |
| AC-4 | `getSessionByThreadId` 最新行 | ✅ PASS (`db.test "getSessionByThreadId ..."`) |

`tsc --noEmit` clean。`db.test + manager-liveness + adapters` 22/22 pass。

## 統合ジャーニーAC
不要・理由: 内部ロジックユニット追加で外部から観測可能な振る舞いは後続 #SUB3/#SUB4/#SUB5 で結線する（Issue 本文の exemption をそのまま継承）。

## 設計判断メモ
- **rename vs alias vs duplicate**: `getLastSessionByThread` は 0 callers の dead code 状態だったため、AC の命名 (`getSessionByThreadId`) に rename する選択を採用（duplicate は YAGNI 違反）。
- **`livenessOf` を method on SessionManager**: SessionManager は既に `effects.tmux` と `effects.process` を保持しており、追加 dependency injection が不要。
- **`isAlive` を新規 adapter method**: 既存 `kill(pid, signal)` を signal 0 で呼び分けると意味的に混乱するため、専用メソッドで意図を明示。
- **`EPERM` を alive 扱い**: 異なる UID のプロセスにシグナルできない場合でも、プロセスは存在する。dead と誤判定すると salvage が誤検知する。