### PR TITLE
feat(#153): フィードバックアンケート prompt を feedback-survey として検出し dismiss する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      # Curated list of deterministic, non-tmux test files. dialog-detect is
+      # pure/deterministic and gated here (#153); dialog-watchdog is wall-clock
+      # timing-flaky and stays out until de-flaked (#190).
       - name: Run tests
         env:
           SUPERVISOR_DB_PATH: ":memory:"
@@ -90,6 +93,7 @@ jobs:
                    tests/commands/session-resume.test.ts \
                    tests/hooks/stop-relay.test.ts \
                    tests/infra/db.test.ts \
+                   tests/session/dialog-detect.test.ts \
                    tests/hijoguchi-routing/p0.test.ts \
                    tests/e2e/ac-verification.test.ts
 

--- a/supervisor/src/session/dialog-detect.ts
+++ b/supervisor/src/session/dialog-detect.ts
@@ -31,7 +31,8 @@ export type DialogKind =
   | "ink-confirm"
   | "bash-yn"
   | "numbered-choice"
-  | "press-enter";
+  | "press-enter"
+  | "feedback-survey";
 
 export interface DialogMatch {
   /** Detected dialog family. */
@@ -53,6 +54,10 @@ export interface DialogMatch {
  *    pressing 'y' explicitly (we don't try to detect default polarity).
  *  - numbered-choice: select option 1 (typically Yes/Continue).
  *  - press-enter: just Enter.
+ *  - feedback-survey: select option 0 (Dismiss). Issue #153: Claude Code's
+ *    "How is Claude doing this session?" survey looks like a numbered choice,
+ *    but options 1/2/3 *submit* feedback (1 = "Bad"). Only `0` (Dismiss)
+ *    clears it without side effects, so this kind MUST press 0, never 1.
  *
  * Each entry is an argv list passed to `tmux send-keys -t <session> ...`.
  * Multiple entries mean multiple sequential send-keys calls (with no
@@ -63,6 +68,7 @@ export const AUTO_ACCEPT_KEYS: Record<DialogKind, string[]> = {
   "bash-yn": ["y", "C-m"],
   "numbered-choice": ["1", "C-m"],
   "press-enter": ["C-m"],
+  "feedback-survey": ["0", "C-m"],
 };
 
 /** Number of trailing lines to inspect. Dialogs render at the bottom of
@@ -81,6 +87,30 @@ export function detectDialog(paneText: string): DialogMatch | null {
   const lines = paneText.split("\n");
   const window = lines.slice(-DETECT_WINDOW_LINES);
   const windowText = window.join("\n");
+
+  // 0. Feedback satisfaction survey (Issue #153). Checked first as a safety
+  //    guard. Today the survey's option line uses colons ("1: Bad ... 0:
+  //    Dismiss") while numbered-choice (case 3) requires periods ("1. Yes"),
+  //    so misclassification can't happen yet — but if a future TUI switches
+  //    the survey to "1. Bad", numbered-choice would send `1` (= submit "Bad"
+  //    feedback). Ordering this first future-proofs against that. We require
+  //    BOTH the distinctive question and a `0: Dismiss` option so prose merely
+  //    quoting the question doesn't trigger auto-dismiss.
+  //    The i+4 lookahead window covers the question line plus the option line
+  //    (adjacent in practice) with slack for a blank spacer line between them.
+  for (let i = 0; i < window.length; i++) {
+    const line = window[i] ?? "";
+    if (/How is Claude doing this session\?/i.test(line)) {
+      const lookahead = window.slice(i, i + 4).join("\n");
+      if (/\b0\s*:\s*Dismiss\b/i.test(lookahead)) {
+        return {
+          kind: "feedback-survey",
+          autoAcceptable: true,
+          line: line.trim(),
+        };
+      }
+    }
+  }
 
   // 1. Ink-style confirm: lines beginning with "❯ Yes" (the cursor marker)
   //    plus an adjacent "No" option line. We require the cursor symbol so

--- a/supervisor/tests/e2e/dialog-stall.test.ts
+++ b/supervisor/tests/e2e/dialog-stall.test.ts
@@ -3,6 +3,7 @@ import { execFileSync } from "child_process";
 import { startDialogWatchdog } from "../../src/session/dialog-watchdog";
 import {
   detectDialog,
+  AUTO_ACCEPT_KEYS,
   type DialogMatch,
 } from "../../src/session/dialog-detect";
 import { TMUX_ARGS, ensureSocketConfigured } from "../../src/session/tmux";
@@ -200,6 +201,51 @@ describe("Issue #57 dialog stall — E2E with real tmux", () => {
         const result = detectDialog(pane);
         expect(result).not.toBeNull();
         expect(result!.kind).toBe("bash-yn");
+      } finally {
+        killSession(name);
+      }
+    }
+  );
+
+  // Issue #153 AC-3 verification: the feedback satisfaction survey, captured
+  // from a real tmux pane, is detected as `feedback-survey` and the watchdog
+  // auto-accepts it by sending `0` (Dismiss) via real tmux send-keys — never
+  // `1` (which would submit "Bad" feedback). This is the round-trip proof
+  // that production capture-pane output for the survey unblocks the relay.
+  itmux(
+    "AC-3 (#153): feedback survey pane → detect feedback-survey + send 0",
+    async () => {
+      const name = makeName("survey");
+      startStalePane(name);
+      try {
+        injectText(
+          name,
+          "How is Claude doing this session? (optional)\n  1: Bad    2: Fine   3: Good   0: Dismiss\n"
+        );
+        await wait(100);
+        const pane = capture(name);
+        const result = detectDialog(pane);
+        expect(result).not.toBeNull();
+        expect(result!.kind).toBe("feedback-survey");
+
+        const accepts: DialogMatch[] = [];
+        const watchdog = startDialogWatchdog({
+          tmuxSessionName: name,
+          pollIntervalMs: 50,
+          maxAutoAcceptAttempts: 1,
+          onAutoAccept: (m) => {
+            accepts.push(m);
+          },
+        });
+        await wait(250);
+        watchdog.stop();
+
+        expect(accepts.length).toBeGreaterThanOrEqual(1);
+        expect(accepts[0]!.kind).toBe("feedback-survey");
+        // Round-trip: AUTO_ACCEPT_KEYS sends `0` then Enter (real send-keys).
+        // We assert via the kind→keys map since send-keys to a `cat` pane
+        // can't be re-read; the kind is the deterministic contract.
+        expect(AUTO_ACCEPT_KEYS["feedback-survey"]).toEqual(["0", "C-m"]);
       } finally {
         killSession(name);
       }

--- a/supervisor/tests/e2e/dialog-stall.test.ts
+++ b/supervisor/tests/e2e/dialog-stall.test.ts
@@ -217,6 +217,9 @@ describe("Issue #57 dialog stall — E2E with real tmux", () => {
     async () => {
       const name = makeName("survey");
       startStalePane(name);
+      // Declared outside try so the finally can stop it even if an assertion
+      // throws — prevents the poll timer leaking past the test.
+      let watchdog: { stop(): void } | null = null;
       try {
         injectText(
           name,
@@ -229,7 +232,7 @@ describe("Issue #57 dialog stall — E2E with real tmux", () => {
         expect(result!.kind).toBe("feedback-survey");
 
         const accepts: DialogMatch[] = [];
-        const watchdog = startDialogWatchdog({
+        watchdog = startDialogWatchdog({
           tmuxSessionName: name,
           pollIntervalMs: 50,
           maxAutoAcceptAttempts: 1,
@@ -238,7 +241,6 @@ describe("Issue #57 dialog stall — E2E with real tmux", () => {
           },
         });
         await wait(250);
-        watchdog.stop();
 
         expect(accepts.length).toBeGreaterThanOrEqual(1);
         expect(accepts[0]!.kind).toBe("feedback-survey");
@@ -247,6 +249,7 @@ describe("Issue #57 dialog stall — E2E with real tmux", () => {
         // can't be re-read; the kind is the deterministic contract.
         expect(AUTO_ACCEPT_KEYS["feedback-survey"]).toEqual(["0", "C-m"]);
       } finally {
+        watchdog?.stop();
         killSession(name);
       }
     }

--- a/supervisor/tests/session/dialog-detect.test.ts
+++ b/supervisor/tests/session/dialog-detect.test.ts
@@ -82,6 +82,46 @@ describe("detectDialog — Claude Code TUI dialogs", () => {
     expect(result!.autoAcceptable).toBe(true);
   });
 
+  // Issue #153: Claude Code's feedback satisfaction survey ("How is Claude
+  // doing this session?") renders as a numbered-choice lookalike but the
+  // numeric options (1: Bad / 2: Fine / 3: Good) are *survey answers* with
+  // side effects, not a Yes/Continue confirmation. Sending `1` would submit
+  // negative feedback. We auto-press `0` (Dismiss) instead. This must be
+  // detected as its own kind so AUTO_ACCEPT_KEYS picks `0`, never `1`.
+  test("detects feedback survey: 'How is Claude doing this session?'", () => {
+    const pane = [
+      "⎿  API Error: Claude Code is unable to respond to this request, which appears to violate our Usage Policy",
+      "   Request ID: req_011CbJu5U5eDtnPErMPtpnXP",
+      "",
+      "● How is Claude doing this session? (optional)",
+      "  1: Bad    2: Fine   3: Good   0: Dismiss",
+    ].join("\n");
+    const result = detectDialog(pane);
+    expect(result).not.toBeNull();
+    expect(result!.kind).toBe("feedback-survey");
+    expect(result!.autoAcceptable).toBe(true);
+  });
+
+  test("feedback survey takes priority over numbered-choice (never sends 1)", () => {
+    // The survey's `0: Dismiss` line resembles a numbered choice. Ensure the
+    // detector classifies it as feedback-survey so AUTO_ACCEPT sends `0`.
+    const pane = [
+      "● How is Claude doing this session? (optional)",
+      "  1: Bad    2: Fine   3: Good   0: Dismiss",
+    ].join("\n");
+    const result = detectDialog(pane);
+    expect(result!.kind).toBe("feedback-survey");
+    expect(AUTO_ACCEPT_KEYS[result!.kind]).toEqual(["0", "C-m"]);
+  });
+
+  test("does NOT match the survey question as prose without the options line", () => {
+    // The question alone (e.g. quoted in a chat message) must not trigger —
+    // we require the numbered options line with `0: Dismiss` to be present.
+    expect(
+      detectDialog("Someone asked: how is Claude doing this session?")
+    ).toBeNull();
+  });
+
   test("does NOT match prose containing 'yes' or 'no' words", () => {
     expect(detectDialog("Yes, the answer is correct.")).toBeNull();
     expect(
@@ -116,6 +156,7 @@ describe("detectDialog — Claude Code TUI dialogs", () => {
     expect(AUTO_ACCEPT_KEYS["bash-yn"]).toEqual(["y", "C-m"]);
     expect(AUTO_ACCEPT_KEYS["numbered-choice"]).toEqual(["1", "C-m"]);
     expect(AUTO_ACCEPT_KEYS["press-enter"]).toEqual(["C-m"]);
+    expect(AUTO_ACCEPT_KEYS["feedback-survey"]).toEqual(["0", "C-m"]);
   });
 });
 

--- a/supervisor/tests/session/dialog-watchdog.test.ts
+++ b/supervisor/tests/session/dialog-watchdog.test.ts
@@ -82,8 +82,12 @@ describe("dialog-watchdog", () => {
       sendKeys: (_, keys) => sentKeys.push(keys),
       onAutoAccept: (m) => accepts.push(m),
     });
-    await wait(SHORT_TICK_MS * 3);
-    watchdog.stop();
+    // finally-guard stop() so a thrown assertion can't leak the poll timer.
+    try {
+      await wait(SHORT_TICK_MS * 3);
+    } finally {
+      watchdog.stop();
+    }
     expect(accepts.length).toBeGreaterThanOrEqual(1);
     expect(accepts[0]!.kind).toBe("feedback-survey");
     expect(sentKeys[0]).toEqual(["0", "C-m"]);

--- a/supervisor/tests/session/dialog-watchdog.test.ts
+++ b/supervisor/tests/session/dialog-watchdog.test.ts
@@ -67,6 +67,30 @@ describe("dialog-watchdog", () => {
     expect(sentKeys[0]).toEqual(["y", "C-m"]);
   });
 
+  // Issue #153: the feedback survey must be dismissed with `0`, NEVER `1`
+  // (option 1 submits "Bad" feedback). This locks the survey wiring against
+  // future regressions.
+  test("auto-dismisses feedback-survey with 0 + Enter (never 1)", async () => {
+    const sentKeys: string[][] = [];
+    const accepts: DialogMatch[] = [];
+    const watchdog = startDialogWatchdog({
+      tmuxSessionName: "test-survey",
+      pollIntervalMs: SHORT_TICK_MS,
+      maxAutoAcceptAttempts: 1,
+      capture: () =>
+        "● How is Claude doing this session? (optional)\n  1: Bad    2: Fine   3: Good   0: Dismiss\n",
+      sendKeys: (_, keys) => sentKeys.push(keys),
+      onAutoAccept: (m) => accepts.push(m),
+    });
+    await wait(SHORT_TICK_MS * 3);
+    watchdog.stop();
+    expect(accepts.length).toBeGreaterThanOrEqual(1);
+    expect(accepts[0]!.kind).toBe("feedback-survey");
+    expect(sentKeys[0]).toEqual(["0", "C-m"]);
+    // Defensive: the survey must never auto-press 1 (= "Bad" feedback).
+    expect(sentKeys.some((k) => k[0] === "1")).toBe(false);
+  });
+
   test("escalates to onHeartbeat after auto-accept budget exhausted", async () => {
     const heartbeats: DialogMatch[] = [];
     const acceptsFired: DialogMatch[] = [];


### PR DESCRIPTION
## 概要

Closes #153

Claude Code TUI の「How is Claude doing this session?」満足度アンケートが Ink モーダルとして居座り、Discord relay メッセージを吸い込んで session が silent stuck（status=running なのに無応答）になる問題を解消する。

採用案: **案 A（最小変更・副作用なし）**

## 主な変更点

| ファイル | 変更 |
|---|---|
| `supervisor/src/session/dialog-detect.ts` | `feedback-survey` kind を追加。質問文 + `0: Dismiss` の AND 条件で検出し、`numbered-choice` より先に判定 |
| 同上 `AUTO_ACCEPT_KEYS` | `feedback-survey` に `["0", "C-m"]` を割当（**1=Bad フィードバック送信を回避**） |
| `tests/session/dialog-detect.test.ts` | 正検出 / 優先順位 / プロンプト誤検知防止 / キー割当の 4 ケース追加 |
| `tests/session/dialog-watchdog.test.ts` | watchdog が `0` を送り `1` を送らないことを検証する回帰テスト追加 |
| `tests/e2e/dialog-stall.test.ts` | 実 tmux pane → capture → 検出 → 自動 dismiss の round-trip テスト追加 |
| `.github/workflows/ci.yml` | 純粋・決定的な `dialog-detect.test.ts` を CI unit-test gating に追加 |

## 安全性

watchdog は `AUTO_ACCEPT_KEYS[match.kind]` を lookup するのみで kind を上書きするパスはなく、`feedback-survey` が `1`/`2`/`3` を送るコードパスは存在しない。numbered-choice はピリオド形式（`1. Yes`）を要求するためコロン形式（`1: Bad`）の survey を誤分類しない。将来 TUI が `1. Bad` に変わっても本 kind を先に判定するため安全（コード内コメントに明記）。

## 統合ジャーニーAC 検証結果

| AC | 検証内容 | 手段 | 判定 |
|---|---|---|---|
| AC-1 | survey pane で `detectDialog` が `{kind: feedback-survey, autoAcceptable: true}` | `dialog-detect.test.ts` (bun test) | PASS |
| AC-2 | watchdog が `["0","C-m"]` を send-keys、`1` を送らない | `dialog-watchdog.test.ts` | PASS |
| AC-3 | 実 tmux capture-pane 出力を検出し dismiss（relay 非封鎖の round-trip） | `e2e/dialog-stall.test.ts`（実 tmux）| PASS |

- typecheck: `bunx tsc --noEmit` → exit 0
- `dialog-detect.test.ts`: 16/16 PASS（3 回連続で決定的）

## コードレビュー

code-review-orchestrator 実施: **must 0 / should 2 / nit 2 / 安全性 PASS**。nit（コメント精度）は反映済み。should（watchdog の CI 除外）は #190 で de-flake 後に gating 予定。

## フォローアップ

- #190: `dialog-watchdog.test.ts` の wall-clock timing flake を解消し CI gating に組み込む（本 PR では決定的な dialog-detect のみ gating）

## レビュー観点

- 検出正規表現の false-positive / false-negative リスク（設計方針: miss はタイムアウトで観測可能なので許容、誤 auto-accept は厳禁）
- `feedback-survey` を `numbered-choice` より先に判定する順序の妥当性

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * フィードバックサーベイダイアログの自動検出および自動操作機能を追加しました。サーベイが表示された際に自動的に処理され、システムのスムーズな動作を実現します。

* **Tests**
  * フィードバックサーベイの検出および自動処理の動作を検証するテストケースを追加しました。

* **Chores**
  * テストカバレッジの対象にダイアログ検出テストを含める設定を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->