### PR TITLE
test(#190): dialog-watchdog の wall-clock flake を仮想クロック注入で解消し CI gating 化

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,8 +75,10 @@ jobs:
         run: bun install --frozen-lockfile
 
       # Curated list of deterministic, non-tmux test files. dialog-detect is
-      # pure/deterministic and gated here (#153); dialog-watchdog is wall-clock
-      # timing-flaky and stays out until de-flaked (#190).
+      # pure/deterministic and gated here (#153). dialog-watchdog was wall-clock
+      # timing-flaky but is now driven by an injected virtual clock (#190), so
+      # it is deterministic and gated here too — this also gates the
+      # feedback-survey "send 0, never 1" regression test it contains (#153).
       - name: Run tests
         env:
           SUPERVISOR_DB_PATH: ":memory:"
@@ -97,6 +99,7 @@ jobs:
                    tests/hooks/stop-relay.test.ts \
                    tests/infra/db.test.ts \
                    tests/session/dialog-detect.test.ts \
+                   tests/session/dialog-watchdog.test.ts \
                    tests/session/notify-pushover.test.ts \
                    tests/session/dialog-stuck-handler.test.ts \
                    tests/session/stall-heartbeat.test.ts \

--- a/supervisor/src/session/dialog-watchdog.ts
+++ b/supervisor/src/session/dialog-watchdog.ts
@@ -170,6 +170,16 @@ function sendKeysViaTmux(sessionName: string, keys: string[]): void {
 export function startDialogWatchdog(
   options: DialogWatchdogOptions
 ): DialogWatchdog {
+  // setTimer / clearTimer is a pair: an injected timer can only be cancelled
+  // by its injected clearTimer. Supplying just one would let stop() call the
+  // default clearTimeout on an injected handle (or vice versa), which silently
+  // fails to cancel the poll loop → timer leak / phantom re-execution. Reject
+  // the half-injected case fail-fast at construction (Issue #190, CodeRabbit).
+  if ((options.setTimer === undefined) !== (options.clearTimer === undefined)) {
+    throw new Error(
+      "startDialogWatchdog: setTimer and clearTimer must both be provided or both omitted"
+    );
+  }
   const {
     tmuxSessionName,
     onHeartbeat,

--- a/supervisor/src/session/dialog-watchdog.ts
+++ b/supervisor/src/session/dialog-watchdog.ts
@@ -59,6 +59,13 @@ export function nextPollInterval(
   return Math.min(current * 2, max);
 }
 
+/**
+ * Opaque handle returned by {@link DialogWatchdogOptions.setTimer}. The real
+ * implementation returns a `setTimeout` handle; an injected virtual clock
+ * returns its own numeric id (Issue #190).
+ */
+export type WatchdogTimerHandle = ReturnType<typeof setTimeout> | number;
+
 export interface DialogWatchdogOptions {
   /** tmux session name (e.g., `claude-<threadId12>`). */
   tmuxSessionName: string;
@@ -88,6 +95,23 @@ export interface DialogWatchdogOptions {
   /** Inject a custom send-keys function — tests pass a recorder to assert
    *  the right keys were sent. Defaults to {@link sendKeysViaTmux}. */
   sendKeys?: (sessionName: string, keys: string[]) => void;
+  /**
+   * Inject the timer primitives that space out poll ticks. Tests pass a
+   * virtual clock to drive ticks in deterministic virtual time, eliminating
+   * the wall-clock `setTimeout` waits that made the watchdog tests flaky
+   * under CI/dev-machine load (Issue #190). Production omits both and gets
+   * real `setTimeout`/`clearTimeout`, so runtime behaviour is unchanged.
+   *
+   * `setTimer` receives the async tick itself (not a void-wrapped wrapper) so
+   * a virtual clock can `await` full tick completion — including the
+   * reschedule performed in the tick's `finally` — before the test asserts.
+   */
+  setTimer?: (
+    callback: () => Promise<void>,
+    delayMs: number
+  ) => WatchdogTimerHandle;
+  /** Companion to {@link setTimer}; defaults to `clearTimeout`. */
+  clearTimer?: (handle: WatchdogTimerHandle) => void;
 }
 
 export interface DialogWatchdog {
@@ -155,13 +179,16 @@ export function startDialogWatchdog(
     maxAutoAcceptAttempts = MAX_AUTO_ACCEPT_ATTEMPTS,
     capture = captureViaTmux,
     sendKeys = sendKeysViaTmux,
+    setTimer = (cb, ms) => setTimeout(() => void cb(), ms),
+    clearTimer = (handle) =>
+      clearTimeout(handle as ReturnType<typeof setTimeout>),
   } = options;
 
   let lastKind: string | null = null;
   let consecutiveAttempts = 0;
   let heartbeatFired = false;
   let stopped = false;
-  let timer: ReturnType<typeof setTimeout> | null = null;
+  let timerHandle: WatchdogTimerHandle | null = null;
 
   // Recursive setTimeout instead of setInterval: each tick is awaited end-to-end
   // before scheduling the next, so a slow `await onHeartbeat(...)` cannot cause
@@ -260,20 +287,20 @@ export function startDialogWatchdog(
           maxBackoffMs,
           capturedOk
         );
-        timer = setTimeout(() => void tick(), currentInterval);
+        timerHandle = setTimer(tick, currentInterval);
       }
     }
   };
 
-  timer = setTimeout(() => void tick(), currentInterval);
+  timerHandle = setTimer(tick, currentInterval);
 
   return {
     stop(): void {
       if (stopped) return;
       stopped = true;
-      if (timer) {
-        clearTimeout(timer);
-        timer = null;
+      if (timerHandle !== null) {
+        clearTimer(timerHandle);
+        timerHandle = null;
       }
     },
   };

--- a/supervisor/tests/session/dialog-watchdog.test.ts
+++ b/supervisor/tests/session/dialog-watchdog.test.ts
@@ -302,6 +302,30 @@ describe("dialog-watchdog", () => {
     expect(captureCount).toBe(countAtStop);
   });
 
+  // Issue #190 (CodeRabbit): setTimer/clearTimer are a pair. Supplying only
+  // one would let stop() cancel an injected timer with the wrong primitive
+  // (timer leak). The constructor must reject the half-injected case.
+  test("throws if only one of setTimer/clearTimer is provided", () => {
+    expect(() =>
+      startDialogWatchdog({
+        tmuxSessionName: "test-pair-set-only",
+        capture: () => "",
+        sendKeys: () => {},
+        setTimer: (cb, ms) => setTimeout(() => void cb(), ms),
+        // clearTimer intentionally omitted
+      })
+    ).toThrow(/both/);
+    expect(() =>
+      startDialogWatchdog({
+        tmuxSessionName: "test-pair-clear-only",
+        capture: () => "",
+        sendKeys: () => {},
+        // setTimer intentionally omitted
+        clearTimer: () => {},
+      })
+    ).toThrow(/both/);
+  });
+
   test("stop() is idempotent", () => {
     const clock = createVirtualClock();
     const watchdog = startDialogWatchdog({

--- a/supervisor/tests/session/dialog-watchdog.test.ts
+++ b/supervisor/tests/session/dialog-watchdog.test.ts
@@ -2,25 +2,115 @@ import { test, expect, describe } from "bun:test";
 import {
   startDialogWatchdog,
   nextPollInterval,
+  type WatchdogTimerHandle,
 } from "../../src/session/dialog-watchdog";
 import type { DialogMatch } from "../../src/session/dialog-detect";
 
 /**
  * Watchdog unit tests with fake capture / sendKeys. No tmux required.
  *
- * Issue #57 / Phase D-3: verify the auto-accept → heartbeat escalation
- * path. We control time by driving the watchdog at a 5ms tick and waiting
- * a deterministic number of ticks via setTimeout.
+ * Issue #57 / Phase D-3: verify the auto-accept → heartbeat escalation path.
+ *
+ * Issue #190: these tests previously drove the watchdog at a 10ms real tick
+ * and used `await setTimeout(...)` to "wait N ticks". That made them
+ * non-deterministic — under CI/dev-machine load a tick could miss its
+ * window and an expected auto-accept/heartbeat would not have fired by the
+ * time the test asserted (base branch flaked ~1/5). We now inject a VIRTUAL
+ * CLOCK so ticks run in deterministic virtual time: `clock.advance(ms)` runs
+ * exactly the callbacks whose scheduled time falls within the window, in time
+ * order, awaiting each tick to completion (including the reschedule in the
+ * tick's `finally`). No wall-clock involved → zero timing flake.
  */
 
 const SHORT_TICK_MS = 10;
 
-function wait(ms: number): Promise<void> {
-  return new Promise((r) => setTimeout(r, ms));
+interface ScheduledTimer {
+  at: number;
+  seq: number;
+  cb: () => Promise<void>;
+  cancelled: boolean;
+}
+
+/**
+ * Deterministic virtual clock. Models `setTimeout`/`clearTimeout` over a
+ * virtual timeline: `setTimer(cb, ms)` enqueues `cb` at `now + ms`;
+ * `advance(ms)` runs all due (non-cancelled) callbacks in time order until the
+ * virtual clock reaches `now + ms`. Because each tick reschedules itself in
+ * its `finally`, a single `advance` drives the recursive poll loop exactly as
+ * real timers would — but with no real time elapsing, so the result is
+ * identical on a fast laptop and a loaded CI runner.
+ *
+ * Crucially the clock RESPECTS each timer's delay, so a watchdog that backs
+ * off (longer interval) fires fewer times than a base-interval one in the same
+ * virtual window — the property the #222 backoff test asserts.
+ */
+function createVirtualClock() {
+  let now = 0;
+  let seq = 0;
+  let handleSeq = 0;
+  // Map handle -> entry so clearTimer can cancel in place.
+  const byHandle = new Map<number, ScheduledTimer>();
+  const queue: ScheduledTimer[] = [];
+
+  const setTimer = (
+    cb: () => Promise<void>,
+    delayMs: number
+  ): WatchdogTimerHandle => {
+    const handle = ++handleSeq;
+    const entry: ScheduledTimer = {
+      at: now + delayMs,
+      seq: ++seq,
+      cb,
+      cancelled: false,
+    };
+    queue.push(entry);
+    byHandle.set(handle, entry);
+    return handle;
+  };
+
+  const clearTimer = (handle: WatchdogTimerHandle): void => {
+    const entry = byHandle.get(handle as number);
+    if (entry) {
+      entry.cancelled = true;
+      byHandle.delete(handle as number);
+    }
+  };
+
+  const advance = async (ms: number): Promise<void> => {
+    const target = now + ms;
+    for (;;) {
+      // Find the earliest non-cancelled callback due at or before `target`,
+      // tie-broken by insertion order (FIFO at equal timestamps).
+      let next: ScheduledTimer | null = null;
+      let nextIdx = -1;
+      for (let i = 0; i < queue.length; i++) {
+        const e = queue[i]!;
+        if (e.cancelled || e.at > target) continue;
+        if (
+          next === null ||
+          e.at < next.at ||
+          (e.at === next.at && e.seq < next.seq)
+        ) {
+          next = e;
+          nextIdx = i;
+        }
+      }
+      if (next === null) break;
+      queue.splice(nextIdx, 1);
+      now = next.at;
+      // Run the tick to completion; its `finally` enqueues the next timer at
+      // the (now-advanced) virtual time, which the loop will pick up if due.
+      await next.cb();
+    }
+    now = target;
+  };
+
+  return { setTimer, clearTimer, advance };
 }
 
 describe("dialog-watchdog", () => {
   test("does not call onAutoAccept when pane is clean", async () => {
+    const clock = createVirtualClock();
     const accepts: DialogMatch[] = [];
     const watchdog = startDialogWatchdog({
       tmuxSessionName: "test-clean",
@@ -28,13 +118,16 @@ describe("dialog-watchdog", () => {
       capture: () => "no dialog here\nnormal output\n",
       sendKeys: () => {},
       onAutoAccept: (m) => accepts.push(m),
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
     });
-    await wait(SHORT_TICK_MS * 4);
+    await clock.advance(SHORT_TICK_MS * 4);
     watchdog.stop();
     expect(accepts.length).toBe(0);
   });
 
   test("auto-accepts ink-confirm with C-m", async () => {
+    const clock = createVirtualClock();
     const accepts: DialogMatch[] = [];
     const sentKeys: { session: string; keys: string[] }[] = [];
     const watchdog = startDialogWatchdog({
@@ -46,8 +139,10 @@ describe("dialog-watchdog", () => {
         sentKeys.push({ session, keys });
       },
       onAutoAccept: (m) => accepts.push(m),
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
     });
-    await wait(SHORT_TICK_MS * 3);
+    await clock.advance(SHORT_TICK_MS * 3);
     watchdog.stop();
     expect(accepts.length).toBeGreaterThanOrEqual(1);
     expect(accepts[0]!.kind).toBe("ink-confirm");
@@ -56,6 +151,7 @@ describe("dialog-watchdog", () => {
   });
 
   test("auto-accepts bash-yn with y + Enter", async () => {
+    const clock = createVirtualClock();
     const sentKeys: string[][] = [];
     const watchdog = startDialogWatchdog({
       tmuxSessionName: "test-bash",
@@ -63,8 +159,10 @@ describe("dialog-watchdog", () => {
       maxAutoAcceptAttempts: 1,
       capture: () => "rm dangerous\nDo you want to proceed? (y/N)\n",
       sendKeys: (_, keys) => sentKeys.push(keys),
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
     });
-    await wait(SHORT_TICK_MS * 3);
+    await clock.advance(SHORT_TICK_MS * 3);
     watchdog.stop();
     expect(sentKeys.length).toBeGreaterThanOrEqual(1);
     expect(sentKeys[0]).toEqual(["y", "C-m"]);
@@ -74,6 +172,7 @@ describe("dialog-watchdog", () => {
   // (option 1 submits "Bad" feedback). This locks the survey wiring against
   // future regressions.
   test("auto-dismisses feedback-survey with 0 + Enter (never 1)", async () => {
+    const clock = createVirtualClock();
     const sentKeys: string[][] = [];
     const accepts: DialogMatch[] = [];
     const watchdog = startDialogWatchdog({
@@ -84,10 +183,12 @@ describe("dialog-watchdog", () => {
         "● How is Claude doing this session? (optional)\n  1: Bad    2: Fine   3: Good   0: Dismiss\n",
       sendKeys: (_, keys) => sentKeys.push(keys),
       onAutoAccept: (m) => accepts.push(m),
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
     });
     // finally-guard stop() so a thrown assertion can't leak the poll timer.
     try {
-      await wait(SHORT_TICK_MS * 3);
+      await clock.advance(SHORT_TICK_MS * 3);
     } finally {
       watchdog.stop();
     }
@@ -99,6 +200,7 @@ describe("dialog-watchdog", () => {
   });
 
   test("escalates to onHeartbeat after auto-accept budget exhausted", async () => {
+    const clock = createVirtualClock();
     const heartbeats: DialogMatch[] = [];
     const acceptsFired: DialogMatch[] = [];
     // Simulate a stuck dialog: pane never clears, watchdog tries 2 times
@@ -115,9 +217,11 @@ describe("dialog-watchdog", () => {
       onHeartbeat: (m) => {
         heartbeats.push(m);
       },
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
     });
     // Need at least maxAutoAcceptAttempts + 1 ticks for heartbeat to fire.
-    await wait(SHORT_TICK_MS * 6);
+    await clock.advance(SHORT_TICK_MS * 6);
     watchdog.stop();
 
     expect(acceptsFired.length).toBeGreaterThanOrEqual(2);
@@ -126,6 +230,7 @@ describe("dialog-watchdog", () => {
   });
 
   test("heartbeat only fires once per dialog instance", async () => {
+    const clock = createVirtualClock();
     const heartbeats: DialogMatch[] = [];
     const watchdog = startDialogWatchdog({
       tmuxSessionName: "test-once",
@@ -136,14 +241,17 @@ describe("dialog-watchdog", () => {
       onHeartbeat: (m) => {
         heartbeats.push(m);
       },
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
     });
     // Run for many ticks — heartbeat should still fire only once.
-    await wait(SHORT_TICK_MS * 10);
+    await clock.advance(SHORT_TICK_MS * 10);
     watchdog.stop();
     expect(heartbeats.length).toBe(1);
   });
 
   test("resets heartbeat state after dialog clears", async () => {
+    const clock = createVirtualClock();
     const heartbeats: DialogMatch[] = [];
     let phase: "stuck" | "clean" | "stuck2" = "stuck";
     const watchdog = startDialogWatchdog({
@@ -159,18 +267,21 @@ describe("dialog-watchdog", () => {
       onHeartbeat: (m) => {
         heartbeats.push(m);
       },
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
     });
-    await wait(SHORT_TICK_MS * 4);
+    await clock.advance(SHORT_TICK_MS * 4);
     phase = "clean";
-    await wait(SHORT_TICK_MS * 3);
+    await clock.advance(SHORT_TICK_MS * 3);
     phase = "stuck2";
-    await wait(SHORT_TICK_MS * 4);
+    await clock.advance(SHORT_TICK_MS * 4);
     watchdog.stop();
     // Two distinct stuck phases → two heartbeats.
     expect(heartbeats.length).toBe(2);
   });
 
   test("stop() prevents further ticks", async () => {
+    const clock = createVirtualClock();
     let captureCount = 0;
     const watchdog = startDialogWatchdog({
       tmuxSessionName: "test-stop",
@@ -180,21 +291,26 @@ describe("dialog-watchdog", () => {
         return "";
       },
       sendKeys: () => {},
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
     });
-    await wait(SHORT_TICK_MS * 3);
+    await clock.advance(SHORT_TICK_MS * 3);
     watchdog.stop();
     const countAtStop = captureCount;
-    await wait(SHORT_TICK_MS * 5);
-    // Allow at most 1 stale tick already mid-flight.
-    expect(captureCount - countAtStop).toBeLessThanOrEqual(1);
+    await clock.advance(SHORT_TICK_MS * 5);
+    // Deterministic: stop() cancels the pending timer, so zero further ticks.
+    expect(captureCount).toBe(countAtStop);
   });
 
   test("stop() is idempotent", () => {
+    const clock = createVirtualClock();
     const watchdog = startDialogWatchdog({
       tmuxSessionName: "test-idem",
       pollIntervalMs: SHORT_TICK_MS,
       capture: () => "",
       sendKeys: () => {},
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
     });
     watchdog.stop();
     expect(() => watchdog.stop()).not.toThrow();
@@ -226,6 +342,10 @@ describe("dialog-watchdog tmux backoff (#222)", () => {
   });
 
   test("backs off when capture throws (fewer calls than a clean poll)", async () => {
+    // Both watchdogs share ONE virtual clock so their ticks interleave in the
+    // same virtual timeline — the throwing one backs off (longer intervals)
+    // and therefore fires strictly fewer captures within the same window.
+    const clock = createVirtualClock();
     let throwingCalls = 0;
     const throwing = startDialogWatchdog({
       tmuxSessionName: "test-timeout",
@@ -238,6 +358,8 @@ describe("dialog-watchdog tmux backoff (#222)", () => {
         throw err;
       },
       sendKeys: () => {},
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
     });
 
     let cleanCalls = 0;
@@ -249,9 +371,11 @@ describe("dialog-watchdog tmux backoff (#222)", () => {
         return "no dialog\n";
       },
       sendKeys: () => {},
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
     });
 
-    await wait(SHORT_TICK_MS * 12);
+    await clock.advance(SHORT_TICK_MS * 12);
     throwing.stop();
     clean.stop();
 
@@ -262,6 +386,7 @@ describe("dialog-watchdog tmux backoff (#222)", () => {
   });
 
   test("a throwing capture never triggers a false auto-accept", async () => {
+    const clock = createVirtualClock();
     const accepts: DialogMatch[] = [];
     const watchdog = startDialogWatchdog({
       tmuxSessionName: "test-timeout-noaccept",
@@ -271,8 +396,10 @@ describe("dialog-watchdog tmux backoff (#222)", () => {
       },
       sendKeys: () => {},
       onAutoAccept: (m) => accepts.push(m),
+      setTimer: clock.setTimer,
+      clearTimer: clock.clearTimer,
     });
-    await wait(SHORT_TICK_MS * 4);
+    await clock.advance(SHORT_TICK_MS * 4);
     watchdog.stop();
     expect(accepts.length).toBe(0);
   });


### PR DESCRIPTION
## 概要

Epic #207（第2バッチ）の子 Issue #190。`dialog-watchdog.test.ts` の wall-clock タイミング flake を**仮想クロック注入**で決定的にし、CI unit-test gating に組み込む。

closes #190

## 背景

`supervisor/tests/session/dialog-watchdog.test.ts` は `SHORT_TICK_MS = 10ms` の実 `setTimeout` 待機（`await wait(SHORT_TICK_MS * N)`）で「N tick 経過」を期待していた。CI/開発機の負荷で tick が時間内に発火せず、期待した auto-accept / heartbeat が未発火のままアサートに到達して非決定的に fail していた（base branch でも約 5 回に 1 回 fail）。このため #153 では本テストを CI から除外していた。

## 変更点

1. **`startDialogWatchdog` に `setTimer` / `clearTimer` を注入可能化**（既存の `capture` / `sendKeys` と同じ DI スタイル）。
   - 本番は省略時に実 `setTimeout` / `clearTimeout` を使用 → **ランタイム挙動は完全に不変**。
   - `setTimer` は async tick 自体を受け取る設計。仮想クロックが tick 完了（`finally` の再スケジュールまで）を `await` できる。
2. **テストを仮想クロックで駆動**。`clock.advance(ms)` がスケジュール遅延を尊重し、仮想時間で due コールバックを時系列に実行。wall-clock 待機を全廃。
   - backoff テスト（#222）も「遅延を尊重した仮想時間」で再現（back off した watchdog は同じ窓で発火回数が少ない）。
3. **`ci.yml` の unit-test job に `dialog-watchdog.test.ts` を追加**。これに伴い、feedback-survey の「`0` を送り `1` を送らない」回帰テスト（#153）も CI で gating されるようになった（タスク3を同時達成）。

## 統合ジャーニーAC

不要（Issue 記載どおりテストインフラの内部改善でユーザーが踏むフローは変わらない）。決定的検証は CI で watchdog テストが安定 PASS することで担保。

## 検証

| 検証 | 結果 |
|---|---|
| `bun test dialog-watchdog.test.ts` | 14 pass / 0 fail（24ms） |
| **30 回連続実行** | **30 pass / 0 fail（決定的）** |
| `bunx tsc --noEmit` | PASS |
| 本番 caller `relay.ts:322` | 新 opts 未使用のため影響なし（typecheck PASS で確認） |
| CI 相当の deterministic subset 77 件 | 77 pass / 0 fail |

## 関連

- Epic #207（第2バッチ）/ #153（feedback-survey 検出の親）/ #57（dialog detection 親）/ #222（backoff）
- agent-base RW-028 教訓: flaky と命名してスキップする前に決定的再現を試みる


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * テストを仮想クロックベースのタイマー駆動へ移行し、決定性と安定性を強化しました（フレークを削減）。
  * ウォッチドッグ周りの振る舞いを網羅する追加テストをカバレッジ対象に含め、回帰検出を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->