### PR TITLE
fix(#152): Discord 添付を project 資産として永続化し 5 分削除を回避

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,7 @@ jobs:
         run: |
           bun test --coverage --coverage-reporter=lcov \
                    tests/session/output-formatter.test.ts \
+                   tests/session/attachment-store.test.ts \
                    tests/session/relay.test.ts \
                    tests/session/relay-server.test.ts \
                    tests/session/queue-resilience.test.ts \

--- a/supervisor/src/session/attachment-store.ts
+++ b/supervisor/src/session/attachment-store.ts
@@ -84,7 +84,8 @@ export async function persistAttachments(
   return Promise.all(
     tmpFiles.map(async (tmp) => {
       if (!dirReady) return tmp;
-      const dest = resolve(destDir, sanitizeFilename(basename(tmp)));
+      // sanitizeFilename applies basename() internally, so pass tmp directly.
+      const dest = resolve(destDir, sanitizeFilename(tmp));
       try {
         await copyFile(tmp, dest);
         return dest;

--- a/supervisor/src/session/attachment-store.ts
+++ b/supervisor/src/session/attachment-store.ts
@@ -1,0 +1,92 @@
+import { resolve, basename } from "path";
+import { mkdirSync, copyFileSync } from "fs";
+
+/**
+ * Persist relayed Discord attachments as project assets (Issue #152).
+ *
+ * Previously attachments lived only in a tmp dir and were deleted 5 minutes
+ * after relay (relay.ts `scheduleCleanup`), so "material screenshots" vanished
+ * mid-task and the user had to re-send them. Materials are project assets, not
+ * ephemeral relay buffers — copy them into
+ * `<projectDir>/.claude/discord-materials/<threadId>/` and hand Claude the
+ * persistent path. The tmp copy is still cleaned up by the relay; only the
+ * persistent copy survives.
+ *
+ * No automatic GC runs over the materials dir: these are assets the user
+ * explicitly wants kept (deleting them is the very bug this fixes), so
+ * unbounded retention is intentional, not an oversight. Re-sending the same
+ * filename in a thread overwrites the previous copy (`copyFileSync`). A
+ * size/age-based retention policy, if ever needed, is tracked as a follow-up.
+ */
+
+const MATERIALS_SUBDIR = ".claude/discord-materials";
+
+/**
+ * Reduce a Discord thread id to a path-safe segment. Thread ids are Discord
+ * snowflakes (numeric) but treat them as untrusted input: strip anything that
+ * is not `[A-Za-z0-9_-]` so a crafted id can never traverse out of the
+ * materials dir (RW-045: untrusted input in filesystem paths).
+ */
+export function sanitizeThreadId(threadId: string): string {
+  const cleaned = threadId.replace(/[^A-Za-z0-9_-]/g, "");
+  return cleaned.length > 0 ? cleaned : "_";
+}
+
+/**
+ * Reduce an attachment filename to a path-safe basename: drop any directory
+ * component and collapse `..` runs so the copy destination can never escape the
+ * materials dir, even if Discord supplied a hostile filename.
+ */
+export function sanitizeFilename(name: string): string {
+  const base = basename(name).replace(/[/\\]/g, "").replace(/\.\.+/g, ".");
+  return base.length > 0 ? base : "file";
+}
+
+/** Absolute path to the persistent materials dir for a given project + thread. */
+export function materialsDir(projectDir: string, threadId: string): string {
+  return resolve(projectDir, MATERIALS_SUBDIR, sanitizeThreadId(threadId));
+}
+
+/**
+ * Copy each tmp file into the project's persistent materials dir and return the
+ * persistent paths (suitable for handing to Claude's `Read` tool).
+ *
+ * Defensive / fail-open per file: if the dir cannot be created or a copy fails,
+ * the original tmp path is returned for that file (degraded — it is still
+ * cleaned up after 5 min) and a warning is logged. Persistence failure must
+ * never fail the relay itself.
+ */
+export function persistAttachments(
+  tmpFiles: string[],
+  projectDir: string,
+  threadId: string
+): string[] {
+  if (tmpFiles.length === 0) return [];
+
+  const destDir = materialsDir(projectDir, threadId);
+  let dirReady = false;
+  try {
+    mkdirSync(destDir, { recursive: true });
+    dirReady = true;
+  } catch (err) {
+    console.warn(
+      `[AttachmentStore] failed to create ${destDir}, keeping tmp paths:`,
+      err
+    );
+  }
+
+  return tmpFiles.map((tmp) => {
+    if (!dirReady) return tmp;
+    const dest = resolve(destDir, sanitizeFilename(basename(tmp)));
+    try {
+      copyFileSync(tmp, dest);
+      return dest;
+    } catch (err) {
+      console.warn(
+        `[AttachmentStore] failed to copy ${tmp} -> ${dest}, keeping tmp path:`,
+        err
+      );
+      return tmp;
+    }
+  });
+}

--- a/supervisor/src/session/attachment-store.ts
+++ b/supervisor/src/session/attachment-store.ts
@@ -1,5 +1,5 @@
 import { resolve, basename } from "path";
-import { mkdirSync, copyFileSync } from "fs";
+import { mkdir, copyFile } from "fs/promises";
 
 /**
  * Persist relayed Discord attachments as project assets (Issue #152).
@@ -39,7 +39,10 @@ export function sanitizeThreadId(threadId: string): string {
  */
 export function sanitizeFilename(name: string): string {
   const base = basename(name).replace(/[/\\]/g, "").replace(/\.\.+/g, ".");
-  return base.length > 0 ? base : "file";
+  // `.` / `..` would resolve to the dir itself (EISDIR on copy) — treat any
+  // dot-only result, or an empty one, as a generic name.
+  if (base.length === 0 || base === "." || base === "..") return "file";
+  return base;
 }
 
 /** Absolute path to the persistent materials dir for a given project + thread. */
@@ -56,17 +59,17 @@ export function materialsDir(projectDir: string, threadId: string): string {
  * cleaned up after 5 min) and a warning is logged. Persistence failure must
  * never fail the relay itself.
  */
-export function persistAttachments(
+export async function persistAttachments(
   tmpFiles: string[],
   projectDir: string,
   threadId: string
-): string[] {
+): Promise<string[]> {
   if (tmpFiles.length === 0) return [];
 
   const destDir = materialsDir(projectDir, threadId);
   let dirReady = false;
   try {
-    mkdirSync(destDir, { recursive: true });
+    await mkdir(destDir, { recursive: true });
     dirReady = true;
   } catch (err) {
     console.warn(
@@ -75,18 +78,23 @@ export function persistAttachments(
     );
   }
 
-  return tmpFiles.map((tmp) => {
-    if (!dirReady) return tmp;
-    const dest = resolve(destDir, sanitizeFilename(basename(tmp)));
-    try {
-      copyFileSync(tmp, dest);
-      return dest;
-    } catch (err) {
-      console.warn(
-        `[AttachmentStore] failed to copy ${tmp} -> ${dest}, keeping tmp path:`,
-        err
-      );
-      return tmp;
-    }
-  });
+  // Copy concurrently: the supervisor is a single process serving every
+  // Discord channel, so blocking the event loop on synchronous disk I/O would
+  // stall unrelated sessions (domain-expert.md: Gateway responsiveness).
+  return Promise.all(
+    tmpFiles.map(async (tmp) => {
+      if (!dirReady) return tmp;
+      const dest = resolve(destDir, sanitizeFilename(basename(tmp)));
+      try {
+        await copyFile(tmp, dest);
+        return dest;
+      } catch (err) {
+        console.warn(
+          `[AttachmentStore] failed to copy ${tmp} -> ${dest}, keeping tmp path:`,
+          err
+        );
+        return tmp;
+      }
+    })
+  );
 }

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -652,6 +652,9 @@ export class SessionManager {
 
     return relayMessage(tmuxName, threadId, message, {
       attachments,
+      // Issue #152: persist attachments as project assets so they outlive the
+      // 5-min tmp cleanup and stay readable for the whole task.
+      persistDir: session.projectDir,
       onDialogStuck: options?.onDialogStuck,
     });
   }

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -3,6 +3,7 @@ import { resolve } from "path";
 import { homedir } from "os";
 import { mkdirSync, writeFileSync, unlinkSync } from "fs";
 import { waitForRelay, type RelayResult } from "./relay-server";
+import { persistAttachments } from "./attachment-store";
 import { TMUX_PATH, TMUX_ARGS } from "./tmux";
 import { createLatencyTracker } from "./latency-logger";
 import { startDialogWatchdog } from "./dialog-watchdog";
@@ -146,6 +147,15 @@ export async function tmuxSend(sessionName: string, extraArgs: string[]): Promis
 export interface RelayMessageOptions {
   attachments?: AttachmentInfo[];
   /**
+   * Project directory of the session (the claude cwd). When provided,
+   * downloaded attachments are also persisted under
+   * `<persistDir>/.claude/discord-materials/<threadId>/` and Claude is handed
+   * the persistent path instead of the ephemeral tmp path (Issue #152). The
+   * tmp copy is still cleaned up after 5 min; the persistent copy survives so
+   * "material screenshots" remain readable for the whole task.
+   */
+  persistDir?: string;
+  /**
    * Called when the watchdog has exhausted its auto-accept budget for a
    * dialog and the user must intervene manually. The callback typically
    * posts a `ダイアログ検出: <kind>、手動操作要求` heartbeat to the
@@ -176,7 +186,13 @@ export async function relayMessage(
     }
 
     if (localFiles.length > 0) {
-      const imageInstructions = localFiles
+      // Issue #152: hand Claude the persistent project-asset paths (when a
+      // persistDir is known) so the materials survive past the 5-min tmp
+      // cleanup. Falls back to the tmp paths per-file if persistence fails.
+      const claudeFiles = options.persistDir
+        ? persistAttachments(localFiles, options.persistDir, threadId)
+        : localFiles;
+      const imageInstructions = claudeFiles
         .map((f) => `Read the image at ${f}`)
         .join(", and ");
       fullMessage = `${imageInstructions}. ${message}`;

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -190,7 +190,7 @@ export async function relayMessage(
       // persistDir is known) so the materials survive past the 5-min tmp
       // cleanup. Falls back to the tmp paths per-file if persistence fails.
       const claudeFiles = options.persistDir
-        ? persistAttachments(localFiles, options.persistDir, threadId)
+        ? await persistAttachments(localFiles, options.persistDir, threadId)
         : localFiles;
       const imageInstructions = claudeFiles
         .map((f) => `Read the image at ${f}`)

--- a/supervisor/tests/session/attachment-store.test.ts
+++ b/supervisor/tests/session/attachment-store.test.ts
@@ -1,0 +1,119 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, existsSync, readFileSync, mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { resolve, basename, dirname } from "path";
+import {
+  persistAttachments,
+  materialsDir,
+  sanitizeThreadId,
+  sanitizeFilename,
+} from "../../src/session/attachment-store";
+
+describe("attachment-store (Issue #152)", () => {
+  let root: string;
+  let projectDir: string;
+  let tmpDir: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(resolve(tmpdir(), "attach-store-"));
+    projectDir = resolve(root, "project");
+    tmpDir = resolve(root, "tmp");
+    mkdirSync(projectDir, { recursive: true });
+    mkdirSync(tmpDir, { recursive: true });
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function makeTmpFile(name: string, content: string): string {
+    const p = resolve(tmpDir, name);
+    writeFileSync(p, content);
+    return p;
+  }
+
+  // Journey AC-1: all attachments saved to the persistent project path.
+  test("copies every attachment into <projectDir>/.claude/discord-materials/<threadId>/", () => {
+    const threadId = "1779450275804";
+    const files = [1, 2, 3, 4].map((n) =>
+      makeTmpFile(`${n}-IMG_479${n}.png`, `image-${n}`)
+    );
+
+    const persisted = persistAttachments(files, projectDir, threadId);
+
+    const dir = materialsDir(projectDir, threadId);
+    expect(persisted.length).toBe(4);
+    for (const p of persisted) {
+      expect(existsSync(p)).toBe(true);
+      expect(dirname(p)).toBe(dir);
+    }
+    // Content is preserved (AC-3: Claude can Read the image content).
+    expect(readFileSync(persisted[0]!, "utf8")).toBe("image-1");
+  });
+
+  // Journey AC-2: persisted path is NOT the tmp path, so the relay's 5-min
+  // tmp cleanup (which targets the tmp list) leaves the persistent copy intact.
+  test("returns persistent paths distinct from the tmp paths", () => {
+    const threadId = "thread-abc";
+    const tmp = makeTmpFile("99-shot.png", "x");
+
+    const persisted = persistAttachments([tmp], projectDir, threadId)[0]!;
+
+    expect(persisted).not.toBe(tmp);
+    expect(persisted.startsWith(projectDir)).toBe(true);
+  });
+
+  test("empty input returns empty array", () => {
+    expect(persistAttachments([], projectDir, "t")).toEqual([]);
+  });
+
+  // Defense: a hostile thread id cannot escape the materials dir.
+  test("sanitizeThreadId strips path-traversal characters", () => {
+    expect(sanitizeThreadId("../../etc")).toBe("etc");
+    expect(sanitizeThreadId("a/b\\c")).toBe("abc");
+    expect(sanitizeThreadId("1779450275804")).toBe("1779450275804");
+    expect(sanitizeThreadId("")).toBe("_");
+  });
+
+  // Defense: a hostile filename cannot escape the materials dir.
+  test("sanitizeFilename drops directory components and collapses ..", () => {
+    expect(sanitizeFilename("../../etc/passwd")).toBe("passwd");
+    expect(sanitizeFilename("a/b/c.png")).toBe("c.png");
+    // A `..` run inside a name (no traversal) is collapsed but not rejected.
+    expect(sanitizeFilename("foo..bar.png")).toBe("foo.bar.png");
+    expect(sanitizeFilename("")).toBe("file");
+  });
+
+  test("traversal-laden threadId still writes inside the project dir", () => {
+    const tmp = makeTmpFile("1-x.png", "x");
+    const persisted = persistAttachments([tmp], projectDir, "../../../../tmp/evil")[0]!;
+    expect(persisted.startsWith(projectDir)).toBe(true);
+    expect(existsSync(persisted)).toBe(true);
+  });
+
+  // Fail-open: if the persistent dir can't be created (projectDir is a file),
+  // the tmp path is returned so the relay still works this turn.
+  test("falls back to tmp path when the materials dir cannot be created", () => {
+    const fileAsProject = resolve(root, "not-a-dir");
+    writeFileSync(fileAsProject, "i am a file");
+    const tmp = makeTmpFile("1-x.png", "x");
+
+    const persisted = persistAttachments([tmp], fileAsProject, "t")[0]!;
+
+    expect(persisted).toBe(tmp);
+  });
+
+  // Fail-open per file: the dir is created fine, but one source file is missing,
+  // so its copy throws — that file falls back to its (nonexistent) tmp path
+  // while the other file still persists.
+  test("falls back per-file when an individual copy fails", () => {
+    const good = makeTmpFile("1-good.png", "ok");
+    const missing = resolve(tmpDir, "2-missing.png"); // never written
+
+    const [p1, p2] = persistAttachments([good, missing], projectDir, "t");
+
+    expect(p1!.startsWith(projectDir)).toBe(true);
+    expect(existsSync(p1!)).toBe(true);
+    expect(p2).toBe(missing); // copy failed → tmp path returned
+  });
+});

--- a/supervisor/tests/session/attachment-store.test.ts
+++ b/supervisor/tests/session/attachment-store.test.ts
@@ -33,13 +33,13 @@ describe("attachment-store (Issue #152)", () => {
   }
 
   // Journey AC-1: all attachments saved to the persistent project path.
-  test("copies every attachment into <projectDir>/.claude/discord-materials/<threadId>/", () => {
+  test("copies every attachment into <projectDir>/.claude/discord-materials/<threadId>/", async () => {
     const threadId = "1779450275804";
     const files = [1, 2, 3, 4].map((n) =>
       makeTmpFile(`${n}-IMG_479${n}.png`, `image-${n}`)
     );
 
-    const persisted = persistAttachments(files, projectDir, threadId);
+    const persisted = await persistAttachments(files, projectDir, threadId);
 
     const dir = materialsDir(projectDir, threadId);
     expect(persisted.length).toBe(4);
@@ -53,18 +53,18 @@ describe("attachment-store (Issue #152)", () => {
 
   // Journey AC-2: persisted path is NOT the tmp path, so the relay's 5-min
   // tmp cleanup (which targets the tmp list) leaves the persistent copy intact.
-  test("returns persistent paths distinct from the tmp paths", () => {
+  test("returns persistent paths distinct from the tmp paths", async () => {
     const threadId = "thread-abc";
     const tmp = makeTmpFile("99-shot.png", "x");
 
-    const persisted = persistAttachments([tmp], projectDir, threadId)[0]!;
+    const persisted = (await persistAttachments([tmp], projectDir, threadId))[0]!;
 
     expect(persisted).not.toBe(tmp);
     expect(persisted.startsWith(projectDir)).toBe(true);
   });
 
-  test("empty input returns empty array", () => {
-    expect(persistAttachments([], projectDir, "t")).toEqual([]);
+  test("empty input returns empty array", async () => {
+    expect(await persistAttachments([], projectDir, "t")).toEqual([]);
   });
 
   // Defense: a hostile thread id cannot escape the materials dir.
@@ -81,24 +81,27 @@ describe("attachment-store (Issue #152)", () => {
     expect(sanitizeFilename("a/b/c.png")).toBe("c.png");
     // A `..` run inside a name (no traversal) is collapsed but not rejected.
     expect(sanitizeFilename("foo..bar.png")).toBe("foo.bar.png");
+    // `.` / `..` would resolve to the dir itself → mapped to a generic name.
+    expect(sanitizeFilename(".")).toBe("file");
+    expect(sanitizeFilename("..")).toBe("file");
     expect(sanitizeFilename("")).toBe("file");
   });
 
-  test("traversal-laden threadId still writes inside the project dir", () => {
+  test("traversal-laden threadId still writes inside the project dir", async () => {
     const tmp = makeTmpFile("1-x.png", "x");
-    const persisted = persistAttachments([tmp], projectDir, "../../../../tmp/evil")[0]!;
+    const persisted = (await persistAttachments([tmp], projectDir, "../../../../tmp/evil"))[0]!;
     expect(persisted.startsWith(projectDir)).toBe(true);
     expect(existsSync(persisted)).toBe(true);
   });
 
   // Fail-open: if the persistent dir can't be created (projectDir is a file),
   // the tmp path is returned so the relay still works this turn.
-  test("falls back to tmp path when the materials dir cannot be created", () => {
+  test("falls back to tmp path when the materials dir cannot be created", async () => {
     const fileAsProject = resolve(root, "not-a-dir");
     writeFileSync(fileAsProject, "i am a file");
     const tmp = makeTmpFile("1-x.png", "x");
 
-    const persisted = persistAttachments([tmp], fileAsProject, "t")[0]!;
+    const persisted = (await persistAttachments([tmp], fileAsProject, "t"))[0]!;
 
     expect(persisted).toBe(tmp);
   });
@@ -106,11 +109,11 @@ describe("attachment-store (Issue #152)", () => {
   // Fail-open per file: the dir is created fine, but one source file is missing,
   // so its copy throws — that file falls back to its (nonexistent) tmp path
   // while the other file still persists.
-  test("falls back per-file when an individual copy fails", () => {
+  test("falls back per-file when an individual copy fails", async () => {
     const good = makeTmpFile("1-good.png", "ok");
     const missing = resolve(tmpDir, "2-missing.png"); // never written
 
-    const [p1, p2] = persistAttachments([good, missing], projectDir, "t");
+    const [p1, p2] = await persistAttachments([good, missing], projectDir, "t");
 
     expect(p1!.startsWith(projectDir)).toBe(true);
     expect(existsSync(p1!)).toBe(true);


### PR DESCRIPTION
## 目的

Close #152

Discord で送った素材スクショが relay の 5 分後 cleanup で消失し、記事執筆等の長時間タスクで「再提供必要」がブロッカー化していた問題を修正する。

## 主な変更点（案 B を採用）

添付は「session の入力」ではなく「project の素材アセット」として扱うべき、という Issue の推奨方針に従う。

- **`supervisor/src/session/attachment-store.ts`（新規）**: `persistAttachments` が tmp の添付を `<projectDir>/.claude/discord-materials/<threadId>/` へコピーし、永続パスを返す。
  - Discord 由来の `threadId` / `filename` は未信頼入力として `sanitizeThreadId` / `sanitizeFilename` で path traversal を境界遮断（RW-045 系列の予防）。
  - 永続化失敗時は per-file で tmp パスへ fail-open（relay 本体は止めない、warn ログ）。
- **`relay.ts`**: `persistDir` オプション追加。添付ありかつ persistDir があれば Claude に永続パスを渡す。tmp の 5 分 cleanup は従来通り（tmp コピーのみ削除、永続コピーは残る）。
- **`manager.ts`**: `session.projectDir` を `persistDir` として渡す。

GC は意図的に未実装（素材は保持したい資産のため）。保持ポリシーと永続化失敗時の Discord 通知は follow-up #188。

## テスト方法

```
cd supervisor && bun test tests/session/attachment-store.test.ts
```

- 8/8 PASS（4 枚コピー / 永続パスが tmp と別 / 空入力 / threadId・filename サニタイズ / traversal threadId / dir 作成失敗フォールバック / per-file コピー失敗フォールバック）
- `bunx tsc --noEmit`: 変更ファイルにエラーなし
- `bun test tests/session/{attachment-store,relay,manager}.test.ts`: 48/48 PASS

## 統合ジャーニーAC 検証

| AC | 検証内容 | 手段 | 判定 |
|---|---|---|---|
| AC-1 | 4 枚すべてが永続パスに保存される | test「copies every attachment...」(4 files, dirname 一致) | PASS |
| AC-2 | 5 分超過後もファイルが残る | 永続パスは tmp と別、cleanup は tmp list のみ対象（test「distinct from tmp paths」+ relay.ts scheduleCleanup(localFiles)） | PASS |
| AC-3 | Read で画像内容を取得できる | test が copy 後の内容一致を assert（readFileSync） | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Discord添付ファイルをプロジェクト内に永続保存できるようになり、短期的な一時ファイル消去後もアセットとして参照可能になりました。
  * 永続化時にファイル名とスレッドIDを安全な形式に正規化します。

* **その他**
  * 永続化に失敗した場合は該当ファイルのみ一時パスへフォールバックし、処理は継続されます。

* **テスト**
  * 永続化・正規化・フェイルオープン動作を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->