### PR TITLE
feat(#170): status トークン / /session status で生死+ID 問い合わせ

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -14,7 +14,11 @@ import { ResourceMonitor } from "./session/resource-monitor";
 import { createSessionCommand, createSessionHandler } from "./commands/session";
 import { CHANNEL_MAP } from "./config/channels";
 import type { AttachmentInfo } from "./session/relay";
-import { updateSessionClaudeId, getSessionByThreadId } from "./infra/db";
+import { updateSessionClaudeId } from "./infra/db";
+import {
+  buildSalvageReply,
+  buildStatusReply,
+} from "./session/status-reply";
 import { onProgress, onLateResponse } from "./session/relay-server";
 import {
   extractFilePaths,
@@ -234,6 +238,33 @@ export async function startBot(token: string): Promise<void> {
     }
 
     const thread = message.channel as ThreadChannel;
+
+    // Status token (#170): `@Supervisor status` in a live thread returns the
+    // session's liveness + claude_session_id WITHOUT relaying the query into
+    // the session. Exact token only (mention + "status", case-insensitive) so a
+    // real work message that merely contains the word "status" is never
+    // hijacked — no NL detection (RW-020/027 lesson). The /session status slash
+    // command (commands/session.ts) is the equivalent deterministic trigger.
+    {
+      const botUserId = client.user?.id;
+      if (botUserId && message.mentions.users.has(botUserId)) {
+        const withoutMention = message.content
+          .replace(new RegExp(`<@!?${botUserId}>`, "g"), "")
+          .trim()
+          .toLowerCase();
+        if (withoutMention === "status") {
+          try {
+            await thread.send(buildStatusReply(sessionManager, threadId));
+          } catch (err) {
+            console.error(
+              `[Bot] Failed to send status reply in thread ${threadId}:`,
+              err
+            );
+          }
+          return;
+        }
+      }
+    }
 
     // Collect attachments
     const attachments: AttachmentInfo[] = [];
@@ -493,63 +524,4 @@ function forwardToViveReading(threadId: string, channel: string, text: string): 
     const msg = err instanceof Error ? err.message : String(err);
     console.warn(`[Bot] vive-reading webhook failed for thread ${threadId} (sync): ${msg}`);
   }
-}
-
-/**
- * Build the salvage reply for a thread whose Supervisor session is no longer
- * active in memory (Epic #166 / Issue #169). Crosses the authoritative liveness
- * verdict (Issue #168) with the persisted row so the user gets the
- * claude_session_id and a ready-to-paste resume command instead of silence.
- *
- * Cases:
- *   - unknown (no DB row)         → no history; suggest /session start
- *   - alive (process still up)    → Supervisor lost tracking; suggest stop+resume/start
- *   - dead + claude_session_id    → stopped; offer `/session resume <id>`
- *   - dead + id missing           → pre-#167 row; suggest /session start
- */
-export function buildSalvageReply(
-  sessionManager: SessionManager,
-  threadId: string
-): string {
-  const verdict = sessionManager.livenessOf(threadId);
-  if (verdict === "unknown") {
-    return "ℹ️ このスレッドにはセッション履歴がありません。`/session start` で開始してください。";
-  }
-
-  const row = getSessionByThreadId(threadId);
-  // verdict !== "unknown" guarantees a row exists, but guard defensively.
-  if (!row) {
-    return "ℹ️ このスレッドにはセッション履歴がありません。`/session start` で開始してください。";
-  }
-
-  if (verdict === "alive") {
-    // Process still up but Supervisor lost tracking. Only suggest resume when
-    // we actually have an id to resume from — otherwise `/session resume` is
-    // not actionable (gemini review on PR #178).
-    if (row.claude_session_id) {
-      return (
-        "⚠️ このスレッドのセッションはプロセス上は生存していますが、Supervisor が管理を見失っています。" +
-        `\`/session stop\` 後に \`/session resume ${row.claude_session_id}\`、または新規 \`/session start\` を検討してください。` +
-        `\n🔑 claude_session_id: \`${row.claude_session_id}\``
-      );
-    }
-    return (
-      "⚠️ このスレッドのセッションはプロセス上は生存していますが、Supervisor が管理を見失っています。" +
-      "claude_session_id は未記録のため、`/session stop` で停止後に `/session start` で起動し直してください。"
-    );
-  }
-
-  // verdict === "dead"
-  const reason = row.stopped_reason ? `（理由: ${row.stopped_reason}）` : "";
-  if (row.claude_session_id) {
-    return (
-      `💀 このスレッドのセッションは停止しています${reason}。\n` +
-      `🔑 claude_session_id: \`${row.claude_session_id}\`\n` +
-      `▶️ 復帰: \`/session resume ${row.claude_session_id}\``
-    );
-  }
-  return (
-    `💀 このスレッドのセッションは停止しています${reason}。\n` +
-    "🔑 claude_session_id は未記録です（#167 導入前に開始されたセッション）。`/session start` で新規起動してください。"
-  );
 }

--- a/supervisor/src/commands/session.ts
+++ b/supervisor/src/commands/session.ts
@@ -8,6 +8,7 @@ import {
 import type { SessionManager } from "../session/manager";
 import { CHANNEL_MAP, MAX_SESSIONS } from "../config/channels";
 import { buildThreadTitle, markTitleStopped } from "../session/thread-title";
+import { buildStatusReply } from "../session/status-reply";
 
 export function createSessionCommand() {
   return new SlashCommandBuilder()
@@ -34,6 +35,11 @@ export function createSessionCommand() {
     )
     .addSubcommand((sub) =>
       sub.setName("list").setDescription("稼働中セッション一覧")
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName("status")
+        .setDescription("このスレッドのセッション生死と claude_session_id を表示")
     )
     .addSubcommand((sub) =>
       sub
@@ -64,11 +70,34 @@ export function createSessionHandler(sessionManager: SessionManager) {
       case "list":
         await handleList(interaction, sessionManager);
         break;
+      case "status":
+        await handleStatus(interaction, sessionManager);
+        break;
       case "resume":
         await handleResume(interaction, sessionManager);
         break;
     }
   };
+}
+
+async function handleStatus(
+  interaction: ChatInputCommandInteraction,
+  sessionManager: SessionManager
+): Promise<void> {
+  const channel = interaction.channel;
+  if (!channel || !channel.isThread()) {
+    await interaction.reply({
+      content: "❌ `/session status` はセッションスレッド内で実行してください。",
+      flags: 64,
+    });
+    return;
+  }
+  // Deterministic status query (Issue #170): authoritative liveness verdict
+  // (#168) + claude_session_id. Runs outside the message-relay path, so it can
+  // never hijack a real work message.
+  await interaction.reply({
+    content: buildStatusReply(sessionManager, channel.id),
+  });
 }
 
 async function handleStart(

--- a/supervisor/src/session/status-reply.ts
+++ b/supervisor/src/session/status-reply.ts
@@ -1,0 +1,95 @@
+import type { SessionManager } from "./manager";
+import { getSessionByThreadId } from "../infra/db";
+
+/**
+ * Shared formatters for "is this thread's session alive, and what's its id?"
+ * replies (Epic #166). Both the dead-thread salvage path (Issue #169) and the
+ * explicit status query (Issue #170) build on the authoritative liveness
+ * verdict (Issue #168) so they never drift from each other.
+ *
+ * Kept in its own module (not bot.ts) so commands/session.ts can import it
+ * without a circular dependency (bot.ts already imports commands/session.ts).
+ */
+
+/**
+ * Salvage reply for a thread whose Supervisor session is no longer active in
+ * memory (Issue #169). Gives the claude_session_id and a ready-to-paste resume
+ * command instead of silence.
+ *
+ * Cases:
+ *   - unknown (no DB row)         → no history; suggest /session start
+ *   - alive (process still up)    → Supervisor lost tracking; suggest stop+resume/start
+ *   - dead + claude_session_id    → stopped; offer `/session resume <id>`
+ *   - dead + id missing           → pre-#167 row; suggest /session start
+ */
+export function buildSalvageReply(
+  sessionManager: SessionManager,
+  threadId: string
+): string {
+  const verdict = sessionManager.livenessOf(threadId);
+  if (verdict === "unknown") {
+    return "ℹ️ このスレッドにはセッション履歴がありません。`/session start` で開始してください。";
+  }
+
+  const row = getSessionByThreadId(threadId);
+  // verdict !== "unknown" guarantees a row exists, but guard defensively.
+  if (!row) {
+    return "ℹ️ このスレッドにはセッション履歴がありません。`/session start` で開始してください。";
+  }
+
+  if (verdict === "alive") {
+    // Process still up but Supervisor lost tracking. Only suggest resume when
+    // we actually have an id to resume from — otherwise `/session resume` is
+    // not actionable (gemini review on PR #178).
+    if (row.claude_session_id) {
+      return (
+        "⚠️ このスレッドのセッションはプロセス上は生存していますが、Supervisor が管理を見失っています。" +
+        `\`/session stop\` 後に \`/session resume ${row.claude_session_id}\`、または新規 \`/session start\` を検討してください。` +
+        `\n🔑 claude_session_id: \`${row.claude_session_id}\``
+      );
+    }
+    return (
+      "⚠️ このスレッドのセッションはプロセス上は生存していますが、Supervisor が管理を見失っています。" +
+      "claude_session_id は未記録のため、`/session stop` で停止後に `/session start` で起動し直してください。"
+    );
+  }
+
+  // verdict === "dead"
+  const reason = row.stopped_reason ? `（理由: ${row.stopped_reason}）` : "";
+  if (row.claude_session_id) {
+    return (
+      `💀 このスレッドのセッションは停止しています${reason}。\n` +
+      `🔑 claude_session_id: \`${row.claude_session_id}\`\n` +
+      `▶️ 復帰: \`/session resume ${row.claude_session_id}\``
+    );
+  }
+  return (
+    `💀 このスレッドのセッションは停止しています${reason}。\n` +
+    "🔑 claude_session_id は未記録です（#167 導入前に開始されたセッション）。`/session start` で新規起動してください。"
+  );
+}
+
+/**
+ * Status reply for an explicit query (Issue #170): `/session status` slash
+ * command, or an `@Supervisor status` token. Unlike salvage, this can run on a
+ * genuinely live + tracked thread, so the `alive` verdict means "running" —
+ * not "Supervisor lost tracking". Dead/unknown reuse the salvage wording so the
+ * resume guidance stays identical.
+ */
+export function buildStatusReply(
+  sessionManager: SessionManager,
+  threadId: string
+): string {
+  if (sessionManager.livenessOf(threadId) === "alive") {
+    const row = getSessionByThreadId(threadId);
+    const id = row?.claude_session_id;
+    return (
+      "✅ このスレッドのセッションは稼働中です。\n" +
+      (id
+        ? `🔑 claude_session_id: \`${id}\``
+        : "🔑 claude_session_id: 未記録（#167 導入前に開始されたセッション）")
+    );
+  }
+  // dead / unknown は salvage と同じ案内（resume / start）で十分。
+  return buildSalvageReply(sessionManager, threadId);
+}

--- a/supervisor/src/session/status-reply.ts
+++ b/supervisor/src/session/status-reply.ts
@@ -80,7 +80,15 @@ export function buildStatusReply(
   sessionManager: SessionManager,
   threadId: string
 ): string {
-  if (sessionManager.livenessOf(threadId) === "alive") {
+  // "稼働中" only when the session is BOTH live AND tracked in memory — i.e. the
+  // Supervisor can actually relay to it. If livenessOf is alive but the session
+  // is no longer tracked (has() === false), the user cannot interact with it;
+  // fall through to the salvage wording which says the Supervisor lost tracking
+  // (gemini HIGH review, PR #179).
+  if (
+    sessionManager.livenessOf(threadId) === "alive" &&
+    sessionManager.has(threadId)
+  ) {
     const row = getSessionByThreadId(threadId);
     const id = row?.claude_session_id;
     return (
@@ -90,6 +98,6 @@ export function buildStatusReply(
         : "🔑 claude_session_id: 未記録（#167 導入前に開始されたセッション）")
     );
   }
-  // dead / unknown は salvage と同じ案内（resume / start）で十分。
+  // not tracked (lost tracking), dead, or unknown → salvage wording covers all.
   return buildSalvageReply(sessionManager, threadId);
 }

--- a/supervisor/tests/session/salvage-reply.test.ts
+++ b/supervisor/tests/session/salvage-reply.test.ts
@@ -163,11 +163,41 @@ describe("buildStatusReply (#170)", () => {
     });
     effects.process.alivePids.add(6161);
     effects.tmux.newSession(tmuxNameFor(threadId), "x");
+    // "稼働中" requires the session to also be tracked in memory (has() true),
+    // not just live by pid/tmux (gemini HIGH review, PR #179). Register a
+    // minimal in-memory entry — has() only checks key presence.
+    (manager as unknown as { sessions: Map<string, unknown> }).sessions.set(
+      threadId,
+      { threadId }
+    );
 
     const reply = buildStatusReply(manager, threadId);
     expect(reply).toContain("稼働中");
     expect(reply).toContain(claudeId);
     expect(reply).not.toContain("見失って");
+  });
+
+  test("alive by pid/tmux but NOT tracked in memory → lost-tracking wording, not 稼働中", () => {
+    const threadId = "thread-st-untracked";
+    insertSession({
+      id: "st-untracked",
+      channel_name: "agent-base",
+      thread_id: threadId,
+      project_dir: "/tmp/x",
+      pid: 6363,
+      claude_session_id: "55555555-5555-5555-5555-555555555555",
+      started_at: new Date().toISOString(),
+      last_activity_at: new Date().toISOString(),
+      status: "running",
+    });
+    effects.process.alivePids.add(6363);
+    effects.tmux.newSession(tmuxNameFor(threadId), "x");
+    // Deliberately do NOT register in the in-memory map: has() === false.
+    expect(manager.livenessOf(threadId)).toBe("alive");
+
+    const reply = buildStatusReply(manager, threadId);
+    expect(reply).toContain("見失って");
+    expect(reply).not.toContain("稼働中です");
   });
 
   test("dead → reuses salvage wording (停止 + resume command)", () => {

--- a/supervisor/tests/session/salvage-reply.test.ts
+++ b/supervisor/tests/session/salvage-reply.test.ts
@@ -8,7 +8,9 @@ import { test, expect, describe, beforeEach } from "bun:test";
 const { insertSession, updateSessionStatus, getDb } = await import(
   "../../src/infra/db"
 );
-const { buildSalvageReply } = await import("../../src/bot");
+const { buildSalvageReply, buildStatusReply } = await import(
+  "../../src/session/status-reply"
+);
 const { SessionManager } = await import("../../src/session/manager");
 const { createFakeEffects } = await import("../../src/session/adapters-fake");
 
@@ -125,5 +127,72 @@ describe("buildSalvageReply (#169)", () => {
     expect(reply).toContain("管理を見失っています");
     expect(reply).toContain("/session start");
     expect(reply).not.toContain("/session resume");
+  });
+});
+
+/**
+ * buildStatusReply (Issue #170) is the explicit-query formatter. Unlike
+ * salvage, `alive` means "running" (the session is live and tracked), while
+ * dead/unknown reuse the salvage wording.
+ */
+describe("buildStatusReply (#170)", () => {
+  let manager: InstanceType<typeof SessionManager>;
+  let effects: ReturnType<typeof createFakeEffects>;
+
+  beforeEach(() => {
+    getDb().run("DELETE FROM sessions");
+    effects = createFakeEffects();
+    manager = new SessionManager({ effects });
+  });
+
+  const tmuxNameFor = (threadId: string) => `claude-${threadId.slice(0, 12)}`;
+
+  test("alive (running + tracked) → reports 稼働中 with the id (not lost-tracking wording)", () => {
+    const claudeId = "33333333-3333-3333-3333-333333333333";
+    const threadId = "thread-st-live";
+    insertSession({
+      id: "st-live",
+      channel_name: "agent-base",
+      thread_id: threadId,
+      project_dir: "/tmp/x",
+      pid: 6161,
+      claude_session_id: claudeId,
+      started_at: new Date().toISOString(),
+      last_activity_at: new Date().toISOString(),
+      status: "running",
+    });
+    effects.process.alivePids.add(6161);
+    effects.tmux.newSession(tmuxNameFor(threadId), "x");
+
+    const reply = buildStatusReply(manager, threadId);
+    expect(reply).toContain("稼働中");
+    expect(reply).toContain(claudeId);
+    expect(reply).not.toContain("見失って");
+  });
+
+  test("dead → reuses salvage wording (停止 + resume command)", () => {
+    const claudeId = "44444444-4444-4444-4444-444444444444";
+    const threadId = "thread-st-dead";
+    insertSession({
+      id: "st-dead",
+      channel_name: "agent-base",
+      thread_id: threadId,
+      project_dir: "/tmp/x",
+      pid: 6262,
+      claude_session_id: claudeId,
+      started_at: new Date().toISOString(),
+      last_activity_at: new Date().toISOString(),
+      status: "running",
+    });
+    updateSessionStatus("st-dead", "stopped", "process_dead");
+
+    const reply = buildStatusReply(manager, threadId);
+    expect(reply).toContain("停止しています");
+    expect(reply).toContain(`/session resume ${claudeId}`);
+  });
+
+  test("unknown (no row) → no history", () => {
+    const reply = buildStatusReply(manager, "thread-st-none");
+    expect(reply).toContain("セッション履歴がありません");
   });
 });


### PR DESCRIPTION
## 概要
Issue #170 — 生死＋ID を明示的に問い合わせる2つのトリガーを追加。

## 変更
- `buildSalvageReply` を `bot.ts` から `session/status-reply.ts` へ移設（commands/session.ts からも使えるよう循環 import 回避）
- `buildStatusReply` を新規追加: `alive` = 「✅ 稼働中」、`dead`/`unknown` は salvage と共通文面（DRY）
- **`/session status`** サブコマンド: 現スレッドの生死＋claude_session_id を返す。message relay 経路の外なので作業メッセージを誤って横取りしない（構造的にハイジャック不可）
- **`@Supervisor status`** トークン: live スレッドで mention + "status" 完全一致のみ発火（case-insensitive、NL 推測なし / RW-020・027 の教訓）。それ以外は従来どおりセッションに中継

## テスト
- `salvage-reply.test.ts` に `buildStatusReply` 3ケース追加（alive→稼働中 / dead→resume / unknown→履歴なし）。計 8/8 PASS
- commands 18/18、infra/db・manager 含め affected 全 PASS、typecheck OK
- 既存の `markTabStopped (#27)` flaky（単体では PASS、フルスイート負荷時のみ fail）は本変更と無関係

## AC（#170 統合ジャーニー）
1. 稼働中スレッドで `/session status` → 「✅ 稼働中」+ claude_session_id ✅
2. 稼働中スレッドで通常メッセージ → status 横取りされず中継（slash は relay 経路外、token は完全一致のみ）✅

## 関連
- Epic #166 / 依存 #167 #168 #169（すべて merged）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * セッションスレッド内で /session status コマンドを使用して、セッションの稼働状態と関連情報を確認できるようになりました。
  * ボットがスレッド内の "status" メッセージに自動応答するようになりました。
  * ステータス応答の文言が整理され、稼働中／停止／不明それぞれに適切な案内（再開や開始方法含む）が表示されます。

* **テスト**
  * セッションステータス確認機能と各応答分岐を検証するテストが追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->