### PR TITLE
feat(#200): /session compact サブコマンドを追加（他 bot の /compact 衝突回避）

### DIFF
--- a/supervisor/src/commands/session.ts
+++ b/supervisor/src/commands/session.ts
@@ -53,8 +53,26 @@ export function createSessionCommand() {
             .setDescription("復帰する claude session id（/session list で確認できる UUID）")
             .setRequired(false)
         )
+    )
+    .addSubcommand((sub) =>
+      sub
+        .setName("compact")
+        // Issue #200: namespaced under /session (claude-hub owns it) so it never
+        // collides with another bot's top-level /compact in the same guild.
+        .setDescription("このスレッドのセッションを compact（コンテキスト圧縮）")
+        .addStringOption((opt) =>
+          opt
+            .setName("intent")
+            .setDescription("圧縮時に保持したい意図（省略時は既定の意図文を付与）")
+            .setRequired(false)
+        )
     );
 }
+
+// RW-032: a bare `/compact` produces a bad compact (the model can't predict the
+// next work direction). When the user omits an intent we attach this default so
+// the summary keeps the current state and next action.
+export const DEFAULT_COMPACT_INTENT = "直近の作業状態と次アクションを保持して圧縮";
 
 export function createSessionHandler(sessionManager: SessionManager) {
   return async (interaction: ChatInputCommandInteraction) => {
@@ -76,8 +94,62 @@ export function createSessionHandler(sessionManager: SessionManager) {
       case "resume":
         await handleResume(interaction, sessionManager);
         break;
+      case "compact":
+        await handleCompact(interaction, sessionManager);
+        break;
     }
   };
+}
+
+async function handleCompact(
+  interaction: ChatInputCommandInteraction,
+  sessionManager: SessionManager
+): Promise<void> {
+  const channel = interaction.channel;
+  // compact targets the session bound to *this* thread (like /session stop), so
+  // it must run inside a session thread. Outside one, return a usage hint and
+  // never send keys (Issue #200 AC-3).
+  if (!channel || !channel.isThread()) {
+    await interaction.reply({
+      content:
+        "ℹ️ `/session compact` は稼働中セッションのスレッド内で実行してください。" +
+        "スレッドが無ければ `/session start <branch>` か `/session resume <session_id>` で開始できます。",
+      flags: 64,
+    });
+    return;
+  }
+
+  const threadId = channel.id;
+  if (!sessionManager.has(threadId)) {
+    await interaction.reply({
+      content:
+        "ℹ️ このスレッドに稼働中のセッションはありません。" +
+        "`/session start <branch>` か `/session resume <session_id>` で開始してください。",
+      flags: 64,
+    });
+    return;
+  }
+
+  // RW-032: never relay a bare /compact. Use the user's intent, or a default
+  // that preserves working state + next action.
+  const rawIntent = interaction.options.getString("intent")?.trim() ?? "";
+  const intent = rawIntent || DEFAULT_COMPACT_INTENT;
+
+  await interaction.deferReply({ flags: 64 });
+
+  try {
+    await sessionManager.compactSession(threadId, intent);
+    await interaction.editReply({
+      content: `🗜️ compact を送信しました: \`/compact ${intent}\``,
+    });
+  } catch (err) {
+    const msg = `❌ compact の送信に失敗: ${err instanceof Error ? err.message : String(err)}`;
+    if (interaction.deferred || interaction.replied) {
+      await interaction.editReply({ content: msg });
+    } else {
+      await interaction.reply({ content: msg, flags: 64 });
+    }
+  }
 }
 
 async function handleStatus(

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -19,6 +19,7 @@ import {
 } from "../infra/db";
 import {
   relayMessage,
+  sendToPane,
   type AttachmentInfo,
   type RelayResult,
   type RelayMessageOptions,
@@ -797,6 +798,46 @@ export class SessionManager {
       persistDir: session.projectDir,
       onDialogStuck: options?.onDialogStuck,
     });
+  }
+
+  /**
+   * Issue #200: relay a `/compact <intent>` into the session's TUI as a
+   * fire-and-forget send. Unlike {@link sendMessage}, this does NOT wait for a
+   * relay (Stop-hook) response: the `/compact` built-in compacts context and
+   * does not POST to the relay server, so waiting would only burn the 5-min
+   * RELAY_TIMEOUT_MS. The caller acks immediately.
+   *
+   * `intent` is always non-empty by contract (the command layer substitutes a
+   * default) — a bare `/compact` is never sent (RW-032: bad-compact prevention).
+   * Throws if the thread has no session or the tmux pane is gone, so the caller
+   * can surface a clear failure instead of silently dropping the request.
+   */
+  async compactSession(threadId: string, intent: string): Promise<void> {
+    // RW-032 made a hard invariant, not just documentation: reject an empty
+    // intent so a future caller can never relay a bare `/compact` (which
+    // produces a bad compact). The command layer always substitutes a default,
+    // so this only fires on a programming error.
+    if (!intent.trim()) {
+      throw new Error("compact intent must be non-empty (RW-032)");
+    }
+
+    const session = this.sessions.get(threadId);
+    if (!session) {
+      throw new Error(`スレッド ${threadId} にセッションが見つかりません`);
+    }
+
+    const tmuxName = this.tmuxSessionName(threadId);
+    if (!this.effects.tmux.hasSession(tmuxName)) {
+      throw new Error("tmux session dead");
+    }
+
+    session.lastActivityAt = new Date();
+    updateSessionActivity(session.id);
+
+    // Fire-and-forget. On a mid-sequence sendToPane failure the pane may be left
+    // in an indeterminate state (e.g. the Escape landed but the literal/Enter
+    // did not); the caller surfaces the throw so the user can retry.
+    await sendToPane(tmuxName, `/compact ${intent}`);
   }
 
   async stop(

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -133,6 +133,39 @@ export async function tmuxSend(sessionName: string, extraArgs: string[]): Promis
 }
 
 /**
+ * Type one line into the pane and submit it, without waiting for any relay
+ * response. This is the shared send sequence used by {@link relayMessage}
+ * (which then waits for the Stop-hook POST) and by fire-and-forget sends such
+ * as `/session compact` (Issue #200), where the TUI built-in does NOT POST a
+ * Stop-hook response — waiting would just burn RELAY_TIMEOUT_MS.
+ *
+ * Steps (mirrors what relayMessage has always relied on):
+ *   1. Exit any stuck tmux mode (copy-mode) so keys reach the app, not the
+ *      mode handler (Issue #73 — silent drop / `not in a mode`).
+ *   2. Escape to clear Ink TUI modal state (error/confirmation dialogs) that
+ *      would otherwise swallow the input (#33).
+ *   3. `send-keys -l <literal>` — argv-based, no shell, so backticks/$/quotes
+ *      can't corrupt long input.
+ *   4. A brief pause, then `C-m` (Enter) as a separate call — the Ink TUI can
+ *      drop an Enter sent in the same call as a long literal (#32).
+ *
+ * Newlines are flattened to spaces because `send-keys -l` would submit at the
+ * first newline.
+ */
+export async function sendToPane(
+  tmuxSessionName: string,
+  text: string
+): Promise<void> {
+  const literalText = text.replace(/\n/g, " ");
+  await ensurePaneNotInMode(tmuxSessionName);
+  await tmuxSend(tmuxSessionName, ["Escape"]);
+  await new Promise((r) => setTimeout(r, 50));
+  await tmuxSend(tmuxSessionName, ["-l", literalText]);
+  await new Promise((r) => setTimeout(r, 100));
+  await tmuxSend(tmuxSessionName, ["C-m"]);
+}
+
+/**
  * Send a message to Claude Code via tmux send-keys and wait for
  * the response via HTTP relay (Stop hook POST).
  *
@@ -209,37 +242,14 @@ export async function relayMessage(
   // 観測機構の失敗は relay 本来の処理を止めない (latency-logger.ts 参照)。
   const tracker = createLatencyTracker(tmuxSessionName);
 
-  // 2. Send via tmux send-keys using execFileSync (argv array, no shell).
-  // We issue the input and the submit as two separate calls:
-  //   (a) `send-keys -l <literal>` — tmux forwards the bytes verbatim.
-  //       Argv-based invocation avoids shell-escape hazards (backticks, $,
-  //       quotes, backslashes) that corrupted long messages in earlier builds.
-  //   (b) A brief delay, then `send-keys C-m` — Claude Code's ink-based TUI
-  //       occasionally drops `Enter` sent in the same call when the input is
-  //       long, leaving the message typed but un-submitted (issue #32).
-  //
-  // tmux server can transiently stall — typically right after a relay timed
-  // out — so each send-keys call is wrapped in a short retry. Total budget
-  // per call: 15s (tmuxSend covers transient lock waits without making the
-  // overall latency unbearable).
-  const literalText = fullMessage.replace(/\n/g, " ");
-
+  // 2. Send via tmux send-keys (mode exit + Escape + send-keys -l + C-m). The
+  // full sequence and its rationale (Issue #73 copy-mode, #33 modal clear, #32
+  // dropped Enter, argv-no-shell safety) live in sendToPane, shared with the
+  // fire-and-forget compact path (Issue #200).
   try {
-    // Segment (b): tmux 経路 (mode exit + Escape + send-keys -l + C-m)
+    // Segment (b): tmux 経路
     tracker.markStart("b");
-    // Exit any stuck tmux mode (copy-mode, view-mode) BEFORE any send-keys.
-    // A pane in copy-mode consumes keys as mode commands and silently drops
-    // the payload or yields `not in a mode` on the retry path (Issue #73).
-    await ensurePaneNotInMode(tmuxSessionName);
-    // Clear any modal state (error dialogs, confirmation prompts) in Claude
-    // Code's Ink TUI before sending input. Without this, text sent via
-    // send-keys silently disappears when the TUI is in a modal state (#33).
-    await tmuxSend(tmuxSessionName, ["Escape"]);
-    await new Promise((r) => setTimeout(r, 50));
-    await tmuxSend(tmuxSessionName, ["-l", literalText]);
-    // Small pause so the TUI finishes ingesting the text before Enter.
-    await new Promise((r) => setTimeout(r, 100));
-    await tmuxSend(tmuxSessionName, ["C-m"]);
+    await sendToPane(tmuxSessionName, fullMessage);
     tracker.markEnd("b");
   } catch (err) {
     tracker.markEnd("b");

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -156,7 +156,7 @@ export async function sendToPane(
   tmuxSessionName: string,
   text: string
 ): Promise<void> {
-  const literalText = text.replace(/\n/g, " ");
+  const literalText = text.replace(/[\\r\\n]+/g, " ");
   await ensurePaneNotInMode(tmuxSessionName);
   await tmuxSend(tmuxSessionName, ["Escape"]);
   await new Promise((r) => setTimeout(r, 50));

--- a/supervisor/tests/commands/session-compact.test.ts
+++ b/supervisor/tests/commands/session-compact.test.ts
@@ -1,0 +1,151 @@
+import { test, expect, describe } from "bun:test";
+import {
+  createSessionHandler,
+  DEFAULT_COMPACT_INTENT,
+} from "../../src/commands/session";
+
+/**
+ * Handler-level tests for `/session compact [intent]` (Issue #200).
+ *
+ * Mirrors session-resume.test.ts: a minimal fake ChatInputCommandInteraction
+ * exercises the real handler without a Discord gateway. The fake SessionManager
+ * records `has` lookups and `compactSession` calls so we can assert the
+ * resolution branches, the never-bare-/compact contract (RW-032), and that no
+ * keys are sent when there is no session to compact.
+ */
+
+interface ReplyRecord {
+  kind: "reply" | "editReply";
+  content?: string;
+  flags?: number;
+}
+
+function makeInteraction(opts: {
+  intent?: string | null;
+  /** false → invoked outside a thread (channel context). */
+  inThread?: boolean;
+  /** whether the thread has a running session (sessionManager.has). */
+  hasSession?: boolean;
+  /** make compactSession reject, to exercise the error branch. */
+  compactImpl?: (threadId: string, intent: string) => unknown;
+}) {
+  const replies: ReplyRecord[] = [];
+  const compactCalls: { threadId: string; intent: string }[] = [];
+  const hasCalls: string[] = [];
+
+  const inThread = opts.inThread ?? true;
+  const channel = {
+    id: "thread-compact-1",
+    isThread: () => inThread,
+  };
+
+  const interaction = {
+    options: {
+      getSubcommand: () => "compact",
+      getString: (name: string) =>
+        name === "intent" ? opts.intent ?? null : null,
+    },
+    channel,
+    deferred: false,
+    replied: false,
+    async reply(msg: { content?: string; flags?: number }) {
+      this.replied = true;
+      replies.push({ kind: "reply", content: msg.content, flags: msg.flags });
+    },
+    async deferReply(msg?: { flags?: number }) {
+      this.deferred = true;
+      // flags captured so we can assert the ack is ephemeral.
+      replies.push({ kind: "reply", flags: msg?.flags });
+    },
+    async editReply(msg: { content?: string }) {
+      replies.push({ kind: "editReply", content: msg.content });
+    },
+  };
+
+  const sessionManager = {
+    has: (threadId: string) => {
+      hasCalls.push(threadId);
+      return opts.hasSession ?? true;
+    },
+    compactSession: async (threadId: string, intent: string) => {
+      compactCalls.push({ threadId, intent });
+      return opts.compactImpl?.(threadId, intent);
+    },
+  };
+
+  return {
+    run: () =>
+      createSessionHandler(sessionManager as never)(interaction as never),
+    replies,
+    compactCalls,
+    hasCalls,
+  };
+}
+
+describe("/session compact (#200)", () => {
+  test("running session + explicit intent: relays /compact <intent>, ephemeral ack", async () => {
+    const fx = makeInteraction({ intent: "直近のリファクタと残テストを保持" });
+    await fx.run();
+
+    expect(fx.compactCalls).toHaveLength(1);
+    expect(fx.compactCalls[0]).toEqual({
+      threadId: "thread-compact-1",
+      intent: "直近のリファクタと残テストを保持",
+    });
+    // Ack must be ephemeral (flags 64) and confirm the sent text.
+    expect(fx.replies.some((r) => r.flags === 64)).toBe(true);
+    const ack = fx.replies.find((r) => r.kind === "editReply");
+    expect(ack?.content).toContain("/compact 直近のリファクタと残テストを保持");
+  });
+
+  test("intent omitted: never sends a bare /compact, substitutes the default (RW-032)", async () => {
+    const fx = makeInteraction({ intent: null });
+    await fx.run();
+
+    expect(fx.compactCalls).toHaveLength(1);
+    expect(fx.compactCalls[0]?.intent).toBe(DEFAULT_COMPACT_INTENT);
+  });
+
+  test("whitespace-only intent is treated as omitted (default substituted)", async () => {
+    const fx = makeInteraction({ intent: "   " });
+    await fx.run();
+
+    expect(fx.compactCalls[0]?.intent).toBe(DEFAULT_COMPACT_INTENT);
+  });
+
+  test("no session in thread: usage hint, no send-keys (AC-3)", async () => {
+    const fx = makeInteraction({ hasSession: false });
+    await fx.run();
+
+    expect(fx.compactCalls).toHaveLength(0);
+    const hint = fx.replies.find((r) => r.kind === "reply");
+    expect(hint?.content).toContain("稼働中のセッションはありません");
+    expect(hint?.flags).toBe(64);
+  });
+
+  test("invoked outside a thread: usage hint, no send-keys, no has() lookup (AC-3)", async () => {
+    const fx = makeInteraction({ inThread: false });
+    await fx.run();
+
+    expect(fx.compactCalls).toHaveLength(0);
+    expect(fx.hasCalls).toHaveLength(0);
+    const hint = fx.replies.find((r) => r.kind === "reply");
+    expect(hint?.content).toContain("スレッド内で実行");
+    expect(hint?.flags).toBe(64);
+  });
+
+  test("compactSession failure: reports error via editReply after defer", async () => {
+    const fx = makeInteraction({
+      compactImpl: () => {
+        throw new Error("tmux session dead");
+      },
+    });
+    await fx.run();
+
+    const err = fx.replies.find(
+      (r) => r.kind === "editReply" && r.content?.includes("失敗")
+    );
+    expect(err).toBeDefined();
+    expect(err?.content).toContain("tmux session dead");
+  });
+});

--- a/supervisor/tests/session/manager.test.ts
+++ b/supervisor/tests/session/manager.test.ts
@@ -496,3 +496,38 @@ describe("SessionManager worktree integration (#154)", () => {
     expect(manager.has("thread-inj")).toBe(false);
   });
 });
+
+/**
+ * Issue #200: compactSession invariants that short-circuit before the real
+ * tmux send (sendToPane). The happy path is covered by the command-layer test
+ * (session-compact.test.ts) and the send sequence by relay.test.ts.
+ */
+describe("SessionManager.compactSession (#200)", () => {
+  let manager: SessionManager;
+
+  beforeEach(() => {
+    manager = new SessionManager({
+      effects: createFakeEffects(),
+      gracefulKillTimeoutMs: 0,
+    });
+  });
+
+  afterEach(async () => {
+    await manager.shutdownAll();
+  });
+
+  test("empty intent throws before any send (RW-032 hard invariant)", async () => {
+    await expect(manager.compactSession("any-thread", "")).rejects.toThrow(
+      /non-empty/
+    );
+    await expect(manager.compactSession("any-thread", "   ")).rejects.toThrow(
+      /non-empty/
+    );
+  });
+
+  test("unknown thread throws (no session to compact)", async () => {
+    await expect(
+      manager.compactSession("no-such-thread", "保持して圧縮")
+    ).rejects.toThrow(/セッションが見つかりません/);
+  });
+});


### PR DESCRIPTION
## 概要

Discord で素の `/compact` を打つと、同一 guild に複数 bot が登録した application command が候補に出て **OpenClaw（openclaw-rpi5-ops）等が interaction を奪い**、対象の claude-hub セッションへ compact が届かない。claude-hub が所有する `/session` の名前空間に `compact` サブコマンドを追加することで、他 bot と衝突しない経路を提供する。

Closes #200

## 主な変更点

| File | 変更 |
|---|---|
| `supervisor/src/session/relay.ts` | `relayMessage` の送出シーケンス（mode exit → Escape → `send-keys -l` → `C-m`）を `sendToPane` として抽出。`relayMessage` はこれを呼ぶよう refactor し、fire-and-forget な compact 送出と共有 |
| `supervisor/src/session/manager.ts` | `compactSession(threadId, intent)` を追加。relay 応答待ちなしで `/compact <intent>` を pane へ送る（compact 組込みは Stop hook を POST しないため、待つと RELAY_TIMEOUT_MS=5分 を浪費する）。空 intent は RW-032 の hard invariant として拒否 |
| `supervisor/src/commands/session.ts` | `compact` サブコマンド + `handleCompact` + `DEFAULT_COMPACT_INTENT`。intent 省略時は既定意図文を付与し**裸 `/compact` は送らない**（RW-032）。スレッド外/セッション未稼働時は usage hint を返し send-keys しない |

## 設計判断

- **名前空間化で衝突回避**: `/session` は claude-hub 所有の application command なので、他 bot の top-level `/compact` と候補が割れない（issue の推奨案）。
- **fire-and-forget**: compact 組込みは relay 応答を返さないため、`sendMessage`（relayMessage）経路だと 5 分タイムアウトする。`compactSession` は send 後すぐ ack する。
- **injection 安全**: intent は `sendToPane → tmuxSend → execFileSync` の argv 経由（shell 非経由）で送るため shell injection 不可（RW-045 の教訓）。

## テスト

- `tests/commands/session-compact.test.ts`（新規 6 ケース）: intent 明示/省略/空白/未稼働/スレッド外/失敗
- `tests/session/manager.test.ts`（compactSession 2 ケース追加）: 空 intent hard invariant・未知スレッド
- `tests/session/relay.test.ts`（既存 15 PASS）: `sendToPane` への refactor で回帰なし
- `tsc --noEmit` クリーン

## 統合ジャーニーAC

| AC | 判定 |
|---|---|
| 1. 稼働スレッド + intent → ack + pane で `/compact <intent>` | PASS（handler + relay 実 tmux） |
| 2. intent 無し → 既定意図付き（裸 compact 禁止） | PASS（handler + manager invariant） |
| 3. 未稼働/スレッド外 → hint, send-keys なし | PASS |
| 4. OpenClaw `/compact` と非衝突 | 設計保証（`/session` 配下に名前空間化）。**UI 反映にはアプリケーションコマンドの再デプロイが必要** |

## デプロイ注記

新サブコマンドを Discord に反映するには、merge 後にアプリケーションコマンドの**再登録（deploy）** が必要です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features（新機能）**
  * `/session compact [intent]` サブコマンドを追加しました。intent 未指定時は既定値が使用されます。
  * スレッド内で稼働中のセッションをコンパクト化でき、成功／失敗に応じた応答が返ります。
* **Refactor（改善）**
  * セッションへの送信処理を共通化して送信の堅牢性を向上しました。
* **Tests（テスト）**
  * コンパクト機能と送信条件の包括的なテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->