### PR TITLE
feat: S7 allowFrom 実行時強制 + メッセージ起動 dispatch 実行役 + CEOハブ/readiness 修正

### DIFF
--- a/examples/access-policy.template.json
+++ b/examples/access-policy.template.json
@@ -15,5 +15,6 @@
   "agent-base": { "requireMention": true, "allowFrom": ["<owner>"] },
   "openclaw-rpi5-ops": { "requireMention": true, "allowFrom": ["<owner>"] },
   "vive-reading": { "requireMention": true, "allowFrom": ["<owner>"] },
-  "video-qa": { "requireMention": true, "allowFrom": ["<owner>"] }
+  "video-qa": { "requireMention": true, "allowFrom": ["<owner>"] },
+  "corp": { "requireMention": false, "allowFrom": ["<owner>"] }
 }

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -33,6 +33,7 @@ import {
 } from "./session/slash-prefix";
 import { ProgressBuffer } from "./session/progress-buffer";
 import { formatForDiscord } from "./session/output-formatter";
+import { evaluateAccess } from "./config/access-policy";
 
 export async function startBot(token: string): Promise<void> {
   const client = new Client({
@@ -213,6 +214,33 @@ export async function startBot(token: string): Promise<void> {
     }
 
     const threadId = message.channel.id;
+
+    // Issue #32 / S7 (Critical): enforce access.json `allowFrom` / `requireMention`
+    // BEFORE any relay or response. The relayed session runs with
+    // `--dangerously-skip-permissions`, so an un-gated message is lateral
+    // movement. Fail-closed: a missing / broken policy or an undefined channel
+    // denies. Threads inherit their parent channel's opt-in, so the policy is
+    // keyed on the parent channel id (matching the upstream channel server gate).
+    {
+      const parentChannelId = message.channel.parentId ?? threadId;
+      const botUserId = client.user?.id;
+      const isMention = botUserId
+        ? message.mentions.users.has(botUserId)
+        : false;
+      const decision = evaluateAccess({
+        channelKey: parentChannelId,
+        userId: message.author.id,
+        isMention,
+      });
+      if (!decision.allowed) {
+        // Structured, identifier-free denial log. Never log the user/channel
+        // snowflakes or message body so transcripts can't leak them.
+        console.warn(
+          `[Bot] Access denied (reason=${decision.reason}) for thread ${threadId}; message not relayed`
+        );
+        return;
+      }
+    }
 
     // No active in-memory session for this thread. Previously the bot silently
     // ignored the message (Issue #41 debug log), leaving the user staring at a

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -254,9 +254,14 @@ export async function startBot(token: string): Promise<void> {
       console.warn(
         `[Bot] Dispatch denied (reason=${decision.reason}) in channel ${channelName}; not started`
       );
-      // A disallowed bot/webhook is handled (and dropped) here so it does not
-      // fall through to the normal relay path.
-      return message.author.bot;
+      // Consume (drop) the message regardless of bot/human. By here it is a
+      // `/dispatch` in a known department channel and — per the isThread guard
+      // at the top — a non-thread message, which the normal relay path never
+      // acts on anyway. Returning a hard `true` stops it explicitly so a future
+      // refactor of the relay path below cannot let a denied source reach the
+      // privileged session start. (Was `return message.author.bot`: correct but
+      // fragile — both review lenses flagged the implicit semantics.)
+      return true;
     }
 
     const parsed = parseDispatchCommand(content);

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -7,12 +7,13 @@ import {
   type Interaction,
   type Message,
   type ThreadChannel,
+  type TextChannel,
 } from "discord.js";
 import { SessionManager } from "./session/manager";
 import { Reaper } from "./session/reaper";
 import { ResourceMonitor } from "./session/resource-monitor";
 import { createSessionCommand, createSessionHandler } from "./commands/session";
-import { CHANNEL_MAP } from "./config/channels";
+import { CHANNEL_MAP, MAX_SESSIONS } from "./config/channels";
 import type { AttachmentInfo } from "./session/relay";
 import { buildDialogStuckHandler } from "./session/dialog-stuck-handler";
 import { updateSessionClaudeId } from "./infra/db";
@@ -33,7 +34,17 @@ import {
 } from "./session/slash-prefix";
 import { ProgressBuffer } from "./session/progress-buffer";
 import { formatForDiscord } from "./session/output-formatter";
-import { evaluateAccess } from "./config/access-policy";
+import {
+  evaluateAccess,
+  isDispatchSourceAllowed,
+  loadAccessPolicy,
+} from "./config/access-policy";
+import {
+  DISPATCH_PREFIX,
+  parseDispatchCommand,
+  runDispatch,
+} from "./session/dispatch";
+import { buildThreadTitle } from "./session/thread-title";
 
 export async function startBot(token: string): Promise<void> {
   const client = new Client({
@@ -198,8 +209,136 @@ export async function startBot(token: string): Promise<void> {
     });
   });
 
+  // Issue #32 / S7 (dispatch transport): handle a `/dispatch <branch> <issue>`
+  // message from an allowed external source (webhook / bot). Returns true when
+  // the message was a dispatch attempt and was fully handled (caller must stop),
+  // false when it is not a dispatch and normal processing should continue.
+  //
+  // This is the ONLY exception to the blanket `message.author.bot` drop, and it
+  // is fail-closed at every step: the channel must be a known department channel
+  // AND configured in the access policy, the source must be enumerated in
+  // `dispatchFrom` / `DISPATCH_ALLOWED_SOURCE_IDS`, the branch passes the RW-045
+  // metachar / traversal guard, and the issue number must be a positive integer.
+  async function handleDispatchMessage(message: Message): Promise<boolean> {
+    // Dispatch only applies to a non-thread message in a known department
+    // channel whose text starts with the dispatch token.
+    if (message.channel.isThread()) return false;
+    const content = message.content ?? "";
+    if (
+      content.trim() !== DISPATCH_PREFIX &&
+      !content.trim().startsWith(DISPATCH_PREFIX + " ")
+    ) {
+      return false;
+    }
+
+    const channelName =
+      "name" in message.channel ? (message.channel.name as string) : "";
+    const config = CHANNEL_MAP.get(channelName);
+    if (!config) {
+      // Unknown channel: not a valid dispatch target. Treat as "not handled"
+      // so a non-bot author still flows through normal processing; a bot author
+      // is dropped by the caller's bot guard.
+      return false;
+    }
+    const channelId = message.channel.id;
+
+    // Authorize the SOURCE (webhook / bot id). Fail-closed.
+    const decision = isDispatchSourceAllowed(
+      loadAccessPolicy(),
+      channelId,
+      message.author.id,
+    );
+    if (!decision.allowed) {
+      // Identifier-free denial log; never log the source/channel snowflake or
+      // the message body.
+      console.warn(
+        `[Bot] Dispatch denied (reason=${decision.reason}) in channel ${channelName}; not started`
+      );
+      // A disallowed bot/webhook is handled (and dropped) here so it does not
+      // fall through to the normal relay path.
+      return message.author.bot;
+    }
+
+    const parsed = parseDispatchCommand(content);
+    if (parsed.kind === "not_dispatch") {
+      return false;
+    }
+    if (parsed.kind === "error") {
+      console.warn(
+        `[Bot] Dispatch rejected (${parsed.reason}) in channel ${channelName}`
+      );
+      return true;
+    }
+
+    const { branch, issueNumber } = parsed;
+    console.log(
+      `[Bot] Dispatch accepted in channel ${channelName} (branch len=${branch.length}, issue=${issueNumber})`
+    );
+
+    const textChannel = message.channel as TextChannel;
+    const result = await runDispatch({
+      config,
+      branch,
+      issueNumber,
+      sessionManager,
+      createThread: async (b: string) => {
+        // Sequence suffix only when another session is already live on the same
+        // branch (mirrors handleStart / RW-046 same-branch multi-session).
+        const sameBranchCount = sessionManager
+          .listRunningByChannel(channelName)
+          .filter((s) => s.branch === b).length;
+        const threadName = buildThreadTitle(
+          "running",
+          b,
+          config.displayName,
+          sameBranchCount + 1
+        );
+        const thread = await textChannel.threads.create({
+          name: threadName,
+          autoArchiveDuration: 10080, // 7 days
+        });
+        return { id: thread.id };
+      },
+    });
+
+    if (result.ok) {
+      try {
+        const thread = await client.channels.fetch(result.threadId);
+        if (thread?.isThread()) {
+          await thread.send(
+            `🛰️ **${config.displayName}** をディスパッチで起動しました\n\n` +
+              `🌿 ブランチ: \`${branch}\`\n` +
+              `▶️ 初期コマンド: \`${result.injected}\`\n` +
+              `📊 稼働中セッション: ${sessionManager.count()}/${MAX_SESSIONS}`
+          );
+        }
+      } catch (err) {
+        console.error(
+          `[Bot] Dispatch welcome message failed for thread ${result.threadId}:`,
+          err
+        );
+      }
+    } else {
+      console.error(
+        `[Bot] Dispatch failed (stage=${result.stage}) in channel ${channelName}: ${result.error}`
+      );
+    }
+    return true;
+  }
+
   // Message relay: thread messages → Claude Code → thread reply
   client.on(Events.MessageCreate, async (message: Message) => {
+    // Issue #32 / S7 (dispatch transport): intercept `/dispatch` from an allowed
+    // external source BEFORE the blanket bot/webhook drop below. Only an
+    // authorized source on a known, policy-configured channel can start a
+    // session this way (fail-closed inside handleDispatchMessage).
+    try {
+      if (await handleDispatchMessage(message)) return;
+    } catch (err) {
+      console.error("[Bot] Dispatch handler error:", err);
+      return;
+    }
+
     if (message.author.bot) return;
 
     // Only handle messages in threads

--- a/supervisor/src/commands/session.ts
+++ b/supervisor/src/commands/session.ts
@@ -9,6 +9,7 @@ import type { SessionManager } from "../session/manager";
 import { CHANNEL_MAP, MAX_SESSIONS } from "../config/channels";
 import { buildThreadTitle, markTitleStopped } from "../session/thread-title";
 import { buildStatusReply } from "../session/status-reply";
+import { evaluateAccess } from "../config/access-policy";
 
 export function createSessionCommand() {
   return new SlashCommandBuilder()
@@ -129,6 +130,36 @@ async function handleStart(
       flags: 64,
     });
     return;
+  }
+
+  // Issue #32 / S7 (Critical): enforce access.json `allowFrom` BEFORE starting a
+  // session. `/session start` spawns a Claude process running with
+  // `--dangerously-skip-permissions`, so an un-gated start is privilege
+  // escalation. Fail-closed: missing/broken policy or an undefined channel
+  // denies. A slash command is an explicit, structured invocation by the user,
+  // so the mention requirement is satisfied — the decisive gate is the per-
+  // channel `allowFrom` allowlist. Policy is keyed on the parent channel id
+  // (threads inherit their parent's opt-in).
+  {
+    const parentChannelId =
+      channel.isThread() && channel.parentId ? channel.parentId : channel.id;
+    const decision = evaluateAccess({
+      channelKey: parentChannelId,
+      userId: interaction.user.id,
+      isMention: true,
+    });
+    if (!decision.allowed) {
+      // Identifier-free denial log; user-facing message stays generic.
+      console.warn(
+        `[Session] /session start access denied (reason=${decision.reason}) in channel ${channelName}`
+      );
+      await interaction.reply({
+        content:
+          "❌ このチャンネルでセッションを開始する権限がありません（アクセスポリシー）。",
+        flags: 64,
+      });
+      return;
+    }
   }
 
   // Issue #154 (Q6): branch is required; only an empty/whitespace value is

--- a/supervisor/src/config/access-policy.ts
+++ b/supervisor/src/config/access-policy.ts
@@ -42,6 +42,15 @@ export interface GroupPolicy {
    * (still subject to `requireMention`).
    */
   allowFrom?: string[];
+  /**
+   * Source snowflakes (webhook / bot ids) allowed to trigger a session via a
+   * `/dispatch` message on this channel. Issue #32 / S7 dispatch transport.
+   *
+   * UNLIKE `allowFrom`, an empty / absent `dispatchFrom` means "no dispatch
+   * source" (fail-closed) — never "any source". Dispatch starts a privileged
+   * session, so it must be explicitly enumerated.
+   */
+  dispatchFrom?: string[];
 }
 
 /** Minimal shape of access.json needed for runtime relay gating. */
@@ -109,6 +118,69 @@ export function isSenderAllowed(
   }
 
   return { allowed: true, reason: "allowed" };
+}
+
+/** Coarse, non-identifying dispatch-source reasons (safe to log). */
+export type DispatchDecisionReason =
+  | "allowed"
+  | "policy_unavailable"
+  | "channel_not_configured"
+  | "source_not_allowlisted";
+
+export interface DispatchDecision {
+  allowed: boolean;
+  reason: DispatchDecisionReason;
+}
+
+/**
+ * Read the optional global dispatch-source allowlist from the
+ * `DISPATCH_ALLOWED_SOURCE_IDS` env var (comma-separated snowflakes). Returns
+ * an empty array when unset / empty. This complements per-channel
+ * `dispatchFrom` but never bypasses the "channel must be configured" gate.
+ */
+export function envDispatchAllowedSourceIds(): string[] {
+  const raw = process.env.DISPATCH_ALLOWED_SOURCE_IDS;
+  if (!raw) return [];
+  return raw
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Decide whether an external source (webhook / bot snowflake) may trigger a
+ * `/dispatch` on `channelKey`. Fail-closed:
+ *
+ *   1. policy unavailable                         -> DENY
+ *   2. channel not present in `groups`            -> DENY
+ *   3. source not in `dispatchFrom` AND not in env allowlist -> DENY
+ *   4. otherwise                                  -> ALLOW
+ *
+ * An empty / absent `dispatchFrom` is NOT "any source" — it denies. This is the
+ * sole exception to the blanket bot/webhook drop, so it is enumerated only.
+ * Never throws. Reasons are coarse enums (no raw ids).
+ */
+export function isDispatchSourceAllowed(
+  policy: AccessPolicy | null | undefined,
+  channelKey: string,
+  sourceId: string,
+  envAllowed: string[] = envDispatchAllowedSourceIds(),
+): DispatchDecision {
+  if (!policy || typeof policy !== "object") {
+    return { allowed: false, reason: "policy_unavailable" };
+  }
+
+  const group = policy.groups?.[channelKey];
+  if (!group) {
+    return { allowed: false, reason: "channel_not_configured" };
+  }
+
+  const channelDispatch = group.dispatchFrom ?? [];
+  if (channelDispatch.includes(sourceId) || envAllowed.includes(sourceId)) {
+    return { allowed: true, reason: "allowed" };
+  }
+
+  return { allowed: false, reason: "source_not_allowlisted" };
 }
 
 /**

--- a/supervisor/src/config/access-policy.ts
+++ b/supervisor/src/config/access-policy.ts
@@ -1,0 +1,167 @@
+/**
+ * Runtime enforcement of the Discord access policy (`~/.claude/channels/
+ * discord/access.json`). Issue #32 / S7 (Critical).
+ *
+ * The supervisor relays Discord messages into Claude sessions that run with
+ * `--dangerously-skip-permissions`. Before this module, the relay path
+ * (`bot.ts` MessageCreate, `real-client.ts` MessageCreate, `commands/session.ts`
+ * `handleStart`) never consulted `access.json`, so any user able to post in a
+ * watched channel could drive a privileged Claude session (lateral movement).
+ *
+ * This module provides the **fail-closed** gate that those call sites evaluate
+ * BEFORE relaying. The decision logic mirrors the upstream discord plugin's
+ * `gate()` group path (claude-plugins-official/external_plugins/discord/
+ * server.ts) so the supervisor and the channel server agree on who is allowed:
+ *
+ *   1. policy unavailable (missing / unparsable file)  -> DENY
+ *   2. channel not present in `groups`                 -> DENY
+ *   3. `groupAllowFrom` non-empty and sender absent    -> DENY
+ *   4. `requireMention` (default true) and not mentioned -> DENY
+ *   5. otherwise                                       -> ALLOW
+ *
+ * An empty `groupAllowFrom` means "any member of this channel" (subject to
+ * `requireMention`), matching upstream and preserving the claudeHubExit primary
+ * entry (`requireMention:false, allowFrom:[]`). The fail-closed default applies
+ * only to *undefined* channels and *unavailable* policy — never silently
+ * widening access.
+ *
+ * Reasons are coarse enum strings, never the raw user/channel snowflakes, so
+ * structured denial logs cannot leak identifiers into transcripts.
+ */
+
+import { readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+/** Per-channel policy entry (keyed by Discord channel snowflake under `groups`). */
+export interface GroupPolicy {
+  /** When true (the default), the bot only acts on @mentions / replies. */
+  requireMention?: boolean;
+  /**
+   * Sender snowflakes allowed to trigger this channel. Empty = any member
+   * (still subject to `requireMention`).
+   */
+  allowFrom?: string[];
+}
+
+/** Minimal shape of access.json needed for runtime relay gating. */
+export interface AccessPolicy {
+  groups?: Record<string, GroupPolicy>;
+  // Other keys (dmPolicy, allowFrom, pending, mentionPatterns, delivery config)
+  // are intentionally not modeled here — relay gating only needs `groups`.
+}
+
+/** Coarse, non-identifying denial/allow reasons (safe to log). */
+export type AccessDecisionReason =
+  | "allowed"
+  | "policy_unavailable"
+  | "channel_not_configured"
+  | "sender_not_allowlisted"
+  | "mention_required";
+
+export interface AccessDecision {
+  allowed: boolean;
+  reason: AccessDecisionReason;
+}
+
+/**
+ * Canonical location of the live access policy. Overridable via
+ * `SUPERVISOR_ACCESS_JSON_PATH` for tests and alternate deployments. Matches
+ * `scripts/check-access-policy.ts` (`~/.claude/channels/discord/access.json`).
+ */
+export function defaultAccessJsonPath(): string {
+  return (
+    process.env.SUPERVISOR_ACCESS_JSON_PATH ??
+    join(homedir(), ".claude", "channels", "discord", "access.json")
+  );
+}
+
+/**
+ * Pure decision function. `policy` may be `null` (unavailable) — that is an
+ * explicit DENY (fail-closed), not an error. Never throws.
+ */
+export function isSenderAllowed(
+  policy: AccessPolicy | null | undefined,
+  channelKey: string,
+  userId: string,
+  isMention: boolean,
+): AccessDecision {
+  if (!policy || typeof policy !== "object") {
+    return { allowed: false, reason: "policy_unavailable" };
+  }
+
+  const group = policy.groups?.[channelKey];
+  if (!group) {
+    // Channel not opted in (or no groups at all) -> fail-closed DENY.
+    return { allowed: false, reason: "channel_not_configured" };
+  }
+
+  const groupAllowFrom = group.allowFrom ?? [];
+  // Default requireMention to true (upstream default + fail-closed bias).
+  const requireMention = group.requireMention ?? true;
+
+  if (groupAllowFrom.length > 0 && !groupAllowFrom.includes(userId)) {
+    return { allowed: false, reason: "sender_not_allowlisted" };
+  }
+
+  if (requireMention && !isMention) {
+    return { allowed: false, reason: "mention_required" };
+  }
+
+  return { allowed: true, reason: "allowed" };
+}
+
+/**
+ * Load and parse the access policy. Returns `null` when the file is missing,
+ * unreadable, not valid JSON, or not a JSON object. A `null` return is the
+ * fail-closed signal — callers must DENY. Never throws.
+ */
+export function loadAccessPolicy(
+  path: string = defaultAccessJsonPath(),
+): AccessPolicy | null {
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8");
+  } catch {
+    // Missing or unreadable file: fail-closed (no relay).
+    return null;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Corrupt JSON: fail-closed rather than guessing intent.
+    return null;
+  }
+
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return null;
+  }
+
+  return parsed as AccessPolicy;
+}
+
+export interface AccessQuery {
+  channelKey: string;
+  userId: string;
+  isMention: boolean;
+}
+
+/**
+ * Load the policy from disk and evaluate it in one call. This is the function
+ * the runtime relay call sites use. Fail-closed: a `null` policy (missing /
+ * broken file) yields `{ allowed: false, reason: "policy_unavailable" }`.
+ */
+export function evaluateAccess(
+  query: AccessQuery,
+  path: string = defaultAccessJsonPath(),
+): AccessDecision {
+  const policy = loadAccessPolicy(path);
+  return isSenderAllowed(
+    policy,
+    query.channelKey,
+    query.userId,
+    query.isMention,
+  );
+}

--- a/supervisor/src/config/channels.ts
+++ b/supervisor/src/config/channels.ts
@@ -33,6 +33,18 @@ const home = homedir();
 
 export const CHANNEL_MAP = new Map<string, ChannelConfig>([
   [
+    // #corp: AI 持株会社の本社（CEO ハブ）。ここで `/session start <branch>` すると
+    // ~/corp（corp secretary）のセッションが立ち、スレッド内の会話に応答し、
+    // `npm run secretary -- dispatch` で各部署（衛星）チャンネルへ実装依頼を出せる。
+    // branch を渡すと worktree（現 HEAD から分岐）で起動するため dispatch コードを含む。
+    "corp",
+    {
+      channelName: "corp",
+      dir: resolve(home, "corp"),
+      displayName: "Corp CEO",
+    },
+  ],
+  [
     "team-salary",
     {
       channelName: "team-salary",

--- a/supervisor/src/discord/real-client.ts
+++ b/supervisor/src/discord/real-client.ts
@@ -21,6 +21,7 @@ import type {
   SlashCommandHandler,
   ThreadMessageHandler,
 } from "./types";
+import { evaluateAccess } from "../config/access-policy";
 
 export interface RealDiscordClientOptions {
   /** discord.js intents. Defaults match bot.ts for backwards compatibility. */
@@ -55,6 +56,31 @@ export class RealDiscordClient implements IDiscordClient {
       if (message.author.bot) return;
       if (!message.channel.isThread()) return;
       const thread = message.channel as ThreadChannel;
+
+      // Issue #32 / S7 (Critical): mirror bot.ts access enforcement. Evaluate
+      // access.json `allowFrom` / `requireMention` BEFORE dispatching the
+      // thread event to any relay handler. Fail-closed (missing/broken policy
+      // or undefined channel denies). Keyed on the parent channel id since
+      // threads inherit their parent's opt-in.
+      {
+        const parentChannelId = thread.parentId ?? thread.id;
+        const botUserId = this.client.user?.id;
+        const isMention = botUserId
+          ? message.mentions.users.has(botUserId)
+          : false;
+        const decision = evaluateAccess({
+          channelKey: parentChannelId,
+          userId: message.author.id,
+          isMention,
+        });
+        if (!decision.allowed) {
+          console.warn(
+            `[RealDiscordClient] Access denied (reason=${decision.reason}) for thread ${thread.id}; message not dispatched`,
+          );
+          return;
+        }
+      }
+
       const attachments: AttachmentInfo[] = [];
       for (const [, att] of message.attachments) {
         attachments.push({

--- a/supervisor/src/session/dispatch.ts
+++ b/supervisor/src/session/dispatch.ts
@@ -112,6 +112,14 @@ export interface DispatchSessionManager {
     threadId: string,
     branch?: string,
   ): Promise<unknown>;
+  /**
+   * Wait until the freshly started session's Ink TUI is ready to accept input.
+   * Resolves true when the input-ready marker is observed, false on timeout or a
+   * dead pane. {@link runDispatch} injects the `/impl` slash command only after
+   * this so the slash-picker doesn't swallow the leading `/` while the TUI is
+   * still booting (RW-025 / RW-047 timing class).
+   */
+  waitForInputReady(threadId: string): Promise<boolean>;
   sendMessage(threadId: string, message: string): Promise<unknown>;
 }
 
@@ -159,6 +167,27 @@ export async function runDispatch(
     await sessionManager.start(config, threadId, branch);
   } catch (err) {
     return { ok: false, stage: "start", error: errMsg(err) };
+  }
+
+  // The dept TUI is still booting when start() returns — start() only waits for
+  // the PID, not an input-ready prompt. Injecting `/impl` into a not-yet-ready
+  // Ink TUI lets the slash-command picker swallow the leading `/` and strands
+  // the text un-submitted (RW-025 / RW-047 timing class — observed live as
+  // "impl <N>" stuck in the input box). Wait for the input-ready marker first.
+  // Best-effort: on timeout / probe error we still inject (the marker may have
+  // scrolled off and the TUI is ready by then) so a transient miss never drops
+  // the dispatch silently.
+  try {
+    const ready = await sessionManager.waitForInputReady(threadId);
+    if (!ready) {
+      console.warn(
+        `[Dispatch] input-ready marker not seen for thread ${threadId}; injecting anyway`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `[Dispatch] waitForInputReady failed for thread ${threadId}: ${errMsg(err)}`,
+    );
   }
 
   const initialCommand = `/impl ${issueNumber}`;

--- a/supervisor/src/session/dispatch.ts
+++ b/supervisor/src/session/dispatch.ts
@@ -1,0 +1,176 @@
+/**
+ * Message-driven dispatch transport (Issue #32 / S7, claude-hub side of the
+ * external "S3 executor" trigger).
+ *
+ * Session startup is otherwise reachable only via the `/session start` slash
+ * command (an InteractionCreate). A webhook / bot cannot send slash commands
+ * and `MessageCreate` drops every `message.author.bot`, so there is no way for
+ * an external system (e.g. a corp dispatcher) to start a session by message.
+ *
+ * This module adds a generic transport: an *allowed source* posts a single
+ * message to a known department channel:
+ *
+ *   /dispatch <branch> <issueNumber>
+ *       e.g.  /dispatch corp-dispatch-42 42
+ *
+ * claude-hub then starts a session in that channel's mapped repo on `<branch>`
+ * and injects `/impl <issueNumber>` as the session's first prompt. The feature
+ * is intentionally generic — it hardcodes no corp-specific names; any source
+ * enumerated in the access policy (`dispatchFrom` / `DISPATCH_ALLOWED_SOURCE_IDS`)
+ * can drive it.
+ *
+ * Authorization (who may dispatch) lives in `config/access-policy.ts`
+ * (`isDispatchSourceAllowed`, fail-closed). This module owns parsing and the
+ * (injectable) orchestration so both are unit-testable without a Discord
+ * gateway or a real SessionManager.
+ */
+
+import { resolveWorktreePath } from "./worktree";
+
+/** Literal trigger token. Exposed so external callers (corp) can match it. */
+export const DISPATCH_PREFIX = "/dispatch";
+
+export type ParsedDispatch =
+  | { kind: "ok"; branch: string; issueNumber: number }
+  | { kind: "not_dispatch" }
+  | { kind: "error"; reason: string };
+
+/**
+ * Sentinel root used only to validate a branch name through the RW-045
+ * worktree guard (`resolveWorktreePath` rejects shell metacharacters, path
+ * traversal and empty/`.` names). The resolved path is discarded — the real
+ * worktree path is computed later against the channel's repo dir.
+ */
+const BRANCH_VALIDATION_ROOT = "/__dispatch_branch_validation__";
+
+/**
+ * Parse a `/dispatch <branch> <issueNumber>` message. Returns:
+ *   - `not_dispatch` when the content is not a `/dispatch` command (caller
+ *     falls through to the normal relay path),
+ *   - `error` with a coarse, identifier-free reason for a malformed command,
+ *   - `ok` with a validated branch + positive-integer issue number.
+ *
+ * Branch validation reuses {@link resolveWorktreePath} (RW-045) so metachar /
+ * traversal rejection cannot drift from the worktree path logic.
+ */
+export function parseDispatchCommand(content: string): ParsedDispatch {
+  const trimmed = content.trim();
+
+  // Match the exact `/dispatch` token (not `/dispatcher`, not `/impl`). The
+  // command must be the whole leading token followed by whitespace or EOL.
+  if (trimmed !== DISPATCH_PREFIX && !trimmed.startsWith(DISPATCH_PREFIX + " ")) {
+    return { kind: "not_dispatch" };
+  }
+
+  const rest = trimmed.slice(DISPATCH_PREFIX.length).trim();
+  const parts = rest.length > 0 ? rest.split(/\s+/) : [];
+
+  if (parts.length !== 2) {
+    return {
+      kind: "error",
+      reason: "形式が不正です。/dispatch <branch> <issueNumber> で指定してください。",
+    };
+  }
+
+  const [branch, issueArg] = parts as [string, string];
+
+  // Issue number: positive integer only (no decimals, signs, or trailing text).
+  if (!/^[0-9]+$/.test(issueArg)) {
+    return {
+      kind: "error",
+      reason: "issueNumber は正の整数で指定してください。",
+    };
+  }
+  const issueNumber = Number(issueArg);
+  if (!Number.isSafeInteger(issueNumber) || issueNumber <= 0) {
+    return {
+      kind: "error",
+      reason: "issueNumber は正の整数で指定してください。",
+    };
+  }
+
+  // Branch: reuse the worktree guard (RW-045) for metachar / traversal / empty.
+  try {
+    resolveWorktreePath(BRANCH_VALIDATION_ROOT, branch);
+  } catch {
+    return {
+      kind: "error",
+      reason: "branch 名が不正です（使用できない文字または path traversal）。",
+    };
+  }
+
+  return { kind: "ok", branch, issueNumber };
+}
+
+/**
+ * Minimal SessionManager surface the dispatch orchestrator needs. Keeping it
+ * structural lets tests inject a fake without the real tmux/claude stack.
+ */
+export interface DispatchSessionManager {
+  start(
+    config: unknown,
+    threadId: string,
+    branch?: string,
+  ): Promise<unknown>;
+  sendMessage(threadId: string, message: string): Promise<unknown>;
+}
+
+/** Creates the Discord thread the session runs in and returns its id. */
+export type DispatchThreadFactory = (
+  branch: string,
+) => Promise<{ id: string }>;
+
+export interface RunDispatchArgs {
+  config: unknown;
+  branch: string;
+  issueNumber: number;
+  sessionManager: DispatchSessionManager;
+  createThread: DispatchThreadFactory;
+}
+
+export type RunDispatchResult =
+  | { ok: true; threadId: string; injected: string }
+  | { ok: false; stage: "thread" | "start" | "inject"; error: string };
+
+/**
+ * Orchestrate a validated dispatch: create the thread, start the session in the
+ * channel's repo on `branch`, then inject `/impl <issueNumber>` as the first
+ * prompt. `start()` does not accept an initial command (it only launches the
+ * pane), so the command is injected via `sendMessage` after the session is
+ * registered — the same path a user's first thread message would take.
+ *
+ * Errors are surfaced (no silent fallback): a failure is tagged with the stage
+ * so the caller can log it without leaking the raw payload.
+ */
+export async function runDispatch(
+  args: RunDispatchArgs,
+): Promise<RunDispatchResult> {
+  const { config, branch, issueNumber, sessionManager, createThread } = args;
+
+  let threadId: string;
+  try {
+    const thread = await createThread(branch);
+    threadId = thread.id;
+  } catch (err) {
+    return { ok: false, stage: "thread", error: errMsg(err) };
+  }
+
+  try {
+    await sessionManager.start(config, threadId, branch);
+  } catch (err) {
+    return { ok: false, stage: "start", error: errMsg(err) };
+  }
+
+  const initialCommand = `/impl ${issueNumber}`;
+  try {
+    await sessionManager.sendMessage(threadId, initialCommand);
+  } catch (err) {
+    return { ok: false, stage: "inject", error: errMsg(err) };
+  }
+
+  return { ok: true, threadId, injected: initialCommand };
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -75,6 +75,24 @@ const RESUME_READY_RE = /bypass permissions|\? for shortcuts/i;
 const RESUME_PROMPT_POLL_ATTEMPTS = 300;
 
 /**
+ * Input-ready marker for a freshly STARTED session's Ink TUI (same prompt
+ * markers as {@link RESUME_READY_RE}; a `--dangerously-skip-permissions` session
+ * shows the "bypass permissions" banner + "? for shortcuts" hint once it can
+ * accept input). The dispatch transport (dispatch.ts) waits for this before
+ * injecting `/impl <N>` so the slash-command picker doesn't swallow the leading
+ * `/` while the TUI is still booting (CLAUDE.md / skills / MCP) and strand the
+ * text un-submitted (RW-025 / RW-027 / RW-047 timing class).
+ */
+const INPUT_READY_RE = /bypass permissions|\? for shortcuts/i;
+/**
+ * Poll attempts (×interval) to detect the input-ready marker before giving up.
+ * A fresh dispatch session (mcpProfile "none") boots in ~5-15s; 60×1s = 60s is a
+ * generous ceiling. On timeout the caller injects anyway (best-effort) — the
+ * marker may have scrolled off, and by then the TUI is almost certainly ready.
+ */
+const INPUT_READY_POLL_ATTEMPTS = 60;
+
+/**
  * Build the argv for the `claude` invocation in a supervisor session.
  *
  * Issue #104 / Epic #101: by default supervisor sessions disable Chrome
@@ -161,6 +179,13 @@ export interface SessionManagerOptions {
    */
   resumePromptPollAttempts?: number;
   resumePromptPollIntervalMs?: number;
+  /**
+   * Input-ready poll tuning for {@link SessionManager.waitForInputReady} (the
+   * dispatch readiness wait). Tests shrink these so they don't pay the
+   * production wait. Defaults: {@link INPUT_READY_POLL_ATTEMPTS} attempts × 1s.
+   */
+  inputReadyPollAttempts?: number;
+  inputReadyPollIntervalMs?: number;
 }
 
 export class SessionManager {
@@ -192,6 +217,8 @@ export class SessionManager {
   private readonly gracefulKillTimeoutMs: number;
   private readonly resumePromptPollAttempts: number;
   private readonly resumePromptPollIntervalMs: number;
+  private readonly inputReadyPollAttempts: number;
+  private readonly inputReadyPollIntervalMs: number;
 
   constructor(options: SessionManagerOptions = {}) {
     this.effects = {
@@ -208,6 +235,10 @@ export class SessionManager {
       options.resumePromptPollAttempts ?? RESUME_PROMPT_POLL_ATTEMPTS;
     this.resumePromptPollIntervalMs =
       options.resumePromptPollIntervalMs ?? 1000;
+    this.inputReadyPollAttempts =
+      options.inputReadyPollAttempts ?? INPUT_READY_POLL_ATTEMPTS;
+    this.inputReadyPollIntervalMs =
+      options.inputReadyPollIntervalMs ?? 1000;
 
     this.effects.tmux.ensureSocketConfigured();
     this.effects.relayServer.start();
@@ -754,6 +785,34 @@ export class SessionManager {
         setTimeout(resolve, this.resumePromptPollIntervalMs)
       );
     }
+  }
+
+  /**
+   * Poll a freshly started session's pane until its Ink TUI is ready to accept
+   * input ({@link INPUT_READY_RE}). The dispatch transport (dispatch.ts) awaits
+   * this before injecting the `/impl <N>` slash command: {@link start} only
+   * waits for the PID, so the TUI is still booting (CLAUDE.md / skills / MCP)
+   * when start() returns. Injecting a slash command into a not-yet-ready TUI
+   * lets the Ink slash-picker eat the leading `/` and strands the text
+   * un-submitted (RW-025 / RW-047 timing class — the same bug a fixed sleep
+   * would only paper over).
+   *
+   * Returns true when the marker appears, false on timeout or a dead pane.
+   * Marker-based, not a fixed sleep; the inter-poll wait is a non-blocking
+   * awaited setTimeout so the single-process bot's event loop stays free for
+   * other channels' relays while this session boots.
+   */
+  async waitForInputReady(threadId: string): Promise<boolean> {
+    const tmuxName = this.tmuxSessionName(threadId);
+    for (let i = 0; i < this.inputReadyPollAttempts; i++) {
+      if (!this.effects.tmux.hasSession(tmuxName)) return false;
+      const pane = this.effects.tmux.capturePane(tmuxName);
+      if (INPUT_READY_RE.test(pane)) return true;
+      await new Promise((resolve) =>
+        setTimeout(resolve, this.inputReadyPollIntervalMs)
+      );
+    }
+    return false;
   }
 
   /**

--- a/supervisor/tests/commands/session-start-access.test.ts
+++ b/supervisor/tests/commands/session-start-access.test.ts
@@ -1,0 +1,194 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createSessionHandler } from "../../src/commands/session";
+
+/**
+ * Issue #32 / S7 (Critical): `/session start` must enforce access.json
+ * `allowFrom` BEFORE creating a thread or spawning a Claude session (which
+ * runs with `--dangerously-skip-permissions`). Fail-closed: missing/broken
+ * policy or an undefined channel denies.
+ *
+ * These build a minimal fake ChatInputCommandInteraction (mirroring
+ * session-start-branch.test.ts) and drive the real handler, pointing the
+ * runtime access loader at a temp access.json via SUPERVISOR_ACCESS_JSON_PATH.
+ */
+
+const PARENT_CHANNEL_ID = "846209781206941736";
+const OWNER = "184695080709324800";
+const OUTSIDER = "999999999999999999";
+
+interface ReplyRecord {
+  kind: "reply" | "editReply";
+  content?: string;
+  flags?: number;
+}
+
+function makeInteraction(opts: {
+  userId: string;
+  branch?: string | null;
+  channelId?: string;
+  channelName?: string;
+}) {
+  const replies: ReplyRecord[] = [];
+  const startCalls: unknown[][] = [];
+  let threadCreated = false;
+
+  const thread = {
+    id: "thread-xyz",
+    send: async () => {},
+    delete: async () => {},
+  };
+
+  const channel = {
+    id: opts.channelId ?? PARENT_CHANNEL_ID,
+    isThread: () => false,
+    isTextBased: () => true,
+    isDMBased: () => false,
+    name: opts.channelName ?? "agent-base",
+    threads: {
+      create: async () => {
+        threadCreated = true;
+        return thread;
+      },
+    },
+  };
+
+  const interaction = {
+    user: { id: opts.userId },
+    options: {
+      getSubcommand: () => "start",
+      getString: (name: string) =>
+        name === "branch" ? opts.branch ?? "feature-foo" : null,
+    },
+    channel,
+    deferred: false,
+    replied: false,
+    async reply(msg: { content?: string; flags?: number }) {
+      this.replied = true;
+      replies.push({ kind: "reply", content: msg.content, flags: msg.flags });
+    },
+    async deferReply() {
+      this.deferred = true;
+    },
+    async editReply(msg: { content?: string }) {
+      replies.push({ kind: "editReply", content: msg.content });
+    },
+  };
+
+  const sessionManager = {
+    count: () => 0,
+    listRunningByChannel: () => [],
+    start: (...args: unknown[]) => {
+      startCalls.push(args);
+      return {
+        worktree: {
+          mainRepoDir: "/Users/x/agent-base",
+          path: "/Users/x/agent-base/.claude/worktrees/feature-foo",
+          branch: "feature-foo",
+        },
+      };
+    },
+  };
+
+  return {
+    run: () =>
+      createSessionHandler(sessionManager as never)(interaction as never),
+    replies,
+    startCalls,
+    get threadCreated() {
+      return threadCreated;
+    },
+  };
+}
+
+describe("/session start access enforcement (#32 / S7)", () => {
+  let dir: string;
+  let accessPath: string;
+  const prev = process.env.SUPERVISOR_ACCESS_JSON_PATH;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "session-start-access-"));
+    accessPath = join(dir, "access.json");
+    process.env.SUPERVISOR_ACCESS_JSON_PATH = accessPath;
+  });
+
+  afterEach(() => {
+    if (prev === undefined) delete process.env.SUPERVISOR_ACCESS_JSON_PATH;
+    else process.env.SUPERVISOR_ACCESS_JSON_PATH = prev;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writePolicy(allowFrom: string[]): void {
+    writeFileSync(
+      accessPath,
+      JSON.stringify({
+        groups: {
+          [PARENT_CHANNEL_ID]: { requireMention: true, allowFrom },
+        },
+      }),
+    );
+  }
+
+  test("allowlisted user can start: thread created, session started", async () => {
+    writePolicy([OWNER]);
+    const h = makeInteraction({ userId: OWNER });
+    await h.run();
+    expect(h.startCalls).toHaveLength(1);
+    expect(h.threadCreated).toBe(true);
+  });
+
+  test("non-allowlisted user is rejected: no thread, no session", async () => {
+    writePolicy([OWNER]);
+    const h = makeInteraction({ userId: OUTSIDER });
+    await h.run();
+    expect(h.startCalls).toHaveLength(0);
+    expect(h.threadCreated).toBe(false);
+    expect(h.replies).toHaveLength(1);
+    expect(h.replies[0]!.kind).toBe("reply");
+    expect(h.replies[0]!.flags).toBe(64); // ephemeral
+    expect(h.replies[0]!.content).toContain("権限がありません");
+  });
+
+  test("fail-closed: missing access.json denies even the would-be owner", async () => {
+    // No writePolicy() — the file does not exist.
+    const h = makeInteraction({ userId: OWNER });
+    await h.run();
+    expect(h.startCalls).toHaveLength(0);
+    expect(h.threadCreated).toBe(false);
+    expect(h.replies[0]!.content).toContain("権限がありません");
+  });
+
+  test("fail-closed: channel not present in groups denies", async () => {
+    // Policy defines a DIFFERENT channel id, leaving this one undefined.
+    writeFileSync(
+      accessPath,
+      JSON.stringify({
+        groups: {
+          "111111111111111111": { requireMention: true, allowFrom: [OWNER] },
+        },
+      }),
+    );
+    const h = makeInteraction({ userId: OWNER });
+    await h.run();
+    expect(h.startCalls).toHaveLength(0);
+    expect(h.threadCreated).toBe(false);
+  });
+
+  test("fail-closed: corrupt access.json denies", async () => {
+    writeFileSync(accessPath, "{ not json ");
+    const h = makeInteraction({ userId: OWNER });
+    await h.run();
+    expect(h.startCalls).toHaveLength(0);
+    expect(h.threadCreated).toBe(false);
+  });
+
+  test("empty allowFrom permits any member (slash invocation satisfies mention)", async () => {
+    writePolicy([]); // empty = any member
+    const h = makeInteraction({ userId: OUTSIDER });
+    await h.run();
+    expect(h.startCalls).toHaveLength(1);
+    expect(h.threadCreated).toBe(true);
+  });
+});

--- a/supervisor/tests/commands/session-start-branch.test.ts
+++ b/supervisor/tests/commands/session-start-branch.test.ts
@@ -1,5 +1,41 @@
-import { test, expect, describe } from "bun:test";
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 import { createSessionHandler } from "../../src/commands/session";
+
+// Issue #32 / S7: handleStart now enforces access.json. These branch-validation
+// tests assert behavior that occurs AFTER access is granted, so we point the
+// runtime loader at a temp policy that allows the fixture user on the fixture
+// channel id. Access-denial behavior is covered in session-start-access.test.ts.
+const FIXTURE_CHANNEL_ID = "fixture-parent-channel";
+const FIXTURE_USER_ID = "fixture-user";
+let accessDir: string;
+const prevAccessPath = process.env.SUPERVISOR_ACCESS_JSON_PATH;
+
+beforeEach(() => {
+  accessDir = mkdtempSync(join(tmpdir(), "session-start-branch-access-"));
+  const accessPath = join(accessDir, "access.json");
+  writeFileSync(
+    accessPath,
+    JSON.stringify({
+      groups: {
+        [FIXTURE_CHANNEL_ID]: {
+          requireMention: true,
+          allowFrom: [FIXTURE_USER_ID],
+        },
+      },
+    }),
+  );
+  process.env.SUPERVISOR_ACCESS_JSON_PATH = accessPath;
+});
+
+afterEach(() => {
+  if (prevAccessPath === undefined)
+    delete process.env.SUPERVISOR_ACCESS_JSON_PATH;
+  else process.env.SUPERVISOR_ACCESS_JSON_PATH = prevAccessPath;
+  rmSync(accessDir, { recursive: true, force: true });
+});
 
 /**
  * Handler-level tests for the `/session start <branch>` migration (Issue #154).
@@ -37,6 +73,7 @@ function makeInteraction(opts: {
   };
 
   const channel = {
+    id: FIXTURE_CHANNEL_ID,
     isThread: () => false,
     isTextBased: () => true,
     isDMBased: () => false,
@@ -51,6 +88,7 @@ function makeInteraction(opts: {
   };
 
   const interaction = {
+    user: { id: FIXTURE_USER_ID },
     options: {
       getSubcommand: () => "start",
       getString: (name: string) =>

--- a/supervisor/tests/commands/session-thread-title.test.ts
+++ b/supervisor/tests/commands/session-thread-title.test.ts
@@ -1,4 +1,7 @@
-import { test, expect, describe } from "bun:test";
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 import { createSessionHandler } from "../../src/commands/session";
 
 /**
@@ -10,6 +13,38 @@ import { createSessionHandler } from "../../src/commands/session";
  * assertion exercises the real handler wiring (same harness style as
  * session-start-branch.test.ts), without a Discord gateway.
  */
+
+// Issue #32 / S7: handleStart now enforces access.json. Allow the fixture user
+// on the fixture channel id so thread-title behavior (which runs after access
+// is granted) is exercised. Access-denial is covered in session-start-access.
+const FIXTURE_CHANNEL_ID = "fixture-parent-channel";
+const FIXTURE_USER_ID = "fixture-user";
+let accessDir: string;
+const prevAccessPath = process.env.SUPERVISOR_ACCESS_JSON_PATH;
+
+beforeEach(() => {
+  accessDir = mkdtempSync(join(tmpdir(), "session-thread-title-access-"));
+  const accessPath = join(accessDir, "access.json");
+  writeFileSync(
+    accessPath,
+    JSON.stringify({
+      groups: {
+        [FIXTURE_CHANNEL_ID]: {
+          requireMention: true,
+          allowFrom: [FIXTURE_USER_ID],
+        },
+      },
+    }),
+  );
+  process.env.SUPERVISOR_ACCESS_JSON_PATH = accessPath;
+});
+
+afterEach(() => {
+  if (prevAccessPath === undefined)
+    delete process.env.SUPERVISOR_ACCESS_JSON_PATH;
+  else process.env.SUPERVISOR_ACCESS_JSON_PATH = prevAccessPath;
+  rmSync(accessDir, { recursive: true, force: true });
+});
 function makeStartInteraction(opts: {
   branch: string;
   // Sessions already running in this channel (to drive the same-branch count).
@@ -20,6 +55,7 @@ function makeStartInteraction(opts: {
   const thread = { id: "thread-xyz", send: async () => {}, delete: async () => {} };
 
   const channel = {
+    id: FIXTURE_CHANNEL_ID,
     isThread: () => false,
     isTextBased: () => true,
     isDMBased: () => false,
@@ -33,6 +69,7 @@ function makeStartInteraction(opts: {
   };
 
   const interaction = {
+    user: { id: FIXTURE_USER_ID },
     options: {
       getSubcommand: () => "start",
       getString: (name: string) => (name === "branch" ? opts.branch : null),

--- a/supervisor/tests/config/access-policy.test.ts
+++ b/supervisor/tests/config/access-policy.test.ts
@@ -1,0 +1,245 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  isSenderAllowed,
+  loadAccessPolicy,
+  evaluateAccess,
+} from "../../src/config/access-policy";
+
+/**
+ * Issue #32 / S7: runtime enforcement of access.json `allowFrom` /
+ * `requireMention` before relaying any Discord message into a Claude session.
+ *
+ * The semantics mirror the upstream discord plugin's `gate()` group path
+ * (external_plugins/discord/server.ts):
+ *   - undefined channel policy            -> DENY (fail-closed)
+ *   - groupAllowFrom non-empty + sender not in it -> DENY
+ *   - requireMention true + not mentioned -> DENY
+ *   - otherwise                           -> ALLOW
+ *
+ * The fail-closed default (missing / broken file, undefined channel) is the
+ * Critical security property: relay only happens for an explicitly allowed
+ * sender on an explicitly defined channel.
+ */
+
+const OWNER = "184695080709324800";
+const OUTSIDER = "999999999999999999";
+const CHANNEL = "846209781206941736";
+
+describe("isSenderAllowed (pure)", () => {
+  test("allows an allowlisted sender that mentions the bot", () => {
+    const policy = {
+      groups: {
+        [CHANNEL]: { requireMention: true, allowFrom: [OWNER] },
+      },
+    };
+    const r = isSenderAllowed(policy, CHANNEL, OWNER, true);
+    expect(r.allowed).toBe(true);
+  });
+
+  test("rejects a non-allowlisted sender even when mentioning the bot", () => {
+    const policy = {
+      groups: {
+        [CHANNEL]: { requireMention: true, allowFrom: [OWNER] },
+      },
+    };
+    const r = isSenderAllowed(policy, CHANNEL, OUTSIDER, true);
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toBe("sender_not_allowlisted");
+  });
+
+  test("rejects an allowlisted sender when requireMention is set but no mention", () => {
+    const policy = {
+      groups: {
+        [CHANNEL]: { requireMention: true, allowFrom: [OWNER] },
+      },
+    };
+    const r = isSenderAllowed(policy, CHANNEL, OWNER, false);
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toBe("mention_required");
+  });
+
+  test("DENY (fail-closed) when the channel is not defined in groups", () => {
+    const policy = {
+      groups: {
+        [CHANNEL]: { requireMention: true, allowFrom: [OWNER] },
+      },
+    };
+    const r = isSenderAllowed(policy, "111111111111111111", OWNER, true);
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toBe("channel_not_configured");
+  });
+
+  test("DENY (fail-closed) when the policy itself is null/undefined", () => {
+    const r = isSenderAllowed(null, CHANNEL, OWNER, true);
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toBe("policy_unavailable");
+  });
+
+  test("empty groupAllowFrom means any member (still subject to requireMention)", () => {
+    // Mirrors upstream: empty allowFrom = unrestricted senders for that channel.
+    // This preserves the claudeHubExit primary entry semantics.
+    const policy = {
+      groups: {
+        [CHANNEL]: { requireMention: false, allowFrom: [] },
+      },
+    };
+    expect(isSenderAllowed(policy, CHANNEL, OUTSIDER, false).allowed).toBe(true);
+    expect(isSenderAllowed(policy, CHANNEL, OWNER, false).allowed).toBe(true);
+  });
+
+  test("empty groupAllowFrom with requireMention true still requires a mention", () => {
+    const policy = {
+      groups: {
+        [CHANNEL]: { requireMention: true, allowFrom: [] },
+      },
+    };
+    expect(isSenderAllowed(policy, CHANNEL, OWNER, false).allowed).toBe(false);
+    expect(isSenderAllowed(policy, CHANNEL, OWNER, true).allowed).toBe(true);
+  });
+
+  test("requireMention defaults to true when omitted (fail-closed default)", () => {
+    const policy = {
+      groups: {
+        // requireMention intentionally omitted
+        [CHANNEL]: { allowFrom: [OWNER] } as { allowFrom: string[] },
+      },
+    };
+    expect(isSenderAllowed(policy, CHANNEL, OWNER, false).allowed).toBe(false);
+    expect(isSenderAllowed(policy, CHANNEL, OWNER, true).allowed).toBe(true);
+  });
+
+  test("channels are independent: an allowlist on one does not leak to another", () => {
+    const chA = "111111111111111111";
+    const chB = "222222222222222222";
+    const policy = {
+      groups: {
+        [chA]: { requireMention: false, allowFrom: [OWNER] },
+        [chB]: { requireMention: false, allowFrom: [OUTSIDER] },
+      },
+    };
+    // OWNER allowed in A, denied in B; OUTSIDER vice-versa.
+    expect(isSenderAllowed(policy, chA, OWNER, false).allowed).toBe(true);
+    expect(isSenderAllowed(policy, chA, OUTSIDER, false).allowed).toBe(false);
+    expect(isSenderAllowed(policy, chB, OUTSIDER, false).allowed).toBe(true);
+    expect(isSenderAllowed(policy, chB, OWNER, false).allowed).toBe(false);
+  });
+
+  test("DENY when groups object is missing entirely (malformed policy)", () => {
+    const r = isSenderAllowed({} as never, CHANNEL, OWNER, true);
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toBe("channel_not_configured");
+  });
+});
+
+describe("loadAccessPolicy", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "access-policy-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("loads a well-formed access.json", () => {
+    const p = join(dir, "access.json");
+    writeFileSync(
+      p,
+      JSON.stringify({
+        groups: { [CHANNEL]: { requireMention: true, allowFrom: [OWNER] } },
+      }),
+    );
+    const policy = loadAccessPolicy(p);
+    expect(policy).not.toBeNull();
+    expect(policy?.groups?.[CHANNEL]?.allowFrom).toEqual([OWNER]);
+  });
+
+  test("returns null when the file is missing (fail-closed signal)", () => {
+    const policy = loadAccessPolicy(join(dir, "does-not-exist.json"));
+    expect(policy).toBeNull();
+  });
+
+  test("returns null when the file is broken JSON (fail-closed signal)", () => {
+    const p = join(dir, "access.json");
+    writeFileSync(p, "{ this is not valid json ");
+    const policy = loadAccessPolicy(p);
+    expect(policy).toBeNull();
+  });
+
+  test("returns null when the JSON is not an object", () => {
+    const p = join(dir, "access.json");
+    writeFileSync(p, "[]");
+    const policy = loadAccessPolicy(p);
+    expect(policy).toBeNull();
+  });
+});
+
+describe("evaluateAccess (load + decide, fail-closed)", () => {
+  let dir: string;
+  let p: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "access-eval-"));
+    p = join(dir, "access.json");
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("allows an allowlisted, mentioning sender", () => {
+    writeFileSync(
+      p,
+      JSON.stringify({
+        groups: { [CHANNEL]: { requireMention: true, allowFrom: [OWNER] } },
+      }),
+    );
+    const r = evaluateAccess(
+      { channelKey: CHANNEL, userId: OWNER, isMention: true },
+      p,
+    );
+    expect(r.allowed).toBe(true);
+  });
+
+  test("DENY (fail-closed) when access.json is absent", () => {
+    const r = evaluateAccess(
+      { channelKey: CHANNEL, userId: OWNER, isMention: true },
+      join(dir, "missing.json"),
+    );
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toBe("policy_unavailable");
+  });
+
+  test("DENY (fail-closed) for an undefined channel", () => {
+    writeFileSync(
+      p,
+      JSON.stringify({
+        groups: { [CHANNEL]: { requireMention: true, allowFrom: [OWNER] } },
+      }),
+    );
+    const r = evaluateAccess(
+      { channelKey: "000000000000000000", userId: OWNER, isMention: true },
+      p,
+    );
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toBe("channel_not_configured");
+  });
+
+  test("reason string never contains the raw user/channel id (no secret leak)", () => {
+    writeFileSync(
+      p,
+      JSON.stringify({
+        groups: { [CHANNEL]: { requireMention: true, allowFrom: [OWNER] } },
+      }),
+    );
+    const r = evaluateAccess(
+      { channelKey: CHANNEL, userId: OUTSIDER, isMention: true },
+      p,
+    );
+    expect(r.allowed).toBe(false);
+    expect(r.reason).not.toContain(OUTSIDER);
+    expect(r.reason).not.toContain(CHANNEL);
+  });
+});

--- a/supervisor/tests/config/access-policy.test.ts
+++ b/supervisor/tests/config/access-policy.test.ts
@@ -6,6 +6,7 @@ import {
   isSenderAllowed,
   loadAccessPolicy,
   evaluateAccess,
+  isDispatchSourceAllowed,
 } from "../../src/config/access-policy";
 
 /**
@@ -241,5 +242,132 @@ describe("evaluateAccess (load + decide, fail-closed)", () => {
     expect(r.allowed).toBe(false);
     expect(r.reason).not.toContain(OUTSIDER);
     expect(r.reason).not.toContain(CHANNEL);
+  });
+});
+
+/**
+ * Issue #32 / S7 (dispatch transport): a generic external source (a Discord
+ * webhook / bot, identified by its snowflake) may trigger a session via a
+ * `/dispatch` message. This is the ONLY exception to the blanket
+ * `message.author.bot` drop, and it is fail-closed: the source must be
+ * explicitly listed in the channel's `dispatchFrom` (or the global
+ * `DISPATCH_ALLOWED_SOURCE_IDS` env list), and the channel must be configured.
+ */
+const SOURCE = "555555555555555555";
+const OTHER_SOURCE = "777777777777777777";
+
+describe("isDispatchSourceAllowed (pure, fail-closed)", () => {
+  test("allows a source listed in the channel's dispatchFrom", () => {
+    const policy = {
+      groups: {
+        [CHANNEL]: { dispatchFrom: [SOURCE] },
+      },
+    };
+    const r = isDispatchSourceAllowed(policy, CHANNEL, SOURCE);
+    expect(r.allowed).toBe(true);
+    expect(r.reason).toBe("allowed");
+  });
+
+  test("rejects a source not in dispatchFrom (fail-closed)", () => {
+    const policy = {
+      groups: {
+        [CHANNEL]: { dispatchFrom: [SOURCE] },
+      },
+    };
+    const r = isDispatchSourceAllowed(policy, CHANNEL, OTHER_SOURCE);
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toBe("source_not_allowlisted");
+  });
+
+  test("DENY when the channel has no dispatchFrom at all (fail-closed)", () => {
+    const policy = {
+      groups: {
+        [CHANNEL]: { requireMention: true, allowFrom: [OWNER] },
+      },
+    };
+    const r = isDispatchSourceAllowed(policy, CHANNEL, SOURCE);
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toBe("source_not_allowlisted");
+  });
+
+  test("DENY (fail-closed) when the channel is not configured", () => {
+    const policy = {
+      groups: {
+        [CHANNEL]: { dispatchFrom: [SOURCE] },
+      },
+    };
+    const r = isDispatchSourceAllowed(policy, "000000000000000000", SOURCE);
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toBe("channel_not_configured");
+  });
+
+  test("DENY (fail-closed) when policy is null/undefined", () => {
+    const r = isDispatchSourceAllowed(null, CHANNEL, SOURCE);
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toBe("policy_unavailable");
+  });
+
+  test("allows a source listed in the env global allowlist (channel must still be configured)", () => {
+    const policy = {
+      groups: {
+        // Channel configured but with an empty/absent dispatchFrom.
+        [CHANNEL]: { requireMention: true, allowFrom: [OWNER] },
+      },
+    };
+    const r = isDispatchSourceAllowed(policy, CHANNEL, SOURCE, [SOURCE]);
+    expect(r.allowed).toBe(true);
+    expect(r.reason).toBe("allowed");
+  });
+
+  test("env allowlist does NOT bypass the channel-configured requirement (fail-closed)", () => {
+    const policy = {
+      groups: {
+        [CHANNEL]: { dispatchFrom: [SOURCE] },
+      },
+    };
+    // Source is in env, but the channel is undefined -> still DENY.
+    const r = isDispatchSourceAllowed(policy, "999000999000999000", SOURCE, [
+      SOURCE,
+    ]);
+    expect(r.allowed).toBe(false);
+    expect(r.reason).toBe("channel_not_configured");
+  });
+
+  test("empty dispatchFrom does NOT mean 'any source' (unlike allowFrom)", () => {
+    // Critical: dispatch is privileged automation; an empty list must DENY,
+    // never widen to any bot/webhook.
+    const policy = {
+      groups: {
+        [CHANNEL]: { dispatchFrom: [] },
+      },
+    };
+    expect(isDispatchSourceAllowed(policy, CHANNEL, SOURCE).allowed).toBe(false);
+    expect(isDispatchSourceAllowed(policy, CHANNEL, SOURCE).reason).toBe(
+      "source_not_allowlisted",
+    );
+  });
+
+  test("reason never contains the raw source/channel id (no secret leak)", () => {
+    const policy = {
+      groups: { [CHANNEL]: { dispatchFrom: [SOURCE] } },
+    };
+    const r = isDispatchSourceAllowed(policy, CHANNEL, OTHER_SOURCE);
+    expect(r.reason).not.toContain(OTHER_SOURCE);
+    expect(r.reason).not.toContain(CHANNEL);
+  });
+
+  test("channels are independent for dispatch sources", () => {
+    const chA = "111111111111111111";
+    const chB = "222222222222222222";
+    const policy = {
+      groups: {
+        [chA]: { dispatchFrom: [SOURCE] },
+        [chB]: { dispatchFrom: [OTHER_SOURCE] },
+      },
+    };
+    expect(isDispatchSourceAllowed(policy, chA, SOURCE).allowed).toBe(true);
+    expect(isDispatchSourceAllowed(policy, chA, OTHER_SOURCE).allowed).toBe(false);
+    expect(isDispatchSourceAllowed(policy, chB, OTHER_SOURCE).allowed).toBe(true);
+    expect(isDispatchSourceAllowed(policy, chB, SOURCE).allowed).toBe(false);
   });
 });

--- a/supervisor/tests/discord/real-client.test.ts
+++ b/supervisor/tests/discord/real-client.test.ts
@@ -6,6 +6,9 @@
 // through InMemoryDiscordClient and the real tmux + claude-mock.sh.
 
 import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 import { Client, GatewayIntentBits } from "discord.js";
 import { RealDiscordClient } from "../../src/discord/real-client";
 
@@ -171,44 +174,164 @@ describe("RealDiscordClient", () => {
     // wrapper subscribes to Events.MessageCreate at construction time, so
     // emitting that event fires the chain. We feed a minimal message-shaped
     // object to assert the propagation contract end-to-end (gating + payload).
+    //
+    // Issue #32 / S7: the wrapper now enforces access.json before dispatching.
+    // Point the runtime loader at a temp policy that allows this sender on the
+    // parent channel (requireMention:false so no mention object is needed) so
+    // we still exercise the propagation contract. The access gate itself is
+    // covered behaviorally below and in tests/config/access-policy.test.ts.
+    const dir = mkdtempSync(join(tmpdir(), "real-client-access-"));
+    const accessPath = join(dir, "access.json");
+    writeFileSync(
+      accessPath,
+      JSON.stringify({
+        groups: {
+          parent_1: { requireMention: false, allowFrom: ["user_1"] },
+        },
+      }),
+    );
+    const prevAccess = process.env.SUPERVISOR_ACCESS_JSON_PATH;
+    process.env.SUPERVISOR_ACCESS_JSON_PATH = accessPath;
+
+    try {
+      const inner = new Client({ intents: [GatewayIntentBits.Guilds] });
+      const wrapper = new RealDiscordClient("fake-token", { client: inner });
+      created.push(wrapper);
+
+      const events: Array<{ threadId: string; content: string; isBot: boolean }> = [];
+      wrapper.onThreadMessage((m) => {
+        events.push({ threadId: m.threadId, content: m.content, isBot: m.authorBot });
+      });
+
+      const baseMessage = {
+        author: { bot: false, id: "user_1" },
+        channel: { isThread: () => true, id: "thread_1", parentId: "parent_1" },
+        mentions: { users: { has: () => false } },
+        content: "hi from user",
+        id: "msg_1",
+        attachments: new Map(),
+      };
+
+      inner.emit("messageCreate", baseMessage as never);
+      expect(events).toEqual([
+        { threadId: "thread_1", content: "hi from user", isBot: false },
+      ]);
+
+      // Bot author → gated out
+      inner.emit("messageCreate", {
+        ...baseMessage,
+        author: { bot: true, id: "bot_2" },
+        id: "msg_2",
+        content: "bot says",
+      } as never);
+
+      // Non-thread channel → gated out
+      inner.emit("messageCreate", {
+        ...baseMessage,
+        id: "msg_3",
+        channel: { isThread: () => false, id: "channel_1" },
+        content: "channel msg",
+      } as never);
+
+      expect(events).toHaveLength(1);
+    } finally {
+      if (prevAccess === undefined)
+        delete process.env.SUPERVISOR_ACCESS_JSON_PATH;
+      else process.env.SUPERVISOR_ACCESS_JSON_PATH = prevAccess;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("RealDiscordClient MessageCreate access enforcement (#32 / S7)", () => {
+  const created: RealDiscordClient[] = [];
+  let dir: string;
+  let accessPath: string;
+  const prevAccess = process.env.SUPERVISOR_ACCESS_JSON_PATH;
+
+  const PARENT = "846209781206941736";
+  const OWNER = "184695080709324800";
+  const OUTSIDER = "999999999999999999";
+
+  afterEach(async () => {
+    while (created.length) {
+      const c = created.pop()!;
+      try {
+        await c.stop();
+      } catch {
+        // best-effort cleanup
+      }
+    }
+    if (prevAccess === undefined) delete process.env.SUPERVISOR_ACCESS_JSON_PATH;
+    else process.env.SUPERVISOR_ACCESS_JSON_PATH = prevAccess;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function setup(policy: unknown | undefined) {
+    dir = mkdtempSync(join(tmpdir(), "real-client-deny-"));
+    accessPath = join(dir, "access.json");
+    if (policy !== undefined) {
+      writeFileSync(accessPath, JSON.stringify(policy));
+    }
+    process.env.SUPERVISOR_ACCESS_JSON_PATH = accessPath;
+
     const inner = new Client({ intents: [GatewayIntentBits.Guilds] });
+    // Stand in for the bot's own user so mention detection has an id to match.
+    (inner as unknown as { user: { id: string } }).user = { id: "bot_self" };
     const wrapper = new RealDiscordClient("fake-token", { client: inner });
     created.push(wrapper);
 
-    const events: Array<{ threadId: string; content: string; isBot: boolean }> = [];
-    wrapper.onThreadMessage((m) => {
-      events.push({ threadId: m.threadId, content: m.content, isBot: m.authorBot });
-    });
+    const events: string[] = [];
+    wrapper.onThreadMessage((m) => events.push(m.content));
+    return { inner, events };
+  }
 
-    const baseMessage = {
-      author: { bot: false, id: "user_1" },
-      channel: { isThread: () => true, id: "thread_1" },
-      content: "hi from user",
-      id: "msg_1",
+  function msg(opts: { userId: string; mentioned?: boolean; content: string }) {
+    return {
+      author: { bot: false, id: opts.userId },
+      channel: { isThread: () => true, id: "thread_1", parentId: PARENT },
+      mentions: { users: { has: (id: string) => !!opts.mentioned && id === "bot_self" } },
+      content: opts.content,
+      id: "m",
       attachments: new Map(),
-    };
+    } as never;
+  }
 
-    inner.emit("messageCreate", baseMessage as never);
-    expect(events).toEqual([
-      { threadId: "thread_1", content: "hi from user", isBot: false },
-    ]);
+  test("allowlisted + mention → dispatched", () => {
+    const { inner, events } = setup({
+      groups: { [PARENT]: { requireMention: true, allowFrom: [OWNER] } },
+    });
+    inner.emit("messageCreate", msg({ userId: OWNER, mentioned: true, content: "ok" }));
+    expect(events).toEqual(["ok"]);
+  });
 
-    // Bot author → gated out
-    inner.emit("messageCreate", {
-      ...baseMessage,
-      author: { bot: true, id: "bot_2" },
-      id: "msg_2",
-      content: "bot says",
-    } as never);
+  test("non-allowlisted sender → dropped", () => {
+    const { inner, events } = setup({
+      groups: { [PARENT]: { requireMention: true, allowFrom: [OWNER] } },
+    });
+    inner.emit("messageCreate", msg({ userId: OUTSIDER, mentioned: true, content: "x" }));
+    expect(events).toEqual([]);
+  });
 
-    // Non-thread channel → gated out
-    inner.emit("messageCreate", {
-      ...baseMessage,
-      id: "msg_3",
-      channel: { isThread: () => false, id: "channel_1" },
-      content: "channel msg",
-    } as never);
+  test("requireMention + no mention → dropped", () => {
+    const { inner, events } = setup({
+      groups: { [PARENT]: { requireMention: true, allowFrom: [OWNER] } },
+    });
+    inner.emit("messageCreate", msg({ userId: OWNER, mentioned: false, content: "x" }));
+    expect(events).toEqual([]);
+  });
 
-    expect(events).toHaveLength(1);
+  test("fail-closed: missing access.json → dropped", () => {
+    const { inner, events } = setup(undefined); // no file written
+    inner.emit("messageCreate", msg({ userId: OWNER, mentioned: true, content: "x" }));
+    expect(events).toEqual([]);
+  });
+
+  test("fail-closed: undefined channel → dropped", () => {
+    const { inner, events } = setup({
+      groups: { "111111111111111111": { requireMention: false, allowFrom: [OWNER] } },
+    });
+    inner.emit("messageCreate", msg({ userId: OWNER, mentioned: true, content: "x" }));
+    expect(events).toEqual([]);
   });
 });

--- a/supervisor/tests/guards/access-enforcement-wired.test.ts
+++ b/supervisor/tests/guards/access-enforcement-wired.test.ts
@@ -1,0 +1,74 @@
+import { test, expect, describe } from "bun:test";
+
+/**
+ * Issue #32 / S7 (Critical): guard that the runtime access enforcement stays
+ * wired at all three relay entry points. Behavioral coverage lives in
+ * tests/config/access-policy.test.ts, tests/discord/real-client.test.ts, and
+ * tests/commands/session-start-access.test.ts; this guard prevents a future
+ * refactor from silently deleting or reordering the gate so the gate is never
+ * bypassed (defense-in-depth against the lateral-movement regression).
+ */
+
+async function read(path: string): Promise<string> {
+  return Bun.file(path).text();
+}
+
+describe("access enforcement is wired (#32 / S7)", () => {
+  test("bot.ts evaluates access before relaying (sendMessage)", async () => {
+    const src = await read("src/bot.ts");
+    expect(src).toContain("evaluateAccess");
+    const gateIdx = src.indexOf("evaluateAccess");
+    const relayIdx = src.indexOf("sessionManager.sendMessage");
+    expect(gateIdx).toBeGreaterThan(-1);
+    expect(relayIdx).toBeGreaterThan(-1);
+    // The gate must appear before the relay call so a denied message never
+    // reaches the session.
+    expect(gateIdx).toBeLessThan(relayIdx);
+    // Fail-closed: a denied decision returns without relaying.
+    expect(src).toContain("decision.allowed");
+  });
+
+  test("real-client.ts evaluates access before dispatching thread handlers", async () => {
+    const src = await read("src/discord/real-client.ts");
+    expect(src).toContain("evaluateAccess");
+    const gateIdx = src.indexOf("evaluateAccess");
+    const dispatchIdx = src.indexOf("for (const h of this.threadHandlers)");
+    expect(gateIdx).toBeGreaterThan(-1);
+    expect(dispatchIdx).toBeGreaterThan(-1);
+    expect(gateIdx).toBeLessThan(dispatchIdx);
+  });
+
+  test("session.ts handleStart evaluates access before starting a session", async () => {
+    const src = await read("src/commands/session.ts");
+    expect(src).toContain("evaluateAccess");
+    const gateIdx = src.indexOf("evaluateAccess");
+    const startIdx = src.indexOf("sessionManager.start(");
+    expect(gateIdx).toBeGreaterThan(-1);
+    expect(startIdx).toBeGreaterThan(-1);
+    expect(gateIdx).toBeLessThan(startIdx);
+  });
+
+  test("denial logs do not interpolate raw user/channel ids", async () => {
+    // The structured denial logs must reference the coarse `decision.reason`
+    // enum and thread id, never the sender/channel snowflake or message body.
+    for (const path of [
+      "src/bot.ts",
+      "src/discord/real-client.ts",
+      "src/commands/session.ts",
+    ]) {
+      const src = await read(path);
+      const denialLines = src
+        .split("\n")
+        .filter((l) => /Access denied|access denied/.test(l));
+      expect(denialLines.length).toBeGreaterThan(0);
+      for (const line of denialLines) {
+        // Must log the reason enum.
+        expect(line).toContain("reason=");
+        // Must NOT log the sender id or message body.
+        expect(line).not.toContain("message.author.id");
+        expect(line).not.toContain("interaction.user.id");
+        expect(line).not.toContain("message.content");
+      }
+    }
+  });
+});

--- a/supervisor/tests/guards/access-enforcement-wired.test.ts
+++ b/supervisor/tests/guards/access-enforcement-wired.test.ts
@@ -72,3 +72,45 @@ describe("access enforcement is wired (#32 / S7)", () => {
     }
   });
 });
+
+describe("dispatch transport is wired fail-closed (#32 / S7)", () => {
+  test("bot.ts intercepts dispatch BEFORE the bot/webhook drop", async () => {
+    const src = await read("src/bot.ts");
+    // The dispatch interception must run before the `message.author.bot` drop,
+    // otherwise an external source (a bot/webhook) can never trigger it.
+    const dispatchIdx = src.indexOf("handleDispatchMessage(message)");
+    const botDropIdx = src.indexOf("if (message.author.bot) return;");
+    expect(dispatchIdx).toBeGreaterThan(-1);
+    expect(botDropIdx).toBeGreaterThan(-1);
+    // The call inside the MessageCreate handler precedes the bot drop.
+    expect(dispatchIdx).toBeLessThan(botDropIdx);
+  });
+
+  test("bot.ts authorizes the source before parsing/starting (fail-closed)", async () => {
+    const src = await read("src/bot.ts");
+    expect(src).toContain("isDispatchSourceAllowed");
+    const authIdx = src.indexOf("isDispatchSourceAllowed");
+    const parseIdx = src.indexOf("parseDispatchCommand(content)");
+    const runIdx = src.indexOf("runDispatch(");
+    expect(authIdx).toBeGreaterThan(-1);
+    expect(parseIdx).toBeGreaterThan(-1);
+    expect(runIdx).toBeGreaterThan(-1);
+    // Source authorization must precede both parsing and the actual start.
+    expect(authIdx).toBeLessThan(parseIdx);
+    expect(authIdx).toBeLessThan(runIdx);
+    // A denied decision must not proceed to runDispatch.
+    expect(src).toContain("decision.allowed");
+  });
+
+  test("dispatch denial logs do not interpolate raw source/channel ids or body", async () => {
+    const src = await read("src/bot.ts");
+    const denialLines = src
+      .split("\n")
+      .filter((l) => /Dispatch denied|Dispatch rejected/.test(l));
+    expect(denialLines.length).toBeGreaterThan(0);
+    for (const line of denialLines) {
+      expect(line).not.toContain("message.author.id");
+      expect(line).not.toContain("message.content");
+    }
+  });
+});

--- a/supervisor/tests/session/dispatch-integration.test.ts
+++ b/supervisor/tests/session/dispatch-integration.test.ts
@@ -56,6 +56,7 @@ async function simulateDispatch(opts: {
       startCalls.push({ threadId, branch });
       return { id: "s" };
     },
+    waitForInputReady: async () => true,
     sendMessage: async (threadId, message) => {
       sendCalls.push({ threadId, message });
       return {};

--- a/supervisor/tests/session/dispatch-integration.test.ts
+++ b/supervisor/tests/session/dispatch-integration.test.ts
@@ -1,0 +1,226 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  isDispatchSourceAllowed,
+  loadAccessPolicy,
+} from "../../src/config/access-policy";
+import {
+  parseDispatchCommand,
+  runDispatch,
+} from "../../src/session/dispatch";
+import type { DispatchSessionManager } from "../../src/session/dispatch";
+
+/**
+ * Issue #32 / S7: end-to-end behavioral coverage of the dispatch decision
+ * sequence, replicating exactly what bot.ts's MessageCreate handler does:
+ *
+ *   1. isDispatchSourceAllowed(loadAccessPolicy(), channelId, sourceId)
+ *   2. parseDispatchCommand(content)
+ *   3. runDispatch(...)  -> start session + inject /impl <issue>
+ *
+ * This proves the integrated gating (auth -> parse -> run) without a live
+ * Discord gateway. bot.ts's wiring (ordering + bot-author exception) is
+ * additionally pinned by tests/guards/access-enforcement-wired.test.ts.
+ */
+
+const CHANNEL_ID = "846209781206941736";
+const SOURCE = "555555555555555555"; // an allowed dispatch source (corp webhook/bot)
+const OUTSIDER = "999999999999999999";
+
+interface SimResult {
+  outcome: "started" | "denied" | "rejected" | "ignored";
+  startCalls: Array<{ threadId: string; branch?: string }>;
+  sendCalls: Array<{ threadId: string; message: string }>;
+  threadsCreated: number;
+}
+
+/**
+ * Simulate the bot.ts dispatch decision for a single message. `policyChannel`
+ * is the channel id present in the written policy; `channelId` is the channel
+ * the message arrived on (differs to model an undefined channel).
+ */
+async function simulateDispatch(opts: {
+  accessPath: string;
+  channelId: string;
+  sourceId: string;
+  content: string;
+}): Promise<SimResult> {
+  const startCalls: Array<{ threadId: string; branch?: string }> = [];
+  const sendCalls: Array<{ threadId: string; message: string }> = [];
+  let threadsCreated = 0;
+
+  const manager: DispatchSessionManager = {
+    start: async (_c, threadId, branch) => {
+      startCalls.push({ threadId, branch });
+      return { id: "s" };
+    },
+    sendMessage: async (threadId, message) => {
+      sendCalls.push({ threadId, message });
+      return {};
+    },
+  };
+
+  const base = { startCalls, sendCalls, get threadsCreated() {
+    return threadsCreated;
+  } };
+
+  // Step 1: authorize the source (fail-closed).
+  const decision = isDispatchSourceAllowed(
+    loadAccessPolicy(opts.accessPath),
+    opts.channelId,
+    opts.sourceId,
+  );
+  if (!decision.allowed) {
+    return { outcome: "denied", ...base, threadsCreated };
+  }
+
+  // Step 2: parse.
+  const parsed = parseDispatchCommand(opts.content);
+  if (parsed.kind === "not_dispatch") {
+    return { outcome: "ignored", ...base, threadsCreated };
+  }
+  if (parsed.kind === "error") {
+    return { outcome: "rejected", ...base, threadsCreated };
+  }
+
+  // Step 3: run.
+  await runDispatch({
+    config: { dir: "/x", channelName: "agent-base", displayName: "Agent Base" },
+    branch: parsed.branch,
+    issueNumber: parsed.issueNumber,
+    sessionManager: manager,
+    createThread: async () => {
+      threadsCreated += 1;
+      return { id: "thread-1" };
+    },
+  });
+  return { outcome: "started", ...base, threadsCreated };
+}
+
+describe("dispatch integration (auth -> parse -> run)", () => {
+  let dir: string;
+  let accessPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "dispatch-int-"));
+    accessPath = join(dir, "access.json");
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writePolicy(dispatchFrom: string[]): void {
+    writeFileSync(
+      accessPath,
+      JSON.stringify({
+        groups: {
+          [CHANNEL_ID]: { requireMention: true, allowFrom: [], dispatchFrom },
+        },
+      }),
+    );
+  }
+
+  test("allowed source + valid /dispatch → session started, /impl injected", async () => {
+    writePolicy([SOURCE]);
+    const r = await simulateDispatch({
+      accessPath,
+      channelId: CHANNEL_ID,
+      sourceId: SOURCE,
+      content: "/dispatch corp-dispatch-42 42",
+    });
+    expect(r.outcome).toBe("started");
+    expect(r.threadsCreated).toBe(1);
+    expect(r.startCalls).toEqual([{ threadId: "thread-1", branch: "corp-dispatch-42" }]);
+    expect(r.sendCalls).toEqual([{ threadId: "thread-1", message: "/impl 42" }]);
+  });
+
+  test("non-allowed source → denied, no session (fail-closed)", async () => {
+    writePolicy([SOURCE]);
+    const r = await simulateDispatch({
+      accessPath,
+      channelId: CHANNEL_ID,
+      sourceId: OUTSIDER,
+      content: "/dispatch corp-dispatch-42 42",
+    });
+    expect(r.outcome).toBe("denied");
+    expect(r.startCalls).toHaveLength(0);
+    expect(r.sendCalls).toHaveLength(0);
+    expect(r.threadsCreated).toBe(0);
+  });
+
+  test("unknown channel → denied (fail-closed), no session", async () => {
+    writePolicy([SOURCE]);
+    const r = await simulateDispatch({
+      accessPath,
+      channelId: "000000000000000000", // not in policy
+      sourceId: SOURCE,
+      content: "/dispatch corp-dispatch-42 42",
+    });
+    expect(r.outcome).toBe("denied");
+    expect(r.startCalls).toHaveLength(0);
+  });
+
+  test("missing access.json → denied (fail-closed)", async () => {
+    // No writePolicy() — file absent.
+    const r = await simulateDispatch({
+      accessPath,
+      channelId: CHANNEL_ID,
+      sourceId: SOURCE,
+      content: "/dispatch corp-dispatch-42 42",
+    });
+    expect(r.outcome).toBe("denied");
+    expect(r.startCalls).toHaveLength(0);
+  });
+
+  test("branch with shell metacharacters → rejected, no session (RW-045)", async () => {
+    writePolicy([SOURCE]);
+    const r = await simulateDispatch({
+      accessPath,
+      channelId: CHANNEL_ID,
+      sourceId: SOURCE,
+      content: "/dispatch bad$branch 42",
+    });
+    expect(r.outcome).toBe("rejected");
+    expect(r.startCalls).toHaveLength(0);
+    expect(r.threadsCreated).toBe(0);
+  });
+
+  test("non-integer issue number → rejected, no session", async () => {
+    writePolicy([SOURCE]);
+    const r = await simulateDispatch({
+      accessPath,
+      channelId: CHANNEL_ID,
+      sourceId: SOURCE,
+      content: "/dispatch good-branch not-a-number",
+    });
+    expect(r.outcome).toBe("rejected");
+    expect(r.startCalls).toHaveLength(0);
+  });
+
+  test("env-allowlisted source works on a configured channel without dispatchFrom", async () => {
+    // Channel configured but no dispatchFrom; the source is in env.
+    writeFileSync(
+      accessPath,
+      JSON.stringify({
+        groups: { [CHANNEL_ID]: { requireMention: true, allowFrom: [] } },
+      }),
+    );
+    const prev = process.env.DISPATCH_ALLOWED_SOURCE_IDS;
+    process.env.DISPATCH_ALLOWED_SOURCE_IDS = `${SOURCE},123`;
+    try {
+      const r = await simulateDispatch({
+        accessPath,
+        channelId: CHANNEL_ID,
+        sourceId: SOURCE,
+        content: "/dispatch env-branch 9",
+      });
+      expect(r.outcome).toBe("started");
+      expect(r.sendCalls).toEqual([{ threadId: "thread-1", message: "/impl 9" }]);
+    } finally {
+      if (prev === undefined) delete process.env.DISPATCH_ALLOWED_SOURCE_IDS;
+      else process.env.DISPATCH_ALLOWED_SOURCE_IDS = prev;
+    }
+  });
+});

--- a/supervisor/tests/session/dispatch-run.test.ts
+++ b/supervisor/tests/session/dispatch-run.test.ts
@@ -1,0 +1,148 @@
+import { describe, test, expect } from "bun:test";
+import { runDispatch } from "../../src/session/dispatch";
+import type {
+  DispatchSessionManager,
+  DispatchThreadFactory,
+} from "../../src/session/dispatch";
+
+/**
+ * Issue #32 / S7: behavioral coverage for the dispatch orchestrator. It must
+ * create the thread, start the session on the requested branch, then inject
+ * `/impl <issueNumber>` via sendMessage (start does not take an initial
+ * command). Failures at each stage surface (no silent fallback).
+ */
+
+function fakeManager(overrides: Partial<{
+  start: (config: unknown, threadId: string, branch?: string) => Promise<unknown>;
+  sendMessage: (threadId: string, message: string) => Promise<unknown>;
+}> = {}): {
+  manager: DispatchSessionManager;
+  startCalls: Array<{ threadId: string; branch?: string }>;
+  sendCalls: Array<{ threadId: string; message: string }>;
+} {
+  const startCalls: Array<{ threadId: string; branch?: string }> = [];
+  const sendCalls: Array<{ threadId: string; message: string }> = [];
+  const manager: DispatchSessionManager = {
+    start:
+      overrides.start ??
+      (async (_config, threadId, branch) => {
+        startCalls.push({ threadId, branch });
+        return { id: "session-1" };
+      }),
+    sendMessage:
+      overrides.sendMessage ??
+      (async (threadId, message) => {
+        sendCalls.push({ threadId, message });
+        return { chunks: [], text: "" };
+      }),
+  };
+  return { manager, startCalls, sendCalls };
+}
+
+const config = { channelName: "agent-base", dir: "/x/agent-base" };
+
+describe("runDispatch", () => {
+  test("happy path: thread created, session started, /impl injected", async () => {
+    const { manager, startCalls, sendCalls } = fakeManager();
+    let threadBranch: string | undefined;
+    const createThread: DispatchThreadFactory = async (branch) => {
+      threadBranch = branch;
+      return { id: "thread-abc" };
+    };
+
+    const r = await runDispatch({
+      config,
+      branch: "corp-dispatch-42",
+      issueNumber: 42,
+      sessionManager: manager,
+      createThread,
+    });
+
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.threadId).toBe("thread-abc");
+      expect(r.injected).toBe("/impl 42");
+    }
+    expect(threadBranch).toBe("corp-dispatch-42");
+    expect(startCalls).toEqual([
+      { threadId: "thread-abc", branch: "corp-dispatch-42" },
+    ]);
+    expect(sendCalls).toEqual([
+      { threadId: "thread-abc", message: "/impl 42" },
+    ]);
+  });
+
+  test("start runs BEFORE the injected command (ordering)", async () => {
+    const order: string[] = [];
+    const { manager } = fakeManager({
+      start: async () => {
+        order.push("start");
+        return { id: "s" };
+      },
+      sendMessage: async () => {
+        order.push("inject");
+        return {};
+      },
+    });
+    await runDispatch({
+      config,
+      branch: "b",
+      issueNumber: 1,
+      sessionManager: manager,
+      createThread: async () => ({ id: "t" }),
+    });
+    expect(order).toEqual(["start", "inject"]);
+  });
+
+  test("thread creation failure → ok:false stage=thread, no start/inject", async () => {
+    const { manager, startCalls, sendCalls } = fakeManager();
+    const r = await runDispatch({
+      config,
+      branch: "b",
+      issueNumber: 1,
+      sessionManager: manager,
+      createThread: async () => {
+        throw new Error("missing perms");
+      },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.stage).toBe("thread");
+    expect(startCalls).toHaveLength(0);
+    expect(sendCalls).toHaveLength(0);
+  });
+
+  test("session start failure → ok:false stage=start, no inject (no silent fallback)", async () => {
+    const { manager, sendCalls } = fakeManager({
+      start: async () => {
+        throw new Error("git worktree add failed");
+      },
+    });
+    const r = await runDispatch({
+      config,
+      branch: "b",
+      issueNumber: 1,
+      sessionManager: manager,
+      createThread: async () => ({ id: "t" }),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.stage).toBe("start");
+    expect(sendCalls).toHaveLength(0);
+  });
+
+  test("inject failure → ok:false stage=inject", async () => {
+    const { manager } = fakeManager({
+      sendMessage: async () => {
+        throw new Error("tmux gone");
+      },
+    });
+    const r = await runDispatch({
+      config,
+      branch: "b",
+      issueNumber: 7,
+      sessionManager: manager,
+      createThread: async () => ({ id: "t" }),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.stage).toBe("inject");
+  });
+});

--- a/supervisor/tests/session/dispatch-run.test.ts
+++ b/supervisor/tests/session/dispatch-run.test.ts
@@ -29,6 +29,7 @@ function fakeManager(overrides: Partial<{
         startCalls.push({ threadId, branch });
         return { id: "session-1" };
       }),
+    waitForInputReady: async () => true,
     sendMessage:
       overrides.sendMessage ??
       (async (threadId, message) => {

--- a/supervisor/tests/session/dispatch.test.ts
+++ b/supervisor/tests/session/dispatch.test.ts
@@ -1,0 +1,95 @@
+import { describe, test, expect } from "bun:test";
+import { parseDispatchCommand } from "../../src/session/dispatch";
+
+/**
+ * Issue #32 / S7 (dispatch transport): an allowed external source posts a
+ * single message to a department channel:
+ *
+ *   /dispatch <branch> <issueNumber>
+ *
+ * `parseDispatchCommand` is the pure validator. It rejects anything that is
+ * not the exact shape, a branch with shell metacharacters / path traversal
+ * (RW-045 reuse), or a non-positive-integer issue number. A non-`/dispatch`
+ * message yields `{ kind: "not_dispatch" }` so the caller falls through to the
+ * normal relay path.
+ */
+
+describe("parseDispatchCommand", () => {
+  test("parses a valid /dispatch command", () => {
+    const r = parseDispatchCommand("/dispatch corp-dispatch-42 42");
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") {
+      expect(r.branch).toBe("corp-dispatch-42");
+      expect(r.issueNumber).toBe(42);
+    }
+  });
+
+  test("tolerates extra surrounding whitespace", () => {
+    const r = parseDispatchCommand("   /dispatch   feat/foo   7   ");
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") {
+      expect(r.branch).toBe("feat/foo");
+      expect(r.issueNumber).toBe(7);
+    }
+  });
+
+  test("non-/dispatch content → not_dispatch (falls through to relay)", () => {
+    expect(parseDispatchCommand("hello world").kind).toBe("not_dispatch");
+    expect(parseDispatchCommand("/impl 42").kind).toBe("not_dispatch");
+    expect(parseDispatchCommand("/dispatcher x 1").kind).toBe("not_dispatch");
+    expect(parseDispatchCommand("").kind).toBe("not_dispatch");
+  });
+
+  test("missing issue number → error (not silently a relay)", () => {
+    const r = parseDispatchCommand("/dispatch some-branch");
+    expect(r.kind).toBe("error");
+  });
+
+  test("too many arguments → error", () => {
+    const r = parseDispatchCommand("/dispatch some-branch 42 extra");
+    expect(r.kind).toBe("error");
+  });
+
+  test("non-integer issue number → error", () => {
+    expect(parseDispatchCommand("/dispatch some-branch abc").kind).toBe("error");
+    expect(parseDispatchCommand("/dispatch some-branch 4.2").kind).toBe("error");
+    expect(parseDispatchCommand("/dispatch some-branch 4x").kind).toBe("error");
+  });
+
+  test("zero / negative issue number → error", () => {
+    expect(parseDispatchCommand("/dispatch some-branch 0").kind).toBe("error");
+    expect(parseDispatchCommand("/dispatch some-branch -5").kind).toBe("error");
+  });
+
+  test("branch with shell metacharacters → error (RW-045)", () => {
+    for (const bad of [
+      '/dispatch foo"bar 1',
+      "/dispatch foo`bar 1",
+      "/dispatch foo$bar 1",
+      "/dispatch foo\\bar 1",
+    ]) {
+      const r = parseDispatchCommand(bad);
+      expect(r.kind).toBe("error");
+    }
+  });
+
+  test("branch path traversal → error (RW-045)", () => {
+    const r = parseDispatchCommand("/dispatch ../../etc 1");
+    expect(r.kind).toBe("error");
+  });
+
+  test("error reason is identifier-free of the raw issue arg", () => {
+    const r = parseDispatchCommand("/dispatch some-branch not-a-number");
+    expect(r.kind).toBe("error");
+    if (r.kind === "error") {
+      // The coarse message names the field, not the raw user-supplied token.
+      expect(r.reason).not.toContain("not-a-number");
+    }
+  });
+
+  test("a very large issue number is accepted as a positive integer", () => {
+    const r = parseDispatchCommand("/dispatch b 1000000");
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.issueNumber).toBe(1000000);
+  });
+});

--- a/supervisor/tests/session/dispatch.test.ts
+++ b/supervisor/tests/session/dispatch.test.ts
@@ -1,5 +1,9 @@
 import { describe, test, expect } from "bun:test";
-import { parseDispatchCommand } from "../../src/session/dispatch";
+import {
+  parseDispatchCommand,
+  runDispatch,
+  type DispatchSessionManager,
+} from "../../src/session/dispatch";
 
 /**
  * Issue #32 / S7 (dispatch transport): an allowed external source posts a
@@ -91,5 +95,95 @@ describe("parseDispatchCommand", () => {
     const r = parseDispatchCommand("/dispatch b 1000000");
     expect(r.kind).toBe("ok");
     if (r.kind === "ok") expect(r.issueNumber).toBe(1000000);
+  });
+});
+
+/**
+ * runDispatch must wait for the dept TUI to be input-ready BEFORE injecting the
+ * `/impl` slash command. start() only waits for the PID, so an immediate inject
+ * lets the Ink slash-picker eat the leading `/` and strands the text
+ * un-submitted (RW-025 / RW-047, observed live as "impl <N>" stuck in the box).
+ * These tests pin the ordering (start → waitForInputReady → sendMessage) and the
+ * best-effort fallback (inject anyway on readiness timeout — never a silent drop).
+ */
+describe("runDispatch readiness ordering (RW-025/047)", () => {
+  function recordingManager(ready: boolean): {
+    sm: DispatchSessionManager;
+    calls: string[];
+  } {
+    const calls: string[] = [];
+    const sm: DispatchSessionManager = {
+      start: async () => {
+        calls.push("start");
+        return {};
+      },
+      waitForInputReady: async () => {
+        calls.push("waitForInputReady");
+        return ready;
+      },
+      sendMessage: async (_threadId: string, message: string) => {
+        calls.push(`send:${message}`);
+        return {};
+      },
+    };
+    return { sm, calls };
+  }
+
+  test("waits for input-ready, then injects /impl in order", async () => {
+    const { sm, calls } = recordingManager(true);
+    const r = await runDispatch({
+      config: {},
+      branch: "corp-dispatch-42",
+      issueNumber: 42,
+      sessionManager: sm,
+      createThread: async () => ({ id: "thread-1" }),
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.threadId).toBe("thread-1");
+      expect(r.injected).toBe("/impl 42");
+    }
+    // Critical: waitForInputReady is BETWEEN start and the /impl inject.
+    expect(calls).toEqual(["start", "waitForInputReady", "send:/impl 42"]);
+  });
+
+  test("injects anyway when readiness times out (best-effort, no silent drop)", async () => {
+    const { sm, calls } = recordingManager(false);
+    const r = await runDispatch({
+      config: {},
+      branch: "b",
+      issueNumber: 7,
+      sessionManager: sm,
+      createThread: async () => ({ id: "t" }),
+    });
+    expect(r.ok).toBe(true);
+    expect(calls).toEqual(["start", "waitForInputReady", "send:/impl 7"]);
+  });
+
+  test("a readiness probe error does not abort the dispatch (still injects)", async () => {
+    const calls: string[] = [];
+    const sm: DispatchSessionManager = {
+      start: async () => {
+        calls.push("start");
+        return {};
+      },
+      waitForInputReady: async () => {
+        calls.push("waitForInputReady");
+        throw new Error("probe boom");
+      },
+      sendMessage: async (_t: string, message: string) => {
+        calls.push(`send:${message}`);
+        return {};
+      },
+    };
+    const r = await runDispatch({
+      config: {},
+      branch: "b",
+      issueNumber: 9,
+      sessionManager: sm,
+      createThread: async () => ({ id: "t" }),
+    });
+    expect(r.ok).toBe(true);
+    expect(calls).toEqual(["start", "waitForInputReady", "send:/impl 9"]);
   });
 });

--- a/supervisor/tests/session/manager-input-ready.test.ts
+++ b/supervisor/tests/session/manager-input-ready.test.ts
@@ -1,0 +1,76 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+
+// Isolate DB writes from the real sessions.db (mirrors manager-resume.test.ts).
+process.env.SUPERVISOR_DB_PATH = ":memory:";
+
+const { SessionManager } = await import("../../src/session/manager");
+const { createFakeEffects } = await import("../../src/session/adapters-fake");
+import type { FakeSessionEffects } from "../../src/session/adapters-fake";
+
+/**
+ * SessionManager.waitForInputReady (dispatch readiness, RW-025 / RW-047).
+ *
+ * The dispatch transport injects `/impl <N>` only after the freshly started
+ * dept TUI is ready for input; otherwise the Ink slash-picker eats the leading
+ * `/` mid-boot and strands the text un-submitted. These tests pin the polling
+ * contract: ready marker → true, no marker within the window → false, dead pane
+ * → false (so the caller can decide to inject best-effort vs. abort).
+ */
+
+const THREAD_ID = "thread-ready-xyz";
+// Mirrors SessionManager.tmuxSessionName: `claude-` + threadId.slice(0, 12).
+const tmuxName = `claude-${THREAD_ID.slice(0, 12)}`;
+
+// A fresh `--dangerously-skip-permissions` TUI shows this once it accepts input.
+const READY_PANE = "❯ \n  ⏵⏵ bypass permissions on (shift+tab to cycle)";
+
+describe("SessionManager.waitForInputReady (RW-025/047)", () => {
+  let manager: InstanceType<typeof SessionManager>;
+  let effects: FakeSessionEffects;
+
+  beforeEach(() => {
+    effects = createFakeEffects();
+  });
+
+  afterEach(async () => {
+    await manager?.shutdownAll();
+  });
+
+  test("returns true once the input-ready marker appears", async () => {
+    manager = new SessionManager({
+      effects,
+      gracefulKillTimeoutMs: 0,
+      inputReadyPollAttempts: 100,
+      inputReadyPollIntervalMs: 5,
+    });
+    effects.tmux.newSession(tmuxName, "claude ...");
+    effects.tmux.setPaneContent(tmuxName, READY_PANE);
+
+    expect(await manager.waitForInputReady(THREAD_ID)).toBe(true);
+  });
+
+  test("returns false when the marker never appears within the window", async () => {
+    manager = new SessionManager({
+      effects,
+      gracefulKillTimeoutMs: 0,
+      inputReadyPollAttempts: 3,
+      inputReadyPollIntervalMs: 5,
+    });
+    effects.tmux.newSession(tmuxName, "claude ...");
+    // Pane shows a still-booting screen with no input-ready marker.
+    effects.tmux.setPaneContent(tmuxName, "Loading project context...");
+
+    expect(await manager.waitForInputReady(THREAD_ID)).toBe(false);
+  });
+
+  test("returns false immediately when the pane is dead (no tmux session)", async () => {
+    manager = new SessionManager({
+      effects,
+      gracefulKillTimeoutMs: 0,
+      inputReadyPollAttempts: 1000,
+      inputReadyPollIntervalMs: 5,
+    });
+    // No newSession → hasSession(tmuxName) is false → bail out without polling.
+    expect(await manager.waitForInputReady(THREAD_ID)).toBe(false);
+  });
+});


### PR DESCRIPTION
## 概要

`feat/s7-allowfrom-enforce` を main へ統合します。S7（access.json の実行時強制）＋メッセージ起動 dispatch 実行役＋CEOハブ接続＋dispatch 注入の readiness 修正を含みます。Supervisor のデプロイ元 working tree を正規化するための取り込みです。

## 主な変更（5 commits, main の 0 個遅れなし／3 個分は #201 含む — マージ時に取り込み）

- **S7: allowFrom 実行時強制（fail-closed）** — `config/access-policy.ts`。policy 不在／空 groups／未設定 channel／空 allowFrom／dispatchFrom 不在 は全て DENY。
- **メッセージ起動 dispatch 実行役** — `session/dispatch.ts` + `bot.ts`。許可された source が `/dispatch <branch> <issue>` を投稿 → 対象 channel の repo で session 起動 → `/impl <N>` を注入。branch 名は RW-045 の `resolveWorktreePath` ガードで検証、issue は正の整数のみ。
- **CEOハブ接続** — `config/channels.ts` の CHANNEL_MAP に corp(CEOハブ) を追加。`claude-hub` メタ依存ガードは維持。
- **dispatch 注入の readiness 修正（RW-025/047 系）** — `session/manager.ts` の `waitForInputReady`。TUI 入力準備マーカー（`bypass permissions` / `? for shortcuts`）を待ってから `/impl` を注入し、スラッシュピッカーに食われて未送信になる事象を解消。best-effort（タイムアウト時も注入）でサイレントドロップを回避。

## レビュー

- code-review-orchestrator によるセキュリティ重点レビュー実施 → **MERGE VERDICT: OK**（must/blocking なし）。
  - fail-closed の正しさ、dispatch の auth 先行チェック、branch/issue の injection 不可、secret 非露出を確認。
- 非ブロッキングの follow-up:
  - should: `bot.ts:228` の `content.trim()` 二重呼び出しをキャッシュ化
  - nit: `access-policy.ts` の `parentId ?? threadId` フォールバック時に区別可能な warn ログを出す

## テスト / CI

- CI（PR→main）は `bunx tsc --noEmit` のみ。ローカルで typecheck exit 0 を確認。
- 変更面のユニットテスト（dispatch / readiness / access）29 件 + 既存スイートで 477 pass。
- 既知の 5 件 fail は **本 branch で未変更のファイル**（`infra/db.ts` の shell-exec guard、`session/tmux.ts`/`relay.ts` の実 tmux 統合テスト）に起因する pre-existing/環境依存で、本変更の regression ではない。
- origin/main との merge-tree dry-run でコンフリクトなしを確認済み。

## デプロイ注意

マージ自体は稼働中 Supervisor を再起動しない（working tree は feat/s7 のまま稼働継続）。デプロイ元を main へ切り替える正規化は、稼働 session が無いタイミングで別途実施。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added access control policy engine for managing permissions across channels and sessions.
  * Introduced dispatch transport to initiate sessions from external webhook sources.
  * Added session input-readiness monitoring for improved initialization tracking.
  * Expanded channel configuration with new "corp" channel support.

* **Tests**
  * Comprehensive test coverage for access enforcement and dispatch workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->