### PR TITLE
fix: tmux 同期I/O呼び出しに timeout を付与しイベントループ無限ブロックを防ぐ (#222)

### DIFF
--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -100,6 +100,18 @@ export interface SessionEffects {
   worktree: WorktreeAdapter;
 }
 
+// Issue #222: bound every synchronous tmux call so a wedged tmux server (whose
+// capture-pane / send-keys ETIMEDOUT rate climbs over Supervisor uptime) cannot
+// block the Node event loop indefinitely. An unbounded execFileSync stall here
+// starves relay HTTP response handling, surfacing as delayed / 5-min-timed-out
+// Discord delivery rather than hard failures (the #222 symptom). 2s matches the
+// existing ceilings in dialog-watchdog.ts / relay.ts; on timeout each call below
+// degrades to its existing error path. new-session is a one-shot start path and
+// gets a more generous ceiling so a momentarily busy server does not abort a
+// genuine session start.
+const TMUX_CALL_TIMEOUT_MS = 2000;
+const TMUX_NEW_SESSION_TIMEOUT_MS = 10_000;
+
 export const realTmuxAdapter: TmuxAdapter = {
   newSession(name, command) {
     // Issue #147: previous `execSync(\`tmux new-session ... '${command}'\`)`
@@ -110,7 +122,9 @@ export const realTmuxAdapter: TmuxAdapter = {
     // arguments and exited immediately. Using execFileSync with an argv array
     // avoids shell parsing entirely: tmux receives `command` as a single
     // argument and invokes /bin/sh -c on it once, inside the new session.
-    execFileSync(TMUX_PATH, [...TMUX_ARGS, "new-session", "-d", "-s", name, command]);
+    execFileSync(TMUX_PATH, [...TMUX_ARGS, "new-session", "-d", "-s", name, command], {
+      timeout: TMUX_NEW_SESSION_TIMEOUT_MS,
+    });
   },
   killSession(name) {
     // PR #148 review (gemini critical): use execFileSync + argv array so an
@@ -120,6 +134,7 @@ export const realTmuxAdapter: TmuxAdapter = {
     try {
       execFileSync(TMUX_PATH, [...TMUX_ARGS, "kill-session", "-t", name], {
         stdio: "ignore",
+        timeout: TMUX_CALL_TIMEOUT_MS,
       });
     } catch {
       // No existing session
@@ -129,6 +144,7 @@ export const realTmuxAdapter: TmuxAdapter = {
     try {
       execFileSync(TMUX_PATH, [...TMUX_ARGS, "has-session", "-t", name], {
         stdio: "ignore",
+        timeout: TMUX_CALL_TIMEOUT_MS,
       });
       return true;
     } catch {
@@ -142,7 +158,7 @@ export const realTmuxAdapter: TmuxAdapter = {
       const output = execFileSync(
         TMUX_PATH,
         [...TMUX_ARGS, "list-panes", "-t", name, "-F", "#{pane_pid}"],
-        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
+        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: TMUX_CALL_TIMEOUT_MS }
       ).trim();
       const pid = parseInt(output.split("\n")[0] ?? "", 10);
       return isNaN(pid) ? null : pid;
@@ -160,7 +176,7 @@ export const realTmuxAdapter: TmuxAdapter = {
       return execFileSync(
         TMUX_PATH,
         [...TMUX_ARGS, "capture-pane", "-p", "-t", name],
-        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] }
+        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: TMUX_CALL_TIMEOUT_MS }
       );
     } catch {
       return "";
@@ -172,6 +188,7 @@ export const realTmuxAdapter: TmuxAdapter = {
     try {
       execFileSync(TMUX_PATH, [...TMUX_ARGS, "send-keys", "-t", name, ...keys], {
         stdio: "ignore",
+        timeout: TMUX_CALL_TIMEOUT_MS,
       });
     } catch {
       // Caller's poll loop retries or proceeds.

--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -112,6 +112,22 @@ export interface SessionEffects {
 const TMUX_CALL_TIMEOUT_MS = 2000;
 const TMUX_NEW_SESSION_TIMEOUT_MS = 10_000;
 
+/**
+ * Issue #222 (gemini PR #226 review): a timeout (ETIMEDOUT) is the very
+ * degradation signal we are bounding — surface it via console.warn so a tmux
+ * server stall stays observable, while keeping the expected errors (no server /
+ * no session / no pane) silent as before. Returns true when the error was a
+ * timeout. newSession is excluded: it has no catch and rethrows, so its caller
+ * already sees the ETIMEDOUT.
+ */
+function warnIfTmuxTimeout(op: string, name: string, err: unknown): boolean {
+  if ((err as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT") {
+    console.warn(`[tmux] ${op} timed out for ${name} after ${TMUX_CALL_TIMEOUT_MS}ms`);
+    return true;
+  }
+  return false;
+}
+
 export const realTmuxAdapter: TmuxAdapter = {
   newSession(name, command) {
     // Issue #147: previous `execSync(\`tmux new-session ... '${command}'\`)`
@@ -136,8 +152,9 @@ export const realTmuxAdapter: TmuxAdapter = {
         stdio: "ignore",
         timeout: TMUX_CALL_TIMEOUT_MS,
       });
-    } catch {
-      // No existing session
+    } catch (err) {
+      // No existing session (expected) — but surface a tmux stall.
+      warnIfTmuxTimeout("kill-session", name, err);
     }
   },
   hasSession(name) {
@@ -147,7 +164,8 @@ export const realTmuxAdapter: TmuxAdapter = {
         timeout: TMUX_CALL_TIMEOUT_MS,
       });
       return true;
-    } catch {
+    } catch (err) {
+      warnIfTmuxTimeout("has-session", name, err);
       return false;
     }
   },
@@ -162,7 +180,8 @@ export const realTmuxAdapter: TmuxAdapter = {
       ).trim();
       const pid = parseInt(output.split("\n")[0] ?? "", 10);
       return isNaN(pid) ? null : pid;
-    } catch {
+    } catch (err) {
+      warnIfTmuxTimeout("list-panes", name, err);
       return null;
     }
   },
@@ -178,7 +197,8 @@ export const realTmuxAdapter: TmuxAdapter = {
         [...TMUX_ARGS, "capture-pane", "-p", "-t", name],
         { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: TMUX_CALL_TIMEOUT_MS }
       );
-    } catch {
+    } catch (err) {
+      warnIfTmuxTimeout("capture-pane", name, err);
       return "";
     }
   },
@@ -190,8 +210,9 @@ export const realTmuxAdapter: TmuxAdapter = {
         stdio: "ignore",
         timeout: TMUX_CALL_TIMEOUT_MS,
       });
-    } catch {
-      // Caller's poll loop retries or proceeds.
+    } catch (err) {
+      // Caller's poll loop retries or proceeds — but surface a tmux stall.
+      warnIfTmuxTimeout("send-keys", name, err);
     }
   },
 };

--- a/supervisor/tests/session/adapters.test.ts
+++ b/supervisor/tests/session/adapters.test.ts
@@ -4,6 +4,7 @@ import {
   expect,
   mock,
   beforeEach,
+  spyOn,
 } from "bun:test";
 
 /**
@@ -233,8 +234,27 @@ describe("realTmuxAdapter tmux call timeouts (#222)", () => {
   });
 
   test("getPid passes a positive timeout", () => {
-    realTmuxAdapter.getPid("claude-test");
-    expect(lastTimeout()).toBeGreaterThan(0);
+    // getPid calls .trim() on the result, so feed a string (not the default
+    // Buffer) to exercise its success path rather than masking a TypeError in
+    // its catch (gemini PR #226 review).
+    const pidMock = mock(
+      (_file: string, _args: readonly string[]): string => "12345\n"
+    );
+    mock.module("child_process", () => ({
+      ...realChildProcess,
+      execFileSync: pidMock,
+    }));
+    return import("../../src/session/adapters").then(({ realTmuxAdapter: a }) => {
+      expect(a.getPid("claude-test")).toBe(12345);
+      const calls = pidMock.mock.calls as ReadonlyArray<readonly unknown[]>;
+      const opts = calls[calls.length - 1]?.[2] as { timeout?: number } | undefined;
+      expect(opts?.timeout).toBeGreaterThan(0);
+      // Restore the call-recording mock for subsequent tests.
+      mock.module("child_process", () => ({
+        ...realChildProcess,
+        execFileSync: mockExecFileSync,
+      }));
+    });
   });
 
   test("capturePane passes a positive timeout", () => {
@@ -245,5 +265,51 @@ describe("realTmuxAdapter tmux call timeouts (#222)", () => {
   test("sendKeys passes a positive timeout", () => {
     realTmuxAdapter.sendKeys("claude-test", ["C-m"]);
     expect(lastTimeout()).toBeGreaterThan(0);
+  });
+
+  test("warns on ETIMEDOUT so the degradation stays observable (#222)", () => {
+    const timeoutErr = Object.assign(new Error("ETIMEDOUT"), {
+      code: "ETIMEDOUT",
+    });
+    const timeoutMock = mock((_file: string, _args: readonly string[]): Buffer => {
+      throw timeoutErr;
+    });
+    mock.module("child_process", () => ({
+      ...realChildProcess,
+      execFileSync: timeoutMock,
+    }));
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    return import("../../src/session/adapters").then(({ realTmuxAdapter: a }) => {
+      // Degrades to the existing error path ("") AND logs the stall.
+      expect(a.capturePane("claude-test")).toBe("");
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0]?.[0])).toContain("timed out");
+      warnSpy.mockRestore();
+      mock.module("child_process", () => ({
+        ...realChildProcess,
+        execFileSync: mockExecFileSync,
+      }));
+    });
+  });
+
+  test("does NOT warn for expected non-timeout errors (no pane / no server)", () => {
+    const noPaneErr = new Error("can't find pane: claude-test");
+    const errMock = mock((_file: string, _args: readonly string[]): Buffer => {
+      throw noPaneErr;
+    });
+    mock.module("child_process", () => ({
+      ...realChildProcess,
+      execFileSync: errMock,
+    }));
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    return import("../../src/session/adapters").then(({ realTmuxAdapter: a }) => {
+      expect(a.capturePane("claude-test")).toBe("");
+      expect(warnSpy).not.toHaveBeenCalled();
+      warnSpy.mockRestore();
+      mock.module("child_process", () => ({
+        ...realChildProcess,
+        execFileSync: mockExecFileSync,
+      }));
+    });
   });
 });

--- a/supervisor/tests/session/adapters.test.ts
+++ b/supervisor/tests/session/adapters.test.ts
@@ -187,3 +187,63 @@ describe("realTmuxAdapter.getPid (#148 review)", () => {
     });
   });
 });
+
+/**
+ * Issue #222: every synchronous tmux call must be bounded by a timeout.
+ *
+ * A wedged tmux server (capture-pane / send-keys ETIMEDOUT stalls that grow
+ * over Supervisor uptime) was blocking these `execFileSync` calls — and with
+ * them the Node event loop — for unbounded time, starving relay HTTP response
+ * handling. That surfaced as delayed / 5-min-timed-out Discord delivery rather
+ * than hard failures. Bounding each call converts an indefinite hang into the
+ * method's existing graceful error path (capturePane → "", hasSession → false,
+ * getPid → null, sendKeys → no-op, killSession → swallow, newSession → throw).
+ */
+describe("realTmuxAdapter tmux call timeouts (#222)", () => {
+  beforeEach(() => {
+    // Guard against earlier tests that swapped the child_process mock: make
+    // sure the call-recording mockExecFileSync is the active impl here.
+    mock.module("child_process", () => ({
+      ...realChildProcess,
+      execFileSync: mockExecFileSync,
+    }));
+  });
+
+  function lastTimeout(): number | undefined {
+    // The mock is declared with a 2-arg signature, but Bun records every actual
+    // argument — read the 3rd (options) positionally via an unknown[] view.
+    const calls = mockExecFileSync.mock.calls as ReadonlyArray<readonly unknown[]>;
+    const opts = calls[calls.length - 1]?.[2] as { timeout?: number } | undefined;
+    return opts?.timeout;
+  }
+
+  test("newSession passes a positive timeout", () => {
+    realTmuxAdapter.newSession("claude-test", "echo hi");
+    expect(lastTimeout()).toBeGreaterThan(0);
+  });
+
+  test("killSession passes a positive timeout", () => {
+    realTmuxAdapter.killSession("claude-test");
+    expect(lastTimeout()).toBeGreaterThan(0);
+  });
+
+  test("hasSession passes a positive timeout", () => {
+    realTmuxAdapter.hasSession("claude-test");
+    expect(lastTimeout()).toBeGreaterThan(0);
+  });
+
+  test("getPid passes a positive timeout", () => {
+    realTmuxAdapter.getPid("claude-test");
+    expect(lastTimeout()).toBeGreaterThan(0);
+  });
+
+  test("capturePane passes a positive timeout", () => {
+    realTmuxAdapter.capturePane("claude-test");
+    expect(lastTimeout()).toBeGreaterThan(0);
+  });
+
+  test("sendKeys passes a positive timeout", () => {
+    realTmuxAdapter.sendKeys("claude-test", ["C-m"]);
+    expect(lastTimeout()).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
## 背景 (#222)

owner の「通知が劣化している」体感をログ実データで検証した結果、症状は「Discord に届かない」ではなく「tmux 層の不安定化で応答が遅延・5分タイムアウトする」劣化だった。

実ログ照合（`logs/supervisor.stderr.log`, 約12h稼働時点）:

```
capture-pane failed : 126   (前半2 → 後半124、62倍)
ETIMEDOUT           : 170   (前半23 → 後半147、6.4倍)
sessions (socket)   : 8
```

## 根本原因

`adapters.ts` の `realTmuxAdapter` は全 tmux 呼び出しを**同期 `execFileSync`** で行うが、`capturePane` 等は **timeout 指定が無く**、楔状態の tmux サーバに対して**無制限にブロック**しうる。同期ブロックは Node イベントループを停止させ、同一ループ上の relay HTTP 応答処理（`waitForRelay`, 5分窓）を starvation させる。

```
稼働時間↑ → tmuxセッション累積 → capture-pane 遅延/ETIMEDOUT↑
  → 同期 execFileSync が event loop を無制限ブロック
  → relay 応答を捌けず Late response / Response timeout が増加
```

## 変更

`realTmuxAdapter` の全 `execFileSync`（newSession / killSession / hasSession / getPid / capturePane / sendKeys）に timeout を付与し、無限ハングを各メソッド既存のエラー経路へ degrade させる。

| 呼び出し | timeout | 備考 |
|---|---|---|
| capturePane / sendKeys / hasSession / getPid / killSession | 2000ms | dialog-watchdog / relay の既存上限に合わせる |
| newSession | 10000ms | 一度きりの起動経路のため余裕を持たせる |

タイムアウト時の挙動は各メソッドの既存 catch がそのまま処理する（capturePane→`""`、hasSession→`false`、getPid→`null`、sendKeys→no-op、killSession→swallow、newSession→throw で caller に表面化）。通常呼び出し（非タイムアウト）には影響なし。

## テスト

- `tests/session/adapters.test.ts` に各メソッドが正の timeout option を渡すことを検証する回帰テストを6件追加（RED→GREEN 確認済）。
- `bunx tsc --noEmit`: PASS
- `bun test tests/session/adapters.test.ts`: 14 pass / 0 fail
- `bun test tests/session/relay.test.ts`（隔離実行）: 15 pass / 0 fail（回帰なし）

## スコープ外（follow-up）

本PRは「同期呼び出しの無限ブロックを bound する」防御的修正。**完全な非同期化（`execFile` 化で event loop を一切ブロックしない構造的 fix）は別 issue** で対応する。dialog-watchdog の poll backoff、tmux セッション GC も follow-up 候補。

## 補足（本PRと無関係）

`tests/guards/shell-exec-safety.test.ts`（shell-exec injection guard）が `src/infra/db.ts:45` の SQL 文字列補間を未justify として fail させているが、これは main でも既に fail する既存事象で本PRとは無関係。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * tmuxセッション管理の同期処理にタイムアウト機構を追加。セッション生成やキル、パネル情報取得などの各操作が、一定時間内に確実に完了するよう改善されました。

* **テスト**
  * 各tmux呼び出しにおけるタイムアウト検証テストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->