### PR TITLE
refactor(#97): session/ の tmux/iTerm2 系 execSync(template) を execFileSync(argv) に統一

### DIFF
--- a/supervisor/src/session/iterm2.ts
+++ b/supervisor/src/session/iterm2.ts
@@ -115,33 +115,23 @@ export function openTab(opts: OpenTabOptions): void {
   // argv form (no shell): tmuxSessionName / tabTitle are passed as discrete
   // arguments, so no quoting or shell parsing is involved (Issue #97). This
   // also removes the prior reliance on these values being injection-safe.
+  // Chain all five window-config commands into ONE tmux invocation via bare
+  // ";" separators (tmux's own command parser treats ";" as a separator — see
+  // ensureSocketConfigured in tmux.ts), cutting five process spawns to one.
   // stdio: "ignore" matches the fire-and-forget tmux calls in adapters.ts —
   // failures are non-fatal (the session may have already exited) and tmux's
   // stderr must not leak to the Supervisor's terminal.
   try {
     execFileSync(
       TMUX_PATH,
-      [...TMUX_ARGS, "rename-window", "-t", opts.tmuxSessionName, tabTitle],
-      { timeout: 3000, stdio: "ignore" }
-    );
-    execFileSync(
-      TMUX_PATH,
-      [...TMUX_ARGS, "set-option", "-t", opts.tmuxSessionName, "automatic-rename", "off"],
-      { timeout: 3000, stdio: "ignore" }
-    );
-    execFileSync(
-      TMUX_PATH,
-      [...TMUX_ARGS, "set-option", "-t", opts.tmuxSessionName, "set-titles", "on"],
-      { timeout: 3000, stdio: "ignore" }
-    );
-    execFileSync(
-      TMUX_PATH,
-      [...TMUX_ARGS, "set-option", "-t", opts.tmuxSessionName, "set-titles-string", "#{window_name}"],
-      { timeout: 3000, stdio: "ignore" }
-    );
-    execFileSync(
-      TMUX_PATH,
-      [...TMUX_ARGS, "select-pane", "-t", opts.tmuxSessionName, "-T", tabTitle],
+      [
+        ...TMUX_ARGS,
+        "rename-window", "-t", opts.tmuxSessionName, tabTitle, ";",
+        "set-option", "-t", opts.tmuxSessionName, "automatic-rename", "off", ";",
+        "set-option", "-t", opts.tmuxSessionName, "set-titles", "on", ";",
+        "set-option", "-t", opts.tmuxSessionName, "set-titles-string", "#{window_name}", ";",
+        "select-pane", "-t", opts.tmuxSessionName, "-T", tabTitle,
+      ],
       { timeout: 3000, stdio: "ignore" }
     );
   } catch {

--- a/supervisor/src/session/iterm2.ts
+++ b/supervisor/src/session/iterm2.ts
@@ -1,4 +1,4 @@
-import { execSync, spawn } from "child_process";
+import { execFileSync, spawn } from "child_process";
 import { readFileSync } from "fs";
 import { resolve, basename } from "path";
 import { homedir } from "os";
@@ -73,7 +73,9 @@ export function resolveColor(projectName: string): string {
 
 export function isItermRunning(): boolean {
   try {
-    const result = execSync("pgrep -x iTerm2", {
+    // argv form (no shell): pgrep exits 1 when nothing matches, which
+    // execFileSync surfaces as a throw → caught below as "not running".
+    const result = execFileSync("pgrep", ["-x", "iTerm2"], {
       encoding: "utf8",
       timeout: 3000,
     }).trim();
@@ -108,37 +110,39 @@ export function openTab(opts: OpenTabOptions): void {
     return;
   }
 
-  // Set tmux window name so it persists after attach
+  // Set tmux window name so it persists after attach.
   const tabTitle = `${opts.channelName} (running)`;
-  // shell-safe: every interpolation below is non-free-text — TMUX_CMD is a
-  // module constant, tmuxSessionName is `claude-<numeric Discord threadId>`,
-  // and tabTitle is built from channelName (a static CHANNEL_MAP key). No
-  // Discord message content reaches these strings (RW-045 guard, #159).
+  // argv form (no shell): tmuxSessionName / tabTitle are passed as discrete
+  // arguments, so no quoting or shell parsing is involved (Issue #97). This
+  // also removes the prior reliance on these values being injection-safe.
+  // stdio: "ignore" matches the fire-and-forget tmux calls in adapters.ts —
+  // failures are non-fatal (the session may have already exited) and tmux's
+  // stderr must not leak to the Supervisor's terminal.
   try {
-    // shell-safe: TMUX_CMD const + internal session id / static channel name
-    execSync(
-      `${TMUX_CMD} rename-window -t "${opts.tmuxSessionName}" "${tabTitle}"`,
-      { timeout: 3000 }
+    execFileSync(
+      TMUX_PATH,
+      [...TMUX_ARGS, "rename-window", "-t", opts.tmuxSessionName, tabTitle],
+      { timeout: 3000, stdio: "ignore" }
     );
-    // shell-safe: TMUX_CMD const + internal session id (no free text)
-    execSync(
-      `${TMUX_CMD} set-option -t "${opts.tmuxSessionName}" automatic-rename off`,
-      { timeout: 3000 }
+    execFileSync(
+      TMUX_PATH,
+      [...TMUX_ARGS, "set-option", "-t", opts.tmuxSessionName, "automatic-rename", "off"],
+      { timeout: 3000, stdio: "ignore" }
     );
-    // shell-safe: TMUX_CMD const + internal session id (no free text)
-    execSync(
-      `${TMUX_CMD} set-option -t "${opts.tmuxSessionName}" set-titles on`,
-      { timeout: 3000 }
+    execFileSync(
+      TMUX_PATH,
+      [...TMUX_ARGS, "set-option", "-t", opts.tmuxSessionName, "set-titles", "on"],
+      { timeout: 3000, stdio: "ignore" }
     );
-    // shell-safe: TMUX_CMD const + internal session id (no free text)
-    execSync(
-      `${TMUX_CMD} set-option -t "${opts.tmuxSessionName}" set-titles-string "#{window_name}"`,
-      { timeout: 3000 }
+    execFileSync(
+      TMUX_PATH,
+      [...TMUX_ARGS, "set-option", "-t", opts.tmuxSessionName, "set-titles-string", "#{window_name}"],
+      { timeout: 3000, stdio: "ignore" }
     );
-    // shell-safe: TMUX_CMD const + internal session id / static channel name
-    execSync(
-      `${TMUX_CMD} select-pane -t "${opts.tmuxSessionName}" -T "${tabTitle}"`,
-      { timeout: 3000 }
+    execFileSync(
+      TMUX_PATH,
+      [...TMUX_ARGS, "select-pane", "-t", opts.tmuxSessionName, "-T", tabTitle],
+      { timeout: 3000, stdio: "ignore" }
     );
   } catch {
     // tmux session may have already exited
@@ -171,9 +175,10 @@ export function openTab(opts: OpenTabOptions): void {
   ].join("\n");
 
   try {
-    // shell-safe: the AppleScript is single-quote-escaped (every `'` → `'\''`)
-    // before being wrapped in the outer single-quoted `osascript -e '...'`.
-    execSync(`osascript -e '${script.replace(/'/g, "'\\''")}'`, {
+    // argv form (no shell): the AppleScript is passed as a single -e argument,
+    // so the prior manual single-quote escaping is no longer needed (Issue
+    // #97). Matches markTabStopped's spawn(osascript, ["-e", script]).
+    execFileSync("osascript", ["-e", script], {
       timeout: 5000,
     });
     console.log(`[iTerm2] Opened tab for ${opts.channelName}`);

--- a/supervisor/src/session/tmux.ts
+++ b/supervisor/src/session/tmux.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execFileSync } from "child_process";
 
 export const TMUX_PATH = process.env.TMUX_PATH ?? "/opt/homebrew/bin/tmux";
 
@@ -31,8 +31,13 @@ export const TMUX_SOCKET = rawSocket;
 export const TMUX_ARGS: readonly string[] = ["-L", TMUX_SOCKET];
 
 /**
- * Shell fragment for template-string execSync calls. Safe because
- * `TMUX_SOCKET` has been validated against `SOCKET_NAME_PATTERN`.
+ * Shell fragment (`tmux -L <socket>`) for the few places that still need a
+ * command *string* rather than argv — currently only the iTerm2 AppleScript
+ * `write text`, which the interactive shell in the new tab runs on attach
+ * (see {@link ./iterm2}.openTab). Safe because `TMUX_SOCKET` has been
+ * validated against `SOCKET_NAME_PATTERN`. Direct tmux calls use argv via
+ * `execFileSync` (Issue #97); do not introduce new template-string execSync
+ * uses of this constant.
  */
 export const TMUX_CMD = `${TMUX_PATH} -L ${TMUX_SOCKET}`;
 
@@ -65,16 +70,30 @@ export const TMUX_CMD = `${TMUX_PATH} -L ${TMUX_SOCKET}`;
  */
 export function ensureSocketConfigured(): void {
   try {
-    // shell-safe: TMUX_CMD is a module constant and every other token is a
-    // hard-coded literal — no external input is interpolated (RW-045 guard).
-    execSync(
-      `${TMUX_CMD} set-option -g mouse off \\; ` +
-        `set-option -g mode-keys emacs \\; ` +
-        `set-option -g history-limit 10000`,
+    // argv form (no shell): tmux's OWN command parser (not the shell) treats a
+    // standalone ";" token as a separator between chained subcommands, so the
+    // three set-option calls still run in one tmux invocation. execFileSync
+    // passes argv directly, eliminating the shell parse step entirely (Issue
+    // #97). NOTE: do not "simplify" by joining these into one string — the
+    // chaining depends on ";" being its own argv element. Every token here is
+    // a hard-coded literal so there is no injection surface to begin with.
+    execFileSync(
+      TMUX_PATH,
+      [
+        ...TMUX_ARGS,
+        "set-option", "-g", "mouse", "off", ";",
+        "set-option", "-g", "mode-keys", "emacs", ";",
+        "set-option", "-g", "history-limit", "10000",
+      ],
       { timeout: 3000, stdio: "pipe" }
     );
   } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
+    // execFileSync surfaces tmux's stderr ("no server running" on the very
+    // first call, before any server exists) via err.stderr rather than
+    // err.message — check both so the expected first-call case stays silent.
+    const e = err as NodeJS.ErrnoException & { stderr?: Buffer | string };
+    const stderr = e?.stderr != null ? e.stderr.toString() : "";
+    const msg = `${err instanceof Error ? err.message : String(err)} ${stderr}`;
     const isNoServer = /no server running/i.test(msg);
     if (!isNoServer) {
       console.warn("[tmux] ensureSocketConfigured failed:", err);

--- a/supervisor/tests/session/tmux.test.ts
+++ b/supervisor/tests/session/tmux.test.ts
@@ -13,20 +13,21 @@ import {
  *
  * The function in src/session/tmux.ts swallows `no server running` (expected
  * on the very first call before any tmux server exists) and warns on any
- * other error. We verify both branches by mocking child_process.execSync.
+ * other error. We verify both branches by mocking child_process.execFileSync
+ * (Issue #97 switched from execSync(template) to execFileSync(argv)).
  */
 
-let mockExecSyncImpl: () => string = () => "";
+let mockExecFileSyncImpl: () => string = () => "";
 
-// Spy-wrapped mock so we can assert the command/options passed to execSync
-// (#117 follow-up: gemini medium #3142222781).
-const mockExecSync = mock((..._args: unknown[]) => mockExecSyncImpl());
+// Spy-wrapped mock so we can assert the file/argv/options passed to
+// execFileSync (#117 follow-up: gemini medium #3142222781).
+const mockExecFileSync = mock((..._args: unknown[]) => mockExecFileSyncImpl());
 
 mock.module("child_process", () => ({
-  execSync: mockExecSync,
+  execFileSync: mockExecFileSync,
 }));
 
-const { ensureSocketConfigured, TMUX_CMD } = await import(
+const { ensureSocketConfigured, TMUX_PATH, TMUX_SOCKET } = await import(
   "../../src/session/tmux"
 );
 
@@ -41,8 +42,8 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
   let warnSpy: ReturnType<typeof setupWarnSpy>;
 
   beforeEach(() => {
-    mockExecSyncImpl = () => "";
-    mockExecSync.mockClear();
+    mockExecFileSyncImpl = () => "";
+    mockExecFileSync.mockClear();
     warnSpy = setupWarnSpy();
   });
 
@@ -50,8 +51,8 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
     warnSpy.mockRestore();
   });
 
-  test("warns when execSync throws an error other than 'no server running'", () => {
-    mockExecSyncImpl = () => {
+  test("warns when execFileSync throws an error other than 'no server running'", () => {
+    mockExecFileSyncImpl = () => {
       throw new Error("EACCES: permission denied, /tmp/tmux-501");
     };
 
@@ -63,8 +64,8 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
     expect(firstCall[1]).toBeInstanceOf(Error);
   });
 
-  test("stays silent when execSync throws 'no server running' (first-call case)", () => {
-    mockExecSyncImpl = () => {
+  test("stays silent when execFileSync throws 'no server running' (first-call case)", () => {
+    mockExecFileSyncImpl = () => {
       throw new Error("no server running on /tmp/tmux-501/claude-hub");
     };
 
@@ -73,8 +74,8 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  test("stays silent when execSync succeeds", () => {
-    mockExecSyncImpl = () => "";
+  test("stays silent when execFileSync succeeds", () => {
+    mockExecFileSyncImpl = () => "";
 
     ensureSocketConfigured();
 
@@ -82,7 +83,7 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
   });
 
   test("matches 'no server running' regex case-insensitively", () => {
-    mockExecSyncImpl = () => {
+    mockExecFileSyncImpl = () => {
       throw new Error("No Server Running");
     };
 
@@ -92,7 +93,7 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
   });
 
   test("re-runs and re-warns on every invocation (no memoisation by design)", () => {
-    mockExecSyncImpl = () => {
+    mockExecFileSyncImpl = () => {
       throw new Error("EBUSY: tmux socket is locked");
     };
 
@@ -105,7 +106,7 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
 
   test("preserves the original Error instance in the warning payload", () => {
     const customError = new Error("ENOSPC: no space left on device");
-    mockExecSyncImpl = () => {
+    mockExecFileSyncImpl = () => {
       throw customError;
     };
 
@@ -120,7 +121,7 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
     // correctly falls through to the warn branch (#117 follow-up: coderabbit
     // minor #3142223332).
     const thrown = { code: "EPERM", path: "/tmp/tmux-501" };
-    mockExecSyncImpl = () => {
+    mockExecFileSyncImpl = () => {
       throw thrown;
     };
 
@@ -130,19 +131,29 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
     expect(warnSpy.mock.calls[0]![1]).toBe(thrown);
   });
 
-  test("invokes execSync with the expected tmux command and options", () => {
-    mockExecSyncImpl = () => "";
+  test("invokes execFileSync with the expected tmux file, argv and options", () => {
+    mockExecFileSyncImpl = () => "";
 
     ensureSocketConfigured();
 
-    expect(mockExecSync).toHaveBeenCalledTimes(1);
-    const call = mockExecSync.mock.calls[0]!;
-    const cmd = call[0] as string;
-    const opts = call[1] as { timeout?: number; stdio?: string };
-    expect(cmd).toContain(TMUX_CMD);
-    expect(cmd).toContain("set-option -g mouse off");
-    expect(cmd).toContain("set-option -g mode-keys emacs");
-    expect(cmd).toContain("set-option -g history-limit 10000");
+    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    const call = mockExecFileSync.mock.calls[0]!;
+    const file = call[0] as string;
+    const argv = call[1] as string[];
+    const opts = call[2] as { timeout?: number; stdio?: string };
+
+    // argv form (Issue #97): file is the tmux binary; the exact argv asserts
+    // both that every option token is a discrete element AND that the two ";"
+    // separators sit between the three set-option groups (an exact match, so a
+    // mis-placed or extra separator fails — `arrayContaining` would not catch
+    // that).
+    expect(file).toBe(TMUX_PATH);
+    expect(argv).toEqual([
+      "-L", TMUX_SOCKET,
+      "set-option", "-g", "mouse", "off", ";",
+      "set-option", "-g", "mode-keys", "emacs", ";",
+      "set-option", "-g", "history-limit", "10000",
+    ]);
     expect(opts).toMatchObject({ timeout: 3000, stdio: "pipe" });
   });
 });


### PR DESCRIPTION
## 目的

Issue #97。`supervisor/src/session/` の tmux/iTerm2 系で残っていた `execSync(テンプレート文字列)` を、`adapters.ts` で既に採用済みの `execFileSync(file, argv[])`（シェルを介さない）形式へ統一し、shell-injection 面を排除する防御的予防修繕。

## 主な変更点

| ファイル | 内容 |
|---|---|
| `src/session/tmux.ts` | `ensureSocketConfigured` を `execFileSync` 化。チェーン `set-option` の `\;` を bare `";"` の argv 要素に変換（tmux 自身のコマンドパーサが区切りとして解釈）。`execFileSync` は stderr を `err.stderr` に載せるため、`no server running` 判定を `message` + `stderr` の両方でチェックするよう堅牢化 |
| `src/session/iterm2.ts` | `isItermRunning`（`pgrep`）/ `openTab` の tmux 5 呼び出し / `osascript` を `execFileSync` 化。openTab の tmux 呼び出しは `adapters.ts` に合わせ `stdio: "ignore"`。AppleScript の手動シングルクオートエスケープは argv 化で不要に |
| `tests/session/tmux.test.ts` | モックを `execFileSync` に切替え、argv を厳密（`toEqual`）検証 |

`manager.ts:354` の `execSync("sleep 0.5")` は非 tmux/iTerm2・非テンプレ文字列のためスコープ外（イベントループ非同期化は別 Issue 領域）。

## AC

- [x] AC-1: 全 tmux/iTerm2 系 `execSync(template)` を `execFileSync(argv)` に置換（`grep` で 0 件確認）
- [x] AC-2: bun test 回帰なし（`tmux.test.ts` 8/8・`iterm2.test.ts` 8/8 PASS。残 fail は実 tmux ペイン必須テストと `db.ts` ガード既存誤検知で着手前から fail・本変更とは無関係）
- [ ] AC-3: 本番 Supervisor 再起動 → 1 セッション開始の動作確認（**マージ後にユーザーが実施**）

## レビュー対応

code-review-orchestrator の must（`openTab`/`markTabStopped` の AppleScript 文字列への `channelName`/`tmuxSessionName` 未エスケープ補間）は、シェル層とは別レイヤーの既存課題（現アーキでは `tmuxSessionName=claude-<数値>`、`channelName=静的 CHANNEL_MAP キー`のため実害なし）。本 PR スコープ外として **#183** に分離。should/nit のうち範囲内のもの（区切りコメント明確化・テスト argv 厳密化・`stdio:"ignore"` 統一）は反映済み。

## テスト方法

```
cd supervisor && bun test tests/session/tmux.test.ts tests/session/iterm2.test.ts
```

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * セッション管理の内部処理を改善し、コマンド実行の安全性と信頼性を向上させました。
  * テストスイートを更新し、改善された動作を検証するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->