### PR TITLE
feat(#110): claudeHubExit を idle 1440 分で自動 context リセットする

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -182,6 +182,16 @@
           }
         ]
       }
+    ],
+    "UserPromptSubmit": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/hijoguchi-record-activity.sh"
+          }
+        ]
+      }
     ]
   }
 }

--- a/com.claude-hub.hijoguchi.plist.template
+++ b/com.claude-hub.hijoguchi.plist.template
@@ -25,7 +25,7 @@
         <!-- Issue #110: reset the session for a fresh context after N idle
              minutes (no Discord message). Set to 0 to disable (opt-out). -->
         <key>HIJOGUCHI_IDLE_RESET_MIN</key>
-        <string>60</string>
+        <string>1440</string>
     </dict>
 
     <key>KeepAlive</key>

--- a/com.claude-hub.hijoguchi.plist.template
+++ b/com.claude-hub.hijoguchi.plist.template
@@ -22,6 +22,10 @@
         <string>__HOME__/.local/bin:__HOME__/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
         <key>HOME</key>
         <string>__HOME__</string>
+        <!-- Issue #110: reset the session for a fresh context after N idle
+             minutes (no Discord message). Set to 0 to disable (opt-out). -->
+        <key>HIJOGUCHI_IDLE_RESET_MIN</key>
+        <string>60</string>
     </dict>
 
     <key>KeepAlive</key>

--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -20,6 +20,11 @@ claude-hub プロジェクトで運用している Discord Bot の役割分担�
 - **起動**: `tmux -CC new-session ... --channels plugin:discord@claude-plugins-official`
   - `CLAUDE_HUB_UNSAFE_SKIP_PERMISSIONS=1` （Phase 1 default）の場合のみ `--dangerously-skip-permissions` を追加。詳細は本 doc 下部の「Permission Mode (claudeHubExit)」参照
 - **役割**: **Channel-Supervisor 自身が壊れた時の非常口**
+- **idle context リセット（Issue #110）**: 1 つの長命 Claude Code session が Discord メッセージを蓄積し続けると context が無制限に膨らみ、auto-compact が非決定的に発火して応答が止まる。`scripts/hijoguchi-record-activity.sh`（UserPromptSubmit hook）が各受信メッセージの epoch を `~/.claude-hub-state/last-message-ts` に記録し、`start-hijoguchi.sh` の watchdog が `HIJOGUCHI_IDLE_RESET_MIN` 分（default 60）アイドルなら tmux session を kill → fresh で再起動する。
+  - 閾値は launchd plist の `HIJOGUCHI_IDLE_RESET_MIN` で上書き可能。`0` で機能無効化（オプトアウト）
+  - hook は `CLAUDE_HUB_HIJOGUCHI_SESSION=1`（watchdog が export）でスコープされるため、開発者が `~/claude-hub` で素の `claude` を起動しても idle timer は温まらない
+  - 既知の制限: idle 判定は「最終メッセージ受信時刻」のみを見る。閾値が短く（テスト用 1 分等）かつ受信直後に長時間 tool 実行が続くケースでは理論上 reset され得るが、default 60 分では受信から 60 分後に tool 実行中という状況は事実上発生しないため許容する。仮に reset が tool 実行中に起きても、watchdog が tmux session を kill → launchd KeepAlive 相当の outer loop が fresh で再起動するだけで復旧する（context を意図的に捨てる設計なので中断自体が許容される）
+  - state file ディレクトリが作成不能な場合、baseline 書き込みは WARN を残して継続し、idle 判定は fail-safe で KEEP（reset 無効）になる。watchdog 本来の責務（クラッシュ時の再起動）は idle 機能の失敗で止めない設計
 
 ## 絶対ルール
 

--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -20,10 +20,10 @@ claude-hub プロジェクトで運用している Discord Bot の役割分担�
 - **起動**: `tmux -CC new-session ... --channels plugin:discord@claude-plugins-official`
   - `CLAUDE_HUB_UNSAFE_SKIP_PERMISSIONS=1` （Phase 1 default）の場合のみ `--dangerously-skip-permissions` を追加。詳細は本 doc 下部の「Permission Mode (claudeHubExit)」参照
 - **役割**: **Channel-Supervisor 自身が壊れた時の非常口**
-- **idle context リセット（Issue #110）**: 1 つの長命 Claude Code session が Discord メッセージを蓄積し続けると context が無制限に膨らみ、auto-compact が非決定的に発火して応答が止まる。`scripts/hijoguchi-record-activity.sh`（UserPromptSubmit hook）が各受信メッセージの epoch を `~/.claude-hub-state/last-message-ts` に記録し、`start-hijoguchi.sh` の watchdog が `HIJOGUCHI_IDLE_RESET_MIN` 分（default 60）アイドルなら tmux session を kill → fresh で再起動する。
+- **idle context リセット（Issue #110）**: 1 つの長命 Claude Code session が Discord メッセージを蓄積し続けると context が無制限に膨らみ、auto-compact が非決定的に発火して応答が止まる。`scripts/hijoguchi-record-activity.sh`（UserPromptSubmit hook）が各受信メッセージの epoch を `~/.claude-hub-state/last-message-ts` に記録し、`start-hijoguchi.sh` の watchdog が `HIJOGUCHI_IDLE_RESET_MIN` 分（default 1440 = 24h）アイドルなら tmux session を kill → fresh で再起動する。半日〜1日程度の放置では reset されず保守スレの文脈が保たれる（短すぎる閾値による「半日後に保守議題へ返信したら記憶ゼロ」を回避）。
   - 閾値は launchd plist の `HIJOGUCHI_IDLE_RESET_MIN` で上書き可能。`0` で機能無効化（オプトアウト）
   - hook は `CLAUDE_HUB_HIJOGUCHI_SESSION=1`（watchdog が export）でスコープされるため、開発者が `~/claude-hub` で素の `claude` を起動しても idle timer は温まらない
-  - 既知の制限: idle 判定は「最終メッセージ受信時刻」のみを見る。閾値が短く（テスト用 1 分等）かつ受信直後に長時間 tool 実行が続くケースでは理論上 reset され得るが、default 60 分では受信から 60 分後に tool 実行中という状況は事実上発生しないため許容する。仮に reset が tool 実行中に起きても、watchdog が tmux session を kill → launchd KeepAlive 相当の outer loop が fresh で再起動するだけで復旧する（context を意図的に捨てる設計なので中断自体が許容される）
+  - 既知の制限: idle 判定は「最終メッセージ受信時刻」のみを見る。閾値が短く（テスト用 1 分等）かつ受信直後に長時間 tool 実行が続くケースでは理論上 reset され得るが、default 1440 分では受信から 24h 後に tool 実行中という状況は事実上発生しないため許容する。仮に reset が tool 実行中に起きても、watchdog が tmux session を kill → launchd KeepAlive 相当の outer loop が fresh で再起動するだけで復旧する（context を意図的に捨てる設計なので中断自体が許容される）
   - state file ディレクトリが作成不能な場合、baseline 書き込みは WARN を残して継続し、idle 判定は fail-safe で KEEP（reset 無効）になる。watchdog 本来の責務（クラッシュ時の再起動）は idle 機能の失敗で止めない設計
 
 ## 絶対ルール

--- a/scripts/hijoguchi-record-activity.sh
+++ b/scripts/hijoguchi-record-activity.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# UserPromptSubmit hook: stamp the time of the latest Discord message into the
+# claudeHubExit idle-reset state file (Issue #110).
+#
+# Registered in .claude/settings.json and therefore loaded by every Claude Code
+# session whose cwd is ~/claude-hub. UserPromptSubmit has no matcher support
+# (Claude Code silently ignores one — it fires on every prompt), so scoping is
+# done here in-code: the body is gated on CLAUDE_HUB_HIJOGUCHI_SESSION so only
+# the watchdog-spawned claudeHubExit session writes the stamp. An ordinary
+# `claude` session a developer opens in ~/claude-hub falls through to `exit 0`
+# after a single cheap env check and never keeps the watchdog's idle timer warm.
+#
+# Always exits 0: a hook that blocked or errored on the prompt path would be
+# worse than a missed stamp (the watchdog just fails safe and keeps the
+# session). See scripts/start-hijoguchi.sh for the consuming watchdog loop.
+set -u
+
+# Drain stdin (Claude passes hook JSON) so the producer never blocks on a pipe.
+cat >/dev/null 2>&1 || true
+
+# Scope to the hijoguchi session only.
+[ "${CLAUDE_HUB_HIJOGUCHI_SESSION:-0}" = "1" ] || exit 0
+
+STATE_DIR="${CLAUDE_HUB_STATE_DIR:-${HOME}/.claude-hub-state}"
+TS_FILE="${LAST_MSG_TS_FILE:-${STATE_DIR}/last-message-ts}"
+
+mkdir -p "${STATE_DIR}" 2>/dev/null
+date +%s > "${TS_FILE}" 2>/dev/null || true
+exit 0

--- a/scripts/start-hijoguchi.sh
+++ b/scripts/start-hijoguchi.sh
@@ -25,11 +25,18 @@ BACKOFF_SEC=5
 # message into LAST_MSG_TS_FILE; the watchdog below kills the session once it
 # has been idle for HIJOGUCHI_IDLE_RESET_MIN minutes so the next message starts
 # from a fresh context. Set the threshold to 0 to opt out entirely.
-HIJOGUCHI_IDLE_RESET_MIN="${HIJOGUCHI_IDLE_RESET_MIN:-60}"
+HIJOGUCHI_IDLE_RESET_MIN="${HIJOGUCHI_IDLE_RESET_MIN:-1440}"
 # How often the watchdog re-checks idle / session liveness. Kept short (10s) so
 # crash-restart latency is unchanged; the idle decision is threshold-based, not
 # poll-count based, so a small poll only bounds reset latency, not its timing.
 HIJOGUCHI_IDLE_POLL_SEC="${HIJOGUCHI_IDLE_POLL_SEC:-10}"
+# Guard against a blank / non-numeric override: an invalid value would make the
+# watchdog `sleep` fail and (without set -e) spin the loop into a 100% CPU busy
+# loop. Fall back to 10s on anything that is not a positive integer.
+if ! [[ "${HIJOGUCHI_IDLE_POLL_SEC}" =~ ^[1-9][0-9]*$ ]]; then
+  echo "[hijoguchi] WARN: invalid HIJOGUCHI_IDLE_POLL_SEC='${HIJOGUCHI_IDLE_POLL_SEC}', using 10" >&2
+  HIJOGUCHI_IDLE_POLL_SEC=10
+fi
 CLAUDE_HUB_STATE_DIR="${CLAUDE_HUB_STATE_DIR:-${HOME}/.claude-hub-state}"
 LAST_MSG_TS_FILE="${LAST_MSG_TS_FILE:-${CLAUDE_HUB_STATE_DIR}/last-message-ts}"
 
@@ -195,7 +202,24 @@ fi
 # re-parses back to the exact same argv — prompt content with $VAR, backticks,
 # or quotes cannot leak into command evaluation, and CLAUDE_BIN paths with
 # spaces remain intact.
-CLAUDE_CMD=$(printf '%q ' "${CLAUDE_ARGV[@]}")
+# Inject the activity-tracking context with an explicit `env` prefix rather than
+# relying on `export` + tmux inheritance. When a tmux server is ALREADY running
+# (this script uses the default socket, which commonly pre-exists), `tmux
+# new-session` spawns the pane from the *server's* cached environment, so a
+# freshly-exported var does not reach the claude process or its UserPromptSubmit
+# hook — the hook would then always skip and the idle timer would never warm,
+# resetting the session on a fixed schedule regardless of activity. `env` sets
+# the vars on the claude process directly, independent of server state.
+CLAUDE_CMD=$(printf 'env CLAUDE_HUB_HIJOGUCHI_SESSION=1 CLAUDE_HUB_STATE_DIR=%q LAST_MSG_TS_FILE=%q ' \
+  "${CLAUDE_HUB_STATE_DIR}" "${LAST_MSG_TS_FILE}")
+CLAUDE_CMD+=$(printf '%q ' "${CLAUDE_ARGV[@]}")
+
+# Opt-in introspection for tests: print the fully-built launch command (incl.
+# the env prefix) and exit before any tmux / filesystem side effect.
+if [ "${HIJOGUCHI_PRINT_CMD:-0}" = "1" ]; then
+  printf '%s\n' "${CLAUDE_CMD}"
+  exit 0
+fi
 
 # Create log dir only for real launches. Deferred past render-only / print-argv
 # so tests don't create directories as a side effect.
@@ -206,11 +230,13 @@ trap 'echo "[hijoguchi] SIGTERM received, killing tmux session" >&2; "${TMUX_BIN
 
 echo "[hijoguchi] watchdog starting at $(date)" >&2
 
-# Surface the activity-tracking context to the in-session UserPromptSubmit hook
-# (scripts/hijoguchi-record-activity.sh). The marker scopes the hook to THIS
-# session, so a developer who runs `claude` in ~/claude-hub doesn't keep the
-# idle timer warm. tmux and claude inherit this environment and the hook runs
-# as a grandchild process, so the exports propagate down to it.
+# The activity-tracking context is propagated to the in-session
+# UserPromptSubmit hook (scripts/hijoguchi-record-activity.sh) via the explicit
+# `env` prefix baked into CLAUDE_CMD above — NOT via these exports, because tmux
+# does not reliably inherit a freshly-exported var when the server pre-exists
+# (see the CLAUDE_CMD comment). The exports remain as harmless defense-in-depth
+# for the fresh-server case; the marker scopes the hook to THIS session so a
+# developer running `claude` in ~/claude-hub never warms the idle timer.
 export CLAUDE_HUB_HIJOGUCHI_SESSION=1
 export CLAUDE_HUB_STATE_DIR
 export LAST_MSG_TS_FILE

--- a/scripts/start-hijoguchi.sh
+++ b/scripts/start-hijoguchi.sh
@@ -16,6 +16,67 @@ LOG_DIR="${CLAUDE_HUB_DIR}/logs"
 CLAUDE_BIN="${HOME}/.local/bin/claude"
 TMUX_BIN="${TMUX_PATH:-/opt/homebrew/bin/tmux}"
 BACKOFF_SEC=5
+
+# --- Idle context reset (Issue #110) ---------------------------------------
+# claudeHubExit accumulates every Discord message in one long-lived Claude Code
+# session, so context grows unbounded and auto-compact fires at random times,
+# stalling responses. A UserPromptSubmit hook
+# (scripts/hijoguchi-record-activity.sh) stamps the epoch of each inbound
+# message into LAST_MSG_TS_FILE; the watchdog below kills the session once it
+# has been idle for HIJOGUCHI_IDLE_RESET_MIN minutes so the next message starts
+# from a fresh context. Set the threshold to 0 to opt out entirely.
+HIJOGUCHI_IDLE_RESET_MIN="${HIJOGUCHI_IDLE_RESET_MIN:-60}"
+# How often the watchdog re-checks idle / session liveness. Kept short (10s) so
+# crash-restart latency is unchanged; the idle decision is threshold-based, not
+# poll-count based, so a small poll only bounds reset latency, not its timing.
+HIJOGUCHI_IDLE_POLL_SEC="${HIJOGUCHI_IDLE_POLL_SEC:-10}"
+CLAUDE_HUB_STATE_DIR="${CLAUDE_HUB_STATE_DIR:-${HOME}/.claude-hub-state}"
+LAST_MSG_TS_FILE="${LAST_MSG_TS_FILE:-${CLAUDE_HUB_STATE_DIR}/last-message-ts}"
+
+# Decide whether the session has been idle long enough to reset. Prints
+# "RESET" / "KEEP" and mirrors the decision in the exit status (0 = reset).
+# `now` is overridable via HIJOGUCHI_NOW_EPOCH so tests stay deterministic.
+# Every non-reset path fails safe (KEEP): opt-out, missing/corrupt stamp, or a
+# not-yet-stale delta must never tear down an active session.
+hijoguchi_idle_should_reset() {
+  local reset_min now last delta
+  reset_min="${HIJOGUCHI_IDLE_RESET_MIN}"
+  if ! [[ "${reset_min}" =~ ^[0-9]+$ ]] || [ "${reset_min}" -eq 0 ]; then
+    echo "KEEP"; return 1   # opt-out or non-numeric → never reset
+  fi
+  if [ ! -r "${LAST_MSG_TS_FILE}" ]; then
+    echo "KEEP"; return 1   # no activity recorded yet → treat as fresh
+  fi
+  last="$(cat "${LAST_MSG_TS_FILE}" 2>/dev/null)"
+  if ! [[ "${last}" =~ ^[0-9]+$ ]]; then
+    echo "KEEP"; return 1   # corrupt stamp → fail safe, keep the session
+  fi
+  now="${HIJOGUCHI_NOW_EPOCH:-$(date +%s)}"
+  delta=$(( now - last ))
+  if [ "${delta}" -ge $(( reset_min * 60 )) ]; then
+    echo "RESET"; return 0
+  fi
+  echo "KEEP"; return 1
+}
+
+# Stamp the activity file with the current time. Used to baseline a freshly
+# launched session so it is not reset before the first Discord message arrives.
+hijoguchi_write_activity_baseline() {
+  mkdir -p "${CLAUDE_HUB_STATE_DIR}" 2>/dev/null
+  if ! date +%s > "${LAST_MSG_TS_FILE}" 2>/dev/null; then
+    echo "[hijoguchi] WARN: cannot write activity baseline to ${LAST_MSG_TS_FILE}" >&2
+  fi
+}
+
+# Dry-run: print the idle decision and exit. Used by tests to exercise the
+# threshold logic without spawning tmux/claude. Placed before the required-env
+# checks so the decision logic can be tested without channel/bot IDs.
+if [ "${HIJOGUCHI_IDLE_DECISION_ONLY:-0}" = "1" ]; then
+  hijoguchi_idle_should_reset
+  exit $?
+fi
+# ---------------------------------------------------------------------------
+
 # System-prompt file for `claude --append-system-prompt`. Overridable via env
 # so tests / alt deploys can swap it. S3 (#49) populates the real content.
 SYSTEM_PROMPT_FILE="${SYSTEM_PROMPT_FILE:-${CLAUDE_HUB_DIR}/scripts/hijoguchi-system-prompt.md}"
@@ -145,6 +206,15 @@ trap 'echo "[hijoguchi] SIGTERM received, killing tmux session" >&2; "${TMUX_BIN
 
 echo "[hijoguchi] watchdog starting at $(date)" >&2
 
+# Surface the activity-tracking context to the in-session UserPromptSubmit hook
+# (scripts/hijoguchi-record-activity.sh). The marker scopes the hook to THIS
+# session, so a developer who runs `claude` in ~/claude-hub doesn't keep the
+# idle timer warm. tmux and claude inherit this environment and the hook runs
+# as a grandchild process, so the exports propagate down to it.
+export CLAUDE_HUB_HIJOGUCHI_SESSION=1
+export CLAUDE_HUB_STATE_DIR
+export LAST_MSG_TS_FILE
+
 while true; do
   # Ensure no stale session
   "${TMUX_BIN}" kill-session -t "${SESSION}" 2>/dev/null
@@ -161,9 +231,20 @@ while true; do
   fi
   echo "[hijoguchi] tmux session verified: ${SESSION}" >&2
 
-  # Block while the session exists
+  # Baseline the activity timestamp so a fresh session isn't reset before the
+  # first Discord message stamps it (Issue #110).
+  hijoguchi_write_activity_baseline
+
+  # Block while the session exists. Every HIJOGUCHI_IDLE_POLL_SEC, re-check
+  # whether the session has been idle past the reset threshold; if so, kill it
+  # so the outer loop restarts claude with a fresh context.
   while "${TMUX_BIN}" has-session -t "${SESSION}" 2>/dev/null; do
-    sleep 10
+    if [ "$(hijoguchi_idle_should_reset)" = "RESET" ]; then
+      echo "[hijoguchi] idle >= ${HIJOGUCHI_IDLE_RESET_MIN}min, resetting session for fresh context at $(date)" >&2
+      "${TMUX_BIN}" kill-session -t "${SESSION}" 2>/dev/null
+      break
+    fi
+    sleep "${HIJOGUCHI_IDLE_POLL_SEC}"
   done
 
   echo "[hijoguchi] session '${SESSION}' ended at $(date), backing off ${BACKOFF_SEC}s" >&2

--- a/scripts/test-start-hijoguchi.sh
+++ b/scripts/test-start-hijoguchi.sh
@@ -371,6 +371,20 @@ t33_hook_noop_without_marker() {
   [ ! -f "${f}" ]
 }
 
+# Launch command injects the activity-tracking env via an explicit `env` prefix
+# (not export), so it survives a pre-existing tmux server (gemini HIGH #192).
+t34_launch_cmd_has_env_prefix() {
+  HIJOGUCHI_PRINT_CMD=1 bash "${TARGET}" 2>/dev/null \
+    | grep -Eq 'env CLAUDE_HUB_HIJOGUCHI_SESSION=1 CLAUDE_HUB_STATE_DIR=.* LAST_MSG_TS_FILE='
+}
+
+# Invalid HIJOGUCHI_IDLE_POLL_SEC falls back to 10 with a warning instead of
+# spinning a busy loop (gemini MEDIUM #192).
+t35_invalid_poll_sec_falls_back() {
+  HIJOGUCHI_IDLE_POLL_SEC=abc HIJOGUCHI_PRINT_CMD=1 bash "${TARGET}" 2>&1 >/dev/null \
+    | grep -Fq "invalid HIJOGUCHI_IDLE_POLL_SEC"
+}
+
 run "T1 channel ID expanded"          t1_channel_id_expanded
 run "T2 no residual {{}} tokens"      t2_no_residual_tokens
 run "T3 env override works"           t3_env_override
@@ -404,6 +418,8 @@ run "T30 corrupt stamp keeps"         t30_corrupt_stamp_keeps
 run "T31 boundary resets"             t31_boundary_resets
 run "T32 hook writes in session"      t32_hook_writes_when_in_session
 run "T33 hook no-op without marker"   t33_hook_noop_without_marker
+run "T34 launch cmd has env prefix"   t34_launch_cmd_has_env_prefix
+run "T35 invalid poll sec falls back" t35_invalid_poll_sec_falls_back
 
 if [ "${fail}" -eq 0 ]; then
   echo "ALL TESTS PASSED"

--- a/scripts/test-start-hijoguchi.sh
+++ b/scripts/test-start-hijoguchi.sh
@@ -278,6 +278,99 @@ t25_empty_channel_id_fails() {
       bash "${TARGET}" >/dev/null 2>&1
 }
 
+# --- Issue #110: idle context reset --------------------------------------
+# The idle decision is exposed via HIJOGUCHI_IDLE_DECISION_ONLY=1, which prints
+# RESET/KEEP and exits before any tmux/claude side effect. `now` is pinned with
+# HIJOGUCHI_NOW_EPOCH so the threshold maths is fully deterministic.
+HOOK="${SCRIPT_DIR}/hijoguchi-record-activity.sh"
+
+# Stamp older than the threshold → reset the session.
+# now - last = 5000 - 1000 = 4000s (66.7min) > 3600s (60min) → RESET.
+t26_idle_past_threshold_resets() {
+  local tmp; tmp=$(mktemp)
+  # shellcheck disable=SC2064
+  trap "rm -f '${tmp}'" RETURN
+  echo 1000 > "${tmp}"
+  HIJOGUCHI_IDLE_DECISION_ONLY=1 HIJOGUCHI_IDLE_RESET_MIN=60 \
+    LAST_MSG_TS_FILE="${tmp}" HIJOGUCHI_NOW_EPOCH=5000 \
+    bash "${TARGET}" 2>/dev/null | grep -Fxq RESET
+}
+
+# Stamp within the threshold → keep the session alive.
+t27_idle_within_threshold_keeps() {
+  local tmp; tmp=$(mktemp)
+  # shellcheck disable=SC2064
+  trap "rm -f '${tmp}'" RETURN
+  echo 1000 > "${tmp}"
+  HIJOGUCHI_IDLE_DECISION_ONLY=1 HIJOGUCHI_IDLE_RESET_MIN=60 \
+    LAST_MSG_TS_FILE="${tmp}" HIJOGUCHI_NOW_EPOCH=2000 \
+    bash "${TARGET}" 2>/dev/null | grep -Fxq KEEP
+}
+
+# Threshold 0 (opt-out) → never reset, even with an ancient stamp.
+t28_optout_never_resets() {
+  local tmp; tmp=$(mktemp)
+  # shellcheck disable=SC2064
+  trap "rm -f '${tmp}'" RETURN
+  echo 1 > "${tmp}"
+  HIJOGUCHI_IDLE_DECISION_ONLY=1 HIJOGUCHI_IDLE_RESET_MIN=0 \
+    LAST_MSG_TS_FILE="${tmp}" HIJOGUCHI_NOW_EPOCH=9999999999 \
+    bash "${TARGET}" 2>/dev/null | grep -Fxq KEEP
+}
+
+# Missing state file → fail safe (keep). Happens transiently before baseline.
+t29_missing_state_keeps() {
+  HIJOGUCHI_IDLE_DECISION_ONLY=1 HIJOGUCHI_IDLE_RESET_MIN=60 \
+    LAST_MSG_TS_FILE=/nonexistent/hijoguchi/ts HIJOGUCHI_NOW_EPOCH=9999999999 \
+    bash "${TARGET}" 2>/dev/null | grep -Fxq KEEP
+}
+
+# Corrupt (non-numeric) stamp → fail safe (keep).
+t30_corrupt_stamp_keeps() {
+  local tmp; tmp=$(mktemp)
+  # shellcheck disable=SC2064
+  trap "rm -f '${tmp}'" RETURN
+  echo "not-a-number" > "${tmp}"
+  HIJOGUCHI_IDLE_DECISION_ONLY=1 HIJOGUCHI_IDLE_RESET_MIN=60 \
+    LAST_MSG_TS_FILE="${tmp}" HIJOGUCHI_NOW_EPOCH=9999999999 \
+    bash "${TARGET}" 2>/dev/null | grep -Fxq KEEP
+}
+
+# Exactly at the boundary (delta == reset_min*60) → reset (>= comparison).
+t31_boundary_resets() {
+  local tmp; tmp=$(mktemp)
+  # shellcheck disable=SC2064
+  trap "rm -f '${tmp}'" RETURN
+  echo 1000 > "${tmp}"
+  HIJOGUCHI_IDLE_DECISION_ONLY=1 HIJOGUCHI_IDLE_RESET_MIN=60 \
+    LAST_MSG_TS_FILE="${tmp}" HIJOGUCHI_NOW_EPOCH=$((1000 + 60 * 60)) \
+    bash "${TARGET}" 2>/dev/null | grep -Fxq RESET
+}
+
+# Hook stamps the activity file when running inside the hijoguchi session.
+t32_hook_writes_when_in_session() {
+  local dir; dir=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '${dir}'" RETURN
+  local f="${dir}/last-message-ts"
+  echo '{"hook_event_name":"UserPromptSubmit"}' \
+    | CLAUDE_HUB_HIJOGUCHI_SESSION=1 CLAUDE_HUB_STATE_DIR="${dir}" \
+      LAST_MSG_TS_FILE="${f}" bash "${HOOK}"
+  [ -f "${f}" ] && grep -Eq '^[0-9]+$' "${f}"
+}
+
+# Hook is a no-op (no write) outside the hijoguchi session.
+t33_hook_noop_without_marker() {
+  local dir; dir=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '${dir}'" RETURN
+  local f="${dir}/last-message-ts"
+  echo '{"hook_event_name":"UserPromptSubmit"}' \
+    | env -u CLAUDE_HUB_HIJOGUCHI_SESSION CLAUDE_HUB_STATE_DIR="${dir}" \
+      LAST_MSG_TS_FILE="${f}" bash "${HOOK}"
+  [ ! -f "${f}" ]
+}
+
 run "T1 channel ID expanded"          t1_channel_id_expanded
 run "T2 no residual {{}} tokens"      t2_no_residual_tokens
 run "T3 env override works"           t3_env_override
@@ -303,6 +396,14 @@ run "T22 unset CHANNEL_ID logs error" t22_unset_channel_id_logs_error
 run "T23 unset BOT_MENTION exits 1"   t23_unset_bot_mention_fails
 run "T24 unset BOT_MENTION logs error" t24_unset_bot_mention_logs_error
 run "T25 empty CHANNEL_ID exits 1"    t25_empty_channel_id_fails
+run "T26 idle past threshold resets"  t26_idle_past_threshold_resets
+run "T27 idle within threshold keeps" t27_idle_within_threshold_keeps
+run "T28 opt-out never resets"        t28_optout_never_resets
+run "T29 missing state keeps"         t29_missing_state_keeps
+run "T30 corrupt stamp keeps"         t30_corrupt_stamp_keeps
+run "T31 boundary resets"             t31_boundary_resets
+run "T32 hook writes in session"      t32_hook_writes_when_in_session
+run "T33 hook no-op without marker"   t33_hook_noop_without_marker
 
 if [ "${fail}" -eq 0 ]; then
   echo "ALL TESTS PASSED"


### PR DESCRIPTION
## 目的

claudeHubExit（`scripts/start-hijoguchi.sh` で launchd 起動される `claude --channels plugin:discord` の watchdog）は 1 つの長命 Claude Code session で Discord メッセージを蓄積し続け、context が無制限に膨らんで auto-compact が非決定的に発火し、その間 Discord 応答が止まる。Issue #110。

## 主な変更点

- **scripts/hijoguchi-record-activity.sh（新規）**: UserPromptSubmit hook。各受信メッセージの epoch を `~/.claude-hub-state/last-message-ts` に記録。`CLAUDE_HUB_HIJOGUCHI_SESSION=1`（watchdog が export）でスコープし、開発者の素の `claude` セッションでは no-op
- **scripts/start-hijoguchi.sh**: idle 判定 `hijoguchi_idle_should_reset`（全 non-reset パスで fail-safe KEEP）、launch 時 baseline、`HIJOGUCHI_IDLE_DECISION_ONLY` dry-run、inner watchdog ループの idle 対応（`HIJOGUCHI_IDLE_RESET_MIN` 分アイドルで `tmux kill-session` → outer ループが fresh 再起動）、session marker / state path の export
- **.claude/settings.json**: UserPromptSubmit hook 登録（公式仕様で matcher 非対応のため in-code で session スコープ gate）
- **scripts/test-start-hijoguchi.sh**: T26-T33 追加（閾値超過 / within / 境界(>=) / opt-out / missing / corrupt / hook 記録 / hook no-op）
- **com.claude-hub.hijoguchi.plist.template / docs/bot-operations.md**: `HIJOGUCHI_IDLE_RESET_MIN`（default 60、0 で opt-out）と既知制限を明記

## 設計判断（fact-check 済み）

- **案A採用**（UserPromptSubmit hook で記録）: `docs/bot-operations.md` と PR #19 実績で「このスタックで hook は発火する」を確認
- **案C不採用**（tmux capture-pane）: TUI 再描画で activity が更新され続け idle 判定が壊れる（RW-027 同型）
- UserPromptSubmit は[公式に matcher 非対応](https://code.claude.com/docs/en/hooks)（指定しても無視・全プロンプトで発火）→ in-code gate が正解

## テスト

- `bash scripts/test-start-hijoguchi.sh` → **33/33 PASS**（既存 25 + 新規 8）
- `bash scripts/test-hijoguchi-routing.sh` → **25/25 PASS**（回帰なし）
- `shellcheck scripts/start-hijoguchi.sh scripts/hijoguchi-record-activity.sh` → clean
- stub-tmux 統合テストで「idle → resetting ログ → kill-session」の配線を決定的に確認

## 統合ジャーニーAC（要本番ホスト検証）

ロジック・配線は上記で決定的に検証済み。Issue 本文の Journey AC 1〜5（live Discord メンション + launchd 再起動、AC5 は 60 分待機）は本番 claude-hub ホストでの deploy 後に手動検証が必要（この worktree では稼働中 claudeHubExit を壊さず実行不可）。

Closes #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic session reset mechanism based on idle time to prevent context buildup from long-running sessions. Idle threshold is configurable via settings.

* **Documentation**
  * Updated operational guidelines with session reset behavior and configuration details.

* **Tests**
  * Added test coverage for idle detection logic and activity tracking functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->