### PR TITLE
feat: dispatch に pdca モードを追加し Epic を /pdca で実行可能にする

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -275,9 +275,9 @@ export async function startBot(token: string): Promise<void> {
       return true;
     }
 
-    const { branch, issueNumber } = parsed;
+    const { branch, issueNumber, command } = parsed;
     console.log(
-      `[Bot] Dispatch accepted in channel ${channelName} (branch len=${branch.length}, issue=${issueNumber})`
+      `[Bot] Dispatch accepted in channel ${channelName} (branch len=${branch.length}, issue=${issueNumber}, mode=${command})`
     );
 
     const textChannel = message.channel as TextChannel;
@@ -285,6 +285,7 @@ export async function startBot(token: string): Promise<void> {
       config,
       branch,
       issueNumber,
+      command,
       sessionManager,
       createThread: async (b: string) => {
         // Sequence suffix only when another session is already live on the same

--- a/supervisor/src/session/dispatch.ts
+++ b/supervisor/src/session/dispatch.ts
@@ -10,14 +10,17 @@
  * This module adds a generic transport: an *allowed source* posts a single
  * message to a known department channel:
  *
- *   /dispatch <branch> <issueNumber>
- *       e.g.  /dispatch corp-dispatch-42 42
+ *   /dispatch <branch> <issueNumber> [impl|pdca]
+ *       e.g.  /dispatch corp-dispatch-42 42          (defaults to /impl)
+ *             /dispatch corp-dispatch-341 341 pdca   (Epic → /pdca)
  *
  * claude-hub then starts a session in that channel's mapped repo on `<branch>`
- * and injects `/impl <issueNumber>` as the session's first prompt. The feature
- * is intentionally generic — it hardcodes no corp-specific names; any source
- * enumerated in the access policy (`dispatchFrom` / `DISPATCH_ALLOWED_SOURCE_IDS`)
- * can drive it.
+ * and injects `/<command> <issueNumber>` as the session's first prompt. The
+ * optional 3rd token selects `impl` (default — a single Issue) or `pdca`
+ * (Epic-aware: the agent-base `/pdca` flow walks the Epic's child Issues). The
+ * feature is intentionally generic — it hardcodes no corp-specific names; any
+ * source enumerated in the access policy (`dispatchFrom` /
+ * `DISPATCH_ALLOWED_SOURCE_IDS`) can drive it.
  *
  * Authorization (who may dispatch) lives in `config/access-policy.ts`
  * (`isDispatchSourceAllowed`, fail-closed). This module owns parsing and the
@@ -30,8 +33,14 @@ import { resolveWorktreePath } from "./worktree";
 /** Literal trigger token. Exposed so external callers (corp) can match it. */
 export const DISPATCH_PREFIX = "/dispatch";
 
+/**
+ * Slash command the dispatched session runs first. `impl` = one Issue (default);
+ * `pdca` = the Epic-aware agent-base `/pdca` flow that walks child Issues.
+ */
+export type DispatchMode = "impl" | "pdca";
+
 export type ParsedDispatch =
-  | { kind: "ok"; branch: string; issueNumber: number }
+  | { kind: "ok"; branch: string; issueNumber: number; command: DispatchMode }
   | { kind: "not_dispatch" }
   | { kind: "error"; reason: string };
 
@@ -44,11 +53,12 @@ export type ParsedDispatch =
 const BRANCH_VALIDATION_ROOT = "/__dispatch_branch_validation__";
 
 /**
- * Parse a `/dispatch <branch> <issueNumber>` message. Returns:
+ * Parse a `/dispatch <branch> <issueNumber> [impl|pdca]` message. Returns:
  *   - `not_dispatch` when the content is not a `/dispatch` command (caller
  *     falls through to the normal relay path),
  *   - `error` with a coarse, identifier-free reason for a malformed command,
- *   - `ok` with a validated branch + positive-integer issue number.
+ *   - `ok` with a validated branch, positive-integer issue number and command
+ *     mode (defaults to `impl` when the optional 3rd token is omitted).
  *
  * Branch validation reuses {@link resolveWorktreePath} (RW-045) so metachar /
  * traversal rejection cannot drift from the worktree path logic.
@@ -65,14 +75,29 @@ export function parseDispatchCommand(content: string): ParsedDispatch {
   const rest = trimmed.slice(DISPATCH_PREFIX.length).trim();
   const parts = rest.length > 0 ? rest.split(/\s+/) : [];
 
-  if (parts.length !== 2) {
+  // Shape: `<branch> <issueNumber>` (mode defaults to impl) or
+  //        `<branch> <issueNumber> <impl|pdca>`.
+  if (parts.length !== 2 && parts.length !== 3) {
     return {
       kind: "error",
-      reason: "形式が不正です。/dispatch <branch> <issueNumber> で指定してください。",
+      reason: "形式が不正です。/dispatch <branch> <issueNumber> [impl|pdca] で指定してください。",
     };
   }
 
-  const [branch, issueArg] = parts as [string, string];
+  const [branch, issueArg, modeArg] = parts as [string, string, string?];
+
+  // Mode: optional 3rd token, default impl (backward compatible). Fail-closed on
+  // any unrecognized command so a typo never silently runs the wrong flow.
+  let command: DispatchMode = "impl";
+  if (modeArg !== undefined) {
+    if (modeArg !== "impl" && modeArg !== "pdca") {
+      return {
+        kind: "error",
+        reason: "mode は impl または pdca を指定してください。",
+      };
+    }
+    command = modeArg;
+  }
 
   // Issue number: positive integer only (no decimals, signs, or trailing text).
   if (!/^[0-9]+$/.test(issueArg)) {
@@ -99,7 +124,7 @@ export function parseDispatchCommand(content: string): ParsedDispatch {
     };
   }
 
-  return { kind: "ok", branch, issueNumber };
+  return { kind: "ok", branch, issueNumber, command };
 }
 
 /**
@@ -115,9 +140,9 @@ export interface DispatchSessionManager {
   /**
    * Wait until the freshly started session's Ink TUI is ready to accept input.
    * Resolves true when the input-ready marker is observed, false on timeout or a
-   * dead pane. {@link runDispatch} injects the `/impl` slash command only after
-   * this so the slash-picker doesn't swallow the leading `/` while the TUI is
-   * still booting (RW-025 / RW-047 timing class).
+   * dead pane. {@link runDispatch} injects the slash command (`/impl` or `/pdca`)
+   * only after this so the slash-picker doesn't swallow the leading `/` while the
+   * TUI is still booting (RW-025 / RW-047 timing class).
    */
   waitForInputReady(threadId: string): Promise<boolean>;
   sendMessage(threadId: string, message: string): Promise<unknown>;
@@ -132,6 +157,7 @@ export interface RunDispatchArgs {
   config: unknown;
   branch: string;
   issueNumber: number;
+  command: DispatchMode;
   sessionManager: DispatchSessionManager;
   createThread: DispatchThreadFactory;
 }
@@ -142,10 +168,11 @@ export type RunDispatchResult =
 
 /**
  * Orchestrate a validated dispatch: create the thread, start the session in the
- * channel's repo on `branch`, then inject `/impl <issueNumber>` as the first
- * prompt. `start()` does not accept an initial command (it only launches the
- * pane), so the command is injected via `sendMessage` after the session is
- * registered — the same path a user's first thread message would take.
+ * channel's repo on `branch`, then inject `/<command> <issueNumber>` as the
+ * first prompt (`command` is `impl` or `pdca`). `start()` does not accept an
+ * initial command (it only launches the pane), so the command is injected via
+ * `sendMessage` after the session is registered — the same path a user's first
+ * thread message would take.
  *
  * Errors are surfaced (no silent fallback): a failure is tagged with the stage
  * so the caller can log it without leaking the raw payload.
@@ -153,7 +180,8 @@ export type RunDispatchResult =
 export async function runDispatch(
   args: RunDispatchArgs,
 ): Promise<RunDispatchResult> {
-  const { config, branch, issueNumber, sessionManager, createThread } = args;
+  const { config, branch, issueNumber, command, sessionManager, createThread } =
+    args;
 
   let threadId: string;
   try {
@@ -170,8 +198,8 @@ export async function runDispatch(
   }
 
   // The dept TUI is still booting when start() returns — start() only waits for
-  // the PID, not an input-ready prompt. Injecting `/impl` into a not-yet-ready
-  // Ink TUI lets the slash-command picker swallow the leading `/` and strands
+  // the PID, not an input-ready prompt. Injecting the slash command into a
+  // not-yet-ready Ink TUI lets the slash-command picker swallow the leading `/` and strands
   // the text un-submitted (RW-025 / RW-047 timing class — observed live as
   // "impl <N>" stuck in the input box). Wait for the input-ready marker first.
   // Best-effort: on timeout / probe error we still inject (the marker may have
@@ -190,7 +218,7 @@ export async function runDispatch(
     );
   }
 
-  const initialCommand = `/impl ${issueNumber}`;
+  const initialCommand = `/${command} ${issueNumber}`;
   try {
     await sessionManager.sendMessage(threadId, initialCommand);
   } catch (err) {

--- a/supervisor/tests/session/dispatch-integration.test.ts
+++ b/supervisor/tests/session/dispatch-integration.test.ts
@@ -91,6 +91,7 @@ async function simulateDispatch(opts: {
     config: { dir: "/x", channelName: "agent-base", displayName: "Agent Base" },
     branch: parsed.branch,
     issueNumber: parsed.issueNumber,
+    command: parsed.command,
     sessionManager: manager,
     createThread: async () => {
       threadsCreated += 1;
@@ -135,6 +136,19 @@ describe("dispatch integration (auth -> parse -> run)", () => {
     expect(r.threadsCreated).toBe(1);
     expect(r.startCalls).toEqual([{ threadId: "thread-1", branch: "corp-dispatch-42" }]);
     expect(r.sendCalls).toEqual([{ threadId: "thread-1", message: "/impl 42" }]);
+  });
+
+  test("allowed source + pdca mode → session started, /pdca injected (Epic)", async () => {
+    writePolicy([SOURCE]);
+    const r = await simulateDispatch({
+      accessPath,
+      channelId: CHANNEL_ID,
+      sourceId: SOURCE,
+      content: "/dispatch corp-dispatch-341 341 pdca",
+    });
+    expect(r.outcome).toBe("started");
+    expect(r.startCalls).toEqual([{ threadId: "thread-1", branch: "corp-dispatch-341" }]);
+    expect(r.sendCalls).toEqual([{ threadId: "thread-1", message: "/pdca 341" }]);
   });
 
   test("non-allowed source → denied, no session (fail-closed)", async () => {

--- a/supervisor/tests/session/dispatch-run.test.ts
+++ b/supervisor/tests/session/dispatch-run.test.ts
@@ -55,6 +55,7 @@ describe("runDispatch", () => {
       config,
       branch: "corp-dispatch-42",
       issueNumber: 42,
+      command: "impl",
       sessionManager: manager,
       createThread,
     });
@@ -89,6 +90,7 @@ describe("runDispatch", () => {
       config,
       branch: "b",
       issueNumber: 1,
+      command: "impl",
       sessionManager: manager,
       createThread: async () => ({ id: "t" }),
     });
@@ -101,6 +103,7 @@ describe("runDispatch", () => {
       config,
       branch: "b",
       issueNumber: 1,
+      command: "impl",
       sessionManager: manager,
       createThread: async () => {
         throw new Error("missing perms");
@@ -122,6 +125,7 @@ describe("runDispatch", () => {
       config,
       branch: "b",
       issueNumber: 1,
+      command: "impl",
       sessionManager: manager,
       createThread: async () => ({ id: "t" }),
     });
@@ -140,6 +144,7 @@ describe("runDispatch", () => {
       config,
       branch: "b",
       issueNumber: 7,
+      command: "impl",
       sessionManager: manager,
       createThread: async () => ({ id: "t" }),
     });

--- a/supervisor/tests/session/dispatch.test.ts
+++ b/supervisor/tests/session/dispatch.test.ts
@@ -19,21 +19,47 @@ import {
  */
 
 describe("parseDispatchCommand", () => {
-  test("parses a valid /dispatch command", () => {
+  test("parses a valid /dispatch command (mode defaults to impl)", () => {
     const r = parseDispatchCommand("/dispatch corp-dispatch-42 42");
     expect(r.kind).toBe("ok");
     if (r.kind === "ok") {
       expect(r.branch).toBe("corp-dispatch-42");
       expect(r.issueNumber).toBe(42);
+      expect(r.command).toBe("impl");
     }
   });
 
+  test("parses an explicit impl mode", () => {
+    const r = parseDispatchCommand("/dispatch corp-dispatch-42 42 impl");
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") {
+      expect(r.issueNumber).toBe(42);
+      expect(r.command).toBe("impl");
+    }
+  });
+
+  test("parses a pdca mode (Epic dispatch)", () => {
+    const r = parseDispatchCommand("/dispatch corp-dispatch-341 341 pdca");
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") {
+      expect(r.branch).toBe("corp-dispatch-341");
+      expect(r.issueNumber).toBe(341);
+      expect(r.command).toBe("pdca");
+    }
+  });
+
+  test("an unrecognized mode token → error (fail-closed)", () => {
+    const r = parseDispatchCommand("/dispatch corp-dispatch-42 42 bogus");
+    expect(r.kind).toBe("error");
+  });
+
   test("tolerates extra surrounding whitespace", () => {
-    const r = parseDispatchCommand("   /dispatch   feat/foo   7   ");
+    const r = parseDispatchCommand("   /dispatch   feat/foo   7   pdca   ");
     expect(r.kind).toBe("ok");
     if (r.kind === "ok") {
       expect(r.branch).toBe("feat/foo");
       expect(r.issueNumber).toBe(7);
+      expect(r.command).toBe("pdca");
     }
   });
 
@@ -50,7 +76,7 @@ describe("parseDispatchCommand", () => {
   });
 
   test("too many arguments → error", () => {
-    const r = parseDispatchCommand("/dispatch some-branch 42 extra");
+    const r = parseDispatchCommand("/dispatch some-branch 42 pdca extra");
     expect(r.kind).toBe("error");
   });
 
@@ -135,6 +161,7 @@ describe("runDispatch readiness ordering (RW-025/047)", () => {
       config: {},
       branch: "corp-dispatch-42",
       issueNumber: 42,
+      command: "impl",
       sessionManager: sm,
       createThread: async () => ({ id: "thread-1" }),
     });
@@ -147,12 +174,28 @@ describe("runDispatch readiness ordering (RW-025/047)", () => {
     expect(calls).toEqual(["start", "waitForInputReady", "send:/impl 42"]);
   });
 
+  test("pdca mode injects /pdca (Epic-aware) after readiness", async () => {
+    const { sm, calls } = recordingManager(true);
+    const r = await runDispatch({
+      config: {},
+      branch: "corp-dispatch-341",
+      issueNumber: 341,
+      command: "pdca",
+      sessionManager: sm,
+      createThread: async () => ({ id: "thread-1" }),
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.injected).toBe("/pdca 341");
+    expect(calls).toEqual(["start", "waitForInputReady", "send:/pdca 341"]);
+  });
+
   test("injects anyway when readiness times out (best-effort, no silent drop)", async () => {
     const { sm, calls } = recordingManager(false);
     const r = await runDispatch({
       config: {},
       branch: "b",
       issueNumber: 7,
+      command: "impl",
       sessionManager: sm,
       createThread: async () => ({ id: "t" }),
     });
@@ -180,6 +223,7 @@ describe("runDispatch readiness ordering (RW-025/047)", () => {
       config: {},
       branch: "b",
       issueNumber: 9,
+      command: "impl",
       sessionManager: sm,
       createThread: async () => ({ id: "t" }),
     });


### PR DESCRIPTION
## 目的

corp の S3 dispatch（`/dispatch <branch> <N>`）は claude-hub の executor が常に **`/impl <N>` をハードコード注入**していたため、Epic を子 Issue まで自動処理する **`/pdca` を部署セッションで起動できなかった**。Epic レベルの dispatch を `/pdca` で回せるよう、dispatch プロトコルに注入コマンド種別を持たせる。

## 主な変更

- **プロトコル拡張（後方互換）**: `/dispatch <branch> <N> [impl|pdca]`。第3トークンは任意で、省略時は `impl`（既存挙動を維持）。`pdca` は agent-base の Epic 対応フロー（子 Issue を順次処理）を起動する。
- `parseDispatchCommand`: 第3トークン `impl|pdca` を解析。未知トークンは **fail-closed で error**（typo で誤フロー実行を防ぐ）。`ParsedDispatch` ok に `command: DispatchMode` を追加。
- `runDispatch`: 注入を `/${command} ${issueNumber}` に変更（従来 `/impl` 固定）。`RunDispatchArgs` に `command` を追加。
- `bot.ts`: `parsed.command` を `runDispatch` へ受け渡し、ログに `mode` を出力。

## テスト

- `dispatch.test.ts` / `dispatch-run.test.ts` / `dispatch-integration.test.ts` に pdca ケース・mode 既定値・未知トークン error を追加。
- 検証: `tests/session tests/guards` 全体で **276 pass**（origin/main は 271 pass）。差分 +5 はすべて本 PR の新規 pdca ケースで、**新規 failure は 0**。既存の 14 fail / 7 errors は本変更と無関係（tmux 実環境依存 + `src/infra/db.ts` の shell-exec guard 指摘）で main と同一。
- `tsc --noEmit` exit 0。

## 関連

- corp 側でこの第3トークンを送る対応（Epic ラベル Issue → `pdca`）を別 PR で実施。
- 親要件: 本社 CEO から「Epic を /pdca で部署に dispatch」する運用（今後常用）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `/dispatch` コマンドでセッションモードを指定可能に。`impl` または `pdca` をパラメータで設定でき、省略時はデフォルトの `impl` が適用されます。指定されたモードがセッション起動時に確実に反映されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->