### PR TITLE
feat: 高コンテキスト時のサイレント停止を検知し Discord へ警告 (#204)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
                    tests/session/notify-pushover.test.ts \
                    tests/session/dialog-stuck-handler.test.ts \
                    tests/session/stall-heartbeat.test.ts \
+                   tests/session/context-budget.test.ts \
                    tests/hijoguchi-routing/p0.test.ts \
                    tests/e2e/ac-verification.test.ts
 

--- a/supervisor/hooks/stop-relay.sh
+++ b/supervisor/hooks/stop-relay.sh
@@ -34,6 +34,7 @@ CONTEXT_TOKENS=""
 TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
 if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
   CONTEXT_TOKENS=$(tail -n 400 "$TRANSCRIPT" 2>/dev/null \
+    | grep '"usage"' 2>/dev/null \
     | jq -c -R 'fromjson? // empty' 2>/dev/null \
     | jq -s -r '
         [ .[] | select(.message.usage) ] as $u

--- a/supervisor/hooks/stop-relay.sh
+++ b/supervisor/hooks/stop-relay.sh
@@ -1,7 +1,16 @@
 #!/bin/bash
 # Claude Code Stop hook: POSTs the assistant response to Supervisor's HTTP relay.
-# Called with JSON on stdin containing last_assistant_message and session_id.
+# Called with JSON on stdin containing last_assistant_message, session_id, and
+# (Claude Code contract) transcript_path.
 # Requires: SUPERVISOR_RELAY_URL environment variable.
+#
+# Issue #204: also computes the session's *current* context token count from the
+# transcript and forwards it as `context_tokens`. At high context (~330k+) a
+# session's tool-call markup can degrade to plain text and the tool silently
+# never runs (context rot); the supervisor uses this number to warn the Discord
+# thread before/when the session enters rot territory. Best-effort: if the
+# transcript or jq is unavailable, the field is simply omitted (the response
+# POST must never break on instrumentation).
 
 if [ -z "$SUPERVISOR_RELAY_URL" ]; then
   exit 0
@@ -15,9 +24,43 @@ if [ -z "$TEXT" ]; then
   exit 0
 fi
 
+# --- Issue #204: context token count (best-effort) ---------------------------
+# Mirrors agent-base hooks/context-budget-check.sh: the *current* context size
+# is the last usage entry's input_tokens + cache_read + cache_creation (summing
+# the whole session would double-count cache re-reads). Only the tail of the
+# transcript is scanned so cost stays bounded even when the file is large — and
+# a large file is exactly the high-context case we care about.
+CONTEXT_TOKENS=""
+TRANSCRIPT=$(echo "$INPUT" | jq -r '.transcript_path // empty')
+if [ -n "$TRANSCRIPT" ] && [ -f "$TRANSCRIPT" ]; then
+  CONTEXT_TOKENS=$(tail -n 400 "$TRANSCRIPT" 2>/dev/null \
+    | jq -c -R 'fromjson? // empty' 2>/dev/null \
+    | jq -s -r '
+        [ .[] | select(.message.usage) ] as $u
+        | if ($u | length) == 0 then empty
+          else ($u[-1].message.usage) as $x
+            | ( ($x.input_tokens // 0)
+              + ($x.cache_read_input_tokens // 0)
+              + ($x.cache_creation_input_tokens // 0) )
+          end
+      ' 2>/dev/null)
+fi
+# Accept only a plain non-negative integer; anything else → omit the field.
+case "$CONTEXT_TOKENS" in
+  '' | *[!0-9]*) CONTEXT_TOKENS="" ;;
+esac
+
+if [ -n "$CONTEXT_TOKENS" ]; then
+  PAYLOAD=$(jq -n --arg text "$TEXT" --arg sid "$SESSION_ID" --argjson ctx "$CONTEXT_TOKENS" \
+    '{text: $text, session_id: $sid, context_tokens: $ctx}')
+else
+  PAYLOAD=$(jq -n --arg text "$TEXT" --arg sid "$SESSION_ID" \
+    '{text: $text, session_id: $sid}')
+fi
+
 curl -s -X POST "$SUPERVISOR_RELAY_URL" \
   -H "Content-Type: application/json" \
-  -d "{\"text\": $(echo "$TEXT" | jq -Rs .), \"session_id\": \"$SESSION_ID\"}" \
+  -d "$PAYLOAD" \
   --max-time 5 \
   > /dev/null 2>&1
 

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -16,6 +16,7 @@ import { createSessionCommand, createSessionHandler } from "./commands/session";
 import { CHANNEL_MAP, MAX_SESSIONS } from "./config/channels";
 import type { AttachmentInfo } from "./session/relay";
 import { buildDialogStuckHandler } from "./session/dialog-stuck-handler";
+import { notifyPushover } from "./session/notify-pushover";
 import { updateSessionClaudeId } from "./infra/db";
 import {
   buildSalvageReply,
@@ -169,6 +170,35 @@ export async function startBot(token: string): Promise<void> {
           if (chunk.trim()) {
             await channel.send(chunk);
           }
+        }
+        // Issue #204: a late Stop event (Monitor-split turn) can still be the
+        // turn where context crossed into rot territory — run the same
+        // per-thread budget check so this path warns too. The tracker is shared
+        // with the main relay path, so de-dup holds across both.
+        try {
+          const budget = sessionManager.contextBudgetWarning(
+            event.threadId,
+            event.contextTokens
+          );
+          if (budget) {
+            console.warn(
+              `[Bot] context-budget ${budget.level} on thread ${event.threadId} (late): ${budget.tokens} tokens`
+            );
+            await channel.send(budget.message);
+            if (budget.level === "red" || budget.level === "critical") {
+              await notifyPushover(
+                "Claude Code: コンテキスト肥大化",
+                `${channel.name ?? event.threadId} (${budget.level}, ${Math.floor(budget.tokens / 1000)}k tokens) — /session compact 推奨 (#204)`
+              ).catch((err) =>
+                console.warn(`[Bot] context-budget pushover failed (late):`, err)
+              );
+            }
+          }
+        } catch (budgetErr) {
+          console.warn(
+            `[Bot] context-budget check failed (late) for thread ${event.threadId}:`,
+            budgetErr
+          );
         }
       } catch (err) {
         console.error(`[Bot] Late response send error for thread ${event.threadId}:`, err);
@@ -579,6 +609,39 @@ export async function startBot(token: string): Promise<void> {
             await thread.send(chunk);
             console.log(`[Bot] Chunk sent successfully`);
           }
+        }
+
+        // Issue #204: warn when this session has entered context-rot territory.
+        // At high context, tool-call markup can degrade to plain text and a
+        // tool silently never runs — the relay still resolves (a text turn), so
+        // the dialog watchdog / stall heartbeat never fire. The Stop hook
+        // reports the context token count; we surface a degraded warning (and
+        // page Pushover for red/critical) once per band crossing. Best-effort:
+        // a failure here must never affect the already-delivered response.
+        try {
+          const budget = sessionManager.contextBudgetWarning(
+            threadId,
+            result.contextTokens
+          );
+          if (budget) {
+            console.warn(
+              `[Bot] context-budget ${budget.level} on thread ${threadId}: ${budget.tokens} tokens`
+            );
+            await thread.send(budget.message);
+            if (budget.level === "red" || budget.level === "critical") {
+              await notifyPushover(
+                "Claude Code: コンテキスト肥大化",
+                `${thread.name ?? threadId} (${budget.level}, ${Math.floor(budget.tokens / 1000)}k tokens) — /session compact 推奨 (#204)`
+              ).catch((err) =>
+                console.warn(`[Bot] context-budget pushover failed:`, err)
+              );
+            }
+          }
+        } catch (budgetErr) {
+          console.warn(
+            `[Bot] context-budget check failed for thread ${threadId}:`,
+            budgetErr
+          );
         }
 
         // Forward to vive-reading TTS webhook (fire-and-forget)

--- a/supervisor/src/session/context-budget.ts
+++ b/supervisor/src/session/context-budget.ts
@@ -138,7 +138,15 @@ export function createContextBudgetTracker(
         return null;
       }
       const rank = LEVEL_RANK[level];
-      if (rank <= warnedRank) return null; // already warned at this or higher level
+      if (rank < warnedRank) {
+        // Dropped to a lower (but still >= yellow) band — e.g. a partial
+        // /session compact that shaved one band but not below yellow. Lower the
+        // high-water mark so a later climb back up re-warns, while the downward
+        // move itself stays silent (we never warn on shrinking context).
+        warnedRank = rank;
+        return null;
+      }
+      if (rank <= warnedRank) return null; // same band — already warned, no spam
       warnedRank = rank;
       return {
         level,

--- a/supervisor/src/session/context-budget.ts
+++ b/supervisor/src/session/context-budget.ts
@@ -1,0 +1,150 @@
+/**
+ * Context-budget monitoring for child Claude Code sessions (Issue #204).
+ *
+ * At high context (~330k+ tokens) a session's tool-call markup can degrade to
+ * literal text (observed: `court`); the harness then treats it as plain text
+ * and the tool silently never runs (context rot). Crucially the session still
+ * produces a *text* turn, so the Stop hook fires and the relay resolves
+ * "normally" — neither the dialog watchdog nor the stall heartbeat (relay.ts)
+ * catches it. The deterministic signal that *precedes* this failure is the
+ * context token count, which the Stop hook (`hooks/stop-relay.sh`) computes
+ * from the official transcript and forwards on the relay POST.
+ *
+ * This module classifies that count against the agent-base context-budget
+ * thresholds (rules/general/context-budget.md) and builds a degraded warning
+ * for the Discord thread.
+ *
+ * Design (Issue #204 MVP, user decision 2026-06-09): notify-only. We surface
+ * the risk and recommend `/session compact`; we do NOT auto-compact/restart
+ * (that is a follow-up). Detection is purely numeric — NOT a TUI string match
+ * of `court` — so it cannot silently break on a Claude Code TUI update (RW-027).
+ */
+
+export type ContextBudgetLevel = "yellow" | "red" | "critical";
+
+export interface ContextBudgetThresholds {
+  yellow: number;
+  red: number;
+  critical: number;
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+/**
+ * Thresholds mirror agent-base rules/general/context-budget.md (#70/#71): on a
+ * 1M-context model, rot appears from ~300-400k. Env-overridable for tuning and
+ * tests. Read at call time (not module load) so tests can set env per-case.
+ */
+export function getThresholds(): ContextBudgetThresholds {
+  return {
+    yellow: envInt("CONTEXT_BUDGET_YELLOW", 300_000),
+    red: envInt("CONTEXT_BUDGET_RED", 400_000),
+    critical: envInt("CONTEXT_BUDGET_CRITICAL", 800_000),
+  };
+}
+
+const LEVEL_RANK: Record<ContextBudgetLevel, number> = {
+  yellow: 1,
+  red: 2,
+  critical: 3,
+};
+
+const LEVEL_EMOJI: Record<ContextBudgetLevel, string> = {
+  yellow: "🟡",
+  red: "🟠",
+  critical: "🔴",
+};
+
+/**
+ * Classify a context token count. Returns null below the yellow threshold so
+ * normal operation produces no warning (false-positive avoidance).
+ */
+export function classifyContextBudget(
+  tokens: number,
+  thresholds: ContextBudgetThresholds = getThresholds()
+): ContextBudgetLevel | null {
+  if (!Number.isFinite(tokens) || tokens < thresholds.yellow) return null;
+  if (tokens >= thresholds.critical) return "critical";
+  if (tokens >= thresholds.red) return "red";
+  return "yellow";
+}
+
+function formatK(tokens: number): string {
+  // floor (not round) so the displayed value never overstates the band — e.g.
+  // 399_999 shows "399k (>=300k)", not a misleading "400k" (the red threshold).
+  return `${Math.floor(tokens / 1000)}k`;
+}
+
+/**
+ * Build the Discord warning text for a classified level. Always references
+ * `/session compact` (the notify-only recovery the user runs) and Issue #204 so
+ * the alert is self-documenting.
+ */
+export function buildContextBudgetWarning(
+  tokens: number,
+  level: ContextBudgetLevel,
+  thresholds: ContextBudgetThresholds = getThresholds()
+): string {
+  const now = formatK(tokens);
+  const emoji = LEVEL_EMOJI[level];
+  if (level === "critical") {
+    return `${emoji} このセッションのコンテキストが ${now} (>=${formatK(thresholds.critical)}) に到達。高コンテキストで tool 呼び出しが破損し黙って停止する恐れがあります (#204)。直ちに \`/session compact\` するか新セッションへ切替えてください。`;
+  }
+  if (level === "red") {
+    return `${emoji} このセッションのコンテキストが ${now} (>=${formatK(thresholds.red)}) を超過 (context rot 領域)。\`/session compact\` を強く推奨します (#204)。`;
+  }
+  return `${emoji} このセッションのコンテキストが ${now} (>=${formatK(thresholds.yellow)}) に到達 (context rot の入り口)。区切りの良い所で \`/session compact\` を検討してください (#204)。`;
+}
+
+export interface ContextBudgetWarning {
+  level: ContextBudgetLevel;
+  message: string;
+  tokens: number;
+}
+
+export interface ContextBudgetTracker {
+  /**
+   * Feed the latest context token count for a session. Returns a warning only
+   * when the session crosses *up* into a higher level than already warned in
+   * the current above-yellow episode — so a steady high-context session is not
+   * re-warned every turn (de-dup). Dropping below the yellow threshold (e.g.
+   * after a `/session compact`) resets the episode so a later climb re-warns.
+   * `null` / non-finite input is treated as "no signal" and never warns.
+   */
+  check(tokens: number | null | undefined): ContextBudgetWarning | null;
+}
+
+/**
+ * Per-session de-dup tracker. The supervisor holds one per thread; thresholds
+ * are snapshotted at creation (process env is stable after start).
+ */
+export function createContextBudgetTracker(
+  thresholds: ContextBudgetThresholds = getThresholds()
+): ContextBudgetTracker {
+  let warnedRank = 0; // 0 = below yellow / nothing warned this episode
+
+  return {
+    check(tokens) {
+      if (tokens == null || !Number.isFinite(tokens)) return null;
+      const level = classifyContextBudget(tokens, thresholds);
+      if (!level) {
+        // Below yellow — reset the episode so post-compact recovery re-arms.
+        warnedRank = 0;
+        return null;
+      }
+      const rank = LEVEL_RANK[level];
+      if (rank <= warnedRank) return null; // already warned at this or higher level
+      warnedRank = rank;
+      return {
+        level,
+        message: buildContextBudgetWarning(tokens, level, thresholds),
+        tokens,
+      };
+    },
+  };
+}

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -28,6 +28,10 @@ import {
   realSessionEffects,
   type SessionEffects,
 } from "./adapters";
+import {
+  createContextBudgetTracker,
+  type ContextBudgetWarning,
+} from "./context-budget";
 
 const CLAUDE_PATH = resolve(homedir(), ".local", "bin", "claude");
 const TMUX_SESSION_PREFIX = "claude-";
@@ -857,6 +861,29 @@ export class SessionManager {
       persistDir: session.projectDir,
       onDialogStuck: options?.onDialogStuck,
     });
+  }
+
+  /**
+   * Issue #204: feed the latest context token count (from the relay's Stop-hook
+   * POST) for a thread and return a degraded warning the caller should post to
+   * the Discord thread — but only when the session first crosses *up* into a
+   * higher context-rot band. Returns null when the count is below the yellow
+   * threshold, was already warned at that band (de-dup, no per-turn spam), or
+   * the session/token count is unknown. Pure bookkeeping: the caller (bot.ts)
+   * owns the actual Discord/Pushover delivery so this stays unit-testable and
+   * cannot break the relay loop.
+   */
+  contextBudgetWarning(
+    threadId: string,
+    tokens: number | undefined
+  ): ContextBudgetWarning | null {
+    if (tokens == null) return null;
+    const session = this.sessions.get(threadId);
+    if (!session) return null;
+    if (!session.contextBudgetTracker) {
+      session.contextBudgetTracker = createContextBudgetTracker();
+    }
+    return session.contextBudgetTracker.check(tokens);
   }
 
   /**

--- a/supervisor/src/session/relay-server.ts
+++ b/supervisor/src/session/relay-server.ts
@@ -7,6 +7,13 @@ export interface RelayResult {
   chunks: string[];
   claudeSessionId?: string;
   error?: string;
+  /**
+   * Session's current context token count at the moment the Stop hook fired
+   * (Issue #204). Forwarded by `hooks/stop-relay.sh`. Absent when the hook
+   * could not compute it (no transcript / older hook). Consumers use it to warn
+   * the Discord thread when a session enters context-rot territory.
+   */
+  contextTokens?: number;
 }
 
 export interface ProgressEvent {
@@ -19,6 +26,9 @@ export interface LateResponseEvent {
   threadId: string;
   chunks: string[];
   text: string;
+  /** Session context token count for this late turn (Issue #204), if reported
+   *  by the Stop hook. Lets the late-response path warn on context rot too. */
+  contextTokens?: number;
 }
 
 // Issue #12 (Phase 1): AskUserQuestion fallback. When `claude` raises an
@@ -320,12 +330,21 @@ export function startRelayServer(): void {
               : "";
         const sessionId =
           typeof body.session_id === "string" ? body.session_id : undefined;
+        // Issue #204: best-effort context size from the Stop hook. Accept only a
+        // non-negative integer (the hook only ever emits one); anything else is
+        // treated as "not reported".
+        const contextTokens =
+          typeof body.context_tokens === "number" &&
+          Number.isInteger(body.context_tokens) &&
+          body.context_tokens >= 0
+            ? body.context_tokens
+            : undefined;
         const chunks = formatForDiscord(text);
 
         const pending = pendingRequests.get(threadId);
         if (pending) {
           clearTimeout(pending.timer);
-          pending.resolve({ text, chunks, claudeSessionId: sessionId });
+          pending.resolve({ text, chunks, claudeSessionId: sessionId, contextTokens });
           pendingRequests.delete(threadId);
           return new Response("ok", { status: 200 });
         }
@@ -335,7 +354,7 @@ export function startRelayServer(): void {
         // Forward to Discord as a follow-up message so responses aren't lost.
         if (text && lateResponseCallback) {
           try {
-            lateResponseCallback({ threadId, chunks, text });
+            lateResponseCallback({ threadId, chunks, text, contextTokens });
           } catch (err) {
             console.error("[relay-server] lateResponseCallback error:", err);
           }

--- a/supervisor/src/session/types.ts
+++ b/supervisor/src/session/types.ts
@@ -1,4 +1,5 @@
 import type { ChildProcess } from "child_process";
+import type { ContextBudgetTracker } from "./context-budget";
 
 export interface SessionInfo {
   id: string;
@@ -26,6 +27,13 @@ export interface SessionInfo {
    * repo from which the worktree was created.
    */
   worktree?: { mainRepoDir: string; path: string; branch: string };
+  /**
+   * Per-session context-budget de-dup tracker (Issue #204). Lazily created on
+   * the first relay turn that reports a context token count; held in memory and
+   * discarded when the session is removed from the map. Ensures a steady
+   * high-context session is warned only when it crosses up into a new band.
+   */
+  contextBudgetTracker?: ContextBudgetTracker;
 }
 
 /**

--- a/supervisor/tests/hooks/stop-relay.test.ts
+++ b/supervisor/tests/hooks/stop-relay.test.ts
@@ -2,8 +2,35 @@
 import { test, expect, describe } from "bun:test";
 import { $ } from "bun";
 import { resolve } from "path";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
 
 const HOOK_PATH = resolve(import.meta.dir, "../../hooks/stop-relay.sh");
+
+/** Capture the single POST body the hook sends, or null if it never posts. */
+async function capturePost(
+  input: string
+): Promise<Record<string, unknown> | null> {
+  let captured: Record<string, unknown> | null = null;
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      captured = (await req.json()) as Record<string, unknown>;
+      return new Response("ok");
+    },
+  });
+  try {
+    const url = `http://localhost:${server.port}/relay/test-thread`;
+    const result =
+      await $`echo ${input} | SUPERVISOR_RELAY_URL=${url} bash ${HOOK_PATH}`
+        .quiet()
+        .nothrow();
+    expect(result.exitCode).toBe(0);
+  } finally {
+    server.stop(true);
+  }
+  return captured;
+}
 
 describe("stop-relay.sh", () => {
   test("exits silently when SUPERVISOR_RELAY_URL is not set", async () => {
@@ -38,5 +65,116 @@ describe("stop-relay.sh", () => {
     const input = JSON.stringify({ session_id: "sess-abc" });
     const result = await $`echo ${input} | SUPERVISOR_RELAY_URL=http://localhost:9999/relay/t bash ${HOOK_PATH}`.quiet().nothrow();
     expect(result.exitCode).toBe(0);
+  });
+
+  // --- Issue #204: context_tokens computation -------------------------------
+
+  test("omits context_tokens when no transcript_path is given (backward compat)", async () => {
+    const body = await capturePost(
+      JSON.stringify({ last_assistant_message: "hi", session_id: "s1" })
+    );
+    expect(body).not.toBeNull();
+    expect(body!.text).toBe("hi");
+    expect(body!.session_id).toBe("s1");
+    expect("context_tokens" in body!).toBe(false);
+  });
+
+  test("computes context_tokens from the last usage entry of the transcript", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "stop-relay-"));
+    const transcript = resolve(dir, "session.jsonl");
+    // Two usage-bearing lines; only the LAST counts as the current context.
+    // Last = 10 + 290000 + 10000 = 300010.
+    const lines = [
+      JSON.stringify({
+        type: "assistant",
+        message: { usage: { input_tokens: 5, cache_read_input_tokens: 100, cache_creation_input_tokens: 0 } },
+      }),
+      JSON.stringify({ type: "user", message: { role: "user", content: "hi" } }), // no usage
+      JSON.stringify({
+        type: "assistant",
+        message: { usage: { input_tokens: 10, cache_read_input_tokens: 290000, cache_creation_input_tokens: 10000 } },
+      }),
+    ];
+    writeFileSync(transcript, lines.join("\n") + "\n");
+    try {
+      const body = await capturePost(
+        JSON.stringify({
+          last_assistant_message: "done",
+          session_id: "s2",
+          transcript_path: transcript,
+        })
+      );
+      expect(body).not.toBeNull();
+      expect(body!.text).toBe("done");
+      expect(body!.context_tokens).toBe(300010);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("omits context_tokens when the transcript has no usage entries", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "stop-relay-"));
+    const transcript = resolve(dir, "session.jsonl");
+    writeFileSync(
+      transcript,
+      JSON.stringify({ type: "user", message: { role: "user", content: "hi" } }) + "\n"
+    );
+    try {
+      const body = await capturePost(
+        JSON.stringify({
+          last_assistant_message: "done",
+          session_id: "s3",
+          transcript_path: transcript,
+        })
+      );
+      expect(body).not.toBeNull();
+      expect("context_tokens" in body!).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("finds the last usage even in a large (>400-line) transcript (tail bound)", async () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "stop-relay-"));
+    const transcript = resolve(dir, "session.jsonl");
+    // 450 non-usage filler lines, then the current turn's usage as the LAST
+    // line — the realistic shape (Stop hook fires right after the turn). The
+    // tail -n 400 bound must still capture it. Last = 1 + 360000 + 0 = 360001.
+    const filler: string[] = [];
+    for (let i = 0; i < 450; i++) {
+      filler.push(JSON.stringify({ type: "user", message: { role: "user", content: `m${i}` } }));
+    }
+    filler.push(
+      JSON.stringify({
+        type: "assistant",
+        message: { usage: { input_tokens: 1, cache_read_input_tokens: 360000, cache_creation_input_tokens: 0 } },
+      })
+    );
+    writeFileSync(transcript, filler.join("\n") + "\n");
+    try {
+      const body = await capturePost(
+        JSON.stringify({
+          last_assistant_message: "done",
+          session_id: "s5",
+          transcript_path: transcript,
+        })
+      );
+      expect(body).not.toBeNull();
+      expect(body!.context_tokens).toBe(360001);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("omits context_tokens when transcript_path points to a missing file", async () => {
+    const body = await capturePost(
+      JSON.stringify({
+        last_assistant_message: "done",
+        session_id: "s4",
+        transcript_path: "/no/such/transcript-204.jsonl",
+      })
+    );
+    expect(body).not.toBeNull();
+    expect("context_tokens" in body!).toBe(false);
   });
 });

--- a/supervisor/tests/session/context-budget.test.ts
+++ b/supervisor/tests/session/context-budget.test.ts
@@ -90,6 +90,17 @@ describe("createContextBudgetTracker (de-dup, Journey AC #2/#3)", () => {
     expect(tr.check(299_999)).toBeNull();
   });
 
+  test("dropping to a lower band (not below yellow) re-arms a re-climb (partial compact)", () => {
+    const tr = createContextBudgetTracker(T);
+    expect(tr.check(820_000)!.level).toBe("critical");
+    expect(tr.check(410_000)).toBeNull(); // partial compact: critical → red, silent
+    const back = tr.check(820_000); // climbs back to critical
+    expect(back).not.toBeNull();
+    expect(back!.level).toBe("critical"); // re-warned
+    // ...and once re-warned at critical, it de-dups again within the band.
+    expect(tr.check(900_000)).toBeNull();
+  });
+
   test("dropping below yellow resets the episode so a re-climb re-warns (post-compact)", () => {
     const tr = createContextBudgetTracker(T);
     expect(tr.check(420_000)!.level).toBe("red");

--- a/supervisor/tests/session/context-budget.test.ts
+++ b/supervisor/tests/session/context-budget.test.ts
@@ -1,0 +1,143 @@
+import { test, expect, describe } from "bun:test";
+import {
+  classifyContextBudget,
+  buildContextBudgetWarning,
+  createContextBudgetTracker,
+  getThresholds,
+  type ContextBudgetThresholds,
+} from "../../src/session/context-budget";
+
+// Explicit thresholds keep logic tests deterministic regardless of env.
+const T: ContextBudgetThresholds = {
+  yellow: 300_000,
+  red: 400_000,
+  critical: 800_000,
+};
+
+describe("classifyContextBudget", () => {
+  test("returns null below yellow (Journey AC #1: no false positives)", () => {
+    expect(classifyContextBudget(0, T)).toBeNull();
+    expect(classifyContextBudget(299_999, T)).toBeNull();
+  });
+
+  test("classifies each band by its lower bound", () => {
+    expect(classifyContextBudget(300_000, T)).toBe("yellow");
+    expect(classifyContextBudget(399_999, T)).toBe("yellow");
+    expect(classifyContextBudget(400_000, T)).toBe("red");
+    expect(classifyContextBudget(799_999, T)).toBe("red");
+    expect(classifyContextBudget(800_000, T)).toBe("critical");
+    expect(classifyContextBudget(1_200_000, T)).toBe("critical");
+  });
+
+  test("non-finite input is treated as no signal (defensive)", () => {
+    expect(classifyContextBudget(NaN, T)).toBeNull();
+    expect(classifyContextBudget(Infinity, T)).toBeNull();
+  });
+});
+
+describe("buildContextBudgetWarning", () => {
+  test("yellow recommends /session compact and cites #204", () => {
+    const msg = buildContextBudgetWarning(320_000, "yellow", T);
+    expect(msg).toContain("🟡");
+    expect(msg).toContain("320k");
+    expect(msg).toContain("/session compact");
+    expect(msg).toContain("#204");
+  });
+
+  test("red is a stronger recommendation", () => {
+    const msg = buildContextBudgetWarning(410_000, "red", T);
+    expect(msg).toContain("🟠");
+    expect(msg).toContain("410k");
+    expect(msg).toContain("強く推奨");
+  });
+
+  test("critical warns about the silent-stop failure mode", () => {
+    const msg = buildContextBudgetWarning(850_000, "critical", T);
+    expect(msg).toContain("🔴");
+    expect(msg).toContain("850k");
+    expect(msg).toContain("破損");
+  });
+});
+
+describe("createContextBudgetTracker (de-dup, Journey AC #2/#3)", () => {
+  test("warns once when first crossing into yellow", () => {
+    const tr = createContextBudgetTracker(T);
+    const w = tr.check(310_000);
+    expect(w).not.toBeNull();
+    expect(w!.level).toBe("yellow");
+    expect(w!.tokens).toBe(310_000);
+  });
+
+  test("does NOT re-warn while staying in the same band", () => {
+    const tr = createContextBudgetTracker(T);
+    expect(tr.check(310_000)).not.toBeNull();
+    expect(tr.check(320_000)).toBeNull(); // same band, no spam
+    expect(tr.check(350_000)).toBeNull();
+  });
+
+  test("re-warns only when crossing UP into a higher band", () => {
+    const tr = createContextBudgetTracker(T);
+    expect(tr.check(310_000)!.level).toBe("yellow");
+    expect(tr.check(420_000)!.level).toBe("red"); // escalation
+    expect(tr.check(450_000)).toBeNull(); // still red
+    expect(tr.check(820_000)!.level).toBe("critical");
+    expect(tr.check(900_000)).toBeNull(); // still critical
+  });
+
+  test("never warns while below yellow", () => {
+    const tr = createContextBudgetTracker(T);
+    expect(tr.check(100_000)).toBeNull();
+    expect(tr.check(299_999)).toBeNull();
+  });
+
+  test("dropping below yellow resets the episode so a re-climb re-warns (post-compact)", () => {
+    const tr = createContextBudgetTracker(T);
+    expect(tr.check(420_000)!.level).toBe("red");
+    expect(tr.check(50_000)).toBeNull(); // compact: dropped below yellow → reset
+    const again = tr.check(330_000);
+    expect(again).not.toBeNull();
+    expect(again!.level).toBe("yellow"); // re-armed
+  });
+
+  test("null / undefined / NaN token counts never warn", () => {
+    const tr = createContextBudgetTracker(T);
+    expect(tr.check(null)).toBeNull();
+    expect(tr.check(undefined)).toBeNull();
+    expect(tr.check(NaN)).toBeNull();
+  });
+});
+
+describe("getThresholds env override", () => {
+  test("defaults to 300k/400k/800k", () => {
+    const prev = {
+      y: process.env.CONTEXT_BUDGET_YELLOW,
+      r: process.env.CONTEXT_BUDGET_RED,
+      c: process.env.CONTEXT_BUDGET_CRITICAL,
+    };
+    delete process.env.CONTEXT_BUDGET_YELLOW;
+    delete process.env.CONTEXT_BUDGET_RED;
+    delete process.env.CONTEXT_BUDGET_CRITICAL;
+    try {
+      expect(getThresholds()).toEqual({
+        yellow: 300_000,
+        red: 400_000,
+        critical: 800_000,
+      });
+    } finally {
+      if (prev.y !== undefined) process.env.CONTEXT_BUDGET_YELLOW = prev.y;
+      if (prev.r !== undefined) process.env.CONTEXT_BUDGET_RED = prev.r;
+      if (prev.c !== undefined) process.env.CONTEXT_BUDGET_CRITICAL = prev.c;
+    }
+  });
+
+  test("honours env overrides", () => {
+    const prev = process.env.CONTEXT_BUDGET_YELLOW;
+    process.env.CONTEXT_BUDGET_YELLOW = "120000";
+    try {
+      expect(getThresholds().yellow).toBe(120_000);
+    } finally {
+      if (prev === undefined) delete process.env.CONTEXT_BUDGET_YELLOW;
+      else process.env.CONTEXT_BUDGET_YELLOW = prev;
+    }
+  });
+});

--- a/supervisor/tests/session/manager.test.ts
+++ b/supervisor/tests/session/manager.test.ts
@@ -98,6 +98,33 @@ describe("SessionManager (thread-based)", () => {
     expect(manager.has("thread-nonexistent")).toBe(false);
   });
 
+  describe("contextBudgetWarning (#204)", () => {
+    test("returns null for unknown thread, undefined tokens, or below yellow", async () => {
+      expect(manager.contextBudgetWarning("no-such-thread", 500_000)).toBeNull();
+      await manager.start(primaryConfig, "thread-cb0");
+      expect(manager.contextBudgetWarning("thread-cb0", undefined)).toBeNull();
+      expect(manager.contextBudgetWarning("thread-cb0", 100_000)).toBeNull();
+    });
+
+    test("warns once on first band crossing, de-dups within band, escalates up", async () => {
+      const t = "thread-cb1";
+      await manager.start(primaryConfig, t);
+      expect(manager.contextBudgetWarning(t, 320_000)?.level).toBe("yellow");
+      expect(manager.contextBudgetWarning(t, 350_000)).toBeNull(); // same band → no spam
+      expect(manager.contextBudgetWarning(t, 410_000)?.level).toBe("red"); // escalate
+      expect(manager.contextBudgetWarning(t, 850_000)?.level).toBe("critical");
+      expect(manager.contextBudgetWarning(t, 900_000)).toBeNull(); // same band
+    });
+
+    test("trackers are per-thread (independent sessions)", async () => {
+      await manager.start(primaryConfig, "thread-cbA");
+      await manager.start(primaryConfig, "thread-cbB");
+      expect(manager.contextBudgetWarning("thread-cbA", 320_000)?.level).toBe("yellow");
+      // B is independent: it still gets its own first-crossing warning.
+      expect(manager.contextBudgetWarning("thread-cbB", 320_000)?.level).toBe("yellow");
+    });
+  });
+
   test("allows multiple sessions in the same channel", async () => {
     await manager.start(primaryConfig, "thread-1");
     await manager.start(primaryConfig, "thread-2");

--- a/supervisor/tests/session/relay-server.test.ts
+++ b/supervisor/tests/session/relay-server.test.ts
@@ -46,6 +46,49 @@ describe("relay-server", () => {
     expect(result.chunks.length).toBeGreaterThanOrEqual(1);
   });
 
+  // Issue #204: context_tokens forwarded by the Stop hook
+  test("POST parses a valid context_tokens into RelayResult", async () => {
+    startRelayServer();
+    const port = getRelayPort();
+    const promise = waitForRelay("thread-ctx", 5000);
+    await fetch(`http://localhost:${port}/relay/thread-ctx`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "hi", session_id: "s", context_tokens: 350000 }),
+    });
+    const result = await promise;
+    expect(result.contextTokens).toBe(350000);
+  });
+
+  test("POST omits contextTokens when absent or invalid", async () => {
+    startRelayServer();
+    const port = getRelayPort();
+
+    const p1 = waitForRelay("thread-noctx", 5000);
+    await fetch(`http://localhost:${port}/relay/thread-noctx`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "hi", session_id: "s" }),
+    });
+    expect((await p1).contextTokens).toBeUndefined();
+
+    const p2 = waitForRelay("thread-badctx", 5000);
+    await fetch(`http://localhost:${port}/relay/thread-badctx`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "hi", session_id: "s", context_tokens: "lots" }),
+    });
+    expect((await p2).contextTokens).toBeUndefined();
+
+    const p3 = waitForRelay("thread-negctx", 5000);
+    await fetch(`http://localhost:${port}/relay/thread-negctx`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "hi", session_id: "s", context_tokens: -5 }),
+    });
+    expect((await p3).contextTokens).toBeUndefined();
+  });
+
   test("waitForRelay times out if no POST received", async () => {
     startRelayServer();
 
@@ -108,6 +151,33 @@ describe("relay-server", () => {
     expect(late.threadId).toBe("thread-monitor");
     expect(late.text).toBe("18 件の下書きがあります。");
     expect(late.chunks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  // Issue #204: a late Stop event must carry context_tokens so the budget check
+  // runs on the Monitor-split path too (not just the resolved relay).
+  test("late-arriving POST forwards context_tokens to onLateResponse", async () => {
+    startRelayServer();
+    const port = getRelayPort();
+
+    const received: LateResponseEvent[] = [];
+    onLateResponse((event) => received.push(event));
+
+    const promise = waitForRelay("thread-late-ctx", 5000);
+    await fetch(`http://localhost:${port}/relay/thread-late-ctx`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "first" }),
+    });
+    await promise;
+
+    await fetch(`http://localhost:${port}/relay/thread-late-ctx`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ text: "second", context_tokens: 820000 }),
+    });
+
+    expect(received.length).toBe(1);
+    expect(received[0]!.contextTokens).toBe(820000);
   });
 
   test("POST with empty text and no pending returns 404 even with late handler", async () => {


### PR DESCRIPTION
## 概要

Issue #204 (P0): 子セッションのコンテキストが肥大化 (~330k+ tokens) すると tool 呼び出しの markup が地の文 (court) に化け、harness が plain text 扱いで無視 → tool が黙って未実行になる (context rot)。turn 自体はテキストとして完了するため Stop hook は発火し relay は正常解決し、既存の dialog watchdog / stall heartbeat では検知できず、Discord 部署セッションがサイレント停止する。

**通知のみ MVP** (ユーザー決定 2026-06-09): 決定的なトークン量シグナルで検知し、Discord スレッドへ degraded 警告を出す。auto compact/restart は follow-up。

## 主な変更点

| ファイル | 内容 |
|---|---|
| `supervisor/hooks/stop-relay.sh` | Stop hook の `transcript_path` から現在コンテキストトークン量を算出 (最後の usage の input + cache_read + cache_creation、`tail -n 400` で範囲限定) し、relay POST に `context_tokens` を付与。best-effort (transcript/jq 不在時は省略) |
| `supervisor/src/session/context-budget.ts` (新規) | 純ロジック: `classifyContextBudget` (閾値 300k/400k/800k、env 上書き可)、`buildContextBudgetWarning` (Discord 文言)、`createContextBudgetTracker` (per-thread de-dup) |
| `supervisor/src/session/relay-server.ts` | `RelayResult` / `LateResponseEvent` に `contextTokens` を追加・parse (非負整数のみ) |
| `supervisor/src/session/types.ts` | in-memory `SessionInfo` に per-session tracker を保持 |
| `supervisor/src/session/manager.ts` | `contextBudgetWarning()`: tracker を lazy 生成し de-dup 判定 |
| `supervisor/src/bot.ts` | relay 完了時 + late-response 経路で警告を Discord スレッドへ投稿 (red/critical は Pushover)。best-effort で配信済み応答を妨げない |

## 設計上のポイント

- **検知は数値トークン量。`court` 等の TUI 文字列 match ではない** → Claude Code の TUI 更新で壊れない (RW-027 整合)。
- **de-dup**: 帯 (yellow→red→critical) を上方向に跨いだ時のみ警告。同帯では毎 turn スパムしない。compact 等で yellow 未満へ下がると episode が reset され再上昇で再警告。
- **late-response 経路** (Monitor 分割 turn) も同一 tracker を共有して警告 (code review must 対応)。
- 閾値は agent-base `rules/general/context-budget.md` (300-400k で rot) に準拠。`CONTEXT_BUDGET_YELLOW/RED/CRITICAL` で上書き可。

## 統合ジャーニーAC 検証

| AC | 検証 | 判定 |
|---|---|---|
| AC-1 | yellow 未満で false positive ゼロ | PASS |
| AC-2 | 初回閾値超過で警告 1 回 / hook 算出 / relay parse | PASS |
| AC-3 | 同帯 de-dup・上位帯で再警告・yellow 未満で reset | PASS |
| 追加 | late-response 経路も警告 | PASS |

## テスト

- `bun test` 影響テスト **92 件 pass / 0 fail**、`tsc --noEmit` エラー 0。
- 新規/追加: `context-budget.test.ts` (14)、`stop-relay.test.ts` (+6)、`relay-server.test.ts` (+3)、`manager.test.ts` (+3)。

> 注: フルスイートの既存 fail (`src/infra/db.ts:45` の shell-exec guard、`relay.test.ts` の tmux AC-7) は本 PR 対象外の既存/flaky (本変更は未関与・db.ts 未変更、tmux は単独実行で 7/7 pass)。

## repro

context rot 依存で最小再現が非決定的なため `repro-waived` (Issue 本文の「repro-waived 相当」に基づく)。観測証拠は Issue 記載の corp CEO セッション (2026-06-08) 多数回再現。

## follow-up (別 Issue 想定)

- auto `/session compact` / restart による self-healing (本 PR はスコープ外)
- `src/infra/db.ts:45` の shell-exec guard 既存 fail の解消

Closes #204

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * コンテキストトークン量の監視機能を追加しました。AI会話のコンテキストサイズが一定値を超えた場合、警告が自動的に表示されます。
  * DiscordスレッドおよびPushover通知を通じて段階的な警告（黄・赤・重大）が送信されるようになりました。
  * ユーザーが `/session compact` コマンドで対応できるようガイダンスが提供されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->