### PR TITLE
feat(#151): Discord素材スクショを30日保持しセッション跨ぎの消失を解消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,7 @@ jobs:
                    tests/session/output-formatter.test.ts \
                    tests/session/relay.test.ts \
                    tests/session/relay-server.test.ts \
+                   tests/session/gc-attachments.test.ts \
                    tests/session/queue-resilience.test.ts \
                    tests/session/manager-resume.test.ts \
                    tests/session/manager-liveness.test.ts \

--- a/README.md
+++ b/README.md
@@ -48,7 +48,8 @@ bun run supervisor/src/session/gc-attachments.ts
 
 # 日次自動 GC を常駐化 (04:00 実行)。logs/ が無ければ先に作成する
 mkdir -p ~/claude-hub/logs
-cp com.claude-hub.gc-attachments.plist ~/Library/LaunchAgents/
+# plist 内の /Users/YOUR_USER プレースホルダを $HOME に置換して配置する
+sed "s|/Users/YOUR_USER|$HOME|g" com.claude-hub.gc-attachments.plist > ~/Library/LaunchAgents/com.claude-hub.gc-attachments.plist
 launchctl load ~/Library/LaunchAgents/com.claude-hub.gc-attachments.plist
 
 # GC ログ確認 (削除実績の consumer)

--- a/README.md
+++ b/README.md
@@ -35,3 +35,22 @@ bun run supervisor/index.ts
 # 常駐 (launchd)
 launchctl load ~/Library/LaunchAgents/com.claude-hub.supervisor.plist
 ```
+
+## 添付ファイルの GC (Issue #151)
+
+Discord で受領した素材は `~/claude-hub/tmp/attachments` に保存され、**30 日保持**される
+（以前は relay 完了の 5 分後に削除され、セッションを跨ぐと素材が消えていた）。
+日次 GC ジョブで 30 日超のファイルのみ削除し、削除ごとに warning ログを残す。
+
+```bash
+# 手動実行 (動作確認・即時 GC)
+bun run supervisor/src/session/gc-attachments.ts
+
+# 日次自動 GC を常駐化 (04:00 実行)。logs/ が無ければ先に作成する
+mkdir -p ~/claude-hub/logs
+cp com.claude-hub.gc-attachments.plist ~/Library/LaunchAgents/
+launchctl load ~/Library/LaunchAgents/com.claude-hub.gc-attachments.plist
+
+# GC ログ確認 (削除実績の consumer)
+tail ~/claude-hub/logs/gc-attachments.stdout.log
+```

--- a/com.claude-hub.gc-attachments.plist
+++ b/com.claude-hub.gc-attachments.plist
@@ -9,26 +9,29 @@
     <!--
       Daily garbage-collection of ~/claude-hub/tmp/attachments.
       Deletes Discord attachment files older than 30 days (Issue #151, 案B).
+      Paths use a /Users/YOUR_USER placeholder; substitute $HOME on install so
+      the job works on any machine (gc-attachments.ts itself resolves paths via
+      os.homedir()).
       Install (logs/ must exist first, or launchd fails to spawn the job):
         mkdir -p ~/claude-hub/logs
-        cp com.claude-hub.gc-attachments.plist ~/Library/LaunchAgents/
+        sed "s|/Users/YOUR_USER|$HOME|g" com.claude-hub.gc-attachments.plist > ~/Library/LaunchAgents/com.claude-hub.gc-attachments.plist
         launchctl load ~/Library/LaunchAgents/com.claude-hub.gc-attachments.plist
     -->
 
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/harieshokunin/.bun/bin/bun</string>
+        <string>/Users/YOUR_USER/.bun/bin/bun</string>
         <string>run</string>
-        <string>/Users/harieshokunin/claude-hub/supervisor/src/session/gc-attachments.ts</string>
+        <string>/Users/YOUR_USER/claude-hub/supervisor/src/session/gc-attachments.ts</string>
     </array>
 
     <key>WorkingDirectory</key>
-    <string>/Users/harieshokunin/claude-hub/supervisor</string>
+    <string>/Users/YOUR_USER/claude-hub/supervisor</string>
 
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/Users/harieshokunin/.local/bin:/Users/harieshokunin/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>/Users/YOUR_USER/.local/bin:/Users/YOUR_USER/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     </dict>
 
     <!-- Run once a day at 04:00 local time. -->
@@ -41,9 +44,9 @@
     </dict>
 
     <key>StandardOutPath</key>
-    <string>/Users/harieshokunin/claude-hub/logs/gc-attachments.stdout.log</string>
+    <string>/Users/YOUR_USER/claude-hub/logs/gc-attachments.stdout.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/harieshokunin/claude-hub/logs/gc-attachments.stderr.log</string>
+    <string>/Users/YOUR_USER/claude-hub/logs/gc-attachments.stderr.log</string>
 
     <key>Nice</key>
     <integer>10</integer>

--- a/com.claude-hub.gc-attachments.plist
+++ b/com.claude-hub.gc-attachments.plist
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.claude-hub.gc-attachments</string>
+
+    <!--
+      Daily garbage-collection of ~/claude-hub/tmp/attachments.
+      Deletes Discord attachment files older than 30 days (Issue #151, 案B).
+      Install (logs/ must exist first, or launchd fails to spawn the job):
+        mkdir -p ~/claude-hub/logs
+        cp com.claude-hub.gc-attachments.plist ~/Library/LaunchAgents/
+        launchctl load ~/Library/LaunchAgents/com.claude-hub.gc-attachments.plist
+    -->
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>/Users/harieshokunin/.bun/bin/bun</string>
+        <string>run</string>
+        <string>/Users/harieshokunin/claude-hub/supervisor/src/session/gc-attachments.ts</string>
+    </array>
+
+    <key>WorkingDirectory</key>
+    <string>/Users/harieshokunin/claude-hub/supervisor</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>PATH</key>
+        <string>/Users/harieshokunin/.local/bin:/Users/harieshokunin/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+    </dict>
+
+    <!-- Run once a day at 04:00 local time. -->
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Hour</key>
+        <integer>4</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>/Users/harieshokunin/claude-hub/logs/gc-attachments.stdout.log</string>
+    <key>StandardErrorPath</key>
+    <string>/Users/harieshokunin/claude-hub/logs/gc-attachments.stderr.log</string>
+
+    <key>Nice</key>
+    <integer>10</integer>
+
+    <key>ProcessType</key>
+    <string>Background</string>
+</dict>
+</plist>

--- a/supervisor/docs/architecture.md
+++ b/supervisor/docs/architecture.md
@@ -20,6 +20,7 @@ Issue #13 で評価した 20 通り（A-T）のうち、以下の **A + B + G** 
 | 中間進捗表示 | **PostToolUse hook → HTTP POST → Supervisor `/progress`** | `hooks/progress-relay.sh` |
 | パーミッションデッドロック回避 | **PermissionRequest hook で自動承認** + Supervisor セッションは `--dangerously-skip-permissions` を常時付与（`manager.ts:130`） | `hooks/auto-approve-permission.sh` + `src/session/manager.ts` |
 | 画像添付 (Discord → Claude) | Discord 画像を `~/claude-hub/tmp/attachments` に DL → メッセージ本文先頭に `Read the image at <path>` を連結して `tmux send-keys` で注入 | `src/session/relay.ts` (`downloadAttachment` + `relayMessage`) |
+| 添付ファイルのライフサイクル | `~/claude-hub/tmp/attachments` に DL したファイルは **30 日保持**（Issue #151, 案B）。以前は relay 完了の 5 分後に削除していたためセッションを跨ぐと素材が消えていた。現在は age ベースで日次 GC するのみ（削除ごとに warning ログ）。GC: `src/session/gc-attachments.ts`（`bun run` 可）/ 日次起動: `com.claude-hub.gc-attachments.plist` | `src/session/gc-attachments.ts` |
 | ファイル添付 (Claude → Discord) | Claude の応答からファイルパスを抽出し Discord にアップロード | `src/session/file-attacher.ts` |
 
 ## メッセージフロー

--- a/supervisor/src/session/gc-attachments.ts
+++ b/supervisor/src/session/gc-attachments.ts
@@ -1,0 +1,108 @@
+import { resolve } from "path";
+import { homedir } from "os";
+import { readdirSync, statSync, unlinkSync } from "fs";
+
+/**
+ * Directory where Discord attachments are downloaded before being relayed to
+ * Claude Code. Owned here (rather than in relay.ts) because this module is the
+ * lifecycle authority for the directory: relay.ts writes into it, this module
+ * garbage-collects it. Keeping the constant here avoids a circular import
+ * (relay.ts → gc-attachments.ts, never the reverse).
+ */
+export const ATTACHMENT_DIR = resolve(homedir(), "claude-hub", "tmp", "attachments");
+
+/** Default retention: 30 days (Issue #151, 案B). */
+export const ATTACHMENT_MAX_AGE_MS = 30 * 24 * 60 * 60 * 1000;
+
+export interface GcOptions {
+  /** Directory to sweep. Defaults to {@link ATTACHMENT_DIR}. */
+  dir?: string;
+  /** Files older than this (by mtime) are deleted. Defaults to 30 days. */
+  maxAgeMs?: number;
+  /** Reference "now" in epoch ms. Injected for deterministic tests. */
+  now?: number;
+}
+
+export interface GcResult {
+  /** Absolute paths of files that were deleted. */
+  deleted: string[];
+  /** Number of files retained (younger than maxAgeMs). */
+  kept: number;
+}
+
+/**
+ * Delete attachment files older than `maxAgeMs` and log a warning for each.
+ *
+ * Replaces the previous behavior where relay.ts deleted every attachment
+ * 5 minutes after a relay completed (Issue #151): material screenshots
+ * disappeared between sessions. Files now persist and are swept only by age,
+ * so cross-session references keep working until the retention window elapses.
+ *
+ * Best-effort: a missing directory is treated as "nothing to do", and a
+ * per-file delete failure is logged but does not abort the sweep. The warning
+ * log on every deletion satisfies the silent-failure guard (AC-4 / RW-023).
+ *
+ * relay.ts only writes here (names files `${Date.now()}-<name>`); it never
+ * deletes. This GC is the sole deleter and decides purely by age, so a freshly
+ * written file is safe until the retention window elapses. If a much-older
+ * conversation still references a since-GC'd path, that is fail-open: the Read
+ * simply fails and Claude reports it — no stale-path bookkeeping is attempted.
+ */
+export function gcAttachments(options: GcOptions = {}): GcResult {
+  const dir = options.dir ?? ATTACHMENT_DIR;
+  const maxAgeMs = options.maxAgeMs ?? ATTACHMENT_MAX_AGE_MS;
+  const now = options.now ?? Date.now();
+  const cutoff = now - maxAgeMs;
+
+  const deleted: string[] = [];
+  let kept = 0;
+
+  let entries: string[];
+  try {
+    entries = readdirSync(dir);
+  } catch (err) {
+    const e = err as NodeJS.ErrnoException;
+    // Directory not yet created (no attachment ever received) is normal.
+    if (e.code !== "ENOENT") {
+      console.warn(`[gc-attachments] cannot read ${dir}: ${e.code ?? err}`);
+    }
+    return { deleted, kept };
+  }
+
+  for (const name of entries) {
+    const filePath = resolve(dir, name);
+    let mtimeMs: number;
+    try {
+      const st = statSync(filePath);
+      if (!st.isFile()) continue;
+      mtimeMs = st.mtimeMs;
+    } catch (err) {
+      console.warn(`[gc-attachments] cannot stat ${filePath}: ${err}`);
+      continue;
+    }
+
+    if (mtimeMs < cutoff) {
+      try {
+        unlinkSync(filePath);
+        const ageDays = Math.floor((now - mtimeMs) / (24 * 60 * 60 * 1000));
+        console.warn(`[gc-attachments] deleted ${filePath} (age ${ageDays}d)`);
+        deleted.push(filePath);
+      } catch (err) {
+        console.warn(`[gc-attachments] failed to delete ${filePath}: ${err}`);
+      }
+    } else {
+      kept++;
+    }
+  }
+
+  return { deleted, kept };
+}
+
+// CLI entry: `bun run src/session/gc-attachments.ts`. Run by the
+// com.claude-hub.gc-attachments launchd job (daily).
+if (import.meta.main) {
+  const result = gcAttachments();
+  console.log(
+    `[gc-attachments] done: ${result.deleted.length} deleted, ${result.kept} kept`
+  );
+}

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -1,14 +1,12 @@
 import { execFileSync } from "child_process";
 import { resolve } from "path";
-import { homedir } from "os";
-import { mkdirSync, writeFileSync, unlinkSync } from "fs";
+import { mkdirSync, writeFileSync } from "fs";
 import { waitForRelay, type RelayResult } from "./relay-server";
 import { TMUX_PATH, TMUX_ARGS } from "./tmux";
 import { createLatencyTracker } from "./latency-logger";
 import { startDialogWatchdog } from "./dialog-watchdog";
 import type { DialogMatch } from "./dialog-detect";
-
-const ATTACHMENT_DIR = resolve(homedir(), "claude-hub", "tmp", "attachments");
+import { ATTACHMENT_DIR } from "./gc-attachments";
 
 /** How long to wait for Claude Code Stop hook to fire (ms) */
 const RELAY_TIMEOUT_MS = 5 * 60_000;
@@ -225,7 +223,6 @@ export async function relayMessage(
     tracker.markEnd("b");
     tracker.setError("b");
     tracker.flush();
-    scheduleCleanup(localFiles, 5 * 60_000);
     return {
       text: "",
       chunks: [`⚠️ Claude Code へのメッセージ送信に失敗: ${err}`],
@@ -268,22 +265,10 @@ export async function relayMessage(
   }
   tracker.flush();
 
-  scheduleCleanup(localFiles, 5 * 60_000);
+  // Note: downloaded attachments are intentionally NOT deleted here. They used
+  // to be unlinked 5 minutes after each relay, which made material screenshots
+  // vanish between sessions (Issue #151). They now persist in ATTACHMENT_DIR and
+  // are swept only by age via gc-attachments (com.claude-hub.gc-attachments,
+  // daily, 30-day retention).
   return result;
-}
-
-/**
- * Schedule file cleanup after a delay.
- */
-function scheduleCleanup(files: string[], delayMs: number): void {
-  if (files.length === 0) return;
-  setTimeout(() => {
-    for (const filePath of files) {
-      try {
-        unlinkSync(filePath);
-      } catch {
-        // Ignore
-      }
-    }
-  }, delayMs);
 }

--- a/supervisor/tests/session/gc-attachments.test.ts
+++ b/supervisor/tests/session/gc-attachments.test.ts
@@ -1,0 +1,120 @@
+import { test, expect, describe, beforeEach, afterEach, spyOn } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync, utimesSync, existsSync } from "fs";
+import * as fs from "fs";
+import { resolve, isAbsolute } from "path";
+import { tmpdir } from "os";
+import {
+  gcAttachments,
+  ATTACHMENT_MAX_AGE_MS,
+  ATTACHMENT_DIR,
+} from "../../src/session/gc-attachments";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const NOW = 1_800_000_000_000; // fixed reference "now" for determinism
+
+/** Create a file and back-date its mtime to `ageMs` before NOW. */
+function makeFile(dir: string, name: string, ageMs: number): string {
+  const p = resolve(dir, name);
+  writeFileSync(p, "x");
+  const mtimeSec = (NOW - ageMs) / 1000;
+  utimesSync(p, mtimeSec, mtimeSec);
+  return p;
+}
+
+describe("gcAttachments", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(resolve(tmpdir(), "gc-attach-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("deletes files older than maxAgeMs", () => {
+    const old = makeFile(dir, "old.png", 31 * DAY_MS);
+    const result = gcAttachments({ dir, maxAgeMs: ATTACHMENT_MAX_AGE_MS, now: NOW });
+    expect(result.deleted).toContain(old);
+    expect(existsSync(old)).toBe(false);
+  });
+
+  test("keeps files younger than maxAgeMs (cross-session persistence)", () => {
+    const fresh = makeFile(dir, "fresh.png", 1 * DAY_MS);
+    const result = gcAttachments({ dir, maxAgeMs: ATTACHMENT_MAX_AGE_MS, now: NOW });
+    expect(result.kept).toBe(1);
+    expect(result.deleted).not.toContain(fresh);
+    expect(existsSync(fresh)).toBe(true);
+  });
+
+  test("boundary: exactly maxAgeMs old is kept (strictly older is deleted)", () => {
+    const exact = makeFile(dir, "exact.png", ATTACHMENT_MAX_AGE_MS);
+    const result = gcAttachments({ dir, maxAgeMs: ATTACHMENT_MAX_AGE_MS, now: NOW });
+    // mtime === cutoff is not "< cutoff", so it is retained.
+    expect(existsSync(exact)).toBe(true);
+    expect(result.kept).toBe(1);
+  });
+
+  test("mixed set: deletes only the old ones", () => {
+    makeFile(dir, "a-old.png", 40 * DAY_MS);
+    makeFile(dir, "b-old.png", 35 * DAY_MS);
+    makeFile(dir, "c-fresh.png", 2 * DAY_MS);
+    const result = gcAttachments({ dir, maxAgeMs: ATTACHMENT_MAX_AGE_MS, now: NOW });
+    expect(result.deleted.length).toBe(2);
+    expect(result.kept).toBe(1);
+  });
+
+  test("logs a warning for each deletion (silent-failure guard, AC-4)", () => {
+    makeFile(dir, "old.png", 31 * DAY_MS);
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      gcAttachments({ dir, maxAgeMs: ATTACHMENT_MAX_AGE_MS, now: NOW });
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn.mock.calls[0]?.[0]).toContain("deleted");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test("missing directory is a no-op (no throw)", () => {
+    const missing = resolve(dir, "does-not-exist");
+    const result = gcAttachments({ dir: missing, maxAgeMs: ATTACHMENT_MAX_AGE_MS, now: NOW });
+    expect(result.deleted).toEqual([]);
+    expect(result.kept).toBe(0);
+  });
+
+  test("ignores subdirectories (only sweeps files)", () => {
+    mkdirSync(resolve(dir, "subdir"));
+    const result = gcAttachments({ dir, maxAgeMs: ATTACHMENT_MAX_AGE_MS, now: NOW });
+    expect(result.deleted).toEqual([]);
+    expect(result.kept).toBe(0);
+  });
+
+  test("default ATTACHMENT_DIR is an absolute tmp/attachments path; default age is 30d", () => {
+    expect(isAbsolute(ATTACHMENT_DIR)).toBe(true);
+    expect(ATTACHMENT_DIR.endsWith("claude-hub/tmp/attachments")).toBe(true);
+    expect(ATTACHMENT_MAX_AGE_MS).toBe(30 * DAY_MS);
+  });
+
+  test("delete failure is logged and does not abort the sweep", () => {
+    makeFile(dir, "old-a.png", 31 * DAY_MS);
+    makeFile(dir, "old-b.png", 31 * DAY_MS);
+    const unlink = spyOn(fs, "unlinkSync").mockImplementation(() => {
+      throw new Error("EPERM: simulated");
+    });
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const result = gcAttachments({ dir, maxAgeMs: ATTACHMENT_MAX_AGE_MS, now: NOW });
+      // Both deletions failed → nothing recorded as deleted, sweep still completed.
+      expect(result.deleted).toEqual([]);
+      // Each failure emits a "failed to delete" warning (silent-failure guard).
+      const failedLogs = warn.mock.calls.filter((c) =>
+        String(c[0]).includes("failed to delete")
+      );
+      expect(failedLogs.length).toBe(2);
+    } finally {
+      warn.mockRestore();
+      unlink.mockRestore();
+    }
+  });
+});


### PR DESCRIPTION
## 目的

Closes #151

Discord で受領した素材スクショが **セッションを跨ぐと消失** する問題を解消する。

## 根本原因

`relay.ts` の `scheduleCleanup(localFiles, 5 * 60_000)` が添付を **relay 完了の5分後に削除** していた。セッション跨ぎどころか同一セッション内でも5分で消えていた。

## 変更点（案B: 30日TTL + 削除前ログ）

| ファイル | 変更 |
|---|---|
| `supervisor/src/session/gc-attachments.ts` (新規) | age ベースで30日超を削除する `gcAttachments()` + CLI エントリ。`ATTACHMENT_DIR` / `ATTACHMENT_MAX_AGE_MS` を所有 |
| `supervisor/src/session/relay.ts` | `scheduleCleanup` と5分削除の2呼び出しを撤廃、`ATTACHMENT_DIR` を gc-attachments から import |
| `com.claude-hub.gc-attachments.plist` (新規) | 日次04:00 GC ジョブ |
| `supervisor/docs/architecture.md` / `README.md` | ライフサイクル・インストール手順を明文化 |
| `.github/workflows/ci.yml` | `gc-attachments.test.ts` を curated list に追加 |

## AC 検証

| AC | 内容 | 結果 |
|---|---|---|
| Journey-1 | スクショ送信→tmp/attachments 保存 | PASS（downloadAttachment 不変） |
| Journey-2 | セッション跨ぎで素材が残る | PASS（5分削除撤廃、30日TTL。`keeps files younger than maxAgeMs` test） |
| Journey-3 | Read で前回素材を開ける | PASS（削除されないため） |
| AC-1 | ライフサイクル明文化 | PASS（architecture.md / README） |
| AC-2 | 保存期間決定 + cron/hook 強制 | PASS（30日 + plist 日次） |
| AC-3 | ユーザー明示の永続化経路 | 別途 #193（案B スコープ外） |
| AC-4 | 削除時 warning ログ | PASS（console.warn per deletion、test） |

## テスト

- `gc-attachments.test.ts` 9ケース（削除/保持/境界/欠如dir/サブディレクトリ除外/warningログ/削除失敗パス/絶対パス/デフォルト値）
- curated CI 全件ローカル PASS（123 pass / 3 skip / 0 fail）、`tsc --noEmit` exit 0
- CLI E2E: 520日前ファイル削除 + fresh 保持を実機確認

## レビュー反映

code-review-orchestrator の must 2件（logs/ 未作成で launchd silent fail / README 手順漏れ）と should（isAbsolute test / 削除失敗パス test）を反映済。

🤖 Generated with [Claude Code](https://claude.com/claude-code)