### PR TITLE
feat(#12): ヘッドレスセッションのダイアログstuck時にDiscord+Pushover通知を配線

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,9 @@ jobs:
                    tests/hooks/stop-relay.test.ts \
                    tests/infra/db.test.ts \
                    tests/session/dialog-detect.test.ts \
+                   tests/session/notify-pushover.test.ts \
+                   tests/session/dialog-stuck-handler.test.ts \
+                   tests/session/stall-heartbeat.test.ts \
                    tests/hijoguchi-routing/p0.test.ts \
                    tests/e2e/ac-verification.test.ts
 

--- a/scripts/repro-unknown-dialog.sh
+++ b/scripts/repro-unknown-dialog.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+# Issue #12 (Journey AC #2): reproduce an "unknown dialog" stall for manual
+# verification of the dialog-stuck heartbeat path.
+#
+# The dialog watchdog (supervisor/src/session/dialog-watchdog.ts) only fires
+# for *known* dialog families. This script starts a tmux pane (on the
+# supervisor's `-L claude-hub` socket, per CLAUDE.md) showing a prompt that
+# `detectDialog` does NOT match, then blocks forever. A relay against this
+# session never receives a Stop-hook response, so the stall timer
+# (stall-heartbeat.ts) is the only thing that pages the user.
+#
+# Usage:
+#   bash scripts/repro-unknown-dialog.sh start   # create the stuck pane
+#   bash scripts/repro-unknown-dialog.sh stop    # kill it
+#
+# After `start`, relay a message to the matching thread and confirm:
+#   - a "⚠️ Claude Code が応答待ちでブロック中" heartbeat appears in the
+#     Discord thread within the stall threshold (default 3 min), including the
+#     tmux session name printed below, and
+#   - a Pushover push arrives (if PUSHOVER_TOKEN / PUSHOVER_USER_KEY are set).
+set -euo pipefail
+
+SOCKET="${SUPERVISOR_TMUX_SOCKET:-claude-hub}"
+# Allow `start <name>` / `stop <name>`; default session name otherwise.
+ACTION="${1:-start}"
+SESSION_NAME="${2:-claude-repro-unknown-dialog}"
+
+usage() {
+  echo "Usage: $0 {start|stop} [session-name]" >&2
+  exit 2
+}
+
+case "$ACTION" in
+  start)
+    if tmux -L "$SOCKET" has-session -t "$SESSION_NAME" 2>/dev/null; then
+      echo "[repro] session '$SESSION_NAME' already exists on socket '$SOCKET'." >&2
+    else
+      # A made-up prompt that none of the DialogKind matchers recognise.
+      # `read -r` blocks forever (no stdin), so the pane never resolves.
+      tmux -L "$SOCKET" new-session -d -s "$SESSION_NAME" \
+        "printf '\\n=== UNKNOWN CUSTOM DIALOG (repro #12) ===\\nEnter the secret passphrase to continue:\\n> '; read -r _; sleep 86400"
+      echo "[repro] started stuck pane."
+    fi
+    echo "[repro] socket : $SOCKET"
+    echo "[repro] session: $SESSION_NAME"
+    echo "[repro] attach : tmux -L $SOCKET attach -t $SESSION_NAME"
+    echo "[repro] verify : relay a message to this thread; expect a stall heartbeat + Pushover."
+    ;;
+  stop)
+    if tmux -L "$SOCKET" has-session -t "$SESSION_NAME" 2>/dev/null; then
+      tmux -L "$SOCKET" kill-session -t "$SESSION_NAME"
+      echo "[repro] killed session '$SESSION_NAME'."
+    else
+      echo "[repro] no session '$SESSION_NAME' on socket '$SOCKET'." >&2
+    fi
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -14,6 +14,7 @@ import { ResourceMonitor } from "./session/resource-monitor";
 import { createSessionCommand, createSessionHandler } from "./commands/session";
 import { CHANNEL_MAP } from "./config/channels";
 import type { AttachmentInfo } from "./session/relay";
+import { buildDialogStuckHandler } from "./session/dialog-stuck-handler";
 import { updateSessionClaudeId } from "./infra/db";
 import {
   buildSalvageReply,
@@ -364,7 +365,11 @@ export async function startBot(token: string): Promise<void> {
         const result = await sessionManager.sendMessage(
           threadId,
           messageText,
-          attachments
+          attachments,
+          // Issue #12: when a dialog slips past auto-accept or the relay
+          // stalls on an unknown dialog, page the user on this thread (+
+          // best-effort Pushover) with the tmux session to attach to.
+          { onDialogStuck: buildDialogStuckHandler(thread) }
         );
 
         console.log(`[Bot] Got ${result.chunks.length} chunks, error: ${result.error ?? "none"}`);

--- a/supervisor/src/session/dialog-stuck-handler.ts
+++ b/supervisor/src/session/dialog-stuck-handler.ts
@@ -1,0 +1,113 @@
+import { notifyPushover } from "./notify-pushover";
+import { TMUX_SOCKET } from "./tmux";
+
+/**
+ * Context handed to the `onDialogStuck` callback (Issue #12).
+ *
+ * Produced by two paths inside {@link import("./relay").relayMessage}:
+ *  - the dialog watchdog, when a *known* dialog family resists auto-accept
+ *    (`kind` is the detected {@link import("./dialog-detect").DialogKind})
+ *  - the stall timer, when the relay produces no response for too long and no
+ *    known dialog matched — i.e. an *unknown* dialog (`kind: "stall"`)
+ *
+ * `tmuxSessionName` lets the heartbeat tell the user exactly which session to
+ * `tmux attach -t` to unblock manually.
+ */
+export interface DialogStuckInfo {
+  kind: string;
+  line: string;
+  tmuxSessionName: string;
+}
+
+/** Minimal slice of a discord.js ThreadChannel we depend on (keeps this unit
+ *  testable without constructing a real Discord client). */
+export interface HeartbeatThread {
+  send(content: string): Promise<unknown>;
+}
+
+export interface DialogStuckHandlerOptions {
+  /** Injectable pager — defaults to {@link notifyPushover}. */
+  pushover?: (title: string, message: string) => Promise<boolean>;
+}
+
+function buildMessage(info: DialogStuckInfo): string {
+  const label =
+    info.kind === "stall"
+      ? "応答待ちでブロック中"
+      : `ダイアログ検出 (${info.kind})、手動操作要求`;
+  return [
+    `⚠️ Claude Code が${label}です。`,
+    "tmux attach して対応してください:",
+    "```",
+    // Use the actual supervisor socket so the attach command works even when
+    // SUPERVISOR_TMUX_SOCKET is customised (TMUX_SOCKET is validated in tmux.ts).
+    `tmux -L ${TMUX_SOCKET} attach -t ${info.tmuxSessionName}`,
+    "```",
+    info.line ? `検出行: \`${info.line}\`` : "",
+  ]
+    .filter(Boolean)
+    .join("\n");
+}
+
+/**
+ * Build the `onDialogStuck` callback for a Discord thread. The returned handler
+ * posts a heartbeat to the thread *and* fires a best-effort Pushover page so a
+ * phone notification lands. Both legs are best-effort: a failure in one is
+ * logged and never prevents the other, and the handler never throws (the relay
+ * loop must not be broken by a paging error).
+ */
+export function buildDialogStuckHandler(
+  thread: HeartbeatThread,
+  options?: DialogStuckHandlerOptions
+): (info: DialogStuckInfo) => Promise<void> {
+  const pushover = options?.pushover ?? notifyPushover;
+
+  return async (info: DialogStuckInfo): Promise<void> => {
+    const message = buildMessage(info);
+
+    // Both legs run concurrently and are independently isolated: a failure in
+    // one is logged and never prevents the other, and the handler never
+    // throws (the relay loop must not break on a paging error). `.then` wraps
+    // pushover so an injected impl that throws synchronously is also caught.
+    await Promise.all([
+      thread
+        .send(message)
+        .catch((err) =>
+          console.warn("[DialogStuck] failed to post Discord heartbeat:", err)
+        ),
+      Promise.resolve()
+        .then(() =>
+          pushover(
+            "Claude Code: 手動操作要求",
+            `${info.tmuxSessionName} (${info.kind})`
+          )
+        )
+        .catch((err) =>
+          console.warn("[DialogStuck] pushover page failed:", err)
+        ),
+    ]);
+  };
+}
+
+/**
+ * Wrap an `onDialogStuck` handler so it pages at most once per relay turn.
+ *
+ * Two independent triggers feed the handler — the dialog watchdog (known
+ * dialog) and the stall timer (unknown dialog). For a persistent known dialog
+ * both would otherwise fire, double-posting to Discord and risking a Pushover
+ * rate-limit. The first call wins; later calls are dropped. Returns a no-op
+ * when `handler` is absent (the relay still logs to stderr via the watchdog).
+ */
+export function createPageOnce(
+  handler?: (info: DialogStuckInfo) => void | Promise<void>
+): (info: DialogStuckInfo) => void | Promise<void> {
+  let paged = false;
+  return (info: DialogStuckInfo) => {
+    if (paged || !handler) return;
+    paged = true;
+    return handler(info);
+  };
+}
+
+// Exported for tests.
+export const __test__ = { buildMessage };

--- a/supervisor/src/session/notify-pushover.ts
+++ b/supervisor/src/session/notify-pushover.ts
@@ -1,0 +1,86 @@
+/**
+ * Best-effort Pushover notification (Issue #12, Journey AC #2).
+ *
+ * The supervisor runs headless: when a dialog slips past
+ * `--dangerously-skip-permissions` and the relay stalls, the user is paged on
+ * Discord *and* (optionally) Pushover so a phone push lands even if Discord is
+ * backgrounded.
+ *
+ * Pushover is strictly optional and credential-gated: when
+ * `PUSHOVER_TOKEN` / `PUSHOVER_USER_KEY` are unset we log a one-line skip and
+ * return `false`. This is NOT a silent fallback — the skip is surfaced so a
+ * missing credential is observable (rules/general/agent-output-quality.md #1).
+ * Network / API errors are caught and logged; this function never throws so a
+ * paging failure can never break the relay path that calls it.
+ */
+
+const PUSHOVER_API = "https://api.pushover.net/1/messages.json";
+const PUSHOVER_TIMEOUT_MS = 10_000;
+
+export interface PushoverEnv {
+  token?: string;
+  userKey?: string;
+}
+
+function readEnv(): PushoverEnv {
+  return {
+    token: process.env.PUSHOVER_TOKEN,
+    userKey: process.env.PUSHOVER_USER_KEY,
+  };
+}
+
+/**
+ * Send a Pushover notification. Returns `true` only when the API accepted the
+ * message (`status: 1`). Returns `false` when credentials are absent or the
+ * request fails — both are logged, never thrown.
+ *
+ * `fetchImpl` and `env` are injectable for tests.
+ */
+export async function notifyPushover(
+  title: string,
+  message: string,
+  opts?: {
+    env?: PushoverEnv;
+    fetchImpl?: typeof fetch;
+  }
+): Promise<boolean> {
+  const env = opts?.env ?? readEnv();
+  const fetchImpl = opts?.fetchImpl ?? fetch;
+
+  if (!env.token || !env.userKey) {
+    console.warn(
+      "[Pushover] skipped: PUSHOVER_TOKEN / PUSHOVER_USER_KEY not set"
+    );
+    return false;
+  }
+
+  const body = new URLSearchParams({
+    token: env.token,
+    user: env.userKey,
+    title,
+    message,
+  });
+
+  try {
+    const res = await fetchImpl(PUSHOVER_API, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: body.toString(),
+      signal: AbortSignal.timeout(PUSHOVER_TIMEOUT_MS),
+    });
+    if (!res.ok) {
+      console.warn(`[Pushover] API returned HTTP ${res.status}`);
+      return false;
+    }
+    const json = (await res.json()) as { status?: number };
+    if (json.status !== 1) {
+      console.warn(`[Pushover] API status=${json.status} (expected 1)`);
+      return false;
+    }
+    return true;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`[Pushover] notification failed: ${msg}`);
+    return false;
+  }
+}

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -6,7 +6,9 @@ import { waitForRelay, type RelayResult } from "./relay-server";
 import { TMUX_PATH, TMUX_ARGS } from "./tmux";
 import { createLatencyTracker } from "./latency-logger";
 import { startDialogWatchdog } from "./dialog-watchdog";
-import type { DialogMatch } from "./dialog-detect";
+import { scheduleStallHeartbeat } from "./stall-heartbeat";
+import { createPageOnce } from "./dialog-stuck-handler";
+import type { DialogStuckInfo } from "./dialog-stuck-handler";
 
 const ATTACHMENT_DIR = resolve(homedir(), "claude-hub", "tmp", "attachments");
 
@@ -146,13 +148,17 @@ export async function tmuxSend(sessionName: string, extraArgs: string[]): Promis
 export interface RelayMessageOptions {
   attachments?: AttachmentInfo[];
   /**
-   * Called when the watchdog has exhausted its auto-accept budget for a
-   * dialog and the user must intervene manually. The callback typically
-   * posts a `ダイアログ検出: <kind>、手動操作要求` heartbeat to the
-   * Discord thread so the user knows the relay is paused. Errors thrown
-   * by the callback are caught and logged — they never block the relay.
+   * Called when the relay is stuck waiting for the user. Two triggers:
+   *  - the dialog watchdog exhausted its auto-accept budget for a *known*
+   *    dialog family (`kind` = detected DialogKind), or
+   *  - no response arrived within the stall threshold and no known dialog
+   *    matched — an *unknown* dialog (`kind: "stall"`).
+   * The callback typically posts a heartbeat to the Discord thread and pages
+   * Pushover so the user can `tmux attach`. Errors thrown by the callback are
+   * caught and logged — they never block the relay. Fired at most once per
+   * trigger per relay turn.
    */
-  onDialogStuck?: (match: DialogMatch) => void | Promise<void>;
+  onDialogStuck?: (info: DialogStuckInfo) => void | Promise<void>;
 }
 
 export async function relayMessage(
@@ -245,15 +251,44 @@ export async function relayMessage(
   // して観測する設計と一致)。
   tracker.markStart("d_e_c");
 
+  // Issue #12: page the user at most once per relay turn. Two independent
+  // triggers can fire — the watchdog (known dialog, ~10s) and the stall timer
+  // (unknown dialog, 3min). For a persistent *known* dialog both would
+  // otherwise fire, double-posting to Discord and risking a Pushover
+  // rate-limit. `createPageOnce` collapses them to a single page; the first
+  // trigger wins (the watchdog reports the precise dialog kind when it can).
+  const pageOnce = createPageOnce(options?.onDialogStuck);
+
   // Issue #57: Start the dialog watchdog *during* the wait. Stops in
   // finally so a thrown error or early return path can never leak the
-  // setInterval handle. onHeartbeat is wired through to the caller; if
-  // they didn't supply onDialogStuck we still log to stderr so the dialog
-  // surfaces in supervisor logs (the Pushover / Discord heartbeat path is
-  // the optional consumer per `rules/general/observability.md`).
+  // timer handle. The watchdog's DialogMatch is adapted to DialogStuckInfo
+  // (adding tmuxSessionName so the heartbeat can tell the user which session
+  // to `tmux attach`). If the caller supplied no onDialogStuck we still log
+  // to stderr inside the watchdog so the dialog surfaces in supervisor logs.
   const watchdog = startDialogWatchdog({
     tmuxSessionName,
-    onHeartbeat: options?.onDialogStuck,
+    onHeartbeat: options?.onDialogStuck
+      ? (match) =>
+          pageOnce({
+            kind: match.kind,
+            line: match.line,
+            tmuxSessionName,
+          })
+      : undefined,
+  });
+
+  // Issue #12 (Journey AC #2): the watchdog only fires for *known* dialog
+  // families. An unknown dialog leaves the relay waiting silently. This
+  // one-shot stall timer is the final defense — it pages the user once if no
+  // response arrives within the stall threshold, then the relay keeps waiting
+  // up to RELAY_TIMEOUT_MS. Cancelled in finally as soon as we resolve.
+  const stall = scheduleStallHeartbeat({
+    fire: () =>
+      pageOnce({
+        kind: "stall",
+        line: "no response within stall threshold",
+        tmuxSessionName,
+      }),
   });
 
   let result: RelayResult;
@@ -261,6 +296,7 @@ export async function relayMessage(
     result = await waitForRelay(threadId, RELAY_TIMEOUT_MS);
   } finally {
     watchdog.stop();
+    stall.cancel();
   }
   tracker.markEnd("d_e_c");
   if (result.error) {

--- a/supervisor/src/session/stall-heartbeat.ts
+++ b/supervisor/src/session/stall-heartbeat.ts
@@ -1,0 +1,64 @@
+/**
+ * Stall heartbeat (Issue #12, Journey AC #2).
+ *
+ * The dialog watchdog ({@link import("./dialog-watchdog").startDialogWatchdog})
+ * only fires for *known* dialog families. A truly unknown dialog — anything
+ * `detectDialog` does not match — leaves the relay waiting silently until the
+ * 5-minute relay timeout, with no notification to the user.
+ *
+ * This one-shot timer is the final defense: started alongside the watchdog, it
+ * fires `fire()` exactly once if the relay has not resolved within `delayMs`
+ * (default 3 min). The caller cancels it as soon as a response arrives, so it
+ * only fires when the session is genuinely stuck. Keeping it a separate,
+ * detection-independent timer means it covers future / unknown dialog families
+ * without coupling to Claude Code's churning TUI (RW-027).
+ */
+
+// MUST stay below RELAY_TIMEOUT_MS in relay.ts (5 min): the stall heartbeat
+// has to fire *while* the relay is still waiting, otherwise the relay times
+// out first and the heartbeat never pages.
+export const DEFAULT_STALL_DELAY_MS = 3 * 60_000;
+
+export interface StallHeartbeat {
+  /** Cancel the pending heartbeat. Idempotent. Safe after it has fired. */
+  cancel(): void;
+}
+
+/**
+ * Schedule a one-shot stall heartbeat. `fire` runs at most once. Errors thrown
+ * by `fire` are caught and logged so a paging failure cannot crash the relay.
+ */
+export function scheduleStallHeartbeat(opts: {
+  delayMs?: number;
+  fire: () => void | Promise<void>;
+}): StallHeartbeat {
+  const delayMs = opts.delayMs ?? DEFAULT_STALL_DELAY_MS;
+  let fired = false;
+
+  const timer = setTimeout(() => {
+    if (fired) return;
+    fired = true;
+    try {
+      const r = opts.fire();
+      if (r instanceof Promise) {
+        r.catch((err) =>
+          console.warn("[StallHeartbeat] fire() rejected:", err)
+        );
+      }
+    } catch (err) {
+      console.warn("[StallHeartbeat] fire() threw:", err);
+    }
+  }, delayMs);
+
+  // Don't keep the event loop alive solely for this timer.
+  if (typeof timer === "object" && timer && "unref" in timer) {
+    (timer as { unref: () => void }).unref();
+  }
+
+  return {
+    cancel(): void {
+      fired = true;
+      clearTimeout(timer);
+    },
+  };
+}

--- a/supervisor/tests/session/dialog-stuck-handler.test.ts
+++ b/supervisor/tests/session/dialog-stuck-handler.test.ts
@@ -1,0 +1,113 @@
+import { test, expect, describe, mock } from "bun:test";
+import {
+  buildDialogStuckHandler,
+  createPageOnce,
+  type DialogStuckInfo,
+} from "../../src/session/dialog-stuck-handler";
+
+function makeThread() {
+  const sent: string[] = [];
+  return {
+    sent,
+    send: async (content: string) => {
+      sent.push(content);
+    },
+  };
+}
+
+describe("buildDialogStuckHandler", () => {
+  test("posts a heartbeat with tmux session name + kind for known dialogs", async () => {
+    const thread = makeThread();
+    const pushover = mock(async () => true);
+    const handler = buildDialogStuckHandler(thread, { pushover });
+
+    const info: DialogStuckInfo = {
+      kind: "ink-confirm",
+      line: "Do you want to proceed?",
+      tmuxSessionName: "claude-abc123",
+    };
+    await handler(info);
+
+    expect(thread.sent).toHaveLength(1);
+    const msg = thread.sent[0]!;
+    expect(msg).toContain("claude-abc123");
+    expect(msg).toContain("tmux -L claude-hub attach -t claude-abc123");
+    expect(msg).toContain("ink-confirm");
+    expect(pushover).toHaveBeenCalledTimes(1);
+  });
+
+  test("uses 'ブロック中' phrasing for stall (unknown dialog)", async () => {
+    const thread = makeThread();
+    const pushover = mock(async () => true);
+    const handler = buildDialogStuckHandler(thread, { pushover });
+
+    await handler({
+      kind: "stall",
+      line: "",
+      tmuxSessionName: "claude-stall1",
+    });
+
+    expect(thread.sent[0]!).toContain("応答待ちでブロック中");
+    expect(thread.sent[0]!).toContain("claude-stall1");
+    expect(pushover).toHaveBeenCalledTimes(1);
+  });
+
+  test("still pages Pushover when Discord thread.send throws", async () => {
+    const pushover = mock(async () => true);
+    const throwingThread = {
+      send: async () => {
+        throw new Error("discord 500");
+      },
+    };
+    const handler = buildDialogStuckHandler(throwingThread, { pushover });
+
+    // must not throw
+    await handler({ kind: "stall", line: "", tmuxSessionName: "claude-x" });
+    expect(pushover).toHaveBeenCalledTimes(1);
+  });
+
+  test("still posts to Discord when pushover throws", async () => {
+    const thread = makeThread();
+    const pushover = mock(async () => {
+      throw new Error("pushover boom");
+    });
+    const handler = buildDialogStuckHandler(thread, { pushover });
+
+    await handler({ kind: "bash-yn", line: "(y/n)", tmuxSessionName: "claude-y" });
+    expect(thread.sent).toHaveLength(1);
+  });
+});
+
+describe("createPageOnce", () => {
+  const info = (kind: string): DialogStuckInfo => ({
+    kind,
+    line: "",
+    tmuxSessionName: "claude-z",
+  });
+
+  test("pages only on the first trigger (watchdog then stall)", async () => {
+    const calls: string[] = [];
+    const pageOnce = createPageOnce((i) => void calls.push(i.kind));
+
+    await pageOnce(info("ink-confirm")); // watchdog wins
+    await pageOnce(info("stall")); // stall suppressed
+    await pageOnce(info("stall"));
+
+    expect(calls).toEqual(["ink-confirm"]);
+  });
+
+  test("forwards the handler's promise on the first call", async () => {
+    let resolved = false;
+    const pageOnce = createPageOnce(async () => {
+      await new Promise((r) => setTimeout(r, 5));
+      resolved = true;
+    });
+    await pageOnce(info("stall"));
+    expect(resolved).toBe(true);
+  });
+
+  test("is a safe no-op when no handler is supplied", () => {
+    const pageOnce = createPageOnce(undefined);
+    expect(pageOnce(info("stall"))).toBeUndefined();
+  });
+});

--- a/supervisor/tests/session/notify-pushover.test.ts
+++ b/supervisor/tests/session/notify-pushover.test.ts
@@ -1,0 +1,76 @@
+import { test, expect, describe, mock } from "bun:test";
+import { notifyPushover } from "../../src/session/notify-pushover";
+
+describe("notifyPushover", () => {
+  test("skips (returns false) when credentials are unset", async () => {
+    const fetchSpy = mock(async () => new Response("{}"));
+    const ok = await notifyPushover("title", "msg", {
+      env: {},
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+    expect(ok).toBe(false);
+    expect(fetchSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test("skips when only token is set (no user key)", async () => {
+    const fetchSpy = mock(async () => new Response("{}"));
+    const ok = await notifyPushover("t", "m", {
+      env: { token: "tok" },
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+    expect(ok).toBe(false);
+    expect(fetchSpy).toHaveBeenCalledTimes(0);
+  });
+
+  test("POSTs to Pushover and returns true on status:1", async () => {
+    let capturedUrl = "";
+    let capturedBody = "";
+    const fetchSpy = mock(async (url: string, init: RequestInit) => {
+      capturedUrl = url;
+      capturedBody = String(init.body);
+      return new Response(JSON.stringify({ status: 1 }), { status: 200 });
+    });
+    const ok = await notifyPushover("Dialog stuck", "tmux attach -t claude-x", {
+      env: { token: "tok123", userKey: "usr456" },
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+    expect(ok).toBe(true);
+    expect(capturedUrl).toContain("api.pushover.net");
+    expect(capturedBody).toContain("token=tok123");
+    expect(capturedBody).toContain("user=usr456");
+    expect(capturedBody).toContain("Dialog+stuck");
+  });
+
+  test("returns false on non-ok HTTP", async () => {
+    const fetchSpy = mock(
+      async () => new Response("nope", { status: 500 })
+    );
+    const ok = await notifyPushover("t", "m", {
+      env: { token: "tok", userKey: "usr" },
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+    expect(ok).toBe(false);
+  });
+
+  test("returns false (never throws) when fetch rejects", async () => {
+    const fetchSpy = mock(async () => {
+      throw new Error("network down");
+    });
+    const ok = await notifyPushover("t", "m", {
+      env: { token: "tok", userKey: "usr" },
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+    expect(ok).toBe(false);
+  });
+
+  test("returns false when API status is not 1", async () => {
+    const fetchSpy = mock(
+      async () => new Response(JSON.stringify({ status: 0 }), { status: 200 })
+    );
+    const ok = await notifyPushover("t", "m", {
+      env: { token: "tok", userKey: "usr" },
+      fetchImpl: fetchSpy as unknown as typeof fetch,
+    });
+    expect(ok).toBe(false);
+  });
+});

--- a/supervisor/tests/session/stall-heartbeat.test.ts
+++ b/supervisor/tests/session/stall-heartbeat.test.ts
@@ -1,0 +1,44 @@
+import { test, expect, describe } from "bun:test";
+import { scheduleStallHeartbeat } from "../../src/session/stall-heartbeat";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("scheduleStallHeartbeat", () => {
+  test("fires once after the delay elapses", async () => {
+    let fired = 0;
+    scheduleStallHeartbeat({ delayMs: 20, fire: () => void fired++ });
+    await sleep(60);
+    expect(fired).toBe(1);
+  });
+
+  test("does not fire when cancelled before the delay", async () => {
+    let fired = 0;
+    const hb = scheduleStallHeartbeat({ delayMs: 30, fire: () => void fired++ });
+    await sleep(5);
+    hb.cancel();
+    await sleep(50);
+    expect(fired).toBe(0);
+  });
+
+  test("cancel is idempotent and safe after firing", async () => {
+    let fired = 0;
+    const hb = scheduleStallHeartbeat({ delayMs: 10, fire: () => void fired++ });
+    await sleep(30);
+    expect(fired).toBe(1);
+    hb.cancel();
+    hb.cancel();
+    await sleep(20);
+    expect(fired).toBe(1);
+  });
+
+  test("does not throw when fire() rejects", async () => {
+    scheduleStallHeartbeat({
+      delayMs: 10,
+      fire: async () => {
+        throw new Error("page failed");
+      },
+    });
+    await sleep(40); // would surface an unhandled rejection if not caught
+    expect(true).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要

#12「ヘッドレスセッションの全ダイアログ対策（フォールバック戦略）」の残課題を実装。Phase 1 (AskUserQuestion 中継, #142) と watchdog (#57/#143) は merge 済みだったが、**`bot.ts` が `onDialogStuck` を一切渡しておらず watchdog の heartbeat が Discord に届いていなかった**。さらに**未知ダイアログ（detectDialog が null を返す）には通知経路が皆無**だった（5 分の relay timeout まで無言）。

## Check（着手前の状態）

| AC | 状態 |
|---|---|
| AskUserQuestion → Discord 中継 | ✅ 済 (#142) |
| ユーザー回答が Claude に伝達 | ✅ 済 |
| 全hookすり抜けダイアログで Discord 警告通知 | ❌ bot.ts 未配線 + 未知ダイアログ非対応 |
| 通常セッションで挙動不変 | ✅ 済 |

## 主な変更点

- **notify-pushover.ts**: 認証情報（PUSHOVER_TOKEN / PUSHOVER_USER_KEY）ゲート付き best-effort Pushover。未設定時は skip を warn ログ（silent fallback ではない）、ネットワーク/API エラーは catch して never throw。
- **dialog-stuck-handler.ts**: `buildDialogStuckHandler(thread)` が Discord に heartbeat（tmux session 名 + 種別 + attach コマンド）を投稿し Pushover をページ。両者は独立 isolate（一方の失敗が他方を止めない、handler は never throw）。`createPageOnce` で 1 relay turn あたり 1 回に集約（watchdog と stall timer の二重ページ防止）。
- **stall-heartbeat.ts**: 未知ダイアログ向けの 3 分 one-shot stall timer（RELAY_TIMEOUT_MS=5分 より前に発火）。watchdog が検出できない families への最終防衛線。
- **relay.ts**: watchdog の DialogMatch を `DialogStuckInfo{kind,line,tmuxSessionName}` に適合、stall timer を追加、finally で watchdog + stall を両方 cancel。
- **bot.ts**: `{ onDialogStuck: buildDialogStuckHandler(thread) }` を sendMessage に供給。
- **scripts/repro-unknown-dialog.sh**: Journey AC #2 の未知ダイアログ再現スクリプト（-L claude-hub socket 準拠）。
- **ci.yml**: 新規 3 テストファイルを curated list に追加。

## レビュー対応（code-review-orchestrator）

- must: watchdog + stall timer の二重ページ → `createPageOnce` で集約（単体テスト付き）
- must: heartbeat メッセージの `tmux -L claude-hub` ハードコード → `TMUX_SOCKET`（検証済み env）から動的生成
- should: `DEFAULT_STALL_DELAY_MS < RELAY_TIMEOUT_MS` の制約コメント追加
- nit: dialog-stuck-handler の error handling を整理

## 検証

決定的検証（ローカル、CI と同条件）:

```
bunx tsc --noEmit                       # exit 0
bun test (CI curated set, 16 files)     # 125 pass / 0 fail
bun scripts/check-access-policy.ts --ci # ✓ in sync
shellcheck scripts/repro-unknown-dialog.sh  # OK
```

repro スクリプトの lifecycle（start→session 生成→未知プロンプト表示→stop→kill）と `detectDialog` が当該プロンプトに対し null を返すこと（= stall timer のみ発火）を実機確認済み。

### Journey AC（手動検証手順）

#1（AskUserQuestion 中継）/ #2（stall heartbeat + Pushover）のライブ検証は実 Discord bot トークンと Pushover 認証が必要なため手動:

1. `bash scripts/repro-unknown-dialog.sh start <session>` で stuck pane を作成
2. 対応スレッドにメッセージを relay
3. 3 分以内に Discord スレッドに「応答待ちでブロック中」+ tmux session 名の heartbeat が出ること、PUSHOVER_TOKEN/PUSHOVER_USER_KEY 設定時は Pushover push が届くことを確認
4. `bash scripts/repro-unknown-dialog.sh stop <session>` で後片付け

closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ダイアログ詰まり時にDiscordスレッドとPushoverへ通知／ページングする仕組みを追加。リレー内での重複ページを抑止します。
  * リレーの遅延（スタール）検出用の一回限りの監視タイマーを実装しました。

* **Tests**
  * 上記機能向けのテストを追加し、動作とエラーハンドリングを検証しました。
  * CIのテストカバレッジ対象を拡張しました。

* **Chores**
  * 未知のダイアログ再現用の実行スクリプトを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->