### PR TITLE
fix(#217): branch セッションの /session stop 後 resume 失敗を worktree 再生成で解消

### DIFF
--- a/supervisor/src/session/adapters-fake.ts
+++ b/supervisor/src/session/adapters-fake.ts
@@ -6,6 +6,7 @@ import type {
   TmuxAdapter,
   WorktreeAdapter,
 } from "./adapters";
+import { mkdirSync } from "fs";
 import { resolveWorktreePath, type EnsureWorktreeResult } from "./worktree";
 import type { OpenTabOptions } from "./iterm2";
 
@@ -130,8 +131,15 @@ export class FakeProcessAdapter implements ProcessAdapter {
 export class FakeWorktreeAdapter implements WorktreeAdapter {
   ensureCalls: { mainRepoDir: string; branch: string }[] = [];
   removeCalls: { mainRepoDir: string; worktreePath: string }[] = [];
+  recreateForBranchCalls: { mainRepoDir: string; branch: string }[] = [];
   /** Worktree paths considered already-present (drives the Q4 reuse path). */
   existingPaths = new Set<string>();
+  /**
+   * Branch names that still resolve in the repo (Issue #217). Drives the Q1
+   * checkout in {@link recreateForBranch}: a branch NOT in this set is treated
+   * as deleted, so recovery returns false.
+   */
+  existingBranches = new Set<string>();
   /** When set, ensure() throws to simulate a git worktree failure. */
   failOnEnsure = false;
 
@@ -151,6 +159,20 @@ export class FakeWorktreeAdapter implements WorktreeAdapter {
   remove(mainRepoDir: string, worktreePath: string): void {
     this.removeCalls.push({ mainRepoDir, worktreePath });
     this.existingPaths.delete(worktreePath);
+  }
+
+  recreateForBranch(mainRepoDir: string, branch: string): boolean {
+    this.recreateForBranchCalls.push({ mainRepoDir, branch });
+    const path = resolveWorktreePath(mainRepoDir, branch.trim());
+    if (this.existingPaths.has(path)) return true; // Q4: already present
+    if (!this.existingBranches.has(branch.trim())) return false; // branch gone
+    // Q1: materialize the real directory so SessionManager's own existsSync()
+    // re-check passes after recovery (manager runs against the real fs). Tests
+    // must clean this up — the dir lives under <mainRepoDir>/.claude/worktrees,
+    // so an afterEach `rmSync(repoDir, { recursive: true })` removes it too.
+    mkdirSync(path, { recursive: true });
+    this.existingPaths.add(path);
+    return true;
   }
 }
 

--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -18,6 +18,7 @@ import {
 import {
   ensureWorktree,
   removeWorktree,
+  recreateWorktreeForExistingBranch,
   realGitGhRunner,
   type EnsureWorktreeResult,
 } from "./worktree";
@@ -82,6 +83,13 @@ export interface WorktreeAdapter {
   ensure(mainRepoDir: string, branch: string): EnsureWorktreeResult;
   /** Remove the worktree (branch is preserved). */
   remove(mainRepoDir: string, worktreePath: string): void;
+  /**
+   * Re-create the worktree for an *existing* branch only — resume recovery
+   * (Issue #217). Returns true when the worktree exists afterwards, false when
+   * the branch is gone (caller surfaces a clear error). Never creates a new
+   * branch from the default branch.
+   */
+  recreateForBranch(mainRepoDir: string, branch: string): boolean;
 }
 
 export interface SessionEffects {
@@ -212,6 +220,13 @@ export const realWorktreeAdapter: WorktreeAdapter = {
   },
   remove(mainRepoDir, worktreePath) {
     removeWorktree(mainRepoDir, worktreePath, realGitGhRunner);
+  },
+  recreateForBranch(mainRepoDir, branch) {
+    return recreateWorktreeForExistingBranch(
+      mainRepoDir,
+      branch,
+      realGitGhRunner,
+    );
   },
 };
 

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -584,12 +584,6 @@ export class SessionManager {
         `claude session id の形式が不正です: ${claudeSessionId}`
       );
     }
-    if (!existsSync(projectDir)) {
-      throw new Error(
-        `プロジェクトディレクトリが見つかりません: ${projectDir}（worktree が削除された可能性があります）`
-      );
-    }
-
     // Single-flight guard (Issue #171, 穴 C): reject a second concurrent resume
     // of the SAME claude session id. Mutated synchronously and held across the
     // awaits inside launchResume, so on the single-threaded event loop the
@@ -612,12 +606,60 @@ export class SessionManager {
           "この session は既に稼働中です。稼働中のスレッドで操作してください（多重 resume 防止）。"
         );
       }
+      // Issue #217: a branch session's worktree is physically removed on
+      // /session stop (Q3, RW-046), but the branch and the conversation
+      // transcript (keyed by cwd) survive. Re-create the worktree at the
+      // recorded projectDir so `claude --resume` finds the transcript. Run this
+      // UNDER the single-flight lock so two concurrent resumes of the same id
+      // cannot both `git worktree add` the same path (review #217 must-1). A
+      // deleted branch is intentionally NOT rebuilt from the default branch
+      // (that would resume into unrelated content) — surface a clear error.
+      let recoveredWorktree: SessionInfo["worktree"];
+      if (!existsSync(projectDir)) {
+        const trimmedBranch = branch?.trim();
+        const recovered = trimmedBranch
+          ? this.recoverWorktreeForResume(config.dir, projectDir, trimmedBranch)
+          : false;
+        if (recovered && existsSync(projectDir) && trimmedBranch) {
+          // We rebuilt the worktree, so THIS resumed session now owns its
+          // cleanup — a later /session stop removes it (last-user-only via
+          // isWorktreePathInUse). Without this the recreated dir would leak,
+          // since resume otherwise carries no worktree (review #217 should-3).
+          recoveredWorktree = {
+            mainRepoDir: config.dir,
+            path: projectDir,
+            branch: trimmedBranch,
+          };
+        } else if (recovered && !existsSync(projectDir)) {
+          // recreateForBranch reported success but the recorded projectDir is
+          // still missing → the rebuilt path differs from projectDir (likely a
+          // config.dir drift between start and resume). Surface it so the
+          // mismatch is diagnosable instead of masquerading as "branch gone"
+          // (review #217 must-2).
+          console.warn(
+            `[SessionManager] Worktree recovery reported success but ${projectDir} is still missing; ` +
+              `the recorded projectDir likely differs from <config.dir>/.claude/worktrees/<branch>`
+          );
+        }
+        if (!existsSync(projectDir)) {
+          if (trimmedBranch) {
+            throw new Error(
+              `セッションの作業ディレクトリ（worktree）を再生成できませんでした: ${projectDir}\n` +
+                `branch '${trimmedBranch}' が削除されている可能性があります。branch を復元してから再度 resume してください。`
+            );
+          }
+          throw new Error(
+            `プロジェクトディレクトリが見つかりません: ${projectDir}（worktree が削除された可能性があります）`
+          );
+        }
+      }
       return await this.launchResume(
         config,
         threadId,
         claudeSessionId,
         projectDir,
-        branch
+        branch,
+        recoveredWorktree
       );
     } finally {
       this.resumingClaudeSessions.delete(claudeSessionId);
@@ -636,7 +678,8 @@ export class SessionManager {
     threadId: string,
     claudeSessionId: string,
     projectDir: string,
-    branch?: string | null
+    branch?: string | null,
+    recoveredWorktree?: SessionInfo["worktree"]
   ): Promise<SessionInfo> {
     const sessionId = randomUUID();
     const tmuxName = this.tmuxSessionName(threadId);
@@ -699,9 +742,12 @@ export class SessionManager {
       startedAt: now,
       lastActivityAt: now,
       status: "running",
-      // No worktree on resume (runs in the project dir), but keep the branch so
-      // same-branch counting and the thread title stay consistent (Issue #175).
+      // Normally no worktree on resume (runs in the recorded cwd). The exception
+      // is Issue #217: when resume re-created a removed branch worktree, carry it
+      // so a later /session stop cleans up what this resume rebuilt. Always keep
+      // the branch for same-branch counting / thread title (Issue #175).
       branch: branch || undefined,
+      worktree: recoveredWorktree,
     };
 
     // Post-launch init (prompt confirm + state registration) can throw. tmux is
@@ -993,6 +1039,41 @@ export class SessionManager {
       console.log(
         `[SessionManager] Worktree ${session.worktree.path} still in use by another session; not removing`
       );
+    }
+  }
+
+  /**
+   * Issue #217: re-create a stopped branch session's worktree so it can resume.
+   * `/session stop` removes the worktree (Q3) but the branch and the cwd-keyed
+   * transcript survive, so rebuilding the worktree at `projectDir` restores the
+   * cwd `claude --resume` needs. Only an existing branch is rebuilt (Q1/Q4); a
+   * deleted branch returns false so the caller reports a clear error rather than
+   * fabricating unrelated content. Failures are swallowed → false, leaving the
+   * caller's existsSync re-check to decide the outcome deterministically.
+   */
+  private recoverWorktreeForResume(
+    mainRepoDir: string,
+    projectDir: string,
+    branch: string
+  ): boolean {
+    try {
+      const ok = this.effects.worktree.recreateForBranch(mainRepoDir, branch);
+      if (ok) {
+        console.log(
+          `[SessionManager] Re-created worktree for branch '${branch}' to resume: ${projectDir}`
+        );
+      } else {
+        console.warn(
+          `[SessionManager] Cannot re-create worktree for branch '${branch}' (branch missing?); resume of ${projectDir} will fail`
+        );
+      }
+      return ok;
+    } catch (err) {
+      console.warn(
+        `[SessionManager] Failed to re-create worktree for branch '${branch}':`,
+        err
+      );
+      return false;
     }
   }
 

--- a/supervisor/src/session/worktree.ts
+++ b/supervisor/src/session/worktree.ts
@@ -135,6 +135,45 @@ export function ensureWorktree(
   return { path: worktreePath, reused: false, baseBranch: base };
 }
 
+/**
+ * Re-create the worktree for an *existing* branch only — the resume-recovery
+ * path (Issue #217). A branch session's worktree is physically removed on
+ * `/session stop` (Q3, RW-046), but the branch and the conversation transcript
+ * (keyed by cwd) survive. Rebuilding the worktree at the SAME path restores the
+ * cwd that `claude --resume` needs.
+ *
+ * Unlike {@link ensureWorktree}, an unknown branch is intentionally NOT created
+ * from the default branch (no Q2): resuming must never fabricate unrelated
+ * content under the original branch's name. Returns true when the worktree
+ * exists afterwards (Q4 already-present, or Q1 freshly checked out), false when
+ * the branch is gone so the caller can surface a clear "cannot recover" error.
+ */
+export function recreateWorktreeForExistingBranch(
+  mainRepoDir: string,
+  branch: string,
+  runner: GitGhRunner,
+): boolean {
+  const trimmed = branch.trim();
+  if (!trimmed) {
+    return false;
+  }
+  const worktreePath = resolveWorktreePath(mainRepoDir, trimmed);
+
+  // Q4: a worktree is already present at the path → nothing to recover.
+  if (runner.pathExists(worktreePath)) {
+    return true;
+  }
+
+  // Q1: the branch still exists → check it out into a fresh worktree. A missing
+  // branch falls through to `false` (no Q2 new-branch creation).
+  if (runner.branchExists(mainRepoDir, trimmed)) {
+    runner.addWorktreeFromBranch(mainRepoDir, worktreePath, trimmed);
+    return true;
+  }
+
+  return false;
+}
+
 /** Remove a worktree (Q3). Caller decides whether failures are fatal. */
 export function removeWorktree(
   mainRepoDir: string,

--- a/supervisor/tests/session/manager-resume.test.ts
+++ b/supervisor/tests/session/manager-resume.test.ts
@@ -1,7 +1,10 @@
 import { test, expect, describe, beforeEach, afterEach } from "bun:test";
-import { mkdirSync, rmSync } from "fs";
+import { existsSync, mkdirSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { resolve } from "path";
+// Pure path resolver (no DB access) — safe to import statically before the
+// SUPERVISOR_DB_PATH override below.
+import { resolveWorktreePath } from "../../src/session/worktree";
 
 // Isolate DB writes from the real sessions.db (mirrors tests/infra/db.test.ts).
 process.env.SUPERVISOR_DB_PATH = ":memory:";
@@ -69,7 +72,9 @@ describe("SessionManager.resumeSession (#161)", () => {
     expect(info.claudeSessionId).toBe(VALID_ID);
     expect(info.projectDir).toBe(projectDir);
     expect(info.status).toBe("running");
-    // No worktree for resume (resumes the recorded cwd, Q2).
+    // No worktree for a non-branch resume: it runs in the recorded cwd and did
+    // not rebuild anything, so it owns no worktree (cf. #217 recovery, which
+    // does set one).
     expect(info.worktree).toBeUndefined();
   });
 
@@ -176,6 +181,146 @@ describe("SessionManager.resumeSession (#161)", () => {
     expect(effects.tmux.list()).toHaveLength(0);
     expect(manager.has(THREAD_ID)).toBe(false);
     expect(manager.count()).toBe(0);
+  });
+});
+
+/**
+ * Resume worktree recovery (Issue #217). A branch session's worktree is removed
+ * on /session stop (Q3, RW-046) but the branch + cwd-keyed transcript survive,
+ * so resume re-creates the worktree at the recorded projectDir. Maps to the
+ * journey AC:
+ *   - AC-2 (branch healthy): missing worktree is rebuilt → resume proceeds.
+ *   - AC-3 (branch gone):    deterministic "cannot recover" error, no rebuild.
+ */
+describe("SessionManager.resumeSession worktree recovery (#217)", () => {
+  let manager: InstanceType<typeof SessionManager>;
+  let effects: FakeSessionEffects;
+  let repoDir: string;
+
+  beforeEach(() => {
+    effects = createFakeEffects();
+    // A main repo dir that exists; the per-branch worktree under it does NOT
+    // (simulates the post-/session stop state where the worktree was removed).
+    repoDir = resolve(tmpdir(), `supervisor-resume-repo-${process.pid}`);
+    mkdirSync(repoDir, { recursive: true });
+  });
+
+  afterEach(async () => {
+    await manager?.shutdownAll();
+    rmSync(repoDir, { recursive: true, force: true });
+  });
+
+  test("AC-2: missing worktree + existing branch → re-creates worktree and resumes", async () => {
+    manager = new SessionManager({
+      effects,
+      gracefulKillTimeoutMs: 0,
+      resumePromptPollAttempts: 0,
+    });
+    const branch = "feat-217";
+    const wtPath = resolveWorktreePath(repoDir, branch);
+    expect(existsSync(wtPath)).toBe(false); // removed on /session stop
+    effects.worktree.existingBranches.add(branch); // branch is healthy
+
+    const info = await manager.resumeSession(
+      makeConfig(repoDir),
+      THREAD_ID,
+      VALID_ID,
+      wtPath,
+      branch
+    );
+
+    // Recovery ran exactly once for this branch, and the worktree now exists.
+    expect(effects.worktree.recreateForBranchCalls).toEqual([
+      { mainRepoDir: repoDir, branch },
+    ]);
+    expect(existsSync(wtPath)).toBe(true);
+    // claude --resume launches with cwd = the recorded (rebuilt) worktree path
+    // so the transcript is found.
+    const cmd = effects.tmux.getCommand(tmuxName) ?? "";
+    expect(cmd).toContain(`cd "${wtPath}"`);
+    expect(cmd).toContain(`--resume ${VALID_ID}`);
+    expect(info.status).toBe("running");
+    expect(info.projectDir).toBe(wtPath);
+    // The resumed session now OWNS the worktree it rebuilt, so /session stop can
+    // clean it up (review #217 should-3). Without this the recreated dir leaks.
+    expect(info.worktree).toEqual({
+      mainRepoDir: repoDir,
+      path: wtPath,
+      branch,
+    });
+  });
+
+  test("should-3: /session stop removes the worktree that resume re-created", async () => {
+    manager = new SessionManager({
+      effects,
+      gracefulKillTimeoutMs: 0,
+      resumePromptPollAttempts: 0,
+    });
+    const branch = "feat-217";
+    const wtPath = resolveWorktreePath(repoDir, branch);
+    effects.worktree.existingBranches.add(branch);
+
+    await manager.resumeSession(
+      makeConfig(repoDir),
+      THREAD_ID,
+      VALID_ID,
+      wtPath,
+      branch
+    );
+    expect(existsSync(wtPath)).toBe(true);
+
+    await manager.stop(THREAD_ID, "manual");
+
+    // The rebuilt worktree is the last user of its path → removed on stop (no leak).
+    expect(effects.worktree.removeCalls).toEqual([
+      { mainRepoDir: repoDir, worktreePath: wtPath },
+    ]);
+  });
+
+  test("AC-3: missing worktree + deleted branch → clear error, no resume", async () => {
+    manager = new SessionManager({
+      effects,
+      gracefulKillTimeoutMs: 0,
+      resumePromptPollAttempts: 0,
+    });
+    const branch = "deleted-branch";
+    const wtPath = resolveWorktreePath(repoDir, branch);
+    // existingBranches intentionally left empty → recreateForBranch returns false.
+
+    await expect(
+      manager.resumeSession(makeConfig(repoDir), THREAD_ID, VALID_ID, wtPath, branch)
+    ).rejects.toThrow(
+      /再生成できませんでした[\s\S]*branch 'deleted-branch' が削除されている/
+    );
+
+    expect(effects.worktree.recreateForBranchCalls.length).toBe(1);
+    expect(existsSync(wtPath)).toBe(false);
+    expect(effects.tmux.list()).toHaveLength(0);
+    expect(manager.has(THREAD_ID)).toBe(false);
+  });
+
+  test("recovery is skipped when the recorded projectDir still exists", async () => {
+    manager = new SessionManager({
+      effects,
+      gracefulKillTimeoutMs: 0,
+      resumePromptPollAttempts: 0,
+    });
+    const branch = "feat-217";
+    // projectDir already present → no rebuild needed even with a branch.
+    const present = resolve(tmpdir(), `supervisor-resume-present-${process.pid}`);
+    mkdirSync(present, { recursive: true });
+    try {
+      await manager.resumeSession(
+        makeConfig(repoDir),
+        THREAD_ID,
+        VALID_ID,
+        present,
+        branch
+      );
+      expect(effects.worktree.recreateForBranchCalls.length).toBe(0);
+    } finally {
+      rmSync(present, { recursive: true, force: true });
+    }
   });
 });
 

--- a/supervisor/tests/session/worktree.test.ts
+++ b/supervisor/tests/session/worktree.test.ts
@@ -3,6 +3,7 @@ import { resolve } from "path";
 import {
   ensureWorktree,
   removeWorktree,
+  recreateWorktreeForExistingBranch,
   resolveWorktreePath,
   WORKTREE_SUBDIR,
   type GitGhRunner,
@@ -167,5 +168,51 @@ describe("removeWorktree", () => {
 
     expect(runner.calls).toContain(`remove:${path}`);
     expect(runner.pathExists(path)).toBe(false);
+  });
+});
+
+/**
+ * Resume-recovery path (Issue #217). A stopped branch session's worktree is
+ * removed on /session stop, but the branch + cwd-keyed transcript survive, so
+ * resume re-creates the worktree at the SAME path. Unlike ensureWorktree, an
+ * unknown branch must NOT be created from default (no Q2) — recovery returns
+ * false so the caller surfaces a clear error.
+ */
+describe("recreateWorktreeForExistingBranch (#217)", () => {
+  let runner: FakeRunner;
+  beforeEach(() => {
+    runner = new FakeRunner();
+  });
+
+  test("Q4: worktree path already present → true, no git add", () => {
+    const path = resolveWorktreePath(REPO, "feat-217");
+    runner.existing.add(path);
+    expect(recreateWorktreeForExistingBranch(REPO, "feat-217", runner)).toBe(
+      true,
+    );
+    expect(runner.calls.some((c) => c.startsWith("add"))).toBe(false);
+  });
+
+  test("Q1: existing branch, missing worktree → checks out from branch, true", () => {
+    runner.branches.add("feat-217");
+    expect(recreateWorktreeForExistingBranch(REPO, "feat-217", runner)).toBe(
+      true,
+    );
+    expect(runner.calls).toContain("addFromBranch:feat-217");
+    // No Q2 new-branch creation on the recovery path.
+    expect(runner.calls.some((c) => c.startsWith("addNewBranch"))).toBe(false);
+  });
+
+  test("branch gone → false WITHOUT creating a new branch (no Q2)", () => {
+    expect(recreateWorktreeForExistingBranch(REPO, "deleted", runner)).toBe(
+      false,
+    );
+    expect(runner.calls).toContain("branchExists:deleted");
+    expect(runner.calls.some((c) => c.startsWith("add"))).toBe(false);
+  });
+
+  test("empty / whitespace branch → false, no git calls", () => {
+    expect(recreateWorktreeForExistingBranch(REPO, "   ", runner)).toBe(false);
+    expect(runner.calls.length).toBe(0);
   });
 });


### PR DESCRIPTION
## 概要

branch を指定して開始した Supervisor セッションは、`/session stop` 後の resume が**必ず失敗**していた（`❌ プロジェクトディレクトリが見つかりません`）。worktree のライフサイクル（start で作成 → stop で物理削除）と resume の前提（cwd ディレクトリ存在必須）が構造的に矛盾していたため。

会話 transcript は cwd でキーされ残存しているので、**resume 時に worktree を再生成すれば復帰できる**。本 PR はその再生成を実装する。

Closes #217

## 根本原因

| 段階 | 挙動 |
|---|---|
| start(branch) | `<repo>/.claude/worktrees/<branch>` に worktree 作成、`project_dir` = worktree パスを記録 |
| /session stop (Q3) | 最後の利用者なら `git worktree remove --force` で worktree を物理削除（branch は保持） |
| resumeSession | `existsSync(projectDir)` 必須 → 削除済み worktree が無く throw |

## 修正方針（案A + 明確なエラー fallback）

- `resumeSession` で `projectDir` 不在 かつ `branch` 記録ありなら、**既存 branch から** worktree を再生成（Q1 checkout / Q4 reuse のみ。`ensureWorktree` の **Q2 = 新規 branch 作成へはフォールバックしない** — 無関係な内容で resume しないため）。
- branch 消失時は決定的な「再生成不可」エラーを返す（AC-3 が許容する「明確なエラー」経路）。案C（placeholder dir）は、報告事例の branch 消失ケースに transcript が残っていないため YAGNI で見送り。

## 主な変更点

- `worktree.ts`: 再生成専用の純粋関数 `recreateWorktreeForExistingBranch`（Q1/Q4 のみ、Q2 なし）
- `adapters.ts` / `adapters-fake.ts`: `WorktreeAdapter.recreateForBranch`（real は git 委譲、fake は実 dir を materialize）
- `manager.ts`:
  - resume 復旧を **single-flight ロック内**で実行（同一 session id の同時 resume が二重に `git worktree add` しない / レビュー must-1）
  - 再生成した worktree は resumed session が所有し、後続 `/session stop` が `isWorktreePathInUse` の最終利用者判定で cleanup（leak 防止 / レビュー should-3）
  - 再生成パスが `projectDir` と乖離（config.dir drift）した場合の診断 warn（レビュー must-2）

## レビュー対応（code-review-orchestrator）

| 指摘 | 種別 | 対応 |
|---|---|---|
| 復旧がロック前で TOCTOU | must | single-flight ロック内へ移動 |
| projectDir 乖離が診断不能 | must | 乖離時に診断 warn |
| 再生成 worktree が stop で消えず leak | should | resumed session に worktree を持たせ stop で cleanup |
| AC-3 正規表現が脆弱 | should | 単一の厳密パターンに簡素化 |
| fake の mkdir cleanup 依存 / 古い Q2 コメント | nit | コメント追記・修正 |

## 統合ジャーニーAC 検証

| AC | 検証内容 | 手段 | 判定 |
|---|---|---|---|
| AC-1 | stop 後も branch / project_dir が保持され resume 可能な状態 | 既存 `insertSession`（branch + project_dir 記録）。resume handler が `row.branch` / `row.project_dir` を渡す（`session.ts:512`） | PASS（既存挙動・前提） |
| AC-2 | stop 済みセッションを resume → worktree 再生成して復帰 | `manager-resume.test.ts` "AC-2"：`recreateForBranch` 呼出 + worktree dir 出現 + `claude --resume` を再生成 cwd で起動 + `info.worktree` 所有 | PASS |
| AC-3 | branch 削除済みセッションを resume → 決定的に分岐 | `manager-resume.test.ts` "AC-3"：明確なエラー、resume 不発火 | PASS |

補助テスト: `should-3`（stop が再生成 worktree を remove）、`worktree.test.ts` の単体（Q1/Q4/branch 消失/空 branch）。

## テスト

```
bunx tsc --noEmit                  # PASS（CI と同一）
bun test tests/session/worktree.test.ts tests/session/manager-resume.test.ts
  # 33 pass / 0 fail（うち #217 で 8 件追加）
bun test                           # 619 tests。新規 8 件すべて PASS、回帰 0
```

> 注: 全件実行で見える `shell-exec guard (db.ts:45)` と `tmuxSend integration` 4 件の fail は本 PR と無関係の**既存事象**（base commit 8001fbf の CI は緑で、CI の unit-test job は明示ファイルリスト実行のため guard を含まない / tmuxSend は実 tmux 依存で単体実行では PASS）。clean tree でも同一 5 件が再現することを確認済み。

## 即時復旧手順（owner 向け・手動、本 PR とは別）

報告された 3 スレッドのうち branch 健在な 2 つは以下で復旧可能:

```bash
cd /Users/harieshokunin/corp
git worktree add .claude/worktrees/convert20260610  convert20260610
git worktree add .claude/worktrees/agentbase10issue agentbase10issue
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * セッション再開時のワークツリー自動復旧機能を追加。ブランチが存在する場合、削除されたワークツリーを自動的に再作成してセッションを復旧できるようになりました。ブランチが削除済みの場合は適切なエラーメッセージを表示します。

* **テスト**
  * ワークツリー復旧シナリオの包括的なテストスイートを追加。ブランチ存在確認、ワークツリー再作成、エラーハンドリングをカバーしています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->