### PR TITLE
feat: 長時間稼働/無報告セッションを検知し Discord へ通知 (#209)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,7 @@ jobs:
                    tests/session/dialog-stuck-handler.test.ts \
                    tests/session/stall-heartbeat.test.ts \
                    tests/session/context-budget.test.ts \
+                   tests/session/session-activity-watchdog.test.ts \
                    tests/hijoguchi-routing/p0.test.ts \
                    tests/e2e/ac-verification.test.ts
 

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -11,6 +11,7 @@ import {
 } from "discord.js";
 import { SessionManager } from "./session/manager";
 import { Reaper } from "./session/reaper";
+import { ActivityWatchdog } from "./session/session-activity-watchdog";
 import { ResourceMonitor } from "./session/resource-monitor";
 import { createSessionCommand, createSessionHandler } from "./commands/session";
 import { CHANNEL_MAP, MAX_SESSIONS } from "./config/channels";
@@ -83,6 +84,39 @@ export async function startBot(token: string): Promise<void> {
     });
   }
   const reaper = new Reaper(sessionManager, client);
+  // Issue #209: nudge the owner when a live session has been running for hours
+  // (long_lived, AC3) or has gone silent (quiet, AC1) — the gap between the
+  // per-turn stall heartbeat and the 7-day reaper. De-dup is internal so each
+  // signal pages at most once per episode.
+  const activityWatchdog = new ActivityWatchdog({
+    entries: () => sessionManager.entries(),
+    isAlive: (threadId) => sessionManager.livenessOf(threadId) === "alive",
+    notify: async (threadId, warning) => {
+      try {
+        const channel = await client.channels.fetch(threadId);
+        if (!channel?.isThread()) return;
+        console.warn(
+          `[Bot] activity-watchdog ${warning.level} on thread ${threadId}`
+        );
+        await channel.send(warning.message);
+        // long_lived is the more serious "is it stuck?" signal — also page
+        // Pushover so the owner sees it off-Discord (best-effort).
+        if (warning.level === "long_lived") {
+          await notifyPushover(
+            "Claude Code: 長時間稼働セッション",
+            `${channel.name ?? threadId} が長時間稼働中（生存・完了報告なし）— /session status で確認 (#209)`
+          ).catch((err) =>
+            console.warn("[Bot] activity-watchdog pushover failed:", err)
+          );
+        }
+      } catch (err) {
+        console.error(
+          `[Bot] activity-watchdog notify error for thread ${threadId}:`,
+          err
+        );
+      }
+    },
+  });
   const resourceMonitor = new ResourceMonitor(sessionManager);
   const sessionHandler = createSessionHandler(sessionManager);
 
@@ -138,12 +172,22 @@ export async function startBot(token: string): Promise<void> {
     }
 
     reaper.start();
+    activityWatchdog.start();
     resourceMonitor.start();
 
     // Register progress callback to send tool progress to Discord threads.
     // Events are buffered (Issue #119) and flushed every 2s as a single
     // message per thread to stay under Discord's 5-msg/5-sec rate limit.
     onProgress((event) => {
+      // Issue #209: a session streaming PostToolUse progress is *not* silent.
+      // Refresh lastActivityAt here so the activity watchdog's "quiet" signal
+      // (AC1) doesn't false-positive on a session that is actively reporting
+      // tool progress between relay turns (the relay path only touches activity
+      // when a turn completes). This is the first live caller of touchActivity.
+      // touchActivity also persists via updateSessionActivity (one small
+      // UPDATE-by-id); at MAX_SESSIONS=10 the per-event write rate is trivial
+      // for SQLite WAL, and the watchdog/reaper both read the in-memory value.
+      sessionManager.touchActivity(event.threadId);
       progressBuffer.add(event.threadId, {
         tool: event.tool,
         message: event.message,
@@ -725,6 +769,7 @@ export async function startBot(token: string): Promise<void> {
   const shutdown = async () => {
     console.log("[Bot] Shutdown signal received");
     reaper.stop();
+    activityWatchdog.stop();
     resourceMonitor.stop();
     // Drain pending progress buffers before tearing down the Discord client
     // so in-flight tool events still reach the user (Issue #119).

--- a/supervisor/src/session/session-activity-watchdog.ts
+++ b/supervisor/src/session/session-activity-watchdog.ts
@@ -1,0 +1,312 @@
+/**
+ * Session activity watchdog (Issue #209).
+ *
+ * Existing safeguards each cover a *different timescale* and leave a gap:
+ *   - the stall heartbeat ({@link import("./stall-heartbeat")}) is per relay turn
+ *     (3 min, below the 5-min relay timeout),
+ *   - the reaper ({@link import("./reaper").Reaper}) only acts after 7 days idle,
+ *   - the context-budget monitor ({@link import("./context-budget")}) fires on
+ *     high token counts reported by the Stop hook (#204).
+ *
+ * None of them notice a session that is *alive but has been running for hours*
+ * or has gone quiet at the session timescale. That gap is exactly what #209
+ * hit: a dispatched session ran ~21h at 33% ctx without any proactive Discord
+ * report, so it looked "dead" to the owner while genuinely working.
+ *
+ * This watchdog periodically scans the live sessions and emits at most one
+ * Discord nudge per signal (de-dup), driven by two numeric thresholds:
+ *   - quiet     — no activity for `quietMs` (default 60 min)  → AC1
+ *   - long_lived — running for `longLivedMs` (default 6 h)     → AC3
+ *
+ * Detection is purely numeric (elapsed/idle ms) — NOT a TUI string match — so a
+ * Claude Code TUI update cannot silently break it (RW-027 consistency). AC2
+ * (mandatory completion report) needs agent-side cooperation and is tracked
+ * separately in #211.
+ */
+
+export type ActivityLevel = "quiet" | "long_lived";
+
+export interface ActivityThresholds {
+  /** No activity for this long → "quiet" (running but no report). */
+  quietMs: number;
+  /** Running for this long → "long_lived" (abnormally long lifetime). */
+  longLivedMs: number;
+}
+
+/** A single observation of a session's age and idle time. */
+export interface ActivitySample {
+  /** ms since the session started. */
+  ageMs: number;
+  /** ms since the last recorded activity (inbound or outbound). */
+  idleMs: number;
+}
+
+export interface ActivityWarning {
+  level: ActivityLevel;
+  message: string;
+}
+
+const MINUTE_MS = 60_000;
+const HOUR_MS = 60 * MINUTE_MS;
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+/**
+ * Thresholds. Env-overridable for tuning and tests; read at call time (not at
+ * module load) so a test can set env per-case. Defaults: a session is "quiet"
+ * after 60 min of no activity and "long-lived" after 6 h of runtime.
+ */
+export function getActivityThresholds(): ActivityThresholds {
+  return {
+    quietMs: envInt("SESSION_QUIET_WARN_MS", 60 * MINUTE_MS),
+    longLivedMs: envInt("SESSION_LONG_LIVED_WARN_MS", 6 * HOUR_MS),
+  };
+}
+
+/**
+ * Classify a single sample. `long_lived` takes precedence over `quiet` (a
+ * session running 21h is the headline even if it is also quiet). Returns null
+ * when neither threshold is met — the common, healthy case — so a steady active
+ * session produces no warning (false-positive avoidance).
+ *
+ * NOTE: {@link createActivityTracker} intentionally re-derives these two
+ * conditions inline (it needs both booleans independently for per-signal
+ * de-dup, not just the priority winner). Keep the threshold comparisons here and
+ * there in sync — both are exercised by the test suite.
+ */
+export function classifyActivity(
+  sample: ActivitySample,
+  thresholds: ActivityThresholds = getActivityThresholds()
+): ActivityLevel | null {
+  const { ageMs, idleMs } = sample;
+  if (Number.isFinite(ageMs) && ageMs >= thresholds.longLivedMs) {
+    return "long_lived";
+  }
+  if (Number.isFinite(idleMs) && idleMs >= thresholds.quietMs) {
+    return "quiet";
+  }
+  return null;
+}
+
+/**
+ * Human-friendly duration: minutes below an hour, else `H時間` (+`M分` when the
+ * remainder is non-zero). Floored so the displayed value never overstates.
+ */
+function formatDuration(ms: number): string {
+  const totalMin = Math.max(0, Math.floor(ms / MINUTE_MS));
+  if (totalMin < 60) return `${totalMin}分`;
+  const hours = Math.floor(totalMin / 60);
+  const min = totalMin % 60;
+  return min === 0 ? `${hours}時間` : `${hours}時間${min}分`;
+}
+
+/**
+ * Build the Discord nudge for a classified level. Both messages cite #209 so
+ * the alert is self-documenting and suggest a concrete next step.
+ */
+export function buildActivityWarning(
+  level: ActivityLevel,
+  sample: ActivitySample,
+  _thresholds: ActivityThresholds = getActivityThresholds()
+): string {
+  if (level === "long_lived") {
+    return `⏳ このセッションは約 ${formatDuration(sample.ageMs)} 稼働し続けています（生存中・完了報告なし）。意図せず長引いている / stall していないか確認してください。\`/session status\` で生死確認、\`/session compact\` も検討 (#209)。`;
+  }
+  return `⚠️ このセッションは約 ${formatDuration(sample.idleMs)} 無活動です（稼働中だが無報告）。停止していないか確認してください (#209)。`;
+}
+
+export interface ActivityTracker {
+  /**
+   * Feed the latest sample. Returns a warning the first time a signal appears,
+   * then stays silent so a steady condition is not re-warned every tick:
+   *   - long_lived warns once for the session's lifetime (one-shot),
+   *   - quiet warns once per quiet *episode* — when activity resumes (idle drops
+   *     below the threshold) the episode resets so a later silence re-warns.
+   * The two signals are tracked independently.
+   */
+  check(sample: ActivitySample): ActivityWarning | null;
+}
+
+/**
+ * Per-session de-dup tracker. The watchdog holds one per live thread and drops
+ * it when the session disappears. Thresholds are snapshotted at creation.
+ */
+export function createActivityTracker(
+  thresholds: ActivityThresholds = getActivityThresholds()
+): ActivityTracker {
+  let longLivedWarned = false;
+  let quietWarned = false;
+
+  return {
+    check(sample) {
+      const { ageMs, idleMs } = sample;
+      const longLived =
+        Number.isFinite(ageMs) && ageMs >= thresholds.longLivedMs;
+      const quiet = Number.isFinite(idleMs) && idleMs >= thresholds.quietMs;
+
+      // Re-arm the quiet episode as soon as the session is active again.
+      if (!quiet) quietWarned = false;
+
+      if (longLived && !longLivedWarned) {
+        longLivedWarned = true;
+        // Suppress an *immediately* redundant quiet follow-up: when a session is
+        // both long-lived and already quiet, the long_lived nudge covers it, so
+        // don't also fire quiet on the next tick. We only mark quiet warned when
+        // it is quiet *now* — so a session that was active when long_lived fired
+        // and falls silent *later* still gets its own quiet alert (re-armed by
+        // the `if (!quiet)` reset above).
+        if (quiet) quietWarned = true;
+        return {
+          level: "long_lived",
+          message: buildActivityWarning("long_lived", sample, thresholds),
+        };
+      }
+      if (quiet && !quietWarned) {
+        quietWarned = true;
+        return {
+          level: "quiet",
+          message: buildActivityWarning("quiet", sample, thresholds),
+        };
+      }
+      return null;
+    },
+  };
+}
+
+/** Minimal session shape the watchdog reads. */
+interface WatchdogSession {
+  startedAt: Date;
+  lastActivityAt: Date;
+}
+
+export interface ActivityWatchdogDeps {
+  /** Live in-memory sessions (e.g. `sessionManager.entries()`). */
+  entries(): IterableIterator<[string, WatchdogSession]>;
+  /**
+   * Authoritative liveness for a thread. Dead sessions are skipped — the reaper
+   * owns terminating them; warning about a dead session would be noise.
+   */
+  isAlive(threadId: string): boolean;
+  /** Deliver a warning (best-effort; throwing is caught per-session). */
+  notify(threadId: string, warning: ActivityWarning): void | Promise<void>;
+  thresholds?: ActivityThresholds;
+  intervalMs?: number;
+  /** Injectable clock for tests. */
+  now?: () => number;
+}
+
+/** Default scan cadence. Coarser than the relay timescale, finer than the reaper. */
+export const DEFAULT_WATCHDOG_INTERVAL_MS = 10 * MINUTE_MS;
+
+/**
+ * Periodic driver (mirrors {@link import("./reaper").Reaper}'s shape). Holds one
+ * {@link ActivityTracker} per live thread for de-dup and GCs trackers whose
+ * session has gone. The pure logic lives in the functions above; this class is a
+ * thin timer + notify shell so it stays trivially testable via `check()`.
+ */
+export class ActivityWatchdog {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly trackers = new Map<string, ActivityTracker>();
+  private readonly thresholds: ActivityThresholds;
+  private readonly intervalMs: number;
+  private readonly now: () => number;
+
+  constructor(private readonly deps: ActivityWatchdogDeps) {
+    this.thresholds = deps.thresholds ?? getActivityThresholds();
+    this.intervalMs =
+      deps.intervalMs ??
+      envInt("SESSION_WATCHDOG_INTERVAL_MS", DEFAULT_WATCHDOG_INTERVAL_MS);
+    this.now = deps.now ?? (() => Date.now());
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      void this.check();
+    }, this.intervalMs);
+    // Don't keep the event loop alive solely for this timer.
+    if (typeof this.timer === "object" && this.timer && "unref" in this.timer) {
+      (this.timer as { unref: () => void }).unref();
+    }
+    console.log(
+      `[ActivityWatchdog] Started (interval ${this.intervalMs / MINUTE_MS}min, quiet ${this.thresholds.quietMs / MINUTE_MS}min, longLived ${this.thresholds.longLivedMs / HOUR_MS}h)`
+    );
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /** One scan pass. Public so tests can drive it deterministically. */
+  async check(): Promise<void> {
+    const now = this.now();
+    const live = new Set<string>();
+    let scanned = 0;
+    let aliveCount = 0;
+    let warned = 0;
+
+    for (const [threadId, session] of this.deps.entries()) {
+      live.add(threadId);
+      scanned++;
+
+      let alive: boolean;
+      try {
+        alive = this.deps.isAlive(threadId);
+      } catch (err) {
+        console.warn(
+          `[ActivityWatchdog] isAlive(${threadId}) threw:`,
+          err
+        );
+        continue;
+      }
+      if (!alive) continue;
+      aliveCount++;
+
+      const ageMs = now - session.startedAt.getTime();
+      const idleMs = now - session.lastActivityAt.getTime();
+
+      let tracker = this.trackers.get(threadId);
+      if (!tracker) {
+        tracker = createActivityTracker(this.thresholds);
+        this.trackers.set(threadId, tracker);
+      }
+
+      const warning = tracker.check({ ageMs, idleMs });
+      if (warning) {
+        warned++;
+        // Sequential await: for the supervisor's small session count
+        // (MAX_SESSIONS = 10) even an all-cross-at-once burst stays well under
+        // Discord's global rate limit. notify() is best-effort and isolated —
+        // one failure must not abort the rest of the scan.
+        try {
+          await this.deps.notify(threadId, warning);
+        } catch (err) {
+          console.warn(
+            `[ActivityWatchdog] notify(${threadId}) failed:`,
+            err
+          );
+        }
+      }
+    }
+
+    // GC tracker state for sessions that have disappeared so a thread id reused
+    // by a brand-new session starts from a clean de-dup slate.
+    for (const id of this.trackers.keys()) {
+      if (!live.has(id)) this.trackers.delete(id);
+    }
+
+    // Heartbeat so a silently-stopped watchdog is detectable in logs (RW-023:
+    // an unobserved background writer can die for days unnoticed).
+    console.debug(
+      `[ActivityWatchdog] scan: ${scanned} sessions, ${aliveCount} alive, ${warned} warned`
+    );
+  }
+}

--- a/supervisor/tests/session/session-activity-watchdog.test.ts
+++ b/supervisor/tests/session/session-activity-watchdog.test.ts
@@ -1,0 +1,334 @@
+import { test, expect, describe } from "bun:test";
+import {
+  classifyActivity,
+  buildActivityWarning,
+  createActivityTracker,
+  getActivityThresholds,
+  ActivityWatchdog,
+  type ActivityThresholds,
+  type ActivityWarning,
+} from "../../src/session/session-activity-watchdog";
+
+const MIN = 60_000;
+const HOUR = 60 * MIN;
+
+// Explicit thresholds keep logic tests deterministic regardless of env.
+const T: ActivityThresholds = {
+  quietMs: 60 * MIN, // 60 min
+  longLivedMs: 6 * HOUR, // 6 h
+};
+
+describe("classifyActivity (Journey AC #3: no false positives)", () => {
+  test("returns null when neither quiet nor long-lived", () => {
+    expect(classifyActivity({ ageMs: 30 * MIN, idleMs: 10 * MIN }, T)).toBeNull();
+    expect(classifyActivity({ ageMs: 0, idleMs: 0 }, T)).toBeNull();
+    // exactly one tick below each threshold
+    expect(
+      classifyActivity({ ageMs: 6 * HOUR - 1, idleMs: 60 * MIN - 1 }, T)
+    ).toBeNull();
+  });
+
+  test("flags quiet at/above the quiet threshold (AC1)", () => {
+    expect(classifyActivity({ ageMs: 70 * MIN, idleMs: 60 * MIN }, T)).toBe(
+      "quiet"
+    );
+  });
+
+  test("flags long_lived at/above the long-lived threshold (AC3)", () => {
+    expect(classifyActivity({ ageMs: 6 * HOUR, idleMs: 5 * MIN }, T)).toBe(
+      "long_lived"
+    );
+  });
+
+  test("long_lived takes precedence when both apply", () => {
+    expect(classifyActivity({ ageMs: 21 * HOUR, idleMs: 2 * HOUR }, T)).toBe(
+      "long_lived"
+    );
+  });
+
+  test("non-finite samples are treated as no signal (defensive)", () => {
+    // ageMs/idleMs are now-minus-Date; an Invalid Date yields NaN. We treat any
+    // non-finite value as "no signal" (matching context-budget.ts) so a corrupt
+    // timestamp can never produce a spurious alert. Infinity cannot occur in
+    // practice (both operands are real ms) but is covered for completeness.
+    expect(classifyActivity({ ageMs: NaN, idleMs: NaN }, T)).toBeNull();
+    expect(classifyActivity({ ageMs: Infinity, idleMs: 0 }, T)).toBeNull();
+    expect(classifyActivity({ ageMs: 0, idleMs: Infinity }, T)).toBeNull();
+  });
+});
+
+describe("buildActivityWarning", () => {
+  test("long_lived cites #209, shows ⏳ and the elapsed duration", () => {
+    const msg = buildActivityWarning(
+      "long_lived",
+      { ageMs: 6 * HOUR, idleMs: 5 * MIN },
+      T
+    );
+    expect(msg).toContain("⏳");
+    expect(msg).toContain("6時間");
+    expect(msg).toContain("#209");
+  });
+
+  test("quiet cites #209, shows ⚠️ and the idle duration", () => {
+    const msg = buildActivityWarning(
+      "quiet",
+      { ageMs: 90 * MIN, idleMs: 75 * MIN },
+      T
+    );
+    expect(msg).toContain("⚠️");
+    expect(msg).toContain("1時間15分");
+    expect(msg).toContain("#209");
+  });
+
+  test("formats sub-hour durations in minutes", () => {
+    const msg = buildActivityWarning(
+      "quiet",
+      { ageMs: 90 * MIN, idleMs: 45 * MIN },
+      T
+    );
+    expect(msg).toContain("45分");
+  });
+});
+
+describe("createActivityTracker (de-dup, Journey AC #1/#3)", () => {
+  test("long_lived warns once, then de-dups on later ticks (AC3 one-shot)", () => {
+    const tr = createActivityTracker(T);
+    const w = tr.check({ ageMs: 6 * HOUR, idleMs: 1 * MIN });
+    expect(w).not.toBeNull();
+    expect(w!.level).toBe("long_lived");
+    // later ticks (even older) do not re-warn
+    expect(tr.check({ ageMs: 7 * HOUR, idleMs: 1 * MIN })).toBeNull();
+    expect(tr.check({ ageMs: 24 * HOUR, idleMs: 1 * MIN })).toBeNull();
+  });
+
+  test("quiet warns once per episode and re-arms after activity resumes (AC1)", () => {
+    const tr = createActivityTracker(T);
+    // becomes quiet
+    expect(tr.check({ ageMs: 90 * MIN, idleMs: 60 * MIN })!.level).toBe("quiet");
+    // still quiet -> no spam
+    expect(tr.check({ ageMs: 100 * MIN, idleMs: 70 * MIN })).toBeNull();
+    // activity resumes (idle below threshold) -> episode resets
+    expect(tr.check({ ageMs: 110 * MIN, idleMs: 2 * MIN })).toBeNull();
+    // goes quiet again -> warns again
+    expect(tr.check({ ageMs: 180 * MIN, idleMs: 60 * MIN })!.level).toBe(
+      "quiet"
+    );
+  });
+
+  test("never warns for a healthy active session (no false positive)", () => {
+    const tr = createActivityTracker(T);
+    expect(tr.check({ ageMs: 30 * MIN, idleMs: 1 * MIN })).toBeNull();
+    expect(tr.check({ ageMs: 2 * HOUR, idleMs: 5 * MIN })).toBeNull();
+  });
+
+  test("long_lived (one-shot) and quiet (episode) are tracked independently", () => {
+    const tr = createActivityTracker(T);
+    // quiet first (age below long-lived)
+    expect(tr.check({ ageMs: 2 * HOUR, idleMs: 60 * MIN })!.level).toBe("quiet");
+    // now also long-lived while still quiet -> long_lived fires (priority, not yet warned)
+    expect(tr.check({ ageMs: 6 * HOUR, idleMs: 90 * MIN })!.level).toBe(
+      "long_lived"
+    );
+    // both already warned -> silent
+    expect(tr.check({ ageMs: 7 * HOUR, idleMs: 120 * MIN })).toBeNull();
+  });
+
+  test("long_lived firing while quiet suppresses the immediately-redundant quiet follow-up", () => {
+    const tr = createActivityTracker(T);
+    // first observation is already both long-lived AND quiet -> long_lived wins
+    expect(tr.check({ ageMs: 6 * HOUR, idleMs: 90 * MIN })!.level).toBe(
+      "long_lived"
+    );
+    // next tick still long-lived + quiet -> NOT a second (quiet) alert
+    expect(tr.check({ ageMs: 7 * HOUR, idleMs: 120 * MIN })).toBeNull();
+  });
+
+  test("a quiet episode that begins AFTER a long_lived alert still fires (not suppressed forever)", () => {
+    const tr = createActivityTracker(T);
+    // long-lived fires while the session is active (idle small) -> not quiet
+    expect(tr.check({ ageMs: 6 * HOUR, idleMs: 2 * MIN })!.level).toBe(
+      "long_lived"
+    );
+    // session keeps running, still active -> silent
+    expect(tr.check({ ageMs: 8 * HOUR, idleMs: 5 * MIN })).toBeNull();
+    // now it falls silent -> a quiet alert is still warranted
+    expect(tr.check({ ageMs: 10 * HOUR, idleMs: 70 * MIN })!.level).toBe(
+      "quiet"
+    );
+  });
+});
+
+describe("getActivityThresholds env override", () => {
+  test("defaults to 60min quiet / 6h long-lived", () => {
+    const prevQ = process.env.SESSION_QUIET_WARN_MS;
+    const prevL = process.env.SESSION_LONG_LIVED_WARN_MS;
+    delete process.env.SESSION_QUIET_WARN_MS;
+    delete process.env.SESSION_LONG_LIVED_WARN_MS;
+    try {
+      expect(getActivityThresholds()).toEqual({
+        quietMs: 60 * MIN,
+        longLivedMs: 6 * HOUR,
+      });
+    } finally {
+      if (prevQ !== undefined) process.env.SESSION_QUIET_WARN_MS = prevQ;
+      if (prevL !== undefined) process.env.SESSION_LONG_LIVED_WARN_MS = prevL;
+    }
+  });
+
+  test("honours env overrides", () => {
+    const prev = process.env.SESSION_QUIET_WARN_MS;
+    process.env.SESSION_QUIET_WARN_MS = "120000";
+    try {
+      expect(getActivityThresholds().quietMs).toBe(120_000);
+    } finally {
+      if (prev === undefined) delete process.env.SESSION_QUIET_WARN_MS;
+      else process.env.SESSION_QUIET_WARN_MS = prev;
+    }
+  });
+});
+
+describe("ActivityWatchdog.check (periodic scan)", () => {
+  type FakeSession = { startedAt: Date; lastActivityAt: Date };
+
+  function makeDeps(opts: {
+    sessions: Map<string, FakeSession>;
+    alive: Set<string>;
+    nowRef: { t: number };
+  }) {
+    const notifications: Array<{ threadId: string; warning: ActivityWarning }> =
+      [];
+    const wd = new ActivityWatchdog({
+      entries: () => opts.sessions.entries(),
+      isAlive: (id) => opts.alive.has(id),
+      notify: (threadId, warning) => {
+        notifications.push({ threadId, warning });
+      },
+      thresholds: T,
+      now: () => opts.nowRef.t,
+    });
+    return { wd, notifications };
+  }
+
+  test("warns a long-lived alive session exactly once across ticks (AC3)", async () => {
+    const start = 0;
+    const sessions = new Map<string, FakeSession>([
+      [
+        "thread-a",
+        { startedAt: new Date(start), lastActivityAt: new Date(start) },
+      ],
+    ]);
+    const nowRef = { t: 0 };
+    const { wd, notifications } = makeDeps({
+      sessions,
+      alive: new Set(["thread-a"]),
+      nowRef,
+    });
+
+    // The session stays active (lastActivityAt tracks now) so the *quiet*
+    // signal never fires — this isolates the long_lived (AC3) one-shot. This is
+    // the #209 shape: ran 21h while the owner kept messaging it.
+    // tick 1 at +5h: not yet long-lived, recent activity -> no warn
+    nowRef.t = 5 * HOUR;
+    sessions.get("thread-a")!.lastActivityAt = new Date(nowRef.t);
+    await wd.check();
+    expect(notifications).toHaveLength(0);
+
+    // tick 2 at +6h: long-lived (age 6h), still active -> warn once
+    nowRef.t = 6 * HOUR;
+    sessions.get("thread-a")!.lastActivityAt = new Date(nowRef.t);
+    await wd.check();
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0]!.threadId).toBe("thread-a");
+    expect(notifications[0]!.warning.level).toBe("long_lived");
+
+    // tick 3 at +8h: still long-lived but already warned -> no new warn
+    nowRef.t = 8 * HOUR;
+    sessions.get("thread-a")!.lastActivityAt = new Date(nowRef.t);
+    await wd.check();
+    expect(notifications).toHaveLength(1);
+  });
+
+  test("skips dead sessions (left to the reaper)", async () => {
+    const sessions = new Map<string, FakeSession>([
+      ["dead-1", { startedAt: new Date(0), lastActivityAt: new Date(0) }],
+    ]);
+    const nowRef = { t: 24 * HOUR };
+    const { wd, notifications } = makeDeps({
+      sessions,
+      alive: new Set(), // dead-1 is not alive
+      nowRef,
+    });
+    await wd.check();
+    expect(notifications).toHaveLength(0);
+  });
+
+  test("does not warn a healthy active session (no false positive)", async () => {
+    const nowRef = { t: 2 * HOUR };
+    const sessions = new Map<string, FakeSession>([
+      [
+        "busy",
+        {
+          startedAt: new Date(0),
+          lastActivityAt: new Date(2 * HOUR - 1 * MIN),
+        },
+      ],
+    ]);
+    const { wd, notifications } = makeDeps({
+      sessions,
+      alive: new Set(["busy"]),
+      nowRef,
+    });
+    await wd.check();
+    expect(notifications).toHaveLength(0);
+  });
+
+  test("GCs tracker state for sessions that disappeared (re-warns on a new session reusing the id)", async () => {
+    const nowRef = { t: 6 * HOUR };
+    const sessions = new Map<string, FakeSession>([
+      ["t1", { startedAt: new Date(0), lastActivityAt: new Date(0) }],
+    ]);
+    const { wd, notifications } = makeDeps({
+      sessions,
+      alive: new Set(["t1"]),
+      nowRef,
+    });
+    // warns long-lived once
+    await wd.check();
+    expect(notifications).toHaveLength(1);
+
+    // session t1 ends and is removed
+    sessions.delete("t1");
+    await wd.check(); // GCs t1 tracker
+
+    // a brand-new session reuses thread id t1, already old -> warns again
+    sessions.set("t1", {
+      startedAt: new Date(nowRef.t - 6 * HOUR),
+      lastActivityAt: new Date(nowRef.t),
+    });
+    await wd.check();
+    expect(notifications).toHaveLength(2);
+  });
+
+  test("a notify() failure does not abort the scan of other sessions", async () => {
+    const nowRef = { t: 7 * HOUR };
+    const sessions = new Map<string, FakeSession>([
+      ["boom", { startedAt: new Date(0), lastActivityAt: new Date(0) }],
+      ["ok", { startedAt: new Date(0), lastActivityAt: new Date(0) }],
+    ]);
+    const seen: string[] = [];
+    const wd = new ActivityWatchdog({
+      entries: () => sessions.entries(),
+      isAlive: () => true,
+      notify: (threadId) => {
+        seen.push(threadId);
+        if (threadId === "boom") throw new Error("discord down");
+      },
+      thresholds: T,
+      now: () => nowRef.t,
+    });
+    await wd.check();
+    // both were visited despite the first throwing
+    expect(seen).toContain("boom");
+    expect(seen).toContain("ok");
+  });
+});


### PR DESCRIPTION
## 目的
Issue #209: dispatch セッションが数時間 Discord へ能動報告せず、生存中でも owner から「落ちた」ように見える notification gap を埋める。実例は corp の記事 dispatch が約 21h 稼働（33% ctx）で無反応に見えたケース。

既存の安全網は時間軸が噛み合わず隙間があった:
- stall-heartbeat: relay 1 ターン単位（3 分、relay timeout 5 分の内側）
- reaper: 7 日 idle でしか発火しない
- context-budget (#204/#205): 高トークン量で発火

この「数時間 稼働 / 沈黙」のセッション時間軸を、新規 `ActivityWatchdog` の定期 scan が埋める。

## 主な変更点
- **`supervisor/src/session/session-activity-watchdog.ts`（新規）**
  - `classifyActivity` / `buildActivityWarning` / `createActivityTracker` の純粋ロジック + 薄い `ActivityWatchdog` クラス（`Reaper` と同型の periodic driver）
  - **long_lived**（既定 6h、`SESSION_LONG_LIVED_WARN_MS`）= one-shot 通知（AC3）
  - **quiet**（既定 60 分無活動、`SESSION_QUIET_WARN_MS`）= episode 単位 de-dup、活動再開で re-arm（AC1）
  - long_lived が quiet と同時成立した場合は直後の冗長 quiet を抑制しつつ、後から沈黙した場合の quiet は保持
  - 検知は数値（経過/無活動 ms）ベースで TUI 文字列に依存しない（RW-027 整合）
  - scan ごとに heartbeat ログ（RW-023: 無観測 watchdog の sudden death 検知）
- **`supervisor/src/bot.ts`**
  - watchdog を構築し ClientReady で start / shutdown で stop。long_lived は Pushover も通知（best-effort、配信済み応答を妨げない）
  - `onProgress` で `sessionManager.touchActivity()` を呼び `lastActivityAt` を更新 → 進捗を streaming 中のセッションを quiet と誤検知しない（`touchActivity` の初の実利用箇所。dead method を解消）
- **`.github/workflows/ci.yml`**: 新テストを curated unit-test list に追加（gate 化）

## スコープ
AC1（無報告検知）+ AC3（長時間稼働検知）を実装。**AC2（dispatch 完了報告の必須化）は #211 に分離**（agent/prompt 側の協調が必要なため）。

## 統合ジャーニーAC 検証（#209 本文に記載）
| AC | 検証 | 結果 |
|---|---|---|
| AC3 長時間稼働 → 1 回だけ通知 | tracker テスト（age>=閾値 で 1 回、以降 null） | PASS |
| AC1 沈黙 → 通知 + 活動再開で re-arm | tracker テスト（idle>=閾値、再開、再沈黙） | PASS |
| 健全セッションで false positive なし | classify/watchdog テスト | PASS |

## テスト
- 新規 `session-activity-watchdog.test.ts`（21 ケース：classify/build/tracker de-dup/env/watchdog scan・dead skip・GC・notify 失敗の隔離）
- curated unit-test list ローカル実行: **242 pass / 0 fail**、`tsc --noEmit` 0 errors
- code-review-orchestrator レビュー反映済（must 0 / should 5 を対応: 二重発火抑制・scan 可観測性・DB write/rate-limit コメント）

## 関連
#209（本体）, #211（AC2 follow-up）, #166 / #172 / #206（セッション生死・watchdog・self-healing 系列）

🤖 Generated with [Claude Code](https://claude.com/claude-code)