### PR TITLE
fix(#141): 前回セッションの要約を Discord スレッドへ表面化する

### DIFF
--- a/supervisor/src/commands/session.ts
+++ b/supervisor/src/commands/session.ts
@@ -10,6 +10,7 @@ import { CHANNEL_MAP, MAX_SESSIONS } from "../config/channels";
 import { buildThreadTitle, markTitleStopped } from "../session/thread-title";
 import { buildStatusReply } from "../session/status-reply";
 import { evaluateAccess } from "../config/access-policy";
+import { postPreviousSummary } from "../session/session-summary";
 
 export function createSessionCommand() {
   return new SlashCommandBuilder()
@@ -360,6 +361,13 @@ async function handleStart(
         `終了するには \`/session stop\` をこのスレッド内で実行してください。`
     );
 
+    // Issue #141: surface the previous-session summary into the thread, since
+    // the ECC SessionStart hook only injects it into Claude's invisible context.
+    await postPreviousSummary(thread, {
+      projectDir: session.worktree?.path ?? config.dir,
+      repoRoot: config.dir,
+    });
+
     await interaction.editReply({
       content: `✅ セッションをスレッドで起動しました → ${thread}`,
     });
@@ -526,6 +534,13 @@ async function handleResume(
         `前回の会話を引き継いで再開します。このスレッドにメッセージを送信すると中継されます。\n` +
         `終了するには \`/session stop\` をこのスレッド内で実行してください。`
     );
+
+    // Issue #141: surface the previous-session summary for the resumed
+    // project_dir (resume runs in the repo dir, not a worktree).
+    await postPreviousSummary(thread, {
+      projectDir: row.project_dir,
+      repoRoot: config.dir,
+    });
 
     await interaction.editReply({
       content: `✅ セッションを復帰しました → ${thread}`,

--- a/supervisor/src/session/session-summary.ts
+++ b/supervisor/src/session/session-summary.ts
@@ -1,0 +1,231 @@
+/**
+ * Previous-session summary lookup for Discord thread surfacing (Issue #141).
+ *
+ * Root cause of #141: the "前回セッションの要約" is produced by an external
+ * SessionStart hook (ECC `scripts/hooks/session-start.js`) that injects the
+ * summary into Claude's *context* (invisible `additionalContext`). The Claude
+ * Code TUI shows it collapsed, so `tmux capture-pane` — which is what the
+ * Supervisor relays to Discord — only carries the "hook success" line, never
+ * the summary body. The user therefore sees the hook ran but no summary.
+ *
+ * Fix (approach A, user-decided 2026-06-11): the Supervisor reads the matching
+ * session summary file directly and posts it into the thread on start/resume.
+ * This avoids depending on Claude echoing it and avoids TUI string matching
+ * (RW-027 / RW-047 anti-pattern).
+ *
+ * Session files are written by ECC's session-end / the save-session skill into
+ * `~/.claude/sessions` and `~/.claude/session-data` as `*-session.tmp`. They
+ * carry a `**Worktree:**` header. The ECC `**Project:**` header is only the
+ * worktree basename (a per-session hash), so the *worktree path* is the one
+ * reliable signal for matching a session to a Supervisor-managed project.
+ */
+
+import { homedir } from "os";
+import { join, sep } from "path";
+import { readdirSync, statSync, readFileSync } from "fs";
+
+const ECC_SUMMARY_START = "<!-- ECC:SUMMARY:START -->";
+const ECC_SUMMARY_END = "<!-- ECC:SUMMARY:END -->";
+const SESSION_FILE_SUFFIX = "-session.tmp";
+const DEFAULT_MAX_AGE_DAYS = 30;
+
+/** Discord's hard per-message limit is 2000; leave headroom for the header. */
+const MAX_SUMMARY_CHARS = 1800;
+
+export interface SessionSummaryResult {
+  /** Extracted summary text (untruncated). */
+  text: string;
+  /** Absolute path of the source `*-session.tmp` file. */
+  sourceFile: string;
+  /** Why this file matched the project. */
+  matchReason: "worktree-exact" | "project-nested";
+}
+
+export interface SummaryCandidate {
+  path: string;
+  content: string;
+  mtimeMs: number;
+}
+
+/** Strip a trailing path separator so comparisons are boundary-safe. */
+function stripTrailingSep(p: string): string {
+  return p.replace(/[/\\]+$/, "");
+}
+
+/**
+ * `child` is `parent` itself, or nested under it at a path boundary.
+ * Boundary check prevents `/a/b-other` from matching parent `/a/b`.
+ */
+export function isPathUnder(child: string, parent: string): boolean {
+  const c = stripTrailingSep(child);
+  const p = stripTrailingSep(parent);
+  if (!p) return false;
+  return c === p || c.startsWith(p + sep) || c.startsWith(p + "/");
+}
+
+/** Read the `**Worktree:**` header value, or "" when absent. */
+export function extractWorktree(content: string): string {
+  const m = content.match(/\*\*Worktree:\*\*\s*(.+)$/m);
+  return m?.[1]?.trim() ?? "";
+}
+
+/**
+ * Pull the summary text out of a session file. Prefers the ECC summary block
+ * (`<!-- ECC:SUMMARY:START -->` … `<!-- ECC:SUMMARY:END -->`); falls back to
+ * the whole trimmed file for non-ECC (save-session) formats.
+ */
+export function extractSummaryText(content: string): string {
+  const start = content.indexOf(ECC_SUMMARY_START);
+  const end = content.indexOf(ECC_SUMMARY_END);
+  if (start !== -1 && end !== -1 && end > start) {
+    return content.slice(start + ECC_SUMMARY_START.length, end).trim();
+  }
+  return content.trim();
+}
+
+/**
+ * Choose the newest session summary that belongs to the project. A candidate
+ * matches when its `**Worktree:**` equals `projectDir` (exact) or is nested
+ * under `repoRoot` (a per-branch worktree of the same repo). Returns null when
+ * nothing matches — an explicit "no previous summary", not a silent failure.
+ */
+export function selectSummaryFromCandidates(
+  candidates: SummaryCandidate[],
+  opts: { projectDir: string; repoRoot: string }
+): SessionSummaryResult | null {
+  const projectDir = stripTrailingSep(opts.projectDir);
+  const repoRoot = stripTrailingSep(opts.repoRoot);
+
+  // Newest first; ties are deterministic by path so behavior is stable.
+  const sorted = [...candidates].sort(
+    (a, b) => b.mtimeMs - a.mtimeMs || a.path.localeCompare(b.path)
+  );
+
+  for (const candidate of sorted) {
+    const worktree = stripTrailingSep(extractWorktree(candidate.content));
+    if (!worktree) continue;
+
+    const exact = worktree === projectDir;
+    const sameProject = exact || isPathUnder(worktree, repoRoot);
+    if (!sameProject) continue;
+
+    const text = extractSummaryText(candidate.content);
+    if (!text) continue;
+
+    return {
+      text,
+      sourceFile: candidate.path,
+      matchReason: exact ? "worktree-exact" : "project-nested",
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Directories to scan for session summaries. Overridable via
+ * `SUPERVISOR_SESSION_SUMMARY_DIRS` (colon-separated) for tests / custom setups.
+ */
+export function getSummarySearchDirs(): string[] {
+  const override = process.env.SUPERVISOR_SESSION_SUMMARY_DIRS;
+  if (override && override.trim()) {
+    return override.split(":").map((s) => s.trim()).filter(Boolean);
+  }
+  const home = homedir();
+  return [
+    join(home, ".claude", "sessions"),
+    join(home, ".claude", "session-data"),
+  ];
+}
+
+/**
+ * Find the most relevant previous-session summary for a project by reading the
+ * session-summary directories from disk. Returns null when none match.
+ */
+export function findPreviousSessionSummary(opts: {
+  projectDir: string;
+  repoRoot: string;
+  searchDirs?: string[];
+  nowMs?: number;
+  maxAgeDays?: number;
+}): SessionSummaryResult | null {
+  const searchDirs = opts.searchDirs ?? getSummarySearchDirs();
+  const nowMs = opts.nowMs ?? Date.now();
+  const maxAgeMs = (opts.maxAgeDays ?? DEFAULT_MAX_AGE_DAYS) * 24 * 60 * 60 * 1000;
+
+  const candidates: SummaryCandidate[] = [];
+  for (const dir of searchDirs) {
+    let entries: string[];
+    try {
+      entries = readdirSync(dir);
+    } catch {
+      // Directory may not exist (fresh machine / CI) — skip it.
+      continue;
+    }
+    for (const name of entries) {
+      if (!name.endsWith(SESSION_FILE_SUFFIX)) continue;
+      const full = join(dir, name);
+      try {
+        const st = statSync(full);
+        if (!st.isFile()) continue;
+        if (nowMs - st.mtimeMs > maxAgeMs) continue;
+        candidates.push({
+          path: full,
+          content: readFileSync(full, "utf8"),
+          mtimeMs: st.mtimeMs,
+        });
+      } catch {
+        // Unreadable / vanished between readdir and stat — skip this one.
+        continue;
+      }
+    }
+  }
+
+  return selectSummaryFromCandidates(candidates, {
+    projectDir: opts.projectDir,
+    repoRoot: opts.repoRoot,
+  });
+}
+
+/** Build the Discord message, truncating to stay under the per-message limit. */
+export function formatSummaryMessage(result: SessionSummaryResult): string {
+  const header = "🗒️ **前回セッションの要約**\n";
+  const budget = MAX_SUMMARY_CHARS - header.length;
+  let body = result.text;
+  if (body.length > budget) {
+    body = body.slice(0, budget - 12).trimEnd() + "\n…（以下省略）";
+  }
+  return header + body;
+}
+
+/** Minimal structural type for a thread we can post into (avoids a discord.js dep here). */
+export interface SummaryThread {
+  send: (content: string) => Promise<unknown>;
+}
+
+/**
+ * Surface the previous-session summary into the thread on start/resume
+ * (Issue #141). Best-effort: a missing summary is the normal "no previous
+ * session" case and is skipped. A genuine failure is logged (not swallowed)
+ * and must never break session start/resume.
+ *
+ * Kept in this module (not commands/session.ts) so session.ts gains no new
+ * try/catch — the #27 interaction-safety guard statically scans session.ts for
+ * `catch … editReply` spans, and an unrelated catch there would false-positive.
+ */
+export async function postPreviousSummary(
+  thread: SummaryThread,
+  opts: { projectDir: string; repoRoot: string }
+): Promise<void> {
+  try {
+    const summary = findPreviousSessionSummary(opts);
+    if (summary) {
+      await thread.send(formatSummaryMessage(summary));
+    }
+  } catch (err) {
+    console.warn(
+      `[Session] previous-summary surfacing failed (non-fatal):`,
+      err instanceof Error ? err.message : String(err)
+    );
+  }
+}

--- a/supervisor/tests/commands/session-start-summary.test.ts
+++ b/supervisor/tests/commands/session-start-summary.test.ts
@@ -1,5 +1,5 @@
 import { test, expect, describe, beforeEach, afterEach } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import { createSessionHandler } from "../../src/commands/session";
@@ -36,7 +36,7 @@ beforeEach(() => {
   process.env.SUPERVISOR_ACCESS_JSON_PATH = accessPath;
 
   summaryDir = join(tmpRoot, "sessions");
-  require("fs").mkdirSync(summaryDir, { recursive: true });
+  mkdirSync(summaryDir, { recursive: true });
   process.env.SUPERVISOR_SESSION_SUMMARY_DIRS = summaryDir;
 });
 
@@ -135,5 +135,75 @@ describe("/session start surfaces previous-session summary (#141)", () => {
     expect(h.sentToThread.length).toBe(1);
     expect(h.sentToThread[0]).toContain("セッションを開始しました");
     expect(h.sentToThread.some((m) => m.includes("前回セッションの要約"))).toBe(false);
+  });
+});
+
+// AC-2: /session resume surfaces the summary for the resumed project_dir.
+const RESUME_PROJECT_DIR = "/tmp/it-141-repo";
+
+function makeResumeInteraction() {
+  const sentToThread: string[] = [];
+  const thread = {
+    id: "thread-resume-summary",
+    send: async (content: string) => {
+      sentToThread.push(content);
+    },
+    delete: async () => {},
+  };
+  const channel = {
+    id: FIXTURE_CHANNEL_ID,
+    isThread: () => false,
+    isTextBased: () => true,
+    isDMBased: () => false,
+    name: "agent-base",
+    parent: null,
+    threads: { create: async () => thread },
+  };
+  const interaction = {
+    user: { id: FIXTURE_USER_ID },
+    options: {
+      getSubcommand: () => "resume",
+      getString: (name: string) => (name === "session_id" ? "sess-123" : null),
+    },
+    channel,
+    deferred: false,
+    replied: false,
+    async reply() {
+      this.replied = true;
+    },
+    async deferReply() {
+      this.deferred = true;
+    },
+    async editReply() {},
+  };
+
+  const sessionManager = {
+    count: () => 0,
+    listRunningByChannel: () => [],
+    findResumableSession: () => ({
+      claude_session_id: "sess-123",
+      channel_name: "agent-base",
+      project_dir: RESUME_PROJECT_DIR,
+      branch: "feat-foo",
+    }),
+    livenessOfClaudeSession: () => "dead",
+    resumeSession: async () => {},
+  };
+
+  return {
+    run: () => createSessionHandler(sessionManager as never)(interaction as never),
+    sentToThread,
+  };
+}
+
+describe("/session resume surfaces previous-session summary (#141)", () => {
+  test("AC-2: matching summary for the resumed project_dir is posted", async () => {
+    writeSummaryFile(RESUME_PROJECT_DIR, "## Session Summary\n復帰前の作業: #199 の compact 配線");
+    const h = makeResumeInteraction();
+    await h.run();
+
+    const summaryMsg = h.sentToThread.find((m) => m.includes("前回セッションの要約"));
+    expect(summaryMsg).toBeDefined();
+    expect(summaryMsg).toContain("#199 の compact 配線");
   });
 });

--- a/supervisor/tests/commands/session-start-summary.test.ts
+++ b/supervisor/tests/commands/session-start-summary.test.ts
@@ -1,0 +1,139 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createSessionHandler } from "../../src/commands/session";
+
+/**
+ * Issue #141 — integration (journey AC): `/session start` surfaces the
+ * previous-session summary into the thread. The ECC SessionStart hook only
+ * injects the summary into Claude's invisible context, so the Supervisor must
+ * post it explicitly. We override the summary search dir (mirrors the
+ * SUPERVISOR_ACCESS_JSON_PATH env-override pattern used elsewhere) and capture
+ * thread.send to assert what reaches Discord.
+ */
+
+const FIXTURE_CHANNEL_ID = "fixture-parent-channel";
+const FIXTURE_USER_ID = "fixture-user";
+const TEST_WORKTREE = "/tmp/it-141-repo/.claude/worktrees/feat-foo";
+
+let tmpRoot: string;
+let summaryDir: string;
+const prevAccessPath = process.env.SUPERVISOR_ACCESS_JSON_PATH;
+const prevSummaryDirs = process.env.SUPERVISOR_SESSION_SUMMARY_DIRS;
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), "session-start-summary-"));
+  const accessPath = join(tmpRoot, "access.json");
+  writeFileSync(
+    accessPath,
+    JSON.stringify({
+      groups: {
+        [FIXTURE_CHANNEL_ID]: { requireMention: true, allowFrom: [FIXTURE_USER_ID] },
+      },
+    })
+  );
+  process.env.SUPERVISOR_ACCESS_JSON_PATH = accessPath;
+
+  summaryDir = join(tmpRoot, "sessions");
+  require("fs").mkdirSync(summaryDir, { recursive: true });
+  process.env.SUPERVISOR_SESSION_SUMMARY_DIRS = summaryDir;
+});
+
+afterEach(() => {
+  if (prevAccessPath === undefined) delete process.env.SUPERVISOR_ACCESS_JSON_PATH;
+  else process.env.SUPERVISOR_ACCESS_JSON_PATH = prevAccessPath;
+  if (prevSummaryDirs === undefined) delete process.env.SUPERVISOR_SESSION_SUMMARY_DIRS;
+  else process.env.SUPERVISOR_SESSION_SUMMARY_DIRS = prevSummaryDirs;
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function writeSummaryFile(worktree: string, body: string) {
+  writeFileSync(
+    join(summaryDir, "fixture-session.tmp"),
+    [
+      "# Session: 2026-06-10",
+      "**Worktree:** " + worktree,
+      "<!-- ECC:SUMMARY:START -->",
+      body,
+      "<!-- ECC:SUMMARY:END -->",
+    ].join("\n")
+  );
+}
+
+function makeInteraction() {
+  const sentToThread: string[] = [];
+  const thread = {
+    id: "thread-summary",
+    send: async (content: string) => {
+      sentToThread.push(content);
+    },
+    delete: async () => {},
+  };
+  const channel = {
+    id: FIXTURE_CHANNEL_ID,
+    isThread: () => false,
+    isTextBased: () => true,
+    isDMBased: () => false,
+    name: "agent-base",
+    threads: { create: async () => thread },
+  };
+  const interaction = {
+    user: { id: FIXTURE_USER_ID },
+    options: {
+      getSubcommand: () => "start",
+      getString: (name: string) => (name === "branch" ? "feat-foo" : null),
+    },
+    channel,
+    deferred: false,
+    replied: false,
+    async reply() {
+      this.replied = true;
+    },
+    async deferReply() {
+      this.deferred = true;
+    },
+    async editReply() {},
+  };
+
+  const sessionManager = {
+    count: () => 0,
+    listRunningByChannel: () => [],
+    start: () => ({
+      worktree: {
+        mainRepoDir: "/tmp/it-141-repo",
+        path: TEST_WORKTREE,
+        branch: "feat-foo",
+      },
+    }),
+  };
+
+  return {
+    run: () => createSessionHandler(sessionManager as never)(interaction as never),
+    sentToThread,
+  };
+}
+
+describe("/session start surfaces previous-session summary (#141)", () => {
+  test("AC-1: matching summary is posted to the thread after welcome", async () => {
+    writeSummaryFile(TEST_WORKTREE, "## Session Summary\n前回は #172 の note 下書きを作成");
+    const h = makeInteraction();
+    await h.run();
+
+    // welcome + summary
+    expect(h.sentToThread.length).toBe(2);
+    const summaryMsg = h.sentToThread.find((m) => m.includes("前回セッションの要約"));
+    expect(summaryMsg).toBeDefined();
+    expect(summaryMsg).toContain("#172 の note 下書き");
+  });
+
+  test("AC-3: no matching summary → only the welcome message, no throw", async () => {
+    writeSummaryFile("/some/other/repo/wt", "should NOT be posted");
+    const h = makeInteraction();
+    await h.run();
+
+    expect(h.sentToThread.length).toBe(1);
+    expect(h.sentToThread[0]).toContain("セッションを開始しました");
+    expect(h.sentToThread.some((m) => m.includes("前回セッションの要約"))).toBe(false);
+  });
+});

--- a/supervisor/tests/session/session-summary.test.ts
+++ b/supervisor/tests/session/session-summary.test.ts
@@ -1,0 +1,237 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, utimesSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  extractWorktree,
+  extractSummaryText,
+  isPathUnder,
+  selectSummaryFromCandidates,
+  findPreviousSessionSummary,
+  formatSummaryMessage,
+  type SummaryCandidate,
+} from "../../src/session/session-summary";
+
+// Issue #141: the Supervisor must surface the previous-session summary into the
+// Discord thread on start/resume, because the ECC SessionStart hook only injects
+// it into Claude's invisible context (never the relayed pane).
+
+const ECC_BLOCK = [
+  "# Session: 2026-06-10",
+  "**Project:** agent-deadbeef",
+  "**Worktree:** /Users/x/team_salary/.claude/worktrees/feat-foo",
+  "",
+  "---",
+  "<!-- ECC:SUMMARY:START -->",
+  "## Session Summary",
+  "### Tasks",
+  "- note 下書きを作成",
+  "<!-- ECC:SUMMARY:END -->",
+  "### Notes",
+  "trailing noise that must NOT be included",
+].join("\n");
+
+describe("extractWorktree", () => {
+  test("reads the **Worktree:** header", () => {
+    expect(extractWorktree(ECC_BLOCK)).toBe(
+      "/Users/x/team_salary/.claude/worktrees/feat-foo"
+    );
+  });
+
+  test("returns empty string when absent", () => {
+    expect(extractWorktree("# Session\n**Project:** x")).toBe("");
+  });
+});
+
+describe("extractSummaryText", () => {
+  test("extracts ONLY the ECC:SUMMARY block (excludes header + trailing)", () => {
+    const text = extractSummaryText(ECC_BLOCK);
+    expect(text).toContain("## Session Summary");
+    expect(text).toContain("note 下書きを作成");
+    expect(text).not.toContain("**Project:**");
+    expect(text).not.toContain("trailing noise");
+  });
+
+  test("falls back to whole trimmed content when no ECC markers", () => {
+    const raw = "  # Session narrative\n**Worktree:** /a/b\nbody  ";
+    expect(extractSummaryText(raw)).toBe(raw.trim());
+  });
+
+  test("empty when markers are malformed (END before START)", () => {
+    // END before START → no valid block → falls back to whole content
+    const raw = "<!-- ECC:SUMMARY:END -->x<!-- ECC:SUMMARY:START -->";
+    // fallback returns the whole trimmed content (non-empty here)
+    expect(extractSummaryText(raw)).toBe(raw.trim());
+  });
+});
+
+describe("isPathUnder", () => {
+  test("exact match", () => {
+    expect(isPathUnder("/a/b", "/a/b")).toBe(true);
+  });
+  test("nested under at boundary", () => {
+    expect(isPathUnder("/a/b/.claude/worktrees/x", "/a/b")).toBe(true);
+  });
+  test("rejects sibling prefix (no false boundary match)", () => {
+    expect(isPathUnder("/a/b-other", "/a/b")).toBe(false);
+  });
+  test("rejects unrelated", () => {
+    expect(isPathUnder("/a/c", "/a/b")).toBe(false);
+  });
+  test("empty parent never matches", () => {
+    expect(isPathUnder("/a/b", "")).toBe(false);
+  });
+});
+
+describe("selectSummaryFromCandidates", () => {
+  const mk = (worktree: string, mtimeMs: number, summary = "S"): SummaryCandidate => ({
+    path: `/tmp/${mtimeMs}-session.tmp`,
+    mtimeMs,
+    content: [
+      "**Worktree:** " + worktree,
+      "<!-- ECC:SUMMARY:START -->",
+      summary,
+      "<!-- ECC:SUMMARY:END -->",
+    ].join("\n"),
+  });
+
+  test("exact worktree match wins and reports reason", () => {
+    const r = selectSummaryFromCandidates([mk("/repo/wt", 100)], {
+      projectDir: "/repo/wt",
+      repoRoot: "/repo",
+    });
+    expect(r?.matchReason).toBe("worktree-exact");
+    expect(r?.text).toBe("S");
+  });
+
+  test("nested worktree (new session, no exact) matches by repo root", () => {
+    const r = selectSummaryFromCandidates(
+      [mk("/repo/.claude/worktrees/old", 100)],
+      { projectDir: "/repo/.claude/worktrees/brand-new", repoRoot: "/repo" }
+    );
+    expect(r?.matchReason).toBe("project-nested");
+  });
+
+  test("picks the NEWEST matching candidate", () => {
+    const r = selectSummaryFromCandidates(
+      [mk("/repo/a", 100, "OLD"), mk("/repo/b", 200, "NEW")],
+      { projectDir: "/repo/x", repoRoot: "/repo" }
+    );
+    expect(r?.text).toBe("NEW");
+  });
+
+  test("ignores sessions from other projects", () => {
+    const r = selectSummaryFromCandidates([mk("/other/wt", 100)], {
+      projectDir: "/repo/wt",
+      repoRoot: "/repo",
+    });
+    expect(r).toBeNull();
+  });
+
+  test("returns null on empty candidate list", () => {
+    expect(
+      selectSummaryFromCandidates([], { projectDir: "/r", repoRoot: "/r" })
+    ).toBeNull();
+  });
+
+  test("skips candidates without a Worktree header", () => {
+    const noWt: SummaryCandidate = {
+      path: "/tmp/x-session.tmp",
+      mtimeMs: 999,
+      content: "**Project:** p\n<!-- ECC:SUMMARY:START -->\nS\n<!-- ECC:SUMMARY:END -->",
+    };
+    expect(
+      selectSummaryFromCandidates([noWt], { projectDir: "/r", repoRoot: "/r" })
+    ).toBeNull();
+  });
+});
+
+describe("findPreviousSessionSummary (fs)", () => {
+  let dir: string;
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "session-summary-"));
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const writeSession = (name: string, worktree: string, ageDays = 0) => {
+    const p = join(dir, name);
+    writeFileSync(
+      p,
+      [
+        "**Worktree:** " + worktree,
+        "<!-- ECC:SUMMARY:START -->",
+        "summary for " + worktree,
+        "<!-- ECC:SUMMARY:END -->",
+      ].join("\n")
+    );
+    if (ageDays > 0) {
+      const t = (Date.now() - ageDays * 86400_000) / 1000;
+      utimesSync(p, t, t);
+    }
+    return p;
+  };
+
+  test("finds an exact-worktree match from disk", () => {
+    writeSession("a-session.tmp", "/repo/wt");
+    const r = findPreviousSessionSummary({
+      projectDir: "/repo/wt",
+      repoRoot: "/repo",
+      searchDirs: [dir],
+    });
+    expect(r?.text).toContain("summary for /repo/wt");
+  });
+
+  test("ignores non *-session.tmp files", () => {
+    writeFileSync(join(dir, "notes.md"), "**Worktree:** /repo/wt\nx");
+    const r = findPreviousSessionSummary({
+      projectDir: "/repo/wt",
+      repoRoot: "/repo",
+      searchDirs: [dir],
+    });
+    expect(r).toBeNull();
+  });
+
+  test("excludes sessions older than maxAgeDays", () => {
+    writeSession("old-session.tmp", "/repo/wt", 40);
+    const r = findPreviousSessionSummary({
+      projectDir: "/repo/wt",
+      repoRoot: "/repo",
+      searchDirs: [dir],
+      maxAgeDays: 30,
+    });
+    expect(r).toBeNull();
+  });
+
+  test("missing directory yields null, not a throw", () => {
+    const r = findPreviousSessionSummary({
+      projectDir: "/repo/wt",
+      repoRoot: "/repo",
+      searchDirs: [join(dir, "does-not-exist")],
+    });
+    expect(r).toBeNull();
+  });
+});
+
+describe("formatSummaryMessage", () => {
+  test("prefixes a header", () => {
+    const msg = formatSummaryMessage({
+      text: "hello",
+      sourceFile: "/x",
+      matchReason: "worktree-exact",
+    });
+    expect(msg).toContain("前回セッションの要約");
+    expect(msg).toContain("hello");
+  });
+
+  test("truncates over-long bodies under the Discord limit", () => {
+    const msg = formatSummaryMessage({
+      text: "あ".repeat(5000),
+      sourceFile: "/x",
+      matchReason: "worktree-exact",
+    });
+    expect(msg.length).toBeLessThanOrEqual(2000);
+    expect(msg).toContain("以下省略");
+  });
+});


### PR DESCRIPTION
## 概要

Discord 経由のセッション開始/復帰時に「前回セッションの要約」が表示されない問題 (#141) を修正する。

## 根本原因

「前回セッションの要約」は外部 hook（ECC `scripts/hooks/session-start.js`）が生成し、Claude の **context（不可視 `additionalContext`）** に注入する。Claude Code TUI ではこの内容は折り畳み表示で、`tmux capture-pane` には `SessionStart hook success` の行しか出ない。supervisor は **可視 pane を Discord に中継** するため、要約本文がスレッドに届かなかった。

- 証拠: Issue のスクショで Claude は前回（#172）の作業を詳細に説明できている = 要約は context に入っていた。ユーザーは折り畳み行だけ見て「これは何？」と質問していた。
- つまり「要約生成のバグ」ではなく **supervisor が要約を Discord に表面化していない** のが本質。

## 対応（方式A・ユーザー決定）

supervisor が `project_dir` に一致する最新の session 要約ファイル（`*-session.tmp` の `ECC:SUMMARY` ブロック）を直接読み、start/resume 時にスレッドへ投稿する。Claude の応答や TUI 文字列マッチ（RW-027/RW-047 アンチパターン）に依存しない。

### 主な変更

- **`supervisor/src/session/session-summary.ts`**（新規）: 要約ファイルの探索・抽出・整形の純関数群 + `postPreviousSummary`
  - 一致判定: `**Worktree:**` が `project_dir` 完全一致、または repo root 配下にネスト（新規 worktree 対応）。最新を選択
  - 抽出: `ECC:SUMMARY` ブロックを優先、無ければ全文 fallback。Discord 上限内に truncate
  - 一致なしは `null`（サイレント失敗ではなく「要約なし」を明示）
  - `postPreviousSummary` は本 module に配置（`session.ts` に新規 catch を増やさず #27 の `catch … editReply` 静的検査の誤検知を回避）
- **`supervisor/src/commands/session.ts`**: `handleStart` / `handleResume` の welcome 投稿直後に要約を投稿

## 統合ジャーニーAC（検証）

| AC | 内容 | 検証 |
|---|---|---|
| 1 | start 時に一致する要約をスレッド投稿 | `session-start-summary.test.ts` AC-1（welcome+要約の2通、本文一致） |
| 3 | 一致なしは welcome のみ・例外なし | `session-start-summary.test.ts` AC-3（要約投稿0件） |

## テスト

- `bunx tsc --noEmit`: clean
- `bun test`: 635 pass / 5 fail / 3 skip
  - 追加分: `session-summary.test.ts` 22 + `session-start-summary.test.ts` 2 = **全 pass**
  - 残 5 fail は **本変更と無関係の既存/環境要因**（`shell-exec injection guard` は clean origin/main でも fail、`tmuxSend` 4件は単体実行では pass する load 依存の flake）

## デプロイ（マージ後）

コード変更のみ（plist/env 変更なし）。**Supervisor の再起動が必要**:

```
launchctl kickstart -k gui/$(id -u)/com.claude-hub.supervisor
```

claudeHubExit は本変更コードを共有しないため再起動不要。Supervisor 再起動は稼働中セッションを全 kill するため、クリティカルなセッションが無いタイミングで実施。

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * セッション開始・再開時に、前回セッションの要約がスレッドに自動投稿されるようになりました。プロジェクトに対応する最新の要約ファイルから内容を復元し、Discord のメッセージ文字制限に対応した形でスレッドへ投稿されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->