### PR TITLE
fix(#155): Discord カスタムコマンド剥がしの allowlist をプロジェクトコマンド経路まで拡張

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -22,6 +22,7 @@ import {
 } from "./session/file-attacher";
 import {
   isKnownSlashCommand,
+  loadProjectCommands,
   looksLikeSlashCommand,
   stripLeadingSlash,
 } from "./session/slash-prefix";
@@ -263,9 +264,19 @@ export async function startBot(token: string): Promise<void> {
     // are now passed through unmodified so legitimate `/save-session` etc. keep
     // working as actual Claude Code slash commands. Strip only fires on
     // unknown / typo'd commands.
+    // Issue #155: also recognise PROJECT-scoped commands for this session's
+    // cwd (`<projectDir>/.claude/commands/*.md`), not just built-ins +
+    // user-global. Without this, a legit project command like
+    // `/write-article` is judged "unknown" and demoted to natural language.
+    // A session is guaranteed to exist here (the `!has` early-return above),
+    // but guard defensively in case of a teardown race.
+    const session = sessionManager.get(threadId);
+    const projectLoader = session
+      ? () => loadProjectCommands(session.projectDir)
+      : undefined;
     if (
       looksLikeSlashCommand(messageText) &&
-      !isKnownSlashCommand(messageText)
+      !isKnownSlashCommand(messageText, undefined, projectLoader)
     ) {
       const original = messageText;
       messageText = stripLeadingSlash(messageText);

--- a/supervisor/src/session/slash-prefix.ts
+++ b/supervisor/src/session/slash-prefix.ts
@@ -17,6 +17,16 @@ import { join } from "node:path";
  * matching only by coincidence. We now keep an allowlist of known commands
  * (built-ins + `~/.claude/commands/*.md`) and only strip the unknown ones.
  *
+ * Issue #155 (#86 follow-up A): The allowlist only knew about user-global
+ * commands (`~/.claude/commands/`), so a session's PROJECT-scoped command
+ * (`<projectDir>/.claude/commands/*.md`, e.g. team_salary's `/write-article`)
+ * was wrongly judged "unknown" and demoted to natural language. We now also
+ * consult the project command dir for the session's cwd. Project commands are
+ * cached per `projectDir` (each thread can run in a different cwd/worktree),
+ * never in the single user-global cache, to avoid cross-project leakage.
+ * Plugin- and skill-sourced commands are out of scope here (fragile,
+ * version-dependent discovery paths) and tracked as a follow-up.
+ *
  * The match is intentionally narrow: a path like `/usr/bin/ls` or
  * `/Users/x/foo` does NOT match because the first token is followed by `/`,
  * not whitespace or end-of-string.
@@ -79,16 +89,22 @@ const BUILTIN_COMMANDS: ReadonlySet<string> = new Set([
   "vim",
 ]);
 
-let cachedUserCommands: ReadonlySet<string> | null = null;
-let cacheLoadedAt = 0;
 const CACHE_TTL_MS = 60_000;
+const EMPTY_COMMAND_SET: ReadonlySet<string> = new Set();
+const emptyCommandLoader = (): ReadonlySet<string> => EMPTY_COMMAND_SET;
 
-function defaultLoadUserCommands(): ReadonlySet<string> {
-  const now = Date.now();
-  if (cachedUserCommands && now - cacheLoadedAt < CACHE_TTL_MS) {
-    return cachedUserCommands;
-  }
-  const dir = join(homedir(), ".claude", "commands");
+/**
+ * Read `*.md` command names from a `.claude/commands` directory.
+ *
+ * Returns the command-name set plus a `cacheable` flag: `true` on success or
+ * ENOENT (a stable, empty-or-populated answer worth caching for the TTL
+ * window), `false` on unexpected errors (EACCES, EMFILE, …) so the caller
+ * retries on the next call instead of caching a transient empty result.
+ */
+function readCommandDir(dir: string): {
+  set: ReadonlySet<string>;
+  cacheable: boolean;
+} {
   const set = new Set<string>();
   try {
     for (const name of readdirSync(dir)) {
@@ -98,48 +114,125 @@ function defaultLoadUserCommands(): ReadonlySet<string> {
       const cmd = name.slice(0, -3);
       if (cmd) set.add(cmd);
     }
-    cachedUserCommands = set;
-    cacheLoadedAt = now;
-    return cachedUserCommands;
+    return { set, cacheable: true };
   } catch (err) {
     const code = (err as NodeJS.ErrnoException).code;
     if (code === "ENOENT") {
-      // Dir doesn't exist (e.g., before any user command is installed).
-      // Empty allowlist is the right answer; cache it for the TTL window.
-      cachedUserCommands = set;
-      cacheLoadedAt = now;
-      return cachedUserCommands;
+      // Dir doesn't exist (e.g., a project with no custom commands). Empty
+      // allowlist is the right answer; cache it for the TTL window.
+      return { set, cacheable: true };
     }
-    // Unexpected error (EACCES, EMFILE, etc.). Don't TTL-cache an empty
-    // result — the next call should retry the read so transient failures
-    // self-heal. Return the previous cache if any, else an empty set
-    // for this single call.
+    // Unexpected error: don't cache an empty result so transient failures
+    // self-heal on the next call.
     console.warn(
       `[slash-prefix] Failed to read ${dir}: code=${code ?? "unknown"} message=${(err as Error).message ?? "n/a"}`,
     );
-    return cachedUserCommands ?? set;
+    return { set, cacheable: false };
   }
 }
 
+let cachedUserCommands: ReadonlySet<string> | null = null;
+let cacheLoadedAt = 0;
+
+function defaultLoadUserCommands(): ReadonlySet<string> {
+  const now = Date.now();
+  if (cachedUserCommands && now - cacheLoadedAt < CACHE_TTL_MS) {
+    return cachedUserCommands;
+  }
+  const dir = join(homedir(), ".claude", "commands");
+  const { set, cacheable } = readCommandDir(dir);
+  if (cacheable) {
+    cachedUserCommands = set;
+    cacheLoadedAt = now;
+    return cachedUserCommands;
+  }
+  // Return the previous cache if any, else an empty set for this single call.
+  return cachedUserCommands ?? set;
+}
+
+interface CommandCacheEntry {
+  set: ReadonlySet<string>;
+  loadedAt: number;
+}
+
+// Per-projectDir cache. Each thread can run in a different cwd/worktree, so a
+// single shared cache (like the user-global one) would mis-attribute one
+// project's commands to another. Bounded by PROJECT_CACHE_MAX to avoid
+// unbounded growth in the long-lived Supervisor as worktree paths churn
+// (cf. RW-039 worktree path proliferation).
+const PROJECT_CACHE_MAX = 64;
+const projectCommandCache = new Map<string, CommandCacheEntry>();
+
 /**
- * Returns true if `text` starts with a known slash command — either a Claude
- * Code built-in or a user-scope custom command from `~/.claude/commands/`.
- * `loader` is injectable so tests can stub the filesystem read.
+ * Returns the set of project-scoped command names defined under
+ * `<projectDir>/.claude/commands/*.md`, cached per `projectDir` for the TTL
+ * window. Exported so `bot.ts` can build a project loader for the session's
+ * cwd, and so tests can exercise the real filesystem path.
+ *
+ * Trust boundary: `projectDir` is the session's recorded cwd — an
+ * operator-configured channel dir (`config.dir`) or a per-branch worktree
+ * whose path already passed the metachar guard in `resolveWorktreePath`
+ * (RW-045). It is NOT raw Discord user input at this point. We only read a
+ * directory listing and use the `*.md` basenames for set membership; nothing
+ * here is executed, so the blast radius is a benign `readdirSync`.
+ *
+ * Deleted-worktree case (RW-046): if the cwd was removed, `readdirSync` hits
+ * ENOENT → empty set → the command is treated as unknown and stripped, which
+ * is the safe fallback (the picker would have nothing to run anyway).
+ */
+export function loadProjectCommands(projectDir: string): ReadonlySet<string> {
+  const now = Date.now();
+  const cached = projectCommandCache.get(projectDir);
+  if (cached && now - cached.loadedAt < CACHE_TTL_MS) {
+    return cached.set;
+  }
+  const dir = join(projectDir, ".claude", "commands");
+  const { set, cacheable } = readCommandDir(dir);
+  if (cacheable) {
+    if (
+      projectCommandCache.size >= PROJECT_CACHE_MAX &&
+      !projectCommandCache.has(projectDir)
+    ) {
+      // Simple bound: clear the whole map rather than track LRU. The next
+      // lookups repopulate from disk within one TTL window. Safe under Bun's
+      // single-threaded JS execution (no preemption between clear and set
+      // below); the map can transiently reach PROJECT_CACHE_MAX entries.
+      projectCommandCache.clear();
+    }
+    projectCommandCache.set(projectDir, { set, loadedAt: now });
+    return set;
+  }
+  // Unexpected read error: reuse the stale entry if present, else empty.
+  return cached?.set ?? set;
+}
+
+/**
+ * Returns true if `text` starts with a known slash command — a Claude Code
+ * built-in, a user-scope custom command from `~/.claude/commands/`, or a
+ * project-scope command for the session's cwd.
+ *
+ * `loader` (user-global) and `projectLoader` (project-scoped) are injectable
+ * so tests can stub the filesystem reads. `projectLoader` defaults to an empty
+ * set, preserving the prior built-in + user-global behaviour for callers that
+ * don't supply a project context.
  */
 export function isKnownSlashCommand(
   text: string,
   loader: () => ReadonlySet<string> = defaultLoadUserCommands,
+  projectLoader: () => ReadonlySet<string> = emptyCommandLoader,
 ): boolean {
   const match = text.match(SLASH_NAME_RE);
   if (!match) return false;
   const name = match[1];
   if (!name) return false;
   if (BUILTIN_COMMANDS.has(name)) return true;
-  return loader().has(name);
+  if (loader().has(name)) return true;
+  return projectLoader().has(name);
 }
 
-// Test helper.
+// Test helper. Clears both the user-global and per-project caches.
 export function _resetUserCommandCache(): void {
   cachedUserCommands = null;
   cacheLoadedAt = 0;
+  projectCommandCache.clear();
 }

--- a/supervisor/tests/session/slash-prefix.test.ts
+++ b/supervisor/tests/session/slash-prefix.test.ts
@@ -1,6 +1,10 @@
-import { describe, test, expect, beforeEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
   isKnownSlashCommand,
+  loadProjectCommands,
   looksLikeSlashCommand,
   stripLeadingSlash,
   _resetUserCommandCache,
@@ -13,6 +17,10 @@ import {
  *
  * Issue #86 follow-up: known commands (built-ins + ~/.claude/commands/) are
  * passed through unmodified so legitimate slash commands keep working.
+ *
+ * Issue #155 (#86 follow-up A): the allowlist also consults project-scoped
+ * commands (`<projectDir>/.claude/commands/*.md`) for the session's cwd, so a
+ * project command like `/write-article` is no longer wrongly stripped.
  */
 
 describe("looksLikeSlashCommand", () => {
@@ -177,5 +185,142 @@ describe("isKnownSlashCommand", () => {
     // returns a boolean without throwing.
     const result = isKnownSlashCommand("/totally-unknown-XYZ");
     expect(typeof result).toBe("boolean");
+  });
+
+  // Issue #155: project-scoped commands (the injected projectLoader path).
+  describe("project-scoped commands (Issue #155)", () => {
+    const projectLoader = () => new Set(["write-article", "draft-article"]);
+
+    test("AC-1: recognises a project command via projectLoader", () => {
+      // built-in + user-global are empty here; only the project loader knows it
+      expect(
+        isKnownSlashCommand("/write-article", emptyLoader, projectLoader),
+      ).toBe(true);
+      expect(
+        isKnownSlashCommand("/write-article 199", emptyLoader, projectLoader),
+      ).toBe(true);
+    });
+
+    test("AC-3: a typo of a project command is still unknown (stripped)", () => {
+      expect(
+        isKnownSlashCommand("/wrtie-article", emptyLoader, projectLoader),
+      ).toBe(false);
+    });
+
+    test("AC-2: built-ins and user-global still recognised alongside project loader", () => {
+      // built-in
+      expect(isKnownSlashCommand("/help", emptyLoader, projectLoader)).toBe(
+        true,
+      );
+      // user-global (customLoader) command unaffected by project loader
+      expect(
+        isKnownSlashCommand("/save-session", customLoader, projectLoader),
+      ).toBe(true);
+    });
+
+    test("absent projectLoader preserves prior built-in + user-global behaviour", () => {
+      // No third arg → empty project loader default. Project-only command is
+      // unknown; built-ins/user-global unchanged.
+      expect(isKnownSlashCommand("/write-article", customLoader)).toBe(false);
+      expect(isKnownSlashCommand("/pdca", customLoader)).toBe(true);
+    });
+  });
+});
+
+describe("loadProjectCommands (Issue #155)", () => {
+  let tmpDirs: string[] = [];
+
+  function makeProject(commands: string[]): string {
+    const root = mkdtempSync(join(tmpdir(), "claude-hub-proj-"));
+    tmpDirs.push(root);
+    const cmdDir = join(root, ".claude", "commands");
+    mkdirSync(cmdDir, { recursive: true });
+    for (const name of commands) {
+      writeFileSync(join(cmdDir, `${name}.md`), `# ${name}\n`);
+    }
+    return root;
+  }
+
+  beforeEach(() => {
+    _resetUserCommandCache(); // also clears the per-project cache
+  });
+
+  afterEach(() => {
+    for (const dir of tmpDirs) {
+      rmSync(dir, { recursive: true, force: true });
+    }
+    tmpDirs = [];
+  });
+
+  test("reads <projectDir>/.claude/commands/*.md into a name set", () => {
+    const proj = makeProject(["write-article", "draft-article"]);
+    const set = loadProjectCommands(proj);
+    expect(set.has("write-article")).toBe(true);
+    expect(set.has("draft-article")).toBe(true);
+    expect(set.has("nonexistent")).toBe(false);
+  });
+
+  test("end-to-end: isKnownSlashCommand resolves a real project command", () => {
+    const proj = makeProject(["write-article"]);
+    expect(
+      isKnownSlashCommand("/write-article 199", () => new Set(), () =>
+        loadProjectCommands(proj),
+      ),
+    ).toBe(true);
+    // typo still unknown
+    expect(
+      isKnownSlashCommand("/wrtie-article", () => new Set(), () =>
+        loadProjectCommands(proj),
+      ),
+    ).toBe(false);
+  });
+
+  test("caches are isolated per projectDir (no cross-project leakage)", () => {
+    const projA = makeProject(["alpha-cmd"]);
+    const projB = makeProject(["beta-cmd"]);
+    const setA = loadProjectCommands(projA);
+    const setB = loadProjectCommands(projB);
+    expect(setA.has("alpha-cmd")).toBe(true);
+    expect(setA.has("beta-cmd")).toBe(false);
+    expect(setB.has("beta-cmd")).toBe(true);
+    expect(setB.has("alpha-cmd")).toBe(false);
+  });
+
+  test("missing project command dir returns empty set without throwing", () => {
+    const root = mkdtempSync(join(tmpdir(), "claude-hub-noproj-"));
+    tmpDirs.push(root);
+    // No .claude/commands dir created → ENOENT path.
+    const set = loadProjectCommands(root);
+    expect(set.size).toBe(0);
+  });
+
+  test("ignores non-.md and .bak.md files", () => {
+    const root = mkdtempSync(join(tmpdir(), "claude-hub-mixed-"));
+    tmpDirs.push(root);
+    const cmdDir = join(root, ".claude", "commands");
+    mkdirSync(cmdDir, { recursive: true });
+    writeFileSync(join(cmdDir, "real-cmd.md"), "# real\n");
+    writeFileSync(join(cmdDir, "notes.txt"), "not a command\n");
+    writeFileSync(join(cmdDir, "old-cmd.bak.md"), "# backup\n");
+    const set = loadProjectCommands(root);
+    expect(set.has("real-cmd")).toBe(true);
+    expect(set.has("notes")).toBe(false);
+    expect(set.has("old-cmd.bak")).toBe(false);
+    expect(set.has("old-cmd")).toBe(false);
+  });
+
+  test("returns cached set within the TTL window after dir changes", () => {
+    const proj = makeProject(["first-cmd"]);
+    const first = loadProjectCommands(proj);
+    expect(first.has("first-cmd")).toBe(true);
+    // Add a new command on disk; within TTL the cached set is returned
+    // unchanged (proves caching is active and per-project).
+    writeFileSync(
+      join(proj, ".claude", "commands", "second-cmd.md"),
+      "# second\n",
+    );
+    const second = loadProjectCommands(proj);
+    expect(second.has("second-cmd")).toBe(false);
+    expect(second).toBe(first); // same cached reference
   });
 });


### PR DESCRIPTION
Closes #155

## 目的

Supervisor の slash 剥がし判定（`isKnownSlashCommand`）が **built-in + user-global (`~/.claude/commands`) のみ**を allowlist としていたため、セッション固有の **プロジェクトコマンド**（`<projectDir>/.claude/commands/*.md`）が「未知」扱いで剥がされ、正規のカスタムコマンドが自然言語に降格していた（例: team_salary の `/write-article` → `Issue番号が指定されていません` 等の誤動作）。

## 主な変更点

- **`loadProjectCommands(projectDir)`** を追加。`<projectDir>/.claude/commands/*.md` を読み、**projectDir ごとの TTL キャッシュ**で保持。スレッドごとに cwd / worktree が異なるため単一キャッシュではなく per-projectDir に分離し、`PROJECT_CACHE_MAX=64` で上限を設けて長寿命 Supervisor のメモリ肥大（cf. RW-039）を防止。
- **`isKnownSlashCommand`** に第3引数 `projectLoader`（注入可能）を追加。デフォルトは空集合のため、**既存の built-in + user-global 挙動は完全に不変**。
- **`bot.ts`** は `sessionManager.get(threadId).projectDir` からプロジェクトローダを構築して渡す（teardown race に備えた防御ガード付き）。
- `readCommandDir` で user / project 読み込みの `ENOENT`（→ 空集合キャッシュ）/ 異常系（→ キャッシュせず self-heal）を DRY 化。

## スコープ判断

Issue の「＋ プラグインコマンド / ＋ スキル名」は **follow-up #186** に分離。プラグインコマンドは 802 ファイル・複数レイアウト・名前空間付きで discovery がバージョン依存に脆弱（RW-020/027 の教訓）、スキルは別 discovery 機構のため。統合ジャーニーAC は全てプロジェクトコマンドで満たせるため YAGNI / thin-scaffolding に従い証拠ドリブンで後続対応。

## テスト / AC 検証

- 新規ユニットテスト 10 件追加（`slash-prefix.test.ts` 計 66/66 PASS）: projectLoader 注入、per-projectDir 分離、ENOENT、`.bak.md`/非 .md 除外、TTL キャッシュ。
- `bunx tsc --noEmit`: 0 errors。
- **統合ジャーニーAC 実機検証 3/3 PASS**（実 `team_salary/.claude/commands/` を読む決定的検証）:

| AC | 操作 | 期待（wouldStrip） | 実測 | 判定 |
|---|---|---|---|---|
| AC-1 | `/write-article 199`（プロジェクト実在） | false（剥がさない） | false | PASS |
| AC-2 | `/hanle-review XXX`（タイポ） | true（従来#86どおり剥がす） | true | PASS |
| AC-3 | `/save-session`（user-global） | false（リグレッションなし） | false | PASS |

> 既存テストスイートの 11 fail / 9 error は Bun 1.3.11 の `execFileSync` import 非互換 + 1 件の flaky timing test による **pre-existing**（clean tree でも同数。本 PR は 159→169 pass で新規失敗ゼロ）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)