### PR TITLE
docs(#199): Supervisor env 反映を kickstart -k から bootout+bootstrap に修正

### DIFF
--- a/com.claude-hub.supervisor.plist
+++ b/com.claude-hub.supervisor.plist
@@ -29,7 +29,10 @@
              (Issue #63 fail-closed). Fill the real id in the installed plist
              (~/Library/LaunchAgents/com.claude-hub.supervisor.plist) — use the
              same value as the hijoguchi plist's HIJOGUCHI_CHANNEL_ID — then
-             `launchctl kickstart -k gui/$(id -u)/com.claude-hub.supervisor`.
+             reload with bootout+bootstrap (NOT `kickstart -k`, which restarts
+             from the cached service definition and ignores plist env changes):
+             `launchctl bootout gui/$(id -u)/com.claude-hub.supervisor &&
+             launchctl bootstrap gui/$(id -u) <this plist>`.
              Blank = feature disabled (fail-safe). -->
         <key>HIJOGUCHI_CHANNEL_ID</key>
         <string></string>

--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -180,10 +180,16 @@ claudeHubExit の primary channel（`#claude-hub-hijoguchi`）はスレッドで
 <string>1487701062205964329</string>
 ```
 
-反映:
+反映（**`kickstart -k` ではなく `bootout`+`bootstrap`**）:
 
 ```bash
-launchctl kickstart -k gui/$(id -u)/com.claude-hub.supervisor
+# kickstart -k はキャッシュされたサービス定義で再起動するだけで plist の
+# env 変更を再読込しない。新規 env を反映するには bootout + bootstrap が必須。
+launchctl bootout   gui/$(id -u)/com.claude-hub.supervisor
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.claude-hub.supervisor.plist
+
+# 確認: environment セクションに HIJOGUCHI_CHANNEL_ID が出ること
+launchctl print gui/$(id -u)/com.claude-hub.supervisor | grep -A4 '	environment = {'
 ```
 
 - **未設定（空文字）= 機能 OFF（fail-safe）**: primary channel で `/session compact` はスレッド用の usage hint を返すだけ。境界（Supervisor↔claudeHubExit の独立性）は明示 wiring するまで閉じたまま。


### PR DESCRIPTION
## 概要

PR #213（#199 AC1）で追記した「Supervisor の `HIJOGUCHI_CHANNEL_ID` 反映手順」が誤っていたため修正する。

## 実機で判明した問題

`HIJOGUCHI_CHANNEL_ID` を installed plist に追加後、ドキュメント通り `launchctl kickstart -k` を実行したが、`launchctl print` の `environment` セクションに env が現れず AC1 が有効化されなかった。

`kickstart -k` は**キャッシュされたサービス定義で再起動するだけで plist の `EnvironmentVariables` 変更を再読込しない**。`bootout` + `bootstrap` で plist を再読込したところ `environment` に `HIJOGUCHI_CHANNEL_ID => 1487701062205964329` が現れ、有効化を確認した。

## 変更

- `docs/bot-operations.md` の #199 AC1 反映手順: `kickstart -k` → `bootout` + `bootstrap` + 確認コマンド（`launchctl print ... | grep environment`）
- `com.claude-hub.supervisor.plist` のコメントも同様に修正
- 「Channel-Supervisor 復旧」セクション（plist 変更を伴わない単純再起動）の `kickstart -k` は正しいため**据え置き**

## 検証

- `plutil -lint com.claude-hub.supervisor.plist` → OK
- 本番 Supervisor で `bootout`+`bootstrap` により `HIJOGUCHI_CHANNEL_ID` がロードされることを確認済み（PID 51609、healthy 起動）

## 関連

- #213（#199 AC1 本体、本 PR で運用手順を訂正）、#199

🤖 Generated with [Claude Code](https://claude.com/claude-code)