### PR TITLE
fix(#222): dialog-watchdog の capture-pane ETIMEDOUT に指数バックオフを導入し relay 遅延を低減

### DIFF
--- a/supervisor/src/session/dialog-watchdog.ts
+++ b/supervisor/src/session/dialog-watchdog.ts
@@ -28,6 +28,36 @@ import {
 
 const POLL_INTERVAL_MS = 5_000;
 const MAX_AUTO_ACCEPT_ATTEMPTS = 2;
+/**
+ * Issue #222: ceiling for the per-session exponential backoff applied when
+ * `capture-pane` times out. With MAX_SESSIONS watchdogs polling the shared
+ * `-L claude-hub` tmux server every 5s, accumulated load pushes capture-pane
+ * past its timeout (observed ETIMEDOUT bursts that cascade into relay delay).
+ * Backing off a failing session's poll lets the server recover; a successful
+ * capture resets it to {@link POLL_INTERVAL_MS}.
+ */
+const MAX_BACKOFF_MS = 30_000;
+/**
+ * Issue #222: `capture-pane` timeout. Raised from 2s to 3s so a transient
+ * stall on the shared tmux server is not misclassified as a failure on every
+ * tick (which would otherwise trigger backoff prematurely).
+ */
+const CAPTURE_TIMEOUT_MS = 3_000;
+
+/**
+ * Compute the next poll interval. On a successful capture, reset to `base`;
+ * on a failure (e.g. ETIMEDOUT under tmux load), exponentially back off
+ * (double) up to `max`. Pure — unit-tested without timers (Issue #222).
+ */
+export function nextPollInterval(
+  current: number,
+  base: number,
+  max: number,
+  capturedOk: boolean
+): number {
+  if (capturedOk) return base;
+  return Math.min(current * 2, max);
+}
 
 export interface DialogWatchdogOptions {
   /** tmux session name (e.g., `claude-<threadId12>`). */
@@ -46,6 +76,10 @@ export interface DialogWatchdogOptions {
   onAutoAccept?: (match: DialogMatch) => void;
   /** Override poll interval — tests use 50ms to keep runtime tight. */
   pollIntervalMs?: number;
+  /** Override the max backoff ceiling for capture-pane ETIMEDOUT backoff —
+   *  tests shrink this to keep runtime tight. Defaults to
+   *  {@link MAX_BACKOFF_MS} (Issue #222). */
+  maxBackoffMs?: number;
   /** Override max auto-accept attempts — tests can drop to 1 for speed. */
   maxAutoAcceptAttempts?: number;
   /** Inject a custom capture function — tests pass a fake to avoid spawning
@@ -66,18 +100,20 @@ function captureViaTmux(sessionName: string): string {
     return execFileSync(
       TMUX_PATH,
       [...TMUX_ARGS, "capture-pane", "-p", "-t", sessionName],
-      { timeout: 2000 }
+      { timeout: CAPTURE_TIMEOUT_MS }
     ).toString();
   } catch (err) {
-    // Pane gone / tmux server transient error — return empty so detect
-    // returns null and we silently no-op until next tick. Surfacing the
-    // error here would spam the supervisor log; a dead pane will be
-    // observed by the SessionManager watcher (manager.ts watchTmuxSession).
+    // Pane gone / server stopped: the session ended — return empty so detect
+    // returns null and the watchdog stays at its base interval until it is
+    // stopped (a dead pane is observed by manager.ts watchTmuxSession).
+    // Any OTHER failure (notably ETIMEDOUT while the shared tmux server is
+    // overloaded) is re-thrown so the caller can back off this session's
+    // poll instead of hammering the slow server every tick (Issue #222).
     const msg = err instanceof Error ? err.message : String(err);
-    if (!/no server running|can't find session/i.test(msg)) {
-      console.warn(`[Dialog] capture-pane failed for ${sessionName}:`, msg);
+    if (/no server running|can't find session/i.test(msg)) {
+      return "";
     }
-    return "";
+    throw err;
   }
 }
 
@@ -115,6 +151,7 @@ export function startDialogWatchdog(
     onHeartbeat,
     onAutoAccept,
     pollIntervalMs = POLL_INTERVAL_MS,
+    maxBackoffMs = MAX_BACKOFF_MS,
     maxAutoAcceptAttempts = MAX_AUTO_ACCEPT_ATTEMPTS,
     capture = captureViaTmux,
     sendKeys = sendKeysViaTmux,
@@ -131,10 +168,28 @@ export function startDialogWatchdog(
   // overlapping ticks. The outer try/catch also prevents an unhandled
   // PromiseRejection if `capture` / `detectDialog` / `sendKeys` throws
   // (review: gemini-code-assist on PR #143, comment 3179498219).
+  let currentInterval = pollIntervalMs;
+
   const tick = async (): Promise<void> => {
     if (stopped) return;
+    let capturedOk = true;
     try {
-      const pane = capture(tmuxSessionName);
+      let pane: string;
+      try {
+        pane = capture(tmuxSessionName);
+      } catch (err) {
+        // capture-pane failed — typically ETIMEDOUT while the shared tmux
+        // server is overloaded by many concurrent watchdogs (Issue #222).
+        // Skip detection this tick; the finally block backs off this
+        // session's poll so we stop hammering the slow server.
+        capturedOk = false;
+        const msg = err instanceof Error ? err.message : String(err);
+        console.warn(
+          `[Dialog] capture-pane failed for ${tmuxSessionName}:`,
+          msg
+        );
+        return;
+      }
       const match = detectDialog(pane);
 
       if (!match) {
@@ -199,12 +254,18 @@ export function startDialogWatchdog(
       );
     } finally {
       if (!stopped) {
-        timer = setTimeout(() => void tick(), pollIntervalMs);
+        currentInterval = nextPollInterval(
+          currentInterval,
+          pollIntervalMs,
+          maxBackoffMs,
+          capturedOk
+        );
+        timer = setTimeout(() => void tick(), currentInterval);
       }
     }
   };
 
-  timer = setTimeout(() => void tick(), pollIntervalMs);
+  timer = setTimeout(() => void tick(), currentInterval);
 
   return {
     stop(): void {

--- a/supervisor/tests/session/dialog-watchdog.test.ts
+++ b/supervisor/tests/session/dialog-watchdog.test.ts
@@ -1,5 +1,8 @@
 import { test, expect, describe } from "bun:test";
-import { startDialogWatchdog } from "../../src/session/dialog-watchdog";
+import {
+  startDialogWatchdog,
+  nextPollInterval,
+} from "../../src/session/dialog-watchdog";
 import type { DialogMatch } from "../../src/session/dialog-detect";
 
 /**
@@ -195,5 +198,82 @@ describe("dialog-watchdog", () => {
     });
     watchdog.stop();
     expect(() => watchdog.stop()).not.toThrow();
+  });
+});
+
+/**
+ * Issue #222: tmux capture-pane ETIMEDOUT backoff. When the shared tmux
+ * server (`-L claude-hub`) is overloaded by MAX_SESSIONS concurrent
+ * watchdogs polling every 5s, capture-pane exceeds its timeout and throws.
+ * The watchdog must exponentially back off the failing session's poll
+ * (self-throttle) instead of hammering the slow server, then reset to the
+ * base interval once a capture succeeds.
+ */
+describe("dialog-watchdog tmux backoff (#222)", () => {
+  test("nextPollInterval: resets to base on a successful capture", () => {
+    expect(nextPollInterval(20_000, 5_000, 30_000, true)).toBe(5_000);
+    expect(nextPollInterval(5_000, 5_000, 30_000, true)).toBe(5_000);
+  });
+
+  test("nextPollInterval: doubles on capture failure", () => {
+    expect(nextPollInterval(5_000, 5_000, 30_000, false)).toBe(10_000);
+    expect(nextPollInterval(10_000, 5_000, 30_000, false)).toBe(20_000);
+  });
+
+  test("nextPollInterval: caps at max backoff", () => {
+    expect(nextPollInterval(20_000, 5_000, 30_000, false)).toBe(30_000);
+    expect(nextPollInterval(30_000, 5_000, 30_000, false)).toBe(30_000);
+  });
+
+  test("backs off when capture throws (fewer calls than a clean poll)", async () => {
+    let throwingCalls = 0;
+    const throwing = startDialogWatchdog({
+      tmuxSessionName: "test-timeout",
+      pollIntervalMs: SHORT_TICK_MS,
+      maxBackoffMs: SHORT_TICK_MS * 8,
+      capture: () => {
+        throwingCalls++;
+        const err = new Error("spawnSync tmux ETIMEDOUT");
+        (err as NodeJS.ErrnoException).code = "ETIMEDOUT";
+        throw err;
+      },
+      sendKeys: () => {},
+    });
+
+    let cleanCalls = 0;
+    const clean = startDialogWatchdog({
+      tmuxSessionName: "test-clean-baseline",
+      pollIntervalMs: SHORT_TICK_MS,
+      capture: () => {
+        cleanCalls++;
+        return "no dialog\n";
+      },
+      sendKeys: () => {},
+    });
+
+    await wait(SHORT_TICK_MS * 12);
+    throwing.stop();
+    clean.stop();
+
+    // The clean poller fires at the base rate every tick; the throwing one
+    // backs off exponentially, so it must run materially fewer captures.
+    expect(throwingCalls).toBeGreaterThan(0);
+    expect(throwingCalls).toBeLessThan(cleanCalls);
+  });
+
+  test("a throwing capture never triggers a false auto-accept", async () => {
+    const accepts: DialogMatch[] = [];
+    const watchdog = startDialogWatchdog({
+      tmuxSessionName: "test-timeout-noaccept",
+      pollIntervalMs: SHORT_TICK_MS,
+      capture: () => {
+        throw new Error("spawnSync tmux ETIMEDOUT");
+      },
+      sendKeys: () => {},
+      onAutoAccept: (m) => accepts.push(m),
+    });
+    await wait(SHORT_TICK_MS * 4);
+    watchdog.stop();
+    expect(accepts.length).toBe(0);
   });
 });


### PR DESCRIPTION
## 目的

#222 の根本原因（relay の遅延/timeout = tmux 層劣化）を、客観データ調査で特定した driver に対して修正する。

## 根本原因（#222 コメントに詳細）

`dialog-watchdog.ts` が**セッションごとに 5秒固定**で `tmux capture-pane`（2秒 timeout）をポーリング。`MAX_SESSIONS=10` で**単一 tmux サーバ（`-L claude-hub`）へ約 2回/秒の持続負荷**。セッション累積で輻輳 → capture-pane が 2秒超過 → **ETIMEDOUT 170件/62倍**（後半 decile 集中）→ 同じ tmux を使う relay が遅延 → 通知が「遅れて届く」。

ログ実証では hard delivery failure（Unknown interaction 等）は横ばい〜減少。劣化の正体は「届かない」ではなく「遅延」と確定。

## 変更点

- **`nextPollInterval()`**（新規 export・純粋関数）: clean capture で base 復帰 / 失敗で指数バックオフ（上限 30s）
- **`capture-pane` 失敗（pane gone 以外）を throw** し、tick が `capturedOk=false` を検知してバックオフ（pane gone は従来どおり空文字で base 維持）
- **capture timeout を 2s→3s** に引き上げ、transient stall の誤検知（毎 tick の早期バックオフ）を抑制
- 輻輳時に各 watchdog が **self-throttle**（5s→10s→20s→30s）し、tmux 負荷を構造的に低減。clean capture で 5s に復帰

## テスト

- `nextPollInterval` の純粋関数テスト（base 復帰 / 倍化 / 上限）
- throwing capture でバックオフが効く統合テスト（clean poll より capture 回数が減る）
- throwing capture が誤 auto-accept を発火しない統合テスト
- **dialog-watchdog 単体: 14 pass / 0 fail**、型チェック clean

### CI の既存 fail について（本 PR と無関係）

`tests/guards/shell-exec-safety.test.ts`（`src/infra/db.ts:45` の ALTER TABLE 補間）, `tests/scripts/cleanup-idle-claude.test.ts`, `tmux.test.ts`（実 tmux 依存）は **main でも同様に fail**（baseline 確認済み）。本 PR は `dialog-watchdog.ts` のみ変更で、これらには触れていない。

## デプロイ注意

本修正は Supervisor 再起動で反映される。**再起動は稼働中セッションを停止する**ため、デプロイのタイミングは運用判断（owner 指示）に委ねる。

## 効果計測（#223 と連動）

修正前後で `logs/supervisor.stderr.log` の `ETIMEDOUT` 件数 / Late response 比率 / relay timeout 率の日次推移を比較し、silent regression を検知する。

## 関連

- Closes #222
- 連動: #221（watchdog 通知の再発火）, #223（通知到達率の効果計測）
- 調査: AgentTeams（2026-06-11）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * キャプチャタイムアウト時の過負荷による連鎖を抑制するバックオフ制御を追加しました。失敗時は監視間隔が指数的に延長され、成功時は基本間隔にリセットされます。

* **Tests**
  * バックオフ動作とタイムアウトシナリオの検証テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->