### PR TITLE
fix(#221): long_lived 通知を加齢バンド方式にし長期セッションの再通知を復活

### DIFF
--- a/supervisor/src/session/session-activity-watchdog.ts
+++ b/supervisor/src/session/session-activity-watchdog.ts
@@ -122,9 +122,12 @@ export function buildActivityWarning(
 
 export interface ActivityTracker {
   /**
-   * Feed the latest sample. Returns a warning the first time a signal appears,
-   * then stays silent so a steady condition is not re-warned every tick:
-   *   - long_lived warns once for the session's lifetime (one-shot),
+   * Feed the latest sample. Returns a warning when a signal first appears,
+   * then de-dups so a steady condition is not re-warned every tick:
+   *   - long_lived re-fires on entry to each escalating age band (6h → 12h →
+   *     24h → 48h …, doubling) so a multi-day session keeps surfacing instead
+   *     of going silent after the first nudge (Issue #221); same-band ticks
+   *     de-dup,
    *   - quiet warns once per quiet *episode* — when activity resumes (idle drops
    *     below the threshold) the episode resets so a later silence re-warns.
    * The two signals are tracked independently.
@@ -136,24 +139,42 @@ export interface ActivityTracker {
  * Per-session de-dup tracker. The watchdog holds one per live thread and drops
  * it when the session disappears. Thresholds are snapshotted at creation.
  */
+/**
+ * Escalating "age band" for the long_lived signal (Issue #221). Returns 0 below
+ * the threshold, then 1 at `longLivedMs`, 2 at 2×, 3 at 4×, … (doubling). The
+ * tracker re-fires long_lived each time the band increases, so a session kept
+ * alive for days keeps surfacing (6h → 12h → 24h → 48h …) instead of going
+ * permanently silent after the first nudge — the #221 one-shot bug.
+ */
+export function longLivedBand(ageMs: number, longLivedMs: number): number {
+  if (!Number.isFinite(ageMs) || longLivedMs <= 0 || ageMs < longLivedMs) {
+    return 0;
+  }
+  return Math.floor(Math.log2(ageMs / longLivedMs)) + 1;
+}
+
 export function createActivityTracker(
   thresholds: ActivityThresholds = getActivityThresholds()
 ): ActivityTracker {
-  let longLivedWarned = false;
+  // Highest long_lived age band already warned (Issue #221). 0 = none yet.
+  let warnedBand = 0;
   let quietWarned = false;
 
   return {
     check(sample) {
       const { ageMs, idleMs } = sample;
-      const longLived =
-        Number.isFinite(ageMs) && ageMs >= thresholds.longLivedMs;
+      const band = longLivedBand(ageMs, thresholds.longLivedMs);
+      const longLived = band > 0;
       const quiet = Number.isFinite(idleMs) && idleMs >= thresholds.quietMs;
 
       // Re-arm the quiet episode as soon as the session is active again.
       if (!quiet) quietWarned = false;
 
-      if (longLived && !longLivedWarned) {
-        longLivedWarned = true;
+      // Fire long_lived on entry to a *new* (higher) age band so a multi-day
+      // session keeps surfacing (6h → 12h → 24h …) instead of going silent
+      // after the first nudge (Issue #221). Same-band ticks de-dup.
+      if (longLived && band > warnedBand) {
+        warnedBand = band;
         // Suppress an *immediately* redundant quiet follow-up: when a session is
         // both long-lived and already quiet, the long_lived nudge covers it, so
         // don't also fire quiet on the next tick. We only mark quiet warned when

--- a/supervisor/tests/session/session-activity-watchdog.test.ts
+++ b/supervisor/tests/session/session-activity-watchdog.test.ts
@@ -3,6 +3,7 @@ import {
   classifyActivity,
   buildActivityWarning,
   createActivityTracker,
+  longLivedBand,
   getActivityThresholds,
   ActivityWatchdog,
   type ActivityThresholds,
@@ -90,15 +91,46 @@ describe("buildActivityWarning", () => {
   });
 });
 
+describe("longLivedBand (#221 escalating re-arm)", () => {
+  test("returns 0 below the long-lived threshold", () => {
+    expect(longLivedBand(5 * HOUR, 6 * HOUR)).toBe(0);
+    expect(longLivedBand(6 * HOUR - 1, 6 * HOUR)).toBe(0);
+  });
+
+  test("band increases at each doubling of the threshold", () => {
+    expect(longLivedBand(6 * HOUR, 6 * HOUR)).toBe(1); // 1x
+    expect(longLivedBand(11 * HOUR, 6 * HOUR)).toBe(1); // <2x stays band 1
+    expect(longLivedBand(12 * HOUR, 6 * HOUR)).toBe(2); // 2x
+    expect(longLivedBand(24 * HOUR, 6 * HOUR)).toBe(3); // 4x
+    expect(longLivedBand(48 * HOUR, 6 * HOUR)).toBe(4); // 8x
+  });
+
+  test("non-finite age or non-positive threshold -> 0 (defensive)", () => {
+    expect(longLivedBand(NaN, 6 * HOUR)).toBe(0);
+    expect(longLivedBand(Infinity, 6 * HOUR)).toBe(0);
+    expect(longLivedBand(10 * HOUR, 0)).toBe(0);
+  });
+});
+
 describe("createActivityTracker (de-dup, Journey AC #1/#3)", () => {
-  test("long_lived warns once, then de-dups on later ticks (AC3 one-shot)", () => {
+  test("long_lived de-dups within a band but re-fires at each new age band (#221)", () => {
     const tr = createActivityTracker(T);
     const w = tr.check({ ageMs: 6 * HOUR, idleMs: 1 * MIN });
     expect(w).not.toBeNull();
     expect(w!.level).toBe("long_lived");
-    // later ticks (even older) do not re-warn
+    // same band (6h..<12h) -> de-dup
     expect(tr.check({ ageMs: 7 * HOUR, idleMs: 1 * MIN })).toBeNull();
-    expect(tr.check({ ageMs: 24 * HOUR, idleMs: 1 * MIN })).toBeNull();
+    expect(tr.check({ ageMs: 11 * HOUR, idleMs: 1 * MIN })).toBeNull();
+    // next band at 12h (2x) -> re-fires (#221: no longer silent for life)
+    expect(tr.check({ ageMs: 12 * HOUR, idleMs: 1 * MIN })!.level).toBe(
+      "long_lived"
+    );
+    // next band at 24h (4x) -> re-fires again
+    expect(tr.check({ ageMs: 24 * HOUR, idleMs: 1 * MIN })!.level).toBe(
+      "long_lived"
+    );
+    // same band (24h..<48h) -> de-dup
+    expect(tr.check({ ageMs: 30 * HOUR, idleMs: 1 * MIN })).toBeNull();
   });
 
   test("quiet warns once per episode and re-arms after activity resumes (AC1)", () => {


### PR DESCRIPTION
## 目的

#221 を修正する。「Discord 通知が日を追ってだんだん届かなくなる」体感の**現存する直接原因**。

## 根本原因（AgentTeams 調査で特定）

`session-activity-watchdog.ts` の `createActivityTracker` の `longLivedWarned` 一度きりフラグには**再発火経路が無い**。複数日生かし続けるセッションは 6h（`longLivedMs` 既定）の初回 `long_lived` 通知以降、二度と通知されない（tracker はセッション消滅時のみ破棄）。→ セッションが長く生きるほど発せられる通知が単調減少 = 「日を追って減る」。

## 変更点

- **`longLivedBand(ageMs, longLivedMs)`**（新規 export・純粋関数）: `longLivedMs × 2^k` の加齢バンドを返す（6h=band1, 12h=band2, 24h=band3, 48h=band4 …、閾値未満は 0）
- **`createActivityTracker` を `warnedBand` 方式に変更**: 上位バンドへ進入したときに `long_lived` を再発火（同一バンド内は de-dup）。これにより 6h→12h→24h→48h… と「まだ生きてる」を段階的に再通知
- `quiet` の episode 再 arm 挙動は**不変**（regression なし）
- doc コメントを one-shot → 段階再通知へ更新

加齢バンドは doubling なので通知過多にならない（24h 稼働で計4回: 6h/12h/24h、48h で +1）。

## テスト

- `longLivedBand` 純粋関数テスト（閾値未満=0 / 倍化でバンド増 / 非有限・非正の防御）
- 同一バンド de-dup + 上位バンド再発火の統合テスト（#221 の挙動を直接検証）
- `quiet` episode・独立性・優先順位など既存テストは不変で pass
- **session-activity-watchdog 24 pass / 0 fail**、型チェック clean

## デプロイ注意

Supervisor 再起動で反映。再起動は稼働中セッションを止めるため、タイミングは運用判断（owner 指示）。

## 関連

- Closes #221
- 連動: #222（tmux 輻輳の relay 遅延, PR #224）, #223（効果計測）
- 調査: AgentTeams（2026-06-11）。`session-activity-watchdog.ts:139-179`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
