### PR TITLE
feat(#169): dead-thread 救済応答（沈黙廃止）

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -523,13 +523,19 @@ export function buildSalvageReply(
   }
 
   if (verdict === "alive") {
-    const idLine = row.claude_session_id
-      ? `\n🔑 claude_session_id: \`${row.claude_session_id}\``
-      : "";
+    // Process still up but Supervisor lost tracking. Only suggest resume when
+    // we actually have an id to resume from — otherwise `/session resume` is
+    // not actionable (gemini review on PR #178).
+    if (row.claude_session_id) {
+      return (
+        "⚠️ このスレッドのセッションはプロセス上は生存していますが、Supervisor が管理を見失っています。" +
+        `\`/session stop\` 後に \`/session resume ${row.claude_session_id}\`、または新規 \`/session start\` を検討してください。` +
+        `\n🔑 claude_session_id: \`${row.claude_session_id}\``
+      );
+    }
     return (
       "⚠️ このスレッドのセッションはプロセス上は生存していますが、Supervisor が管理を見失っています。" +
-      "`/session stop` 後に `/session resume`、または新規 `/session start` を検討してください。" +
-      idLine
+      "claude_session_id は未記録のため、`/session stop` で停止後に `/session start` で起動し直してください。"
     );
   }
 

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -14,7 +14,7 @@ import { ResourceMonitor } from "./session/resource-monitor";
 import { createSessionCommand, createSessionHandler } from "./commands/session";
 import { CHANNEL_MAP } from "./config/channels";
 import type { AttachmentInfo } from "./session/relay";
-import { updateSessionClaudeId } from "./infra/db";
+import { updateSessionClaudeId, getSessionByThreadId } from "./infra/db";
 import { onProgress, onLateResponse } from "./session/relay-server";
 import {
   extractFilePaths,
@@ -203,10 +203,33 @@ export async function startBot(token: string): Promise<void> {
 
     const threadId = message.channel.id;
 
-    // Check if this thread has an active session
+    // No active in-memory session for this thread. Previously the bot silently
+    // ignored the message (Issue #41 debug log), leaving the user staring at a
+    // dead thread with no feedback (Epic #166). When the bot is @mentioned,
+    // reply with the authoritative liveness verdict (Issue #168) plus the
+    // claude_session_id and resume command so the session can be salvaged
+    // (Issue #169). Non-mention messages keep the quiet debug log to avoid
+    // spamming a dead thread on every line.
     if (!sessionManager.has(threadId)) {
-      // Log when a message arrives for a thread that once had a session (helps debug #41)
-      console.debug(`[Bot] Ignoring message in thread ${threadId} (no active session)`);
+      const botUserId = client.user?.id;
+      const mentioned = botUserId
+        ? message.mentions.users.has(botUserId)
+        : false;
+      if (!mentioned) {
+        console.debug(
+          `[Bot] Ignoring message in thread ${threadId} (no active session)`
+        );
+        return;
+      }
+      const salvage = buildSalvageReply(sessionManager, threadId);
+      try {
+        await (message.channel as ThreadChannel).send(salvage);
+      } catch (err) {
+        console.error(
+          `[Bot] Failed to send salvage reply in thread ${threadId}:`,
+          err
+        );
+      }
       return;
     }
 
@@ -470,4 +493,57 @@ function forwardToViveReading(threadId: string, channel: string, text: string): 
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(`[Bot] vive-reading webhook failed for thread ${threadId} (sync): ${msg}`);
   }
+}
+
+/**
+ * Build the salvage reply for a thread whose Supervisor session is no longer
+ * active in memory (Epic #166 / Issue #169). Crosses the authoritative liveness
+ * verdict (Issue #168) with the persisted row so the user gets the
+ * claude_session_id and a ready-to-paste resume command instead of silence.
+ *
+ * Cases:
+ *   - unknown (no DB row)         → no history; suggest /session start
+ *   - alive (process still up)    → Supervisor lost tracking; suggest stop+resume/start
+ *   - dead + claude_session_id    → stopped; offer `/session resume <id>`
+ *   - dead + id missing           → pre-#167 row; suggest /session start
+ */
+export function buildSalvageReply(
+  sessionManager: SessionManager,
+  threadId: string
+): string {
+  const verdict = sessionManager.livenessOf(threadId);
+  if (verdict === "unknown") {
+    return "ℹ️ このスレッドにはセッション履歴がありません。`/session start` で開始してください。";
+  }
+
+  const row = getSessionByThreadId(threadId);
+  // verdict !== "unknown" guarantees a row exists, but guard defensively.
+  if (!row) {
+    return "ℹ️ このスレッドにはセッション履歴がありません。`/session start` で開始してください。";
+  }
+
+  if (verdict === "alive") {
+    const idLine = row.claude_session_id
+      ? `\n🔑 claude_session_id: \`${row.claude_session_id}\``
+      : "";
+    return (
+      "⚠️ このスレッドのセッションはプロセス上は生存していますが、Supervisor が管理を見失っています。" +
+      "`/session stop` 後に `/session resume`、または新規 `/session start` を検討してください。" +
+      idLine
+    );
+  }
+
+  // verdict === "dead"
+  const reason = row.stopped_reason ? `（理由: ${row.stopped_reason}）` : "";
+  if (row.claude_session_id) {
+    return (
+      `💀 このスレッドのセッションは停止しています${reason}。\n` +
+      `🔑 claude_session_id: \`${row.claude_session_id}\`\n` +
+      `▶️ 復帰: \`/session resume ${row.claude_session_id}\``
+    );
+  }
+  return (
+    `💀 このスレッドのセッションは停止しています${reason}。\n` +
+    "🔑 claude_session_id は未記録です（#167 導入前に開始されたセッション）。`/session start` で新規起動してください。"
+  );
 }

--- a/supervisor/tests/session/salvage-reply.test.ts
+++ b/supervisor/tests/session/salvage-reply.test.ts
@@ -19,11 +19,16 @@ const { createFakeEffects } = await import("../../src/session/adapters-fake");
  */
 describe("buildSalvageReply (#169)", () => {
   let manager: InstanceType<typeof SessionManager>;
+  let effects: ReturnType<typeof createFakeEffects>;
 
   beforeEach(() => {
     getDb().run("DELETE FROM sessions");
-    manager = new SessionManager({ effects: createFakeEffects() });
+    effects = createFakeEffects();
+    manager = new SessionManager({ effects });
   });
+
+  // tmux name is deterministic: "claude-" + first 12 chars of threadId.
+  const tmuxNameFor = (threadId: string) => `claude-${threadId.slice(0, 12)}`;
 
   test("no DB row → reports no history and suggests /session start", () => {
     const reply = buildSalvageReply(manager, "thread-never-seen");
@@ -70,6 +75,54 @@ describe("buildSalvageReply (#169)", () => {
     const reply = buildSalvageReply(manager, "thread-noid");
     expect(reply).toContain("停止しています");
     expect(reply).toContain("未記録");
+    expect(reply).toContain("/session start");
+    expect(reply).not.toContain("/session resume");
+  });
+
+  // verdict === "alive": running row + pid alive + tmux session present, but
+  // Supervisor lost in-memory tracking (e.g. restart). gemini review on #178.
+  test("alive (process up, Supervisor lost tracking) with id → suggests resume with the id", () => {
+    const claudeId = "22222222-2222-2222-2222-222222222222";
+    const threadId = "thread-alive";
+    insertSession({
+      id: "s-alive",
+      channel_name: "agent-base",
+      thread_id: threadId,
+      project_dir: "/tmp/x",
+      pid: 5151,
+      claude_session_id: claudeId,
+      started_at: new Date().toISOString(),
+      last_activity_at: new Date().toISOString(),
+      status: "running",
+    });
+    effects.process.alivePids.add(5151);
+    effects.tmux.newSession(tmuxNameFor(threadId), "x");
+    expect(manager.livenessOf(threadId)).toBe("alive");
+
+    const reply = buildSalvageReply(manager, threadId);
+    expect(reply).toContain("管理を見失っています");
+    expect(reply).toContain(`/session resume ${claudeId}`);
+  });
+
+  test("alive without id → suggests start (resume is not actionable without an id)", () => {
+    const threadId = "thread-alivnoid";
+    insertSession({
+      id: "s-alive-noid",
+      channel_name: "agent-base",
+      thread_id: threadId,
+      project_dir: "/tmp/x",
+      pid: 5252,
+      claude_session_id: null,
+      started_at: new Date().toISOString(),
+      last_activity_at: new Date().toISOString(),
+      status: "running",
+    });
+    effects.process.alivePids.add(5252);
+    effects.tmux.newSession(tmuxNameFor(threadId), "x");
+    expect(manager.livenessOf(threadId)).toBe("alive");
+
+    const reply = buildSalvageReply(manager, threadId);
+    expect(reply).toContain("管理を見失っています");
     expect(reply).toContain("/session start");
     expect(reply).not.toContain("/session resume");
   });

--- a/supervisor/tests/session/salvage-reply.test.ts
+++ b/supervisor/tests/session/salvage-reply.test.ts
@@ -1,0 +1,76 @@
+// Isolate DB writes from the real sessions.db (mirrors tests/infra/db.test.ts).
+// Must be set before any module that transitively loads infra/db is imported,
+// so everything below uses dynamic import after the env is in place.
+process.env.SUPERVISOR_DB_PATH = ":memory:";
+
+import { test, expect, describe, beforeEach } from "bun:test";
+
+const { insertSession, updateSessionStatus, getDb } = await import(
+  "../../src/infra/db"
+);
+const { buildSalvageReply } = await import("../../src/bot");
+const { SessionManager } = await import("../../src/session/manager");
+const { createFakeEffects } = await import("../../src/session/adapters-fake");
+
+/**
+ * buildSalvageReply (Issue #169) turns a dead thread's silence into an
+ * actionable reply: liveness verdict (Issue #168) + claude_session_id +
+ * resume command. These tests cover the AC-critical "dead" paths.
+ */
+describe("buildSalvageReply (#169)", () => {
+  let manager: InstanceType<typeof SessionManager>;
+
+  beforeEach(() => {
+    getDb().run("DELETE FROM sessions");
+    manager = new SessionManager({ effects: createFakeEffects() });
+  });
+
+  test("no DB row → reports no history and suggests /session start", () => {
+    const reply = buildSalvageReply(manager, "thread-never-seen");
+    expect(reply).toContain("セッション履歴がありません");
+    expect(reply).toContain("/session start");
+  });
+
+  test("dead session with claude_session_id → offers a resume command", () => {
+    const claudeId = "11111111-1111-1111-1111-111111111111";
+    insertSession({
+      id: "s-dead",
+      channel_name: "agent-base",
+      thread_id: "thread-dead",
+      project_dir: "/tmp/x",
+      pid: 4242,
+      claude_session_id: claudeId,
+      started_at: new Date().toISOString(),
+      last_activity_at: new Date().toISOString(),
+      status: "running",
+    });
+    updateSessionStatus("s-dead", "stopped", "process_dead");
+
+    const reply = buildSalvageReply(manager, "thread-dead");
+    expect(reply).toContain("停止しています");
+    expect(reply).toContain("process_dead");
+    expect(reply).toContain(claudeId);
+    expect(reply).toContain(`/session resume ${claudeId}`);
+  });
+
+  test("dead session without claude_session_id → degrades to /session start (pre-#167)", () => {
+    insertSession({
+      id: "s-noid",
+      channel_name: "agent-base",
+      thread_id: "thread-noid",
+      project_dir: "/tmp/x",
+      pid: null,
+      claude_session_id: null,
+      started_at: new Date().toISOString(),
+      last_activity_at: new Date().toISOString(),
+      status: "running",
+    });
+    updateSessionStatus("s-noid", "stopped", "tmux_exited");
+
+    const reply = buildSalvageReply(manager, "thread-noid");
+    expect(reply).toContain("停止しています");
+    expect(reply).toContain("未記録");
+    expect(reply).toContain("/session start");
+    expect(reply).not.toContain("/session resume");
+  });
+});


### PR DESCRIPTION
## 概要
Issue #169 — dead-thread の沈黙を救済応答に置換する。

## 問題
`bot.ts:209` がアクティブセッションのないスレッドのメッセージを silent ignore していたため、`@Channel-Supervisor` / `@claudeHubExit` にメンションしても無反応だった（Epic #166 の発端）。実ログ: `[Bot] Ignoring message in thread ... (no active session)`。

## 変更
- dead thread で **bot が @mention された時**、`livenessOf`（#168）の判定 + `claude_session_id` + `/session resume <id>` を返す `buildSalvageReply` を追加
- 区別: 履歴なし → `/session start` 案内 / 生存(管理喪失) → stop+resume 案内 / 停止+ID → resume コマンド / 停止+ID未記録 → `/session start` 案内（#167 導入前セッション）
- 非メンションのメッセージは従来どおり debug ログのみ（dead thread のスパム回避）
- 送信失敗は握りつぶさず error ログ（agent-output-quality 準拠）

## テスト
- `tests/session/salvage-reply.test.ts`（3 ケース: 履歴なし / 停止+ID → resume / 停止+ID未記録 → start）
- infra/db + manager + resume + salvage 52/52 PASS、typecheck OK

## AC（#169 統合ジャーニー）
1. 死んだスレッドで @mention → 沈黙せず「停止 / stopped_reason / claude_session_id / resume コマンド」を返す ✅
2. ID 未記録の死んだスレッドで @mention → `/session start` 案内 ✅

## 関連
- Epic #166 / 依存 #167(merged) #168(merged)
