### PR TITLE
fix(#238): hasSession の tmux ETIMEDOUT を終了と誤判定せず生存とみなす

### DIFF
--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -165,7 +165,15 @@ export const realTmuxAdapter: TmuxAdapter = {
       });
       return true;
     } catch (err) {
-      warnIfTmuxTimeout("has-session", name, err);
+      // Issue #238: a tmux *timeout* (ETIMEDOUT) under server contention is NOT
+      // proof the session exited — it means liveness is undeterminable. This is
+      // a liveness gate (watchTmuxSession tears the session down when false), so
+      // a false "exited" orphans the user's live work. Treat "unknown" as "still
+      // alive". A genuine "no such session" surfaces as a non-timeout error and
+      // still returns false, so real exits are detected as before.
+      if (warnIfTmuxTimeout("has-session", name, err)) {
+        return true;
+      }
       return false;
     }
   },

--- a/supervisor/tests/session/adapters-hassession.test.ts
+++ b/supervisor/tests/session/adapters-hassession.test.ts
@@ -1,0 +1,91 @@
+import {
+  describe,
+  test,
+  expect,
+  mock,
+  spyOn,
+  beforeEach,
+  afterEach,
+} from "bun:test";
+
+/**
+ * Issue #238: `realTmuxAdapter.hasSession()` must NOT treat a tmux *timeout*
+ * (ETIMEDOUT) as "session exited".
+ *
+ * Under tmux-server contention (Issue #222 symptom) `has-session` can time out
+ * at TMUX_CALL_TIMEOUT_MS even though the session is alive. The previous catch
+ * discarded `warnIfTmuxTimeout`'s return value and always returned `false`, so
+ * `watchTmuxSession` (manager.ts) tore down a live session and orphaned the
+ * user's work ("started then immediately exited"). A timeout means "liveness
+ * unknown" — for a teardown gate we must assume alive (return true). A genuine
+ * "no such session" surfaces as a non-timeout error and must still return false.
+ *
+ * We mock child_process.execFileSync (same approach as tmux.test.ts).
+ */
+
+import * as childProcess from "child_process";
+
+let mockExecFileSyncImpl: (...args: unknown[]) => string = () => "";
+const mockExecFileSync = mock((...args: unknown[]) =>
+  mockExecFileSyncImpl(...args)
+);
+
+// Preserve the rest of child_process (relay-server / iterm2 in adapters.ts's
+// import graph use `spawn`) and override only execFileSync.
+mock.module("child_process", () => ({
+  ...childProcess,
+  execFileSync: mockExecFileSync,
+}));
+
+const { realTmuxAdapter } = await import("../../src/session/adapters");
+
+function makeTimeoutError(): NodeJS.ErrnoException {
+  const err = new Error(
+    "spawnSync /opt/homebrew/bin/tmux ETIMEDOUT"
+  ) as NodeJS.ErrnoException;
+  err.code = "ETIMEDOUT";
+  return err;
+}
+
+describe("realTmuxAdapter.hasSession ETIMEDOUT handling (#238)", () => {
+  let warnSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    mockExecFileSyncImpl = () => "";
+    mockExecFileSync.mockClear();
+    warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    warnSpy.mockRestore();
+  });
+
+  test("returns true (assume alive) when has-session times out (ETIMEDOUT)", () => {
+    mockExecFileSyncImpl = () => {
+      throw makeTimeoutError();
+    };
+
+    // Regression: a transient 2s timeout must NOT be read as an exit, otherwise
+    // watchTmuxSession tears down a live session.
+    expect(realTmuxAdapter.hasSession("claude-151520552301")).toBe(true);
+    // Observability (#222): the timeout is still surfaced via console.warn.
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns false when the session genuinely does not exist (non-timeout error)", () => {
+    mockExecFileSyncImpl = () => {
+      throw new Error("can't find session: claude-dead");
+    };
+
+    expect(realTmuxAdapter.hasSession("claude-dead")).toBe(false);
+    // A real "no session" is not a timeout, so no timeout warning.
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("returns true when has-session succeeds (session present)", () => {
+    mockExecFileSyncImpl = () => "";
+
+    expect(realTmuxAdapter.hasSession("claude-alive")).toBe(true);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要

Supervisor が **生存中の Claude Code セッションを「終了」と誤判定**し、以後そのスレッドのメッセージを `no active session` で無視する不具合（#238）を修正する。dispatch したセッションが「始まった瞬間に終わった」ように見える症状の真因。

## 根本原因

`supervisor/src/session/adapters.ts` の `realTmuxAdapter.hasSession()` が、`warnIfTmuxTimeout` の戻り値（ETIMEDOUT 判定, #222 由来）を捨てて常に `false` を返していた。tmux サーバ高負荷で `has-session` が 2 秒タイムアウトすると、`watchTmuxSession` が生存中のセッションを `tmux_exited` と誤判定して teardown → `no active session`。

## 変更点

- `hasSession()` の catch で、ETIMEDOUT のとき `false` ではなく `true`（生存と仮定）を返す。タイムアウトは「終了の証拠」ではなく「生存判定不能」であり、teardown ゲートでは生存とみなすのが安全（live セッションの誤切断・ユーザー作業の orphan 化を防ぐ）。
- 非タイムアウトエラー（実際にセッションが無い場合）は従来どおり `false` を返すため、本物の終了検知は維持。
- 回帰テスト `supervisor/tests/session/adapters-hassession.test.ts`（3 ケース）を同梱。

## テスト

- `bun test tests/session/adapters-hassession.test.ts` → 3 pass / 0 fail
- `bunx tsc --noEmit` → exit 0

## 統合ジャーニーAC

Issue #238 本文の通り。ETIMEDOUT 時に生存維持・中継継続、実セッション終了時は従来どおり `tmux_exited` 検知。

Closes #238
