### PR TITLE
feat(#175): セッションスレッドのタイトルをブランチ名ベースに変更

### DIFF
--- a/supervisor/src/commands/session.ts
+++ b/supervisor/src/commands/session.ts
@@ -7,6 +7,7 @@ import {
 } from "discord.js";
 import type { SessionManager } from "../session/manager";
 import { CHANNEL_MAP, MAX_SESSIONS } from "../config/channels";
+import { buildThreadTitle, markTitleStopped } from "../session/thread-title";
 
 export function createSessionCommand() {
   return new SlashCommandBuilder()
@@ -132,12 +133,20 @@ async function handleStart(
   let createdThread: ThreadChannel | null = null;
 
   try {
-    // Count existing sessions in this channel
-    const existingSessions = sessionManager.listRunningByChannel(channelName);
-    const sessionNum = existingSessions.length + 1;
-    const threadName = sessionNum > 1
-      ? `🟢 Session: ${config.displayName} (${sessionNum})`
-      : `🟢 Session: ${config.displayName}`;
+    // Issue #175: title by branch, with a sequence suffix only when another
+    // session is already live on the *same* branch (RW-046: same-branch
+    // multi-session is allowed). Counting same-branch (not channel-wide) keeps
+    // distinct branches at "(1)" so they read cleanly.
+    const sameBranchCount = sessionManager
+      .listRunningByChannel(channelName)
+      .filter((s) => s.branch === branch).length;
+    const sessionNum = sameBranchCount + 1;
+    const threadName = buildThreadTitle(
+      "running",
+      branch,
+      config.displayName,
+      sessionNum
+    );
 
     // Create a thread in the channel
     // Get the text channel to create thread in
@@ -275,12 +284,22 @@ async function handleResume(
   let createdThread: ThreadChannel | null = null;
   let resumed = false;
   try {
-    const existingSessions = sessionManager.listRunningByChannel(channelName);
-    const sessionNum = existingSessions.length + 1;
-    const threadName =
-      sessionNum > 1
-        ? `♻️ Resume: ${config.displayName} (${sessionNum})`
-        : `♻️ Resume: ${config.displayName}`;
+    // Issue #175: resumed thread title matches the start scheme. Branch comes
+    // from the original session row (null for pre-migration rows → falls back
+    // to a display-name-only title inside buildThreadTitle). Sequence counts
+    // same-branch live sessions; with a null branch it counts channel-wide,
+    // preserving the legacy "(N)" behaviour.
+    const liveSessions = sessionManager.listRunningByChannel(channelName);
+    const sessionNum =
+      (row.branch
+        ? liveSessions.filter((s) => s.branch === row.branch).length
+        : liveSessions.length) + 1;
+    const threadName = buildThreadTitle(
+      "resume",
+      row.branch,
+      config.displayName,
+      sessionNum
+    );
 
     const parentChannel =
       channel.isThread() && channel.parent ? channel.parent : channel;
@@ -310,7 +329,8 @@ async function handleResume(
       config,
       thread.id,
       sessionId,
-      row.project_dir
+      row.project_dir,
+      row.branch
     );
     resumed = true;
 
@@ -390,12 +410,11 @@ async function handleStop(
   try {
     await sessionManager.stop(threadId, "manual");
 
-    // Update thread name to show stopped. Start threads lead with "🟢",
-    // resume threads with "♻️" — replace whichever prefix is present so resume
-    // threads also reflect the stopped state (PR #162 review: CodeRabbit).
+    // Update thread name to show stopped. markTitleStopped swaps a leading 🟢
+    // (start) or ♻️ (resume) to 🔴 — shared with the reaper so both paths stay
+    // consistent (Issue #175).
     const thread = channel as ThreadChannel;
-    const currentName = thread.name;
-    const stoppedName = currentName.replace("🟢", "🔴").replace("♻️", "🔴");
+    const stoppedName = markTitleStopped(thread.name);
     await thread.setName(stoppedName);
 
     // Archive and lock the thread

--- a/supervisor/src/infra/db.ts
+++ b/supervisor/src/infra/db.ts
@@ -25,21 +25,28 @@ export function getDb(): Database {
       )
     `);
     // Migration: add thread_id if missing (for existing DBs)
-    try {
-      db.exec(`ALTER TABLE sessions ADD COLUMN thread_id TEXT`);
-    } catch {
-      // Column already exists
-    }
+    addColumnIfMissing(db, "thread_id", "TEXT");
     // Migration: add branch if missing (Issue #175). Nullable so existing rows
     // (started before this column) stay valid; resume of such a row falls back
     // to the display-name-only thread title.
-    try {
-      db.exec(`ALTER TABLE sessions ADD COLUMN branch TEXT`);
-    } catch {
-      // Column already exists
-    }
+    addColumnIfMissing(db, "branch", "TEXT");
   }
   return db;
+}
+
+/**
+ * Idempotent `ALTER TABLE sessions ADD COLUMN`. Swallows only the
+ * already-exists case; any other failure (locked DB, disk error, bad type) is
+ * rethrown so a real migration failure surfaces here instead of as a confusing
+ * INSERT error later (CodeRabbit review).
+ */
+function addColumnIfMissing(db: Database, column: string, type: string): void {
+  try {
+    db.exec(`ALTER TABLE sessions ADD COLUMN ${column} ${type}`);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!message.includes("duplicate column")) throw err;
+  }
 }
 
 export interface SessionRow {

--- a/supervisor/src/infra/db.ts
+++ b/supervisor/src/infra/db.ts
@@ -30,6 +30,14 @@ export function getDb(): Database {
     } catch {
       // Column already exists
     }
+    // Migration: add branch if missing (Issue #175). Nullable so existing rows
+    // (started before this column) stay valid; resume of such a row falls back
+    // to the display-name-only thread title.
+    try {
+      db.exec(`ALTER TABLE sessions ADD COLUMN branch TEXT`);
+    } catch {
+      // Column already exists
+    }
   }
   return db;
 }
@@ -45,13 +53,19 @@ export interface SessionRow {
   last_activity_at: string;
   status: string;
   stopped_reason: string | null;
+  /** Branch the session runs on, when started via `/session start <branch>` (Issue #175). */
+  branch: string | null;
 }
 
-export function insertSession(row: Omit<SessionRow, "stopped_reason">): void {
+export function insertSession(
+  // `branch` is optional so existing callers/tests that predate Issue #175 keep
+  // compiling; it defaults to NULL (no branch recorded).
+  row: Omit<SessionRow, "stopped_reason" | "branch"> & { branch?: string | null }
+): void {
   const db = getDb();
   db.prepare(
-    `INSERT INTO sessions (id, channel_name, thread_id, project_dir, pid, claude_session_id, started_at, last_activity_at, status)
-     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    `INSERT INTO sessions (id, channel_name, thread_id, project_dir, pid, claude_session_id, started_at, last_activity_at, status, branch)
+     VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
   ).run(
     row.id,
     row.channel_name,
@@ -61,7 +75,8 @@ export function insertSession(row: Omit<SessionRow, "stopped_reason">): void {
     row.claude_session_id,
     row.started_at,
     row.last_activity_at,
-    row.status
+    row.status,
+    row.branch ?? null
   );
 }
 

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -330,6 +330,7 @@ export class SessionManager {
       startedAt: now,
       lastActivityAt: now,
       status: "running",
+      branch: trimmedBranch || undefined,
       worktree,
     };
 
@@ -345,6 +346,7 @@ export class SessionManager {
       started_at: now.toISOString(),
       last_activity_at: now.toISOString(),
       status: "running",
+      branch: trimmedBranch ?? null,
     });
 
     // Monitor tmux session for exit
@@ -391,7 +393,8 @@ export class SessionManager {
     config: ChannelConfig,
     threadId: string,
     claudeSessionId: string,
-    projectDir: string
+    projectDir: string,
+    branch?: string | null
   ): Promise<SessionInfo> {
     if (this.sessions.size >= MAX_SESSIONS) {
       throw new Error(`最大セッション数 (${MAX_SESSIONS}) に達しています`);
@@ -471,6 +474,9 @@ export class SessionManager {
       startedAt: now,
       lastActivityAt: now,
       status: "running",
+      // No worktree on resume (runs in the project dir), but keep the branch so
+      // same-branch counting and the thread title stay consistent (Issue #175).
+      branch: branch || undefined,
     };
 
     // Post-launch init (prompt confirm + state registration) can throw. tmux is
@@ -495,6 +501,9 @@ export class SessionManager {
         started_at: now.toISOString(),
         last_activity_at: now.toISOString(),
         status: "running",
+        // Carry the original session's branch (Issue #175) so the resumed
+        // thread title and any later /session list stay branch-consistent.
+        branch: branch ?? null,
       });
     } catch (err) {
       this.sessions.delete(threadId);

--- a/supervisor/src/session/reaper.ts
+++ b/supervisor/src/session/reaper.ts
@@ -4,6 +4,7 @@ import {
   IDLE_TIMEOUT_MS,
   IDLE_CHECK_INTERVAL_MS,
 } from "../config/channels";
+import { markTitleStopped } from "./thread-title";
 
 export class Reaper {
   private timer: ReturnType<typeof setInterval> | null = null;
@@ -52,8 +53,9 @@ export class Reaper {
           `⏰ 7日間無操作のためセッションを自動終了しました。`
         );
 
-        // Rename and archive
-        const stoppedName = thread.name.replace("🟢", "🔴");
+        // Rename and archive. markTitleStopped also handles ♻️ resume threads,
+        // which the old `.replace("🟢", ...)` skipped (Issue #175).
+        const stoppedName = markTitleStopped(thread.name);
         await thread.setName(stoppedName);
         await thread.setArchived(true);
       }

--- a/supervisor/src/session/thread-title.ts
+++ b/supervisor/src/session/thread-title.ts
@@ -67,25 +67,30 @@ function truncateWhole(s: string, max: number): string {
  * leaving an ellipsis to mark the cut. Both ends of the branch carry identifying
  * information (prefix like `feat/123-`, suffix like the feature name), so centre
  * truncation preserves more signal than head/tail truncation.
+ *
+ * Single pass (O(n)): grow a head and a tail window inward from both ends,
+ * taking from the head first (prefix bias), until the next character would
+ * exceed the budget. The branch is untrusted Discord input, so the prior
+ * slice/join-in-a-loop (O(n²)) is avoided (gemini review).
  */
 function centreTruncate(s: string, max: number): string {
   if (s.length <= max) return s;
   if (max <= ELLIPSIS.length) return truncateWhole(ELLIPSIS, max);
   const chars = [...s];
-  let head = Math.ceil(chars.length / 2); // bias the kept half to the prefix
-  let tail = chars.length - head;
-  while (head + tail > 0) {
-    const candidate =
-      chars.slice(0, head).join("") +
-      ELLIPSIS +
-      chars.slice(chars.length - tail).join("");
-    if (candidate.length <= max) return candidate;
-    // Shrink the larger half; Math.max keeps the index non-negative even though
-    // the loop guard already prevents the negative path.
-    if (head >= tail) head = Math.max(0, head - 1);
-    else tail = Math.max(0, tail - 1);
+  const budget = max - ELLIPSIS.length; // UTF-16 units left for kept content
+  let used = 0;
+  let i = 0; // exclusive end of the head window
+  let j = chars.length; // inclusive start of the tail window
+  let takeHead = true; // bias the first kept char to the prefix
+  while (i < j) {
+    const ch = takeHead ? chars[i]! : chars[j - 1]!;
+    if (used + ch.length > budget) break;
+    used += ch.length;
+    if (takeHead) i++;
+    else j--;
+    takeHead = !takeHead;
   }
-  return ELLIPSIS;
+  return chars.slice(0, i).join("") + ELLIPSIS + chars.slice(j).join("");
 }
 
 /**

--- a/supervisor/src/session/thread-title.ts
+++ b/supervisor/src/session/thread-title.ts
@@ -1,0 +1,132 @@
+/**
+ * Session thread-title formatting (Issue #175).
+ *
+ * Titles use a branch-based scheme so each session is identifiable at a glance:
+ *
+ *   {emoji} {branch} · {displayName}            (single same-branch session)
+ *   {emoji} {branch} · {displayName} (N)        (Nth concurrent same-branch one)
+ *   {emoji} {displayName}                        (no branch — e.g. resume of a
+ *                                                 pre-migration session)
+ *
+ * The branch is untrusted Discord input. Discord renders thread names (never
+ * executes them), so there is no injection vector here, but a right-to-left
+ * override (U+202E) or zero-width character could visually spoof a title — so
+ * those are stripped before the branch reaches the title. Shell safety of the
+ * branch (for the worktree path) is enforced separately in worktree.ts.
+ */
+
+export type ThreadTitleStatus = "running" | "resume" | "stopped";
+
+const STATUS_EMOJI: Record<ThreadTitleStatus, string> = {
+  running: "🟢",
+  resume: "♻️",
+  stopped: "🔴",
+};
+
+// Discord caps thread names at 100 characters; discord.js validates with the
+// UTF-16 `.length`, so we measure and truncate against that same unit.
+const MAX_TITLE_LEN = 100;
+const ELLIPSIS = "…";
+
+/**
+ * Remove characters that are dangerous to *display* in a thread title: C0/C1
+ * control chars, DEL, bidi overrides/embeddings/isolates, and zero-width
+ * characters. Ordinary branch characters — including `/` — are kept.
+ */
+export function sanitizeBranchForTitle(branch: string): string {
+  let out = "";
+  for (const ch of branch) {
+    const code = ch.codePointAt(0)!;
+    const dangerous =
+      code <= 0x1f || // C0 controls (incl. tab/newline/CR)
+      code === 0x7f || // DEL
+      (code >= 0x80 && code <= 0x9f) || // C1 controls
+      (code >= 0x200b && code <= 0x200f) || // zero-width + LRM/RLM
+      (code >= 0x202a && code <= 0x202e) || // bidi embeddings/overrides
+      (code >= 0x2066 && code <= 0x2069) || // bidi isolates
+      code === 0xfeff; // BOM / zero-width no-break space
+    if (!dangerous) out += ch;
+  }
+  return out;
+}
+
+/** Hard-truncate by UTF-16 length without splitting a surrogate pair. */
+function truncateWhole(s: string, max: number): string {
+  if (s.length <= max) return s;
+  const chars = [...s];
+  let out = "";
+  for (const ch of chars) {
+    if ((out + ch).length > max) break;
+    out += ch;
+  }
+  return out;
+}
+
+/**
+ * Drop characters from the middle of `s` until it fits in `max` UTF-16 units,
+ * leaving an ellipsis to mark the cut. Both ends of the branch carry identifying
+ * information (prefix like `feat/123-`, suffix like the feature name), so centre
+ * truncation preserves more signal than head/tail truncation.
+ */
+function centreTruncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  if (max <= ELLIPSIS.length) return truncateWhole(ELLIPSIS, max);
+  const chars = [...s];
+  let head = Math.ceil(chars.length / 2); // bias the kept half to the prefix
+  let tail = chars.length - head;
+  while (head + tail > 0) {
+    const candidate =
+      chars.slice(0, head).join("") +
+      ELLIPSIS +
+      chars.slice(chars.length - tail).join("");
+    if (candidate.length <= max) return candidate;
+    // Shrink the larger half; Math.max keeps the index non-negative even though
+    // the loop guard already prevents the negative path.
+    if (head >= tail) head = Math.max(0, head - 1);
+    else tail = Math.max(0, tail - 1);
+  }
+  return ELLIPSIS;
+}
+
+/**
+ * Build a session thread title. `seq` is the 1-based position among concurrent
+ * same-branch sessions; only `seq > 1` gets a `(N)` suffix.
+ */
+export function buildThreadTitle(
+  status: ThreadTitleStatus,
+  branch: string | null | undefined,
+  displayName: string,
+  seq: number
+): string {
+  const emoji = STATUS_EMOJI[status];
+  const suffix = seq > 1 ? ` (${seq})` : "";
+  const cleaned = branch ? sanitizeBranchForTitle(branch) : "";
+
+  if (!cleaned) {
+    // No usable branch: fall back to the legacy display-name-only title.
+    return truncateWhole(`${emoji} ${displayName}${suffix}`, MAX_TITLE_LEN);
+  }
+
+  const prefix = `${emoji} `;
+  const middle = ` · ${displayName}${suffix}`;
+  const budget = MAX_TITLE_LEN - prefix.length - middle.length;
+  if (budget <= 0) {
+    // The display name + suffix already fill the title; there is no room for the
+    // branch. Fall back to the display-name-only form (no dangling " · " or
+    // double space) and let the final guard trim it to length.
+    return truncateWhole(`${emoji} ${displayName}${suffix}`, MAX_TITLE_LEN);
+  }
+  const branchPart = centreTruncate(cleaned, budget);
+  return truncateWhole(`${prefix}${branchPart}${middle}`, MAX_TITLE_LEN);
+}
+
+/**
+ * Rewrite a live title to its stopped form by swapping the leading status emoji
+ * to 🔴. Handles both 🟢 (running) and ♻️ (resume) — the latter fixes the
+ * reaper.ts bug where resumed threads kept their ♻️ after being reaped.
+ */
+export function markTitleStopped(currentName: string): string {
+  return currentName
+    .replace(STATUS_EMOJI.running, STATUS_EMOJI.stopped)
+    .replace(STATUS_EMOJI.resume, STATUS_EMOJI.stopped);
+}

--- a/supervisor/src/session/types.ts
+++ b/supervisor/src/session/types.ts
@@ -13,6 +13,14 @@ export interface SessionInfo {
   lastActivityAt: Date;
   status: "running" | "stopping";
   /**
+   * Branch this session belongs to (Issue #175). Set for both `start` (the
+   * worktree branch) and `resume` (carried from the original session row, which
+   * runs in the project dir without a worktree). Used to count concurrent
+   * same-branch sessions for the thread-title sequence suffix. Undefined when
+   * no branch was recorded.
+   */
+  branch?: string;
+  /**
    * Set when the session runs in a per-branch git worktree (Issue #154,
    * `/session start <branch>`). Removed on stop; `mainRepoDir` is the channel
    * repo from which the worktree was created.

--- a/supervisor/tests/commands/session-thread-title.test.ts
+++ b/supervisor/tests/commands/session-thread-title.test.ts
@@ -1,0 +1,98 @@
+import { test, expect, describe } from "bun:test";
+import { createSessionHandler } from "../../src/commands/session";
+
+/**
+ * Issue #175 — integration-journey AC at the handler level: the `/session start`
+ * command must create the Discord thread with a branch-based title, and append a
+ * (N) suffix only when another session is already live on the *same* branch.
+ *
+ * We capture the name passed to `threads.create` from a fake interaction so the
+ * assertion exercises the real handler wiring (same harness style as
+ * session-start-branch.test.ts), without a Discord gateway.
+ */
+function makeStartInteraction(opts: {
+  branch: string;
+  // Sessions already running in this channel (to drive the same-branch count).
+  // `branch` mirrors SessionInfo.branch, which start/resume both set (Issue #175).
+  running?: { branch?: string }[];
+}) {
+  let createdName: string | undefined;
+  const thread = { id: "thread-xyz", send: async () => {}, delete: async () => {} };
+
+  const channel = {
+    isThread: () => false,
+    isTextBased: () => true,
+    isDMBased: () => false,
+    name: "agent-base", // → displayName "Agent Base" via CHANNEL_MAP
+    threads: {
+      create: async (o: { name: string }) => {
+        createdName = o.name;
+        return thread;
+      },
+    },
+  };
+
+  const interaction = {
+    options: {
+      getSubcommand: () => "start",
+      getString: (name: string) => (name === "branch" ? opts.branch : null),
+    },
+    channel,
+    deferred: false,
+    replied: false,
+    async reply() {
+      this.replied = true;
+    },
+    async deferReply() {
+      this.deferred = true;
+    },
+    async editReply() {},
+  };
+
+  const sessionManager = {
+    count: () => 0,
+    listRunningByChannel: () => opts.running ?? [],
+    listRunning: () => opts.running ?? [],
+    start: () => ({
+      worktree: {
+        mainRepoDir: "/x",
+        path: `/x/.claude/worktrees/${opts.branch}`,
+        branch: opts.branch,
+      },
+    }),
+  };
+
+  return {
+    run: () =>
+      createSessionHandler(sessionManager as never)(interaction as never),
+    get createdName() {
+      return createdName;
+    },
+  };
+}
+
+describe("/session start thread title (Issue #175)", () => {
+  test("journey AC step 1: first session on a branch → 🟢 {branch} · {displayName}", async () => {
+    const h = makeStartInteraction({ branch: "feat/167-foo" });
+    await h.run();
+    expect(h.createdName).toBe("🟢 feat/167-foo · Agent Base");
+  });
+
+  test("journey AC step 2: 2nd live session on the same branch → (2) suffix", async () => {
+    const h = makeStartInteraction({
+      branch: "feat/167-foo",
+      running: [{ branch: "feat/167-foo" }],
+    });
+    await h.run();
+    expect(h.createdName).toBe("🟢 feat/167-foo · Agent Base (2)");
+  });
+
+  test("a live session on a *different* branch does not bump the suffix", async () => {
+    const h = makeStartInteraction({
+      branch: "feat/167-foo",
+      running: [{ branch: "other-branch" }],
+    });
+    await h.run();
+    expect(h.createdName).toBe("🟢 feat/167-foo · Agent Base");
+  });
+});

--- a/supervisor/tests/session/thread-title.test.ts
+++ b/supervisor/tests/session/thread-title.test.ts
@@ -1,0 +1,130 @@
+import { test, expect, describe } from "bun:test";
+import {
+  buildThreadTitle,
+  sanitizeBranchForTitle,
+  markTitleStopped,
+} from "../../src/session/thread-title";
+
+/**
+ * Issue #175: session thread titles switch from "chat name + increment" to a
+ * branch-based scheme `{emoji} {branch} · {displayName}` with a same-branch
+ * sequence suffix. These pin the pure helper against the agreed component AC.
+ */
+describe("buildThreadTitle (Issue #175)", () => {
+  test("AC-1: single same-branch session omits the sequence suffix", () => {
+    expect(buildThreadTitle("running", "feat/x", "Team Salary", 1)).toBe(
+      "🟢 feat/x · Team Salary"
+    );
+  });
+
+  test("AC-2: a 2nd same-branch session appends (2)", () => {
+    expect(buildThreadTitle("running", "feat/x", "Team Salary", 2)).toBe(
+      "🟢 feat/x · Team Salary (2)"
+    );
+  });
+
+  test("resume uses the ♻️ emoji with the same branch scheme", () => {
+    expect(buildThreadTitle("resume", "feat/x", "Team Salary", 1)).toBe(
+      "♻️ feat/x · Team Salary"
+    );
+  });
+
+  test("AC-3: an over-long branch is centre-truncated to keep the title ≤ 100", () => {
+    const longBranch = "feat/" + "a".repeat(200) + "/end";
+    const title = buildThreadTitle("running", longBranch, "Team Salary", 1);
+    expect(title.length).toBeLessThanOrEqual(100);
+    // The display name and separator survive truncation (only the branch is cut).
+    expect(title.endsWith(" · Team Salary")).toBe(true);
+    // Centre truncation keeps both ends of the branch around an ellipsis.
+    expect(title).toContain("…");
+    expect(title.startsWith("🟢 feat/")).toBe(true);
+  });
+
+  test("a pathologically long display name falls back to display-name-only (no dangling ' · ')", () => {
+    const longName = "X".repeat(120);
+    const title = buildThreadTitle("running", "feat/x", longName, 1);
+    expect(title.length).toBeLessThanOrEqual(100);
+    expect(title).not.toContain(" · ");
+    expect(title).not.toContain("  "); // no double space
+    expect(title.startsWith("🟢 X")).toBe(true);
+  });
+
+  test("AC-5: a null branch falls back to the display-name-only legacy title", () => {
+    expect(buildThreadTitle("running", null, "Team Salary", 1)).toBe(
+      "🟢 Team Salary"
+    );
+    expect(buildThreadTitle("resume", undefined, "Team Salary", 1)).toBe(
+      "♻️ Team Salary"
+    );
+    expect(buildThreadTitle("running", "", "Team Salary", 2)).toBe(
+      "🟢 Team Salary (2)"
+    );
+  });
+});
+
+describe("sanitizeBranchForTitle (Issue #175 AC-4)", () => {
+  test("strips RTL override (U+202E) used for display spoofing", () => {
+    expect(sanitizeBranchForTitle("feat‮evil")).toBe("featevil");
+  });
+
+  test("strips zero-width characters", () => {
+    expect(sanitizeBranchForTitle("feat​x﻿y")).toBe("featxy");
+  });
+
+  test("strips newlines and control characters", () => {
+    expect(sanitizeBranchForTitle("feat\nx\ty\r")).toBe("featxy");
+  });
+
+  test("keeps ordinary spaces (display-safe; git rejects them in refs anyway)", () => {
+    expect(sanitizeBranchForTitle("a b")).toBe("a b");
+  });
+
+  test("strips bidi isolates", () => {
+    expect(sanitizeBranchForTitle("a⁦b⁩c")).toBe("abc");
+  });
+
+  test("leaves ordinary branch names (including slashes) untouched", () => {
+    expect(sanitizeBranchForTitle("feat/167-session-id")).toBe(
+      "feat/167-session-id"
+    );
+  });
+
+  test("AC-4: a sanitised branch cannot reintroduce a control char via the title", () => {
+    const title = buildThreadTitle(
+      "running",
+      "feat‮/evil\n",
+      "Team Salary",
+      1
+    );
+    // No control / bidi chars survive in the rendered title.
+    for (const ch of title) {
+      const code = ch.codePointAt(0)!;
+      const isBidiOrControl =
+        (code <= 0x1f && code !== 0x20) ||
+        code === 0x7f ||
+        (code >= 0x202a && code <= 0x202e) ||
+        (code >= 0x2066 && code <= 0x2069);
+      expect(isBidiOrControl).toBe(false);
+    }
+  });
+});
+
+describe("markTitleStopped (Issue #175 AC-6)", () => {
+  test("running 🟢 → 🔴", () => {
+    expect(markTitleStopped("🟢 feat/x · Team Salary")).toBe(
+      "🔴 feat/x · Team Salary"
+    );
+  });
+
+  test("resume ♻️ → 🔴 (fixes the reaper.ts:56 bug that skipped ♻️)", () => {
+    expect(markTitleStopped("♻️ feat/x · Team Salary")).toBe(
+      "🔴 feat/x · Team Salary"
+    );
+  });
+
+  test("an already-stopped title is left unchanged", () => {
+    expect(markTitleStopped("🔴 feat/x · Team Salary")).toBe(
+      "🔴 feat/x · Team Salary"
+    );
+  });
+});

--- a/supervisor/tests/session/thread-title.test.ts
+++ b/supervisor/tests/session/thread-title.test.ts
@@ -100,7 +100,7 @@ describe("sanitizeBranchForTitle (Issue #175 AC-4)", () => {
     for (const ch of title) {
       const code = ch.codePointAt(0)!;
       const isBidiOrControl =
-        (code <= 0x1f && code !== 0x20) ||
+        code <= 0x1f || // space (0x20) is already excluded by <= 0x1f
         code === 0x7f ||
         (code >= 0x202a && code <= 0x202e) ||
         (code >= 0x2066 && code <= 0x2069);


### PR DESCRIPTION
## 目的

Issue #175: セッションスレッドのタイトルを「チャット名＋連番（例: Session: Team Salary (3)）」から、ユニークかつ視認性の高い**ブランチ名ベース**に変更する。

AgentTeams（architect / devils-advocate / security-reviewer）で設計を壁打ちし、ユーザー決定で「ブランチ＋チャンネル併記」「DB永続化でresume一貫」を採用した。

## 主な変更点

| ファイル | 内容 |
|---|---|
| `supervisor/src/session/thread-title.ts`（新規） | 純粋ヘルパー buildThreadTitle / sanitizeBranchForTitle / markTitleStopped |
| `supervisor/src/infra/db.ts` | sessions に branch カラム追加（nullable, ALTER TABLE 後方互換マイグレーション） |
| `supervisor/src/session/manager.ts` | start/resume で branch を永続化、SessionInfo.branch を設定 |
| `supervisor/src/session/types.ts` | SessionInfo.branch 追加 |
| `supervisor/src/commands/session.ts` | start/resume で buildThreadTitle 利用、同一ブランチ単位の連番、stop で markTitleStopped |
| `supervisor/src/session/reaper.ts` | markTitleStopped 利用（♻️ を見落とす既存バグ修正） |

## タイトル仕様

- 形式: `{emoji} {branch} · {displayName}`、同一ブランチ複数稼働時のみ `(N)`
- emoji: 🟢 稼働中 / ♻️ resume / 🔴 停止
- 連番は同一ブランチ単位でカウント（RW-046: 同一ブランチ複数セッション対応）
- ブランチ名は未信頼入力のため bidi override(U+202E) / zero-width / 制御文字を除去（表示偽装防止）
- Discord 100字制限に中央truncateで対応

## テスト

- `tests/session/thread-title.test.ts`（ヘルパー、AC-1〜6）
- `tests/commands/session-thread-title.test.ts`（統合ジャーニーAC step1/2）
- 関連テスト 85/85 PASS、typecheck クリーン

## レビュー反映

code-review-orchestrator の指摘を反映:
- must: budget≤0 時の二重スペース → display-name-only fallback
- should: resume セッションの同一ブランチ計数漏れ → SessionInfo.branch 追加
- must: centreTruncate の防御ガード
- nit: テストの生NULバイト除去

## 統合ジャーニーAC

1. `/session start feat/167-foo` → `🟢 feat/167-foo · {channel}`
2. 同一ブランチ2つ目 → `🟢 feat/167-foo · {channel} (2)`
3. `/session resume <id>` → `♻️ feat/167-foo · {channel}`（DB branch から復元）
4. `/session stop` → `🔴 feat/167-foo · {channel}`

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * セッションスレッドにブランチ情報を統合し、タイトルに表示するようになりました。

* **改善**
  * 同一ブランチでの複数セッション実行時の番号表示ロジックを改善しました。
  * スレッドタイトルの表示形式を統一し、危険な制御文字をフィルタリングするようになりました。
  * セッション停止時のステータス表示更新処理を統一しました。

* **Tests**
  * スレッドタイトル生成機能のテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->