### PR TITLE
feat(#199): primary channel の /session compact を claudeHubExit へ routing (AC1)

### DIFF
--- a/com.claude-hub.supervisor.plist
+++ b/com.claude-hub.supervisor.plist
@@ -22,6 +22,17 @@
     <dict>
         <key>PATH</key>
         <string>/Users/harieshokunin/.local/bin:/Users/harieshokunin/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <!-- Issue #199 AC1: claudeHubExit primary channel id. When set, `/session
+             compact` invoked in that channel routes to the claudeHubExit tmux
+             session (default socket) instead of showing the thread-only hint.
+             Left BLANK in source on purpose: channel ids are not committed
+             (Issue #63 fail-closed). Fill the real id in the installed plist
+             (~/Library/LaunchAgents/com.claude-hub.supervisor.plist) — use the
+             same value as the hijoguchi plist's HIJOGUCHI_CHANNEL_ID — then
+             `launchctl kickstart -k gui/$(id -u)/com.claude-hub.supervisor`.
+             Blank = feature disabled (fail-safe). -->
+        <key>HIJOGUCHI_CHANNEL_ID</key>
+        <string></string>
     </dict>
 
     <key>KeepAlive</key>

--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -11,7 +11,7 @@ claude-hub プロジェクトで運用している Discord Bot の役割分担�
   - 現在: team-salary, convert-service, segment-anything, claude-context-manager, dev-tool, obsidian-img-annotator, oci-develop
   - 追加は `supervisor/src/config/channels.ts` の `CHANNEL_MAP` を編集
 - **方式**: tmux + Claude Code CLI + HTTP relay (Stop/PostToolUse hook)
-- **コマンド**: `/session start|stop|list`
+- **コマンド**: `/session start|stop|list|status|resume|compact`（`compact` は Issue #200。primary channel での compact は Issue #199 AC1、下記 §「Required env vars (Supervisor ...)」参照）
 - **メッセージ中継**: Discord thread ↔ tmux send-keys ↔ Claude Code
 
 ### 2. claudeHubExit（旧 PM-Agent）
@@ -168,6 +168,26 @@ plist に env 漏れがあると `[hijoguchi] ERROR: HIJOGUCHI_CHANNEL_ID is req
 ### Phase 2 移行チェックリスト前提
 
 下記 Phase 2 移行は本 env 注入が完了している前提。両 env が plist にあることを `defaults read ~/Library/LaunchAgents/com.claude-hub.hijoguchi.plist EnvironmentVariables` などで確認してから進めること。
+
+## Required env vars (Supervisor — `/session compact` の primary channel routing, Issue #199 AC1)
+
+claudeHubExit の primary channel（`#claude-hub-hijoguchi`）はスレッドではない通常チャンネルで、その長命セッションは **default tmux socket** の `claudeHubExit` session（`start-hijoguchi.sh` 管理、Supervisor の `-L claude-hub` socket とは別サーバ）。この channel で `/session compact` を実行したとき claudeHubExit を compact できるよう、**Supervisor 側にも** primary channel id を教える。
+
+`~/Library/LaunchAgents/com.claude-hub.supervisor.plist` の `EnvironmentVariables` に以下を追加（値は hijoguchi plist の `HIJOGUCHI_CHANNEL_ID` と同じ。上記 §「Required env vars (claudeHubExit)」の `1487701062205964329`）:
+
+```xml
+<key>HIJOGUCHI_CHANNEL_ID</key>
+<string>1487701062205964329</string>
+```
+
+反映:
+
+```bash
+launchctl kickstart -k gui/$(id -u)/com.claude-hub.supervisor
+```
+
+- **未設定（空文字）= 機能 OFF（fail-safe）**: primary channel で `/session compact` はスレッド用の usage hint を返すだけ。境界（Supervisor↔claudeHubExit の独立性）は明示 wiring するまで閉じたまま。
+- スレッド内セッションの `/session compact`（Issue #200）は本 env に依存せず従来どおり動作する。
 
 ## 参考: 過去の事故
 

--- a/supervisor/src/commands/session.ts
+++ b/supervisor/src/commands/session.ts
@@ -75,6 +75,22 @@ export function createSessionCommand() {
 // the summary keeps the current state and next action.
 export const DEFAULT_COMPACT_INTENT = "直近の作業状態と次アクションを保持して圧縮";
 
+/**
+ * Issue #199 AC1: the claudeHubExit primary channel id, read from the
+ * `HIJOGUCHI_CHANNEL_ID` env (same name start-hijoguchi.sh already uses, so the
+ * operator sets one value). Read at call time (not module load) so tests and a
+ * launchd reload pick it up without rebuilding the importing module.
+ *
+ * Returns undefined when unset/blank — the compact handler then fails safe to
+ * the normal thread-bound path (the primary channel just shows the usage hint),
+ * keeping the Supervisor↔claudeHubExit boundary closed unless explicitly wired.
+ * Channel ids are kept out of committed source (Issue #63 convention); env-only.
+ */
+export function claudeHubExitPrimaryChannelId(): string | undefined {
+  const id = process.env.HIJOGUCHI_CHANNEL_ID?.trim();
+  return id ? id : undefined;
+}
+
 export function createSessionHandler(sessionManager: SessionManager) {
   return async (interaction: ChatInputCommandInteraction) => {
     const subcommand = interaction.options.getSubcommand();
@@ -107,6 +123,34 @@ async function handleCompact(
   sessionManager: SessionManager
 ): Promise<void> {
   const channel = interaction.channel;
+
+  // Issue #199 AC1: the claudeHubExit primary channel is a normal text channel
+  // (not a thread) whose long-lived session runs on the DEFAULT tmux socket,
+  // outside SessionManager. Route its `/session compact` to compactPrimarySession
+  // (claudeHubExit) instead of the thread-bound path. Checked before the
+  // isThread() guard precisely because the primary channel is not a thread.
+  // Gated on HIJOGUCHI_CHANNEL_ID so it no-ops when the Supervisor isn't wired.
+  const primaryChannelId = claudeHubExitPrimaryChannelId();
+  if (primaryChannelId && channel?.id === primaryChannelId) {
+    const rawIntent = interaction.options.getString("intent")?.trim() ?? "";
+    const intent = rawIntent || DEFAULT_COMPACT_INTENT;
+    await interaction.deferReply({ flags: 64 });
+    try {
+      await sessionManager.compactPrimarySession(intent);
+      await interaction.editReply({
+        content: `🗜️ claudeHubExit に compact を送信しました: \`/compact ${intent}\``,
+      });
+    } catch (err) {
+      const msg = `❌ compact の送信に失敗: ${err instanceof Error ? err.message : String(err)}`;
+      if (interaction.deferred || interaction.replied) {
+        await interaction.editReply({ content: msg });
+      } else {
+        await interaction.reply({ content: msg, flags: 64 });
+      }
+    }
+    return;
+  }
+
   // compact targets the session bound to *this* thread (like /session stop), so
   // it must run inside a session thread. Outside one, return a usage hint and
   // never send keys (Issue #200 AC-3).

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -32,6 +32,7 @@ import {
   createContextBudgetTracker,
   type ContextBudgetWarning,
 } from "./context-budget";
+import { compactClaudeHubExit } from "./primary-compact";
 
 const CLAUDE_PATH = resolve(homedir(), ".local", "bin", "claude");
 const TMUX_SESSION_PREFIX = "claude-";
@@ -924,6 +925,21 @@ export class SessionManager {
     // in an indeterminate state (e.g. the Escape landed but the literal/Enter
     // did not); the caller surfaces the throw so the user can retry.
     await sendToPane(tmuxName, `/compact ${intent}`);
+  }
+
+  /**
+   * Issue #199 AC1: compact the claudeHubExit primary-channel session.
+   *
+   * Unlike {@link compactSession} (a SessionManager-managed thread session on
+   * the `-L claude-hub` socket), claudeHubExit is a long-lived launchd process
+   * on the DEFAULT tmux socket, outside SessionManager. Delegated to
+   * primary-compact — the single sanctioned cross-socket reach — which checks
+   * liveness and throws `"claudeHubExit session dead"` when absent so the
+   * command layer can surface an ephemeral error (AC3 parity). `intent` is
+   * non-empty by contract (the command layer substitutes a default; RW-032).
+   */
+  async compactPrimarySession(intent: string): Promise<void> {
+    await compactClaudeHubExit(intent);
   }
 
   async stop(

--- a/supervisor/src/session/primary-compact.ts
+++ b/supervisor/src/session/primary-compact.ts
@@ -1,0 +1,70 @@
+import { execFileSync } from "child_process";
+import { TMUX_PATH } from "./tmux";
+import { sendToPane } from "./relay";
+
+/**
+ * Issue #199 AC1 — compact the claudeHubExit primary-channel session.
+ *
+ * claudeHubExit runs in a tmux session named `claudeHubExit` on the DEFAULT
+ * tmux socket (`start-hijoguchi.sh` calls `tmux new-session` with no `-L`),
+ * which is a different tmux server than the Supervisor's dedicated `-L
+ * claude-hub` socket. This module is the single sanctioned place where the
+ * Supervisor reaches across that socket boundary, and only to relay a
+ * user-initiated `/session compact` keystroke — it never manages that
+ * session's lifecycle, preserving the claudeHubExit independence boundary
+ * documented in CLAUDE.md / docs/bot-operations.md.
+ */
+
+/** Tmux session name created by start-hijoguchi.sh (SESSION=claudeHubExit). */
+export const CLAUDEHUBEXIT_TMUX_SESSION = "claudeHubExit";
+
+/** Empty socket args select the DEFAULT tmux socket (no `-L`). */
+const DEFAULT_SOCKET_ARGS: readonly string[] = [];
+
+/**
+ * True iff the claudeHubExit tmux session is alive on the default socket.
+ * Best-effort: any tmux error (no server running / no such session) is treated
+ * as "dead". The session name is a hard-coded constant, so there is no shell
+ * injection surface even though this spawns tmux directly.
+ */
+export function claudeHubExitSessionAlive(): boolean {
+  try {
+    execFileSync(TMUX_PATH, ["has-session", "-t", CLAUDEHUBEXIT_TMUX_SESSION], {
+      timeout: 2000,
+      stdio: "pipe",
+    });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Relay `/compact <intent>` to the claudeHubExit session on the default socket.
+ *
+ * Throws `"claudeHubExit session dead"` when the session is absent so the
+ * command layer surfaces an ephemeral error instead of silently dropping keys
+ * (#199 AC3 parity with the thread-bound path). RW-032: refuse an empty intent
+ * — the command layer always substitutes a default, so an empty value here can
+ * only be a programming error. The send sequence reuses {@link sendToPane}
+ * (mode-exit / Escape / `send-keys -l` / `C-m`) so the battle-tested,
+ * injection-safe relay path is the single source of truth (RW-019/045/047).
+ */
+export async function compactClaudeHubExit(intent: string): Promise<void> {
+  if (!intent.trim()) {
+    throw new Error("compact intent must be non-empty (RW-032)");
+  }
+  // Pre-flight liveness probe. There is a benign TOCTOU vs the send below (the
+  // session could die in the gap), but sendToPane would then throw anyway and
+  // the command layer surfaces it the same way — so this only upgrades the
+  // user-facing message to a clear "session dead" instead of a raw tmux error.
+  // Worth one extra cross-socket RTT on a manual, infrequent command.
+  if (!claudeHubExitSessionAlive()) {
+    throw new Error("claudeHubExit session dead");
+  }
+  await sendToPane(
+    CLAUDEHUBEXIT_TMUX_SESSION,
+    `/compact ${intent}`,
+    DEFAULT_SOCKET_ARGS
+  );
+}

--- a/supervisor/src/session/primary-compact.ts
+++ b/supervisor/src/session/primary-compact.ts
@@ -1,4 +1,4 @@
-import { execFileSync } from "child_process";
+import { execFile } from "child_process";
 import { TMUX_PATH } from "./tmux";
 import { sendToPane } from "./relay";
 
@@ -26,17 +26,20 @@ const DEFAULT_SOCKET_ARGS: readonly string[] = [];
  * Best-effort: any tmux error (no server running / no such session) is treated
  * as "dead". The session name is a hard-coded constant, so there is no shell
  * injection surface even though this spawns tmux directly.
+ *
+ * Async (execFile, not execFileSync) so the 2 s probe never blocks the
+ * Supervisor's single Discord event loop if tmux is slow to respond
+ * (gemini-code-assist review on #213).
  */
-export function claudeHubExitSessionAlive(): boolean {
-  try {
-    execFileSync(TMUX_PATH, ["has-session", "-t", CLAUDEHUBEXIT_TMUX_SESSION], {
-      timeout: 2000,
-      stdio: "pipe",
-    });
-    return true;
-  } catch {
-    return false;
-  }
+export function claudeHubExitSessionAlive(): Promise<boolean> {
+  return new Promise((resolve) => {
+    execFile(
+      TMUX_PATH,
+      ["has-session", "-t", CLAUDEHUBEXIT_TMUX_SESSION],
+      { timeout: 2000 },
+      (err) => resolve(!err)
+    );
+  });
 }
 
 /**
@@ -59,7 +62,7 @@ export async function compactClaudeHubExit(intent: string): Promise<void> {
   // the command layer surfaces it the same way — so this only upgrades the
   // user-facing message to a clear "session dead" instead of a raw tmux error.
   // Worth one extra cross-socket RTT on a manual, infrequent command.
-  if (!claudeHubExitSessionAlive()) {
+  if (!(await claudeHubExitSessionAlive())) {
     throw new Error("claudeHubExit session dead");
   }
   await sendToPane(

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -69,12 +69,18 @@ function getExecStderr(err: unknown): string {
  *
  * See Issue #73: tmux pane copy-mode stuck → send-keys silent drop + `not in a mode`.
  */
-export async function ensurePaneNotInMode(sessionName: string): Promise<void> {
+export async function ensurePaneNotInMode(
+  sessionName: string,
+  // Issue #199 AC1: socket selector. Defaults to the Supervisor's dedicated
+  // `-L claude-hub` socket; pass `[]` to target the DEFAULT socket where the
+  // claudeHubExit session lives (started by start-hijoguchi.sh with no -L).
+  socketArgs: readonly string[] = TMUX_ARGS
+): Promise<void> {
   let mode: string;
   try {
     mode = execFileSync(
       TMUX_PATH,
-      [...TMUX_ARGS, "display-message", "-t", sessionName, "-p", "#{pane_in_mode}"],
+      [...socketArgs, "display-message", "-t", sessionName, "-p", "#{pane_in_mode}"],
       { timeout: 2000 }
     ).toString().trim();
   } catch (err) {
@@ -87,7 +93,7 @@ export async function ensurePaneNotInMode(sessionName: string): Promise<void> {
   if (mode !== "1") return;
   console.warn(`[Relay] pane ${sessionName} in copy-mode, cancelling before send-keys`);
   try {
-    execFileSync(TMUX_PATH, [...TMUX_ARGS, "send-keys", "-t", sessionName, "-X", "cancel"], {
+    execFileSync(TMUX_PATH, [...socketArgs, "send-keys", "-t", sessionName, "-X", "cancel"], {
       timeout: 2000,
     });
   } catch (err) {
@@ -99,8 +105,14 @@ export async function ensurePaneNotInMode(sessionName: string): Promise<void> {
   }
 }
 
-export async function tmuxSend(sessionName: string, extraArgs: string[]): Promise<void> {
-  const args = [...TMUX_ARGS, "send-keys", "-t", sessionName, ...extraArgs];
+export async function tmuxSend(
+  sessionName: string,
+  extraArgs: string[],
+  // Issue #199 AC1: socket selector (see ensurePaneNotInMode). Defaults to the
+  // claude-hub socket; `[]` targets the default socket (claudeHubExit).
+  socketArgs: readonly string[] = TMUX_ARGS
+): Promise<void> {
+  const args = [...socketArgs, "send-keys", "-t", sessionName, ...extraArgs];
   const PER_CALL_TIMEOUT = 7000;
   try {
     execFileSync(TMUX_PATH, args, { timeout: PER_CALL_TIMEOUT });
@@ -118,7 +130,7 @@ export async function tmuxSend(sessionName: string, extraArgs: string[]): Promis
     console.warn(
       `[Relay] tmux send-keys transient error for ${sessionName} (${isModeErr ? "not-in-a-mode" : summary.code}), recovering...`
     );
-    await ensurePaneNotInMode(sessionName);
+    await ensurePaneNotInMode(sessionName, socketArgs);
     await new Promise((r) => setTimeout(r, 250));
     try {
       execFileSync(TMUX_PATH, args, { timeout: PER_CALL_TIMEOUT });
@@ -154,15 +166,20 @@ export async function tmuxSend(sessionName: string, extraArgs: string[]): Promis
  */
 export async function sendToPane(
   tmuxSessionName: string,
-  text: string
+  text: string,
+  // Issue #199 AC1: socket selector. Defaults to the Supervisor's `-L
+  // claude-hub` socket; pass `[]` to reach the claudeHubExit session on the
+  // default socket. The send sequence (mode-exit/Escape/-l/C-m) is identical on
+  // either socket, so this stays the single source of truth (no dead copy).
+  socketArgs: readonly string[] = TMUX_ARGS
 ): Promise<void> {
   const literalText = text.replace(/[\\r\\n]+/g, " ");
-  await ensurePaneNotInMode(tmuxSessionName);
-  await tmuxSend(tmuxSessionName, ["Escape"]);
+  await ensurePaneNotInMode(tmuxSessionName, socketArgs);
+  await tmuxSend(tmuxSessionName, ["Escape"], socketArgs);
   await new Promise((r) => setTimeout(r, 50));
-  await tmuxSend(tmuxSessionName, ["-l", literalText]);
+  await tmuxSend(tmuxSessionName, ["-l", literalText], socketArgs);
   await new Promise((r) => setTimeout(r, 100));
-  await tmuxSend(tmuxSessionName, ["C-m"]);
+  await tmuxSend(tmuxSessionName, ["C-m"], socketArgs);
 }
 
 /**

--- a/supervisor/tests/commands/session-compact.test.ts
+++ b/supervisor/tests/commands/session-compact.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { test, expect, describe, afterEach } from "bun:test";
 import {
   createSessionHandler,
   DEFAULT_COMPACT_INTENT,
@@ -28,14 +28,19 @@ function makeInteraction(opts: {
   hasSession?: boolean;
   /** make compactSession reject, to exercise the error branch. */
   compactImpl?: (threadId: string, intent: string) => unknown;
+  /** override the channel id (default "thread-compact-1"). */
+  channelId?: string;
+  /** make compactPrimarySession reject, to exercise the error branch (#199 AC1). */
+  primaryCompactImpl?: (intent: string) => unknown;
 }) {
   const replies: ReplyRecord[] = [];
   const compactCalls: { threadId: string; intent: string }[] = [];
+  const primaryCompactCalls: { intent: string }[] = [];
   const hasCalls: string[] = [];
 
   const inThread = opts.inThread ?? true;
   const channel = {
-    id: "thread-compact-1",
+    id: opts.channelId ?? "thread-compact-1",
     isThread: () => inThread,
   };
 
@@ -71,6 +76,10 @@ function makeInteraction(opts: {
       compactCalls.push({ threadId, intent });
       return opts.compactImpl?.(threadId, intent);
     },
+    compactPrimarySession: async (intent: string) => {
+      primaryCompactCalls.push({ intent });
+      return opts.primaryCompactImpl?.(intent);
+    },
   };
 
   return {
@@ -78,6 +87,7 @@ function makeInteraction(opts: {
       createSessionHandler(sessionManager as never)(interaction as never),
     replies,
     compactCalls,
+    primaryCompactCalls,
     hasCalls,
   };
 }
@@ -147,5 +157,88 @@ describe("/session compact (#200)", () => {
     );
     expect(err).toBeDefined();
     expect(err?.content).toContain("tmux session dead");
+  });
+});
+
+/**
+ * #199 AC1: the claudeHubExit primary channel is a normal text channel (not a
+ * thread) whose long-lived session runs on the DEFAULT tmux socket, outside
+ * SessionManager. `/session compact` invoked there must route to
+ * compactPrimarySession (NOT the thread-bound compactSession), gated on the
+ * HIJOGUCHI_CHANNEL_ID env so it fail-safes to the usage hint when the
+ * Supervisor isn't told the primary channel id.
+ */
+describe("/session compact in claudeHubExit primary channel (#199 AC1)", () => {
+  const PRIMARY = "primary-chan-199";
+
+  afterEach(() => {
+    delete process.env.HIJOGUCHI_CHANNEL_ID;
+  });
+
+  test("primary channel + explicit intent: routes to compactPrimarySession, never compactSession, ephemeral ack", async () => {
+    process.env.HIJOGUCHI_CHANNEL_ID = PRIMARY;
+    const fx = makeInteraction({
+      inThread: false,
+      channelId: PRIMARY,
+      intent: "残作業: Epic #182 dispatcher follow-up",
+    });
+    await fx.run();
+
+    expect(fx.primaryCompactCalls).toEqual([
+      { intent: "残作業: Epic #182 dispatcher follow-up" },
+    ]);
+    // Must not touch the thread-bound path.
+    expect(fx.compactCalls).toHaveLength(0);
+    expect(fx.hasCalls).toHaveLength(0);
+    // Ephemeral ack confirming the relayed text.
+    expect(fx.replies.some((r) => r.flags === 64)).toBe(true);
+    const ack = fx.replies.find((r) => r.kind === "editReply");
+    expect(ack?.content).toContain("/compact 残作業: Epic #182 dispatcher follow-up");
+  });
+
+  test("primary channel + omitted intent: substitutes default (RW-032)", async () => {
+    process.env.HIJOGUCHI_CHANNEL_ID = PRIMARY;
+    const fx = makeInteraction({ inThread: false, channelId: PRIMARY, intent: null });
+    await fx.run();
+
+    expect(fx.primaryCompactCalls).toHaveLength(1);
+    expect(fx.primaryCompactCalls[0]?.intent).toBe(DEFAULT_COMPACT_INTENT);
+  });
+
+  test("primary channel + dead claudeHubExit: reports error via editReply", async () => {
+    process.env.HIJOGUCHI_CHANNEL_ID = PRIMARY;
+    const fx = makeInteraction({
+      inThread: false,
+      channelId: PRIMARY,
+      primaryCompactImpl: () => {
+        throw new Error("claudeHubExit session dead");
+      },
+    });
+    await fx.run();
+
+    const err = fx.replies.find(
+      (r) => r.kind === "editReply" && r.content?.includes("失敗")
+    );
+    expect(err?.content).toContain("claudeHubExit session dead");
+  });
+
+  test("HIJOGUCHI_CHANNEL_ID unset: primary channel falls through to usage hint, no primary compact", async () => {
+    // env intentionally unset (afterEach cleared it)
+    const fx = makeInteraction({ inThread: false, channelId: PRIMARY });
+    await fx.run();
+
+    expect(fx.primaryCompactCalls).toHaveLength(0);
+    const hint = fx.replies.find((r) => r.kind === "reply");
+    expect(hint?.content).toContain("スレッド内で実行");
+    expect(hint?.flags).toBe(64);
+  });
+
+  test("non-primary channel id with env set: unaffected (still thread-bound path)", async () => {
+    process.env.HIJOGUCHI_CHANNEL_ID = PRIMARY;
+    const fx = makeInteraction({ intent: "通常スレッド" }); // default channelId = thread-compact-1, inThread true
+    await fx.run();
+
+    expect(fx.primaryCompactCalls).toHaveLength(0);
+    expect(fx.compactCalls).toHaveLength(1);
   });
 });


### PR DESCRIPTION
## 概要

Issue #199 の残作業 **AC1** を実装する。`/session compact` を **claudeHubExit primary channel**（`#claude-hub-hijoguchi`）で実行したとき、claudeHubExit 自身の長命セッションを compact できるようにする。

### #199 と #200 の関係（重要）

#199 の AC2/AC3/AC4 は **既に #200（`/session compact`）で実装済み**。ただし #200 は SessionManager 管理のスレッド束縛セッション（`-L claude-hub` socket）のみ対象で、`handleCompact` は `channel.isThread()` でない場合 usage hint を返すだけだった。

一方 #199 の**本来の動機**は「claudeHubExit が高コンテキスト（684k→713k, RW-032 系列）になったとき Discord 経由で compact したい」= primary channel での compact であり、これは #200 で**未対応**のまま残っていた。本 PR はその AC1 ギャップのみを埋める。

| #199 AC | 状態 |
|---|---|
| AC2 スレッドセッション → tmux compact | #200 で実装済 |
| AC3 dead → ephemeral | #200 で実装済 |
| AC4 bare → default intent | #200 で実装済（`DEFAULT_COMPACT_INTENT`） |
| **AC1 primary channel → claudeHubExit compact** | **本 PR** |

## アーキテクチャ

- claudeHubExit は **default tmux socket** の `claudeHubExit` session（`start-hijoguchi.sh` 管理）。Supervisor 通常の `-L claude-hub` socket とは別サーバ。
- 本 PR は Supervisor が **唯一意図的に** その socket 境界を越える経路（`primary-compact.ts`）。ユーザー起動の compact keystroke の relay のみで、lifecycle 管理は一切しない（CLAUDE.md の claudeHubExit 独立性を維持）。
- `HIJOGUCHI_CHANNEL_ID` env で gating。**未設定 = 機能 OFF（fail-safe）**、境界は明示 wiring するまで閉じたまま。

## 変更

- `supervisor/src/commands/session.ts`: `claudeHubExitPrimaryChannelId()` env helper + `handleCompact` の primary channel 分岐（`isThread()` ガードより前）
- `supervisor/src/session/primary-compact.ts`（新規）: `compactClaudeHubExit()` / `claudeHubExitSessionAlive()`。default socket 経由 send + liveness 検査 + dead 時 throw（AC3 parity）
- `supervisor/src/session/manager.ts`: `compactPrimarySession()` 委譲。RW-032 invariant 維持
- `supervisor/src/session/relay.ts`: `sendToPane`/`tmuxSend`/`ensurePaneNotInMode` に任意 `socketArgs`（default = claude-hub socket、既存 caller 不変）。send 経路の single source of truth を保ち dead copy drift 回避（RW-031/038）
- `com.claude-hub.supervisor.plist` + `docs/bot-operations.md`: `HIJOGUCHI_CHANNEL_ID` の wiring point（source は空、Issue #63）と運用手順

## テスト / 検証

- `session-compact.test.ts` に AC1 5 ケース追加 → **11/11 pass**（primary routing / RW-032 default intent / dead→error / env 未設定 fall-through / 非 primary 不変）
- `relay.test.ts` **7/7 pass**（`socketArgs` 後方互換を確認）
- `tsc --noEmit` **exit 0**
- 非破壊ライブ確認: `tmux has-session -t claudeHubExit`（default socket）存在を確認 → `claudeHubExitSessionAlive()` の対象 session/socket が正しいこと

### ⚠️ AC1 ライブ end-to-end 検証は未実施（要オペレータ操作）

実際の Discord→compact end-to-end は以下が必要なため本 PR では未実施（本番 claudeHubExit を実 compact する副作用 + 本番 launchd 操作のため自律実行しない）:

1. installed plist（`~/Library/LaunchAgents/com.claude-hub.supervisor.plist`）の `HIJOGUCHI_CHANNEL_ID` に hijoguchi と同じ id（`1487701062205964329`）を設定
2. `launchctl kickstart -k gui/$(id -u)/com.claude-hub.supervisor`
3. Discord の `#claude-hub-hijoguchi` で `/session compact <intent>` 実行 → claudeHubExit pane に `/compact` 行が出ることを `tmux capture-pane` で確認

## レビュー

code-review-orchestrator で fan-out レビュー済（security-sensitive: cross-socket send-keys / cross-layer）。must 指摘なし。指摘対応:
- nit `relay.ts` の改行 regex バグ → クリティカルパス（relayMessage）への影響分離のため **#212** に follow-up（本 PR の compact intent は単一行のため実害なし）
- should pre-flight liveness の TOCTOU → 意図的（clean error message > raw tmux error、手動・低頻度コマンド）。コメントで明記

## 関連

- Issue #199（本 PR で AC1 を close、AC2-4 は #200 で完了済）
- #200（`/session compact` 本体）, #212（follow-up: relay 改行 regex）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `/session compact` コマンドにプライマリチャネルからの新しいルーティング機能を追加。環境変数の設定により、特定チャネルでのセッション圧縮動作が変更されます。

* **Documentation**
  * `/session compact` の新機能と環境設定手順についてドキュメントを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->