### PR TITLE
fix(#74): send-keys 失敗時に生 tmux エラーを Discord へ転送せずクリーン通知に置換

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
                    tests/infra/db.test.ts \
                    tests/session/dialog-detect.test.ts \
                    tests/session/dialog-watchdog.test.ts \
+                   tests/session/relay-send-failure.test.ts \
                    tests/session/notify-pushover.test.ts \
                    tests/session/dialog-stuck-handler.test.ts \
                    tests/session/stall-heartbeat.test.ts \

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -233,6 +233,34 @@ export interface RelayMessageOptions {
   onDialogStuck?: (info: DialogStuckInfo) => void | Promise<void>;
 }
 
+/**
+ * Issue #74: user-facing notice when relaying a message to the tmux pane fails
+ * outright (i.e. after the in-call retry in {@link tmuxSend}). The raw failure
+ * is typically a copy-mode `not in a mode` or an ETIMEDOUT under tmux load
+ * (Issue #73 / RW-019). Previously the catch path interpolated `${err}` — the
+ * raw `tmux send-keys ...` command line plus the bare `not in a mode` string —
+ * straight into a Discord chunk, so the thread showed bogus "responses" (the
+ * #74 screenshot: `not in a mode` posted 5×). This message is deliberately
+ * free of tmux internals; the raw cause is preserved in logs + `RelayResult.error`.
+ */
+export const SEND_FAILURE_USER_MESSAGE =
+  "⚠️ メッセージを Claude Code セッションに送信できませんでした（セッションが応答不能、または画面が一時的に固まっている可能性があります）。少し待って再送するか、`/session restart` で再開してください。";
+
+/**
+ * Build the {@link RelayResult} for a send-keys failure. Pure + exported so a
+ * unit test can lock that raw tmux internals never reach the user-facing chunk
+ * while the diagnostic cause is still carried in `error` (Issue #74). By the
+ * time this fires, {@link tmuxSend} has already retried once after exiting any
+ * stuck copy-mode (Issue #73 / RW-019), so the failure is non-transient.
+ */
+export function buildSendFailureResult(err: unknown): RelayResult {
+  return {
+    text: "",
+    chunks: [SEND_FAILURE_USER_MESSAGE],
+    error: String(err),
+  };
+}
+
 export async function relayMessage(
   tmuxSessionName: string,
   threadId: string,
@@ -286,11 +314,15 @@ export async function relayMessage(
     tracker.markEnd("b");
     tracker.setError("b");
     tracker.flush();
-    return {
-      text: "",
-      chunks: [`⚠️ Claude Code へのメッセージ送信に失敗: ${err}`],
-      error: String(err),
-    };
+    // Issue #74: keep the raw tmux cause in logs + `RelayResult.error`, but
+    // NEVER forward it into the Discord chunk (it would surface as a bogus
+    // `not in a mode` "response"). buildSendFailureResult returns a clean,
+    // actionable notice instead.
+    console.error(
+      `[Relay] sendToPane failed for ${tmuxSessionName}:`,
+      summarizeExecError(err)
+    );
+    return buildSendFailureResult(err);
   }
 
   // Segment (c): tmux send 完了 → waitForRelay 開始までの隙間 (大体ゼロ、

--- a/supervisor/tests/session/relay-send-failure.test.ts
+++ b/supervisor/tests/session/relay-send-failure.test.ts
@@ -1,0 +1,68 @@
+import { test, expect, describe } from "bun:test";
+import {
+  buildSendFailureResult,
+  SEND_FAILURE_USER_MESSAGE,
+} from "../../src/session/relay";
+
+/**
+ * Issue #74: "Session stop 後なのにメッセージが来てる".
+ *
+ * Confirmed root cause (see issue's 再現手順): when `sendToPane` fails — pane
+ * stuck in copy-mode → tmux returns `not in a mode`, or ETIMEDOUT under load
+ * (Issue #73 / RW-019) — the relay catch path used to interpolate `${err}`
+ * straight into a Discord chunk. The raw `tmux send-keys ...` command line and
+ * the bare `not in a mode` string were posted to the thread as if they were
+ * Claude's reply (screenshot in #74: `not in a mode` ×5).
+ *
+ * These tests are pure (no tmux) and lock the contract: a send failure yields a
+ * clean, actionable user notice with NO raw tmux internals, while the raw cause
+ * is still preserved in `RelayResult.error` for diagnostics/logs.
+ */
+describe("relay send-keys failure does not leak tmux internals (#74)", () => {
+  // The exact error string observed in supervisor.stdout.log for the #74 thread.
+  const rawErr = new Error(
+    "Command failed: /opt/homebrew/bin/tmux send-keys -t claude-149565894251 -l Skill...\nnot in a mode"
+  );
+
+  test("user-facing chunk contains no raw tmux internals", () => {
+    const result = buildSendFailureResult(rawErr);
+    expect(result.chunks).toHaveLength(1);
+    const chunk = result.chunks[0]!;
+    // The exact symptom from the #74 screenshot must never reach Discord.
+    expect(chunk).not.toMatch(/not in a mode/i);
+    expect(chunk).not.toMatch(/send-keys/i);
+    expect(chunk).not.toMatch(/Command failed/i);
+    expect(chunk).not.toMatch(/tmux/i);
+    expect(chunk).toBe(SEND_FAILURE_USER_MESSAGE);
+  });
+
+  test("raw cause is preserved in error for diagnostics", () => {
+    const result = buildSendFailureResult(rawErr);
+    expect(result.error).toContain("not in a mode");
+    expect(result.error).toContain("send-keys");
+    expect(result.text).toBe("");
+  });
+
+  test("the canned message is clean and actionable", () => {
+    expect(SEND_FAILURE_USER_MESSAGE).not.toMatch(/not in a mode|tmux|send-keys/i);
+    // Actionable: tells the user how to recover.
+    expect(SEND_FAILURE_USER_MESSAGE).toContain("/session restart");
+  });
+
+  test("handles non-Error throwables without leaking", () => {
+    // execFileSync can throw objects whose String() still embeds the command.
+    const weird = { toString: () => "tmux send-keys ... not in a mode" };
+    const result = buildSendFailureResult(weird);
+    expect(result.chunks[0]).toBe(SEND_FAILURE_USER_MESSAGE);
+    expect(result.chunks[0]).not.toMatch(/not in a mode/i);
+    expect(result.error).toContain("not in a mode"); // still captured for logs
+  });
+
+  test("handles a bare string throwable without leaking", () => {
+    // Defensive: a `throw "raw tmux string"` must also be sanitized.
+    const result = buildSendFailureResult("tmux send-keys -t x not in a mode");
+    expect(result.chunks[0]).toBe(SEND_FAILURE_USER_MESSAGE);
+    expect(result.chunks[0]).not.toMatch(/not in a mode|tmux|send-keys/i);
+    expect(result.error).toContain("not in a mode");
+  });
+});

--- a/supervisor/tests/session/relay.test.ts
+++ b/supervisor/tests/session/relay.test.ts
@@ -244,3 +244,31 @@ describe("tmuxSend integration (Issue #73 / AC-7)", () => {
     }
   });
 });
+
+// Issue #74: integration coverage for the send-failure catch in relayMessage.
+// The pure-function unit test (relay-send-failure.test.ts) locks
+// buildSendFailureResult; this exercises the real production path where
+// sendToPane throws (here: a nonexistent tmux session → "can't find session"),
+// proving the raw tmux error never reaches the returned chunk.
+describe("relayMessage send failure (#74)", () => {
+  itmux(
+    "returns a clean notice with no raw tmux internals when send-keys fails",
+    async () => {
+      const relay = await import("../../src/session/relay");
+      const result = await relay.relayMessage(
+        `relay-test-missing-${process.pid}-${Date.now()}`,
+        "thread-irrelevant",
+        "hello"
+      );
+      expect(result.chunks).toHaveLength(1);
+      expect(result.chunks[0]).toBe(relay.SEND_FAILURE_USER_MESSAGE);
+      // The screenshot symptom / raw tmux strings must never reach Discord.
+      expect(result.chunks[0]).not.toMatch(/not in a mode/i);
+      expect(result.chunks[0]).not.toMatch(/can't find (session|pane)/i);
+      expect(result.chunks[0]).not.toMatch(/send-keys|tmux/i);
+      // Raw cause is still preserved for diagnostics.
+      expect(result.error).toBeTruthy();
+      expect(result.text).toBe("");
+    }
+  );
+});


### PR DESCRIPTION
## 概要

Epic #207 の子 Issue #74（P1 bug）。「Session stop 後なのにメッセージが来てる」の確定根本原因を修正する。

closes #74

## 確定根本原因（再現手順で実証済み）

当初の観測「停止後に応答が来る」の実体は、**relay の `send-keys` 失敗時に生 tmux エラーがそのまま Discord に転送される**こと:

- pane が copy-mode（`WheelUpPane` 自動遷移, Issue #73 / RW-019）→ tmux が `not in a mode` を返す、または高負荷で ETIMEDOUT
- `tmuxSend` の 1 回リトライも失敗すると `relayMessage` の catch が `${err}`（`tmux send-keys ...` コマンド列 + `not in a mode`）をそのまま chunk として返す
- `bot.ts` がその chunk を Claude の応答であるかのようにスレッドへ送信

本番ログ `supervisor.stdout.log` に、Issue 添付スクショと**同一スレッド** `1495658942511059004` での発生（`not in a mode` 転送）を確認。隔離 tmux socket で `send-keys -X cancel`（非モード pane）→ exit 1 + `not in a mode` を再現率100%で再現（詳細は #74 の「## 再現手順」）。

## 変更点

| ファイル | 変更 |
|---|---|
| `supervisor/src/session/relay.ts` | send 失敗 catch を新規 pure 関数 `buildSendFailureResult(err)` 経由に。ユーザー向けは生 tmux 内部を含まない定型文 `SEND_FAILURE_USER_MESSAGE`（再送 / `/session restart` を案内）。生原因は `console.error` + `RelayResult.error` に保持（診断性維持） |
| `supervisor/tests/session/relay-send-failure.test.ts` | 決定的 unit test（tmux 不要）。`not in a mode` / `tmux` / `send-keys` / `Command failed` が chunk に漏れないこと、生原因は `error` に残ること、非 Error/文字列 throwable も漏れないことを固定 |
| `.github/workflows/ci.yml` | unit-test job に上記テストを追加（gating） |

## AC 検証

| AC | 内容 | 検証 | 結果 |
|---|---|---|---|
| AC-1 | send 失敗時 chunk に生 tmux 内部が漏れない | `relay-send-failure.test.ts` | ✅ 5 pass |
| AC-2 | 正常系（送信成功）に回帰なし | `relay.test.ts` | ✅ 15 pass |
| AC-3 | 生原因は log + `RelayResult.error` に保持 | `relay-send-failure.test.ts` | ✅ pass |
| typecheck | `bunx tsc --noEmit` | — | ✅ PASS |

## レビュー対応

code-review-orchestrator 実施。must 指摘なし。

- should（別経路の生エラー漏洩 `bot.ts` 外側 catch）→ **follow-up #236** を起票（本 PR スコープ外。send-keys 失敗は throw しなくなったため #74 シナリオでは到達しないが、`waitForRelay`/`downloadAttachment` 等の throw で到達しうる別経路）
- nit（文字列 throwable test 追加 / JSDoc に RW-019 クロスリンク）→ 本 PR で対応済み

## スコープ外（参考）

copy-mode 遷移自体の頻度低減（送信失敗の発生源）は Issue #73 / RW-019 系列。本 PR は「失敗時に生エラーをユーザーへ漏らさない」境界の修正に絞る（KISS）。

## 関連

- Epic #207 / #73 / RW-019 / follow-up #236


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Relay send failures now display consistent, user-friendly error messages instead of exposing internal system details to users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->