### PR TITLE
feat(#171): resume を single-flight 化し TOCTOU と stale status 誤判定を封じる

### DIFF
--- a/supervisor/src/commands/session.ts
+++ b/supervisor/src/commands/session.ts
@@ -263,9 +263,17 @@ async function handleResume(
     });
     return;
   }
-  if (row.status === "running") {
+  // Issue #171 (穴 A): trust the authoritative liveness verdict (#168), not the
+  // DB `status` column. A stale `status='running'` row (process died without a
+  // clean stop) must NOT block a legitimate resume; conversely a genuinely-live
+  // session must reject. `livenessOfClaudeSession` resolves the latest row for
+  // this claude session id and crosses pid + tmux reality. This is a fast-path
+  // UX check — `resumeSession` re-checks under the single-flight lock to close
+  // the TOCTOU (穴 C).
+  if (sessionManager.livenessOfClaudeSession(sessionId) === "alive") {
     await interaction.reply({
-      content: "⚠️ この session は既に稼働中です。`/session list` で確認してください。",
+      content:
+        "⚠️ この session は既に稼働中です。稼働中のスレッドで操作してください（`/session list` で確認できます）。",
       flags: 64,
     });
     return;

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -169,6 +169,15 @@ export class SessionManager {
   private sessions = new Map<string, SessionInfo>();
   /** Map<threadId, intervalHandle> — watchdogs to clear on stop/shutdown */
   private watchers = new Map<string, ReturnType<typeof setInterval>>();
+  /**
+   * claude_session_ids with a resume currently in flight (Issue #171, 穴 C).
+   * Acquired synchronously at the top of {@link resumeSession} and released in
+   * its `finally`, so on the single-threaded event loop a second near-
+   * simultaneous resume of the SAME id observes the lock and is rejected before
+   * it can launch a duplicate `claude --resume <id>` in the same cwd (which
+   * would double-write the transcript jsonl — RW-046-type corruption).
+   */
+  private readonly resumingClaudeSessions = new Set<string>();
   private readonly effects: SessionEffects;
   private readonly gracefulKillTimeoutMs: number;
   private readonly resumePromptPollAttempts: number;
@@ -232,6 +241,23 @@ export class SessionManager {
       this.tmuxSessionName(threadId)
     );
     return pidAlive && tmuxAlive ? "alive" : "dead";
+  }
+
+  /**
+   * Authoritative liveness for a claude session id (Issue #171). Resolves the
+   * most-recent row for the id (a single claude session may have several rows
+   * across start + prior resumes — the latest run is what "is it alive now"
+   * cares about) and defers to {@link livenessOf} on that row's thread.
+   *
+   * The resume guard uses this instead of the DB `status` column so a stale
+   * `status='running'` row can't block a legitimate resume (穴 A), while a
+   * genuinely-live session still rejects. Returns `unknown` when no row exists
+   * for the id (callers treat `unknown` as "not alive → resume may proceed").
+   */
+  livenessOfClaudeSession(claudeSessionId: string): Liveness {
+    const row = getSessionByClaudeSessionId(claudeSessionId);
+    if (!row || row.thread_id == null) return "unknown";
+    return this.livenessOf(row.thread_id);
   }
 
   entries(): IterableIterator<[string, SessionInfo]> {
@@ -461,6 +487,54 @@ export class SessionManager {
       );
     }
 
+    // Single-flight guard (Issue #171, 穴 C): reject a second concurrent resume
+    // of the SAME claude session id. Mutated synchronously and held across the
+    // awaits inside launchResume, so on the single-threaded event loop the
+    // second caller observes the lock and fails before launching a duplicate
+    // `claude --resume <id>` in the same cwd (RW-046-type transcript corruption).
+    if (this.resumingClaudeSessions.has(claudeSessionId)) {
+      throw new Error(
+        "この session は現在 resume 処理中です。完了までお待ちください（多重 resume 防止）。"
+      );
+    }
+    this.resumingClaudeSessions.add(claudeSessionId);
+    try {
+      // Authoritative liveness re-check UNDER the lock (Issue #171, 穴 A). The
+      // handler checks too for fast UX, but re-checking here closes the TOCTOU
+      // between the handler's check and our insert: a session that became alive
+      // (or was already alive) is rejected; a stale `status='running'` row whose
+      // process is dead is treated as dead and resume proceeds.
+      if (this.livenessOfClaudeSession(claudeSessionId) === "alive") {
+        throw new Error(
+          "この session は既に稼働中です。稼働中のスレッドで操作してください（多重 resume 防止）。"
+        );
+      }
+      return await this.launchResume(
+        config,
+        threadId,
+        claudeSessionId,
+        projectDir,
+        branch
+      );
+    } finally {
+      this.resumingClaudeSessions.delete(claudeSessionId);
+    }
+  }
+
+  /**
+   * Internal: the actual tmux launch + state registration for a resume, run
+   * under the single-flight lock held by {@link resumeSession}. Split out so the
+   * lock acquire/release and the authoritative liveness re-check stay a thin,
+   * readable wrapper. Every guard (MAX_SESSIONS, thread collision, UUID shape,
+   * projectDir existence, liveness) is enforced by the caller before this runs.
+   */
+  private async launchResume(
+    config: ChannelConfig,
+    threadId: string,
+    claudeSessionId: string,
+    projectDir: string,
+    branch?: string | null
+  ): Promise<SessionInfo> {
     const sessionId = randomUUID();
     const tmuxName = this.tmuxSessionName(threadId);
     this.effects.tmux.killSession(tmuxName);

--- a/supervisor/tests/commands/session-resume.test.ts
+++ b/supervisor/tests/commands/session-resume.test.ts
@@ -33,6 +33,12 @@ function makeInteraction(opts: {
   resumableRow?: ResumableRow | undefined;
   resumeImpl?: (...args: unknown[]) => unknown;
   sendImpl?: () => unknown;
+  /**
+   * Issue #171: the handler now keys the "already running" guard on the
+   * authoritative liveness verdict, not the DB `status` column. Defaults to
+   * "dead" so legacy stopped-row tests keep passing.
+   */
+  liveness?: "alive" | "dead" | "unknown";
 }) {
   const replies: ReplyRecord[] = [];
   const resumeCalls: unknown[][] = [];
@@ -88,6 +94,7 @@ function makeInteraction(opts: {
   const sessionManager = {
     count: () => 0,
     listRunningByChannel: () => [],
+    livenessOfClaudeSession: () => opts.liveness ?? "dead",
     findResumableSession: (id: string) => {
       findCalls.push(id);
       return opts.resumableRow;
@@ -172,10 +179,11 @@ describe("/session resume validation (#161)", () => {
     expect(h.replies[0]!.content).toContain("agent-base");
   });
 
-  test("session already running → warns, no resume", async () => {
+  test("session genuinely alive (liveness=alive) → warns, no resume (#171 穴 A)", async () => {
     const h = makeInteraction({
       sessionId: VALID_ID,
       channelName: "team-salary",
+      liveness: "alive",
       resumableRow: {
         channel_name: "team-salary",
         project_dir: "/Users/x/team_salary",
@@ -185,6 +193,24 @@ describe("/session resume validation (#161)", () => {
     await h.run();
     expect(h.resumeCalls).toHaveLength(0);
     expect(h.replies[0]!.content).toContain("既に稼働中");
+  });
+
+  test("stale status='running' but liveness=dead → resume proceeds (#171 穴 A)", async () => {
+    // The DB row still says running (process died without a clean stop), but the
+    // authoritative liveness verdict is dead — the handler must NOT block resume.
+    const h = makeInteraction({
+      sessionId: VALID_ID,
+      channelName: "team-salary",
+      liveness: "dead",
+      resumableRow: {
+        channel_name: "team-salary",
+        project_dir: "/Users/x/team_salary",
+        status: "running",
+      },
+    });
+    await h.run();
+    expect(h.threadCreated).toBe(true);
+    expect(h.resumeCalls).toHaveLength(1);
   });
 
   test("valid stopped session → resumeSession called with project_dir, thread created", async () => {

--- a/supervisor/tests/session/manager-liveness.test.ts
+++ b/supervisor/tests/session/manager-liveness.test.ts
@@ -119,3 +119,77 @@ describe("SessionManager.livenessOf (#168)", () => {
     expect(manager.livenessOf(threadId)).toBe("alive");
   });
 });
+
+/**
+ * livenessOfClaudeSession (Issue #171, 穴 A). The resume guard keys liveness on
+ * the claude_session_id (not the DB `status` column), resolving the latest row
+ * for the id and deferring to livenessOf on its thread. Same in-memory SQLite +
+ * fake adapters — no real tmux/process.
+ */
+function rowWithClaudeId(
+  id: string,
+  threadId: string,
+  claudeId: string,
+  status: "running" | "stopped",
+  pid: number | null,
+  startedAt: string = new Date().toISOString()
+) {
+  return { ...rowFor(id, threadId, status, pid, startedAt), claude_session_id: claudeId };
+}
+
+describe("SessionManager.livenessOfClaudeSession (#171)", () => {
+  let manager: InstanceType<typeof SessionManager>;
+  let effects: FakeSessionEffects;
+  const CID = "3139aa23-fe2a-485a-831a-2209081f9935";
+
+  beforeEach(() => {
+    getDb().exec("DELETE FROM sessions");
+    effects = createFakeEffects();
+    manager = new SessionManager({ effects, gracefulKillTimeoutMs: 0 });
+  });
+
+  afterEach(async () => {
+    await manager?.shutdownAll();
+  });
+
+  test("no row for the id → unknown (caller treats as not-alive)", () => {
+    expect(manager.livenessOfClaudeSession(CID)).toBe("unknown");
+  });
+
+  test("running + pid alive + tmux present → alive", () => {
+    const threadId = "thread-cid-live";
+    insertSession(rowWithClaudeId("c1", threadId, CID, "running", 5151));
+    effects.process.alivePids.add(5151);
+    effects.tmux.newSession(tmuxNameFor(threadId), "echo ok");
+    expect(manager.livenessOfClaudeSession(CID)).toBe("alive");
+  });
+
+  test("穴 A: DB status=running but pid dead → dead (stale status must not block resume)", () => {
+    const threadId = "thread-cid-zombie";
+    insertSession(rowWithClaudeId("c2", threadId, CID, "running", 6262));
+    // pid 6262 NOT alive, no tmux → reality wins → dead.
+    expect(manager.livenessOfClaudeSession(CID)).toBe("dead");
+  });
+
+  test("explicitly stopped row → dead", () => {
+    const threadId = "thread-cid-stopped";
+    insertSession(rowWithClaudeId("c3", threadId, CID, "stopped", 7373));
+    effects.process.alivePids.add(7373);
+    effects.tmux.newSession(tmuxNameFor(threadId), "echo ok");
+    expect(manager.livenessOfClaudeSession(CID)).toBe("dead");
+  });
+
+  test("resolves the LATEST row for the id (older dead run does not mask a newer alive one)", () => {
+    // A single claude session accumulates rows across resumes; the newest run is
+    // what "is it alive now" cares about (getSessionByClaudeSessionId DESC LIMIT 1).
+    insertSession(
+      rowWithClaudeId("old", "thread-old", CID, "stopped", 1111, "2026-05-29T10:00:00.000Z")
+    );
+    insertSession(
+      rowWithClaudeId("new", "thread-new", CID, "running", 2222, "2026-05-31T10:00:00.000Z")
+    );
+    effects.process.alivePids.add(2222);
+    effects.tmux.newSession(tmuxNameFor("thread-new"), "echo ok");
+    expect(manager.livenessOfClaudeSession(CID)).toBe("alive");
+  });
+});

--- a/supervisor/tests/session/manager-resume.test.ts
+++ b/supervisor/tests/session/manager-resume.test.ts
@@ -10,6 +10,7 @@ const { SessionManager } = await import("../../src/session/manager");
 const { createFakeEffects } = await import(
   "../../src/session/adapters-fake"
 );
+const { insertSession, getDb } = await import("../../src/infra/db");
 import type { FakeSessionEffects } from "../../src/session/adapters-fake";
 import type { ChannelConfig } from "../../src/config/channels";
 
@@ -175,5 +176,132 @@ describe("SessionManager.resumeSession (#161)", () => {
     expect(effects.tmux.list()).toHaveLength(0);
     expect(manager.has(THREAD_ID)).toBe(false);
     expect(manager.count()).toBe(0);
+  });
+});
+
+/**
+ * Single-flight + liveness guard for resume (Issue #171). Covers 穴 A (DB
+ * `status` column must not be trusted over real liveness) and 穴 C (two near-
+ * simultaneous resumes of the same claude session id must not both launch —
+ * RW-046-type transcript double-write). Clears the shared in-memory DB in
+ * beforeEach so inserted rows are the only ones livenessOfClaudeSession sees.
+ */
+function tmuxNameForThread(threadId: string): string {
+  return `claude-${threadId.slice(0, 12)}`;
+}
+
+describe("SessionManager resume single-flight & liveness (#171)", () => {
+  let manager: InstanceType<typeof SessionManager>;
+  let effects: FakeSessionEffects;
+  let projectDir: string;
+
+  beforeEach(() => {
+    getDb().exec("DELETE FROM sessions");
+    effects = createFakeEffects();
+    projectDir = makeProjectDir();
+    manager = new SessionManager({
+      effects,
+      gracefulKillTimeoutMs: 0,
+      resumePromptPollAttempts: 0,
+    });
+  });
+
+  afterEach(async () => {
+    await manager?.shutdownAll();
+  });
+
+  test("穴 C: two concurrent resumes of the same claude session id — only one launches, the other is rejected", async () => {
+    const cfg = makeConfig(projectDir);
+    // Both invoked synchronously up to their first await: the first acquires the
+    // in-flight lock and suspends inside launchResume; the second sees the held
+    // lock and throws before touching tmux.
+    const results = await Promise.allSettled([
+      manager.resumeSession(cfg, "thread-A", VALID_ID, projectDir),
+      manager.resumeSession(cfg, "thread-B", VALID_ID, projectDir),
+    ]);
+
+    const fulfilled = results.filter((r) => r.status === "fulfilled");
+    const rejected = results.filter((r) => r.status === "rejected");
+    expect(fulfilled).toHaveLength(1);
+    expect(rejected).toHaveLength(1);
+    expect(
+      (rejected[0] as PromiseRejectedResult).reason.message
+    ).toMatch(/多重 resume 防止|稼働中/);
+    // Exactly one tmux session was launched (no duplicate `claude --resume`).
+    expect(effects.tmux.list()).toHaveLength(1);
+  });
+
+  test("穴 A: a stale status='running' row whose process is dead does NOT block resume", async () => {
+    // Prior run recorded as running, but its pid is dead and no tmux session
+    // exists → authoritative liveness is `dead`, so resume must proceed.
+    insertSession({
+      id: "stale-run",
+      channel_name: "team-salary",
+      thread_id: "old-dead-thread",
+      project_dir: projectDir,
+      pid: 9999, // not in alivePids → dead
+      claude_session_id: VALID_ID,
+      started_at: new Date().toISOString(),
+      last_activity_at: new Date().toISOString(),
+      status: "running",
+      branch: null,
+    });
+
+    const info = await manager.resumeSession(
+      makeConfig(projectDir),
+      "fresh-thread",
+      VALID_ID,
+      projectDir
+    );
+    expect(info.status).toBe("running");
+    expect(manager.has("fresh-thread")).toBe(true);
+  });
+
+  test("穴 A: a genuinely-live session (pid alive + tmux present) rejects resume", async () => {
+    const oldThread = "alive-old-thread";
+    effects.tmux.newSession(tmuxNameForThread(oldThread), "exec claude");
+    const oldPid = effects.tmux.getPid(tmuxNameForThread(oldThread))!;
+    effects.process.alivePids.add(oldPid);
+    insertSession({
+      id: "live-run",
+      channel_name: "team-salary",
+      thread_id: oldThread,
+      project_dir: projectDir,
+      pid: oldPid,
+      claude_session_id: VALID_ID,
+      started_at: new Date().toISOString(),
+      last_activity_at: new Date().toISOString(),
+      status: "running",
+      branch: null,
+    });
+
+    await expect(
+      manager.resumeSession(
+        makeConfig(projectDir),
+        "alive-new-thread",
+        VALID_ID,
+        projectDir
+      )
+    ).rejects.toThrow(/稼働中/);
+    expect(manager.has("alive-new-thread")).toBe(false);
+    // No new tmux session for the rejected resume (only the pre-existing one).
+    expect(effects.tmux.hasSession(tmuxNameForThread("alive-new-thread"))).toBe(
+      false
+    );
+  });
+
+  test("the in-flight lock is released after a successful resume (a later resume of the same id is not falsely blocked)", async () => {
+    const cfg = makeConfig(projectDir);
+    await manager.resumeSession(cfg, "first-thread", VALID_ID, projectDir);
+    // Stop the first so liveness is no longer alive, then resume again: must not
+    // be rejected by a leaked lock.
+    await manager.stop("first-thread");
+    const info = await manager.resumeSession(
+      cfg,
+      "second-thread",
+      VALID_ID,
+      projectDir
+    );
+    expect(info.status).toBe("running");
   });
 });


### PR DESCRIPTION
## 概要
Epic #166 / Phase 1。複数同時 resume による同一 transcript 二重書き破損（RW-046 同型）を構造的に防ぐ。`claude_session_id` をキーに「どこかで alive なら拒否＋稼働中スレッド案内」。status 列だけを信用せず liveness 判定（#168）を使い、resume 進行中の in-flight ロックで status 確認→行 insert 間の TOCTOU を封じる。

Closes #171

## 既存ガードの穴と対応
| 穴 | 内容 | 対応 |
|---|---|---|
| A | DB status 列だけ信用 → 陳腐化で誤判定 | 権威ある liveness 判定（#168）に置換。新メソッド `livenessOfClaudeSession` |
| B | claude_session_id NULL で引けない | #167 で解消済み |
| C | 別スレッドからほぼ同時 resume の TOCTOU | claude_session_id キーの in-flight ロック |

## 主な変更点
- `manager.ts`:
  - `livenessOfClaudeSession(id)` を追加。`claude_session_id` の最新行を解決し `livenessOf`（pid + tmux の実体突合）に委譲。
  - `resumeSession` の冒頭で `resumingClaudeSessions` Set による single-flight ロックを同期取得し `finally` で解放。ロック下で liveness を再判定（ハンドラのチェック→insert 間の TOCTOU を閉じる二段防御）。launch 本体は `launchResume` に分離してロックの薄いラッパとして維持。
- `session.ts`: resume ハンドラの guard を `row.status === "running"` から `livenessOfClaudeSession(...) === "alive"` に変更（fast-path UX チェック）。stale な running 行は dead 扱いで resume を阻害しない。

## 統合ジャーニーAC
1. 稼働中の claude_session_id を 2 スレッドからほぼ同時に resume → 1 本目のみ起動・2 本目拒否
   - 検証: `manager-resume.test.ts` 穴C（Promise.allSettled で fulfilled 1 / rejected 1、tmux session 1 本のみ）
2. DB は running だが実体が死んでいるセッションを resume → 誤拒否されず復帰
   - 検証: `manager-resume.test.ts` / `manager-liveness.test.ts` / `session-resume.test.ts` の穴A（liveness=dead で resume 成功）

## テスト
- `manager-liveness.test.ts`: `livenessOfClaudeSession` 5 ケース追加（unknown / alive / stale-running→dead / stopped→dead / 最新行解決）
- `manager-resume.test.ts`: single-flight TOCTOU / stale-status 続行 / alive 拒否 / ロック解放 の 4 ケース追加
- `session-resume.test.ts`: ハンドラ liveness 2 ケース（alive 拒否 / stale 続行）
- `bunx tsc --noEmit` green、新規 12 テスト全 pass

## 既知の事前 fail（本 PR 起因ではない）
`origin/main` 既存の `db.ts:45` shell-exec guard 債務 1 件 + real-tmux 統合テスト（AC-6/AC-7）4 件は環境依存で、resume/liveness 経路に非接触。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * セッション復帰時の稼働状況判定を改善。DB上のステータスだけに依存せず、実際の生存確認に基づいて稼働中セッションを正確に検出するようになりました。
  * 同一セッションの同時復帰を防止する機構を追加。誤った重複起動を回避できます。

* **バグ修正**
  * DB上は「稼働中」だが実際には停止しているセッション（ステイル状態）を正しく処理するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->