### PR TITLE
fix(relay): 改行平坦化 regex の二重エスケープ修正で複数行 relay の silent drop を解消 (#210)

### DIFF
--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -145,6 +145,20 @@ export async function tmuxSend(
 }
 
 /**
+ * Flatten every newline (CR / LF, in any combination or run) to a single space
+ * so a multi-line message survives `tmux send-keys -l`, which would otherwise
+ * submit at the first newline and split/corrupt the input (Issue #210).
+ *
+ * The regex MUST use single-backslash `\r` / `\n` (the real CR 0x0D / LF 0x0A
+ * code points). The earlier `/[\\r\\n]+/` was double-escaped and matched only
+ * the literal characters `\`, `r`, `n`, so it never removed actual newlines —
+ * multi-line Discord relays were silently dropped while single-line ones worked.
+ */
+export function flattenForSendKeys(text: string): string {
+  return text.replace(/[\r\n]+/g, " ");
+}
+
+/**
  * Type one line into the pane and submit it, without waiting for any relay
  * response. This is the shared send sequence used by {@link relayMessage}
  * (which then waits for the Stop-hook POST) and by fire-and-forget sends such
@@ -173,7 +187,7 @@ export async function sendToPane(
   // either socket, so this stays the single source of truth (no dead copy).
   socketArgs: readonly string[] = TMUX_ARGS
 ): Promise<void> {
-  const literalText = text.replace(/[\\r\\n]+/g, " ");
+  const literalText = flattenForSendKeys(text);
   await ensurePaneNotInMode(tmuxSessionName, socketArgs);
   await tmuxSend(tmuxSessionName, ["Escape"], socketArgs);
   await new Promise((r) => setTimeout(r, 50));

--- a/supervisor/tests/session/relay.test.ts
+++ b/supervisor/tests/session/relay.test.ts
@@ -4,8 +4,59 @@ import {
   startRelayServer,
   stopRelayServer,
 } from "../../src/session/relay-server";
-import { tmuxSend, ensurePaneNotInMode } from "../../src/session/relay";
+import {
+  tmuxSend,
+  ensurePaneNotInMode,
+  flattenForSendKeys,
+} from "../../src/session/relay";
 import { TMUX_ARGS, ensureSocketConfigured } from "../../src/session/tmux";
+
+// Issue #210: the newline-flatten regex was double-escaped (`/[\\r\\n]+/`) so it
+// matched only the literal chars `\`, `r`, `n` and never removed real CR/LF.
+// Multi-line Discord messages kept their newlines, so `send-keys -l` submitted
+// at the first newline and the input was split/corrupted -> silent drop -> stall.
+describe("flattenForSendKeys (Issue #210)", () => {
+  test("AC-1: mixed LF and CRLF collapse to single spaces", () => {
+    expect(flattenForSendKeys("A\nB\r\nC")).toBe("A B C");
+  });
+
+  test("a run of consecutive newlines collapses to ONE space (the `+` quantifier)", () => {
+    expect(flattenForSendKeys("A\n\n\nB")).toBe("A B");
+    expect(flattenForSendKeys("A\r\n\r\nB")).toBe("A B");
+  });
+
+  test("a newline-only string flattens to a single space, not empty", () => {
+    expect(flattenForSendKeys("\n")).toBe(" ");
+    expect(flattenForSendKeys("\r\n\r\n")).toBe(" ");
+  });
+
+  test("bare CR and bare LF are both removed", () => {
+    expect(flattenForSendKeys("A\rB")).toBe("A B");
+    expect(flattenForSendKeys("A\nB")).toBe("A B");
+  });
+
+  test("a single-line message is returned unchanged", () => {
+    expect(flattenForSendKeys("just one line")).toBe("just one line");
+  });
+
+  test("a leading `--` (tmux flag-like) line is preserved as literal text", () => {
+    // The dangerous part for tmux is argv injection, handled by `-l`; flatten
+    // only normalizes newlines and must not mangle the rest of the content.
+    expect(flattenForSendKeys("next:\n- a\n- b")).toBe("next: - a - b");
+  });
+
+  test("realistic 3-line bullet message becomes one prompt line", () => {
+    const msg = "次から\n- note記事にヘッダ画像\n- nanobanana2で";
+    expect(flattenForSendKeys(msg)).toBe(
+      "次から - note記事にヘッダ画像 - nanobanana2で",
+    );
+  });
+
+  test("the buggy double-escaped behavior is gone (regression guard)", () => {
+    // The old regex would leave real newlines in place; assert they're gone.
+    expect(flattenForSendKeys("A\nB\nC")).not.toContain("\n");
+  });
+});
 
 describe("relayMessage", () => {
   beforeAll(() => {


### PR DESCRIPTION
## 概要

Closes #210

`sendToPane` の改行平坦化正規表現が二重バックスラッシュ `/[\\r\\n]+/` になっており、文字 `\` `r` `n` にしかマッチせず**実 CR(0x0D)/LF(0x0A) を除去できていなかった**。複数行 Discord メッセージは改行が残ったまま `tmux send-keys -l` され、最初の改行で submit して入力が分断・破損し、Claude に1プロンプトとして届かず stall していた（単一行は改行がないため正常 = 「複数行だけ黙って落ちる」挙動の正体）。

## 変更点

| ファイル | 内容 |
|---|---|
| `supervisor/src/session/relay.ts` | `flattenForSendKeys` 純関数を抽出し、regex を単一バックスラッシュ `/[\r\n]+/g` へ修正（root cause） |
| `supervisor/tests/session/relay.test.ts` | LF / CRLF / 連続改行 / 改行のみ / 先頭ハイフン / 全角混在 を網羅する回帰テスト 8 件 |

## AC 検証

| AC | 内容 | 結果 |
|---|---|---|
| AC-1 | `flattenForSendKeys("A\nB\r\nC") === "A B C"` の unit test が PASS | PASS（bun test 15 pass / 0 fail） |
| AC-2 | `relay.ts` の regex が単一バックスラッシュ `/[\r\n]+/g` | PASS（grep 確認済み） |
| AC-3 | 複数行 relay で stall が再発しない | ロジックを決定的に修正・回帰テストで保証（live E2E は別途） |

## 検証ログ

- `bunx tsc --noEmit`: exit 0
- `bun test tests/session/relay.test.ts`: 15 pass / 0 fail / 23 expect

## 関連

- #209（stall 検知・能動報告、merge 済み PR #214）— 本 fix は #209 が検知していた「無反応に見えた」事象の root cause の一つ
- #79 / #72（tmux send-keys silent drop の Epic）
- agent-base RW-019 / RW-025 / RW-027 / RW-047（複数行 relay / send-keys 系列）

## 二次強化（本 PR スコープ外）

stall 検知後の自動再送/復旧は #209（PR #214）で別実装済みのため、本 PR は root cause の1行修正 + 回帰テストに限定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * マルチラインメッセージの処理時における欠落・分断の問題を修正しました
  * 改行文字（CR/LF）の処理を改善し、各種改行パターンでのメッセージ送信の信頼性を向上させました

* **テスト**
  * マルチラインメッセージ処理の複数パターンに対応した回帰テストを追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->