### PR TITLE
fix(#183): AppleScript文字列補間をescape choke pointに集約しinjection防止

### DIFF
--- a/supervisor/src/session/iterm2.test.ts
+++ b/supervisor/src/session/iterm2.test.ts
@@ -1,0 +1,84 @@
+import { test, expect, describe } from "bun:test";
+import {
+  escapeAppleScriptString,
+  buildOpenTabAppleScript,
+  buildMarkTabStoppedAppleScript,
+} from "./iterm2";
+
+// Issue #183: values interpolated into AppleScript double-quoted string
+// literals (tabTitle / tmuxSessionName / tabName / newName) were not escaped.
+// A value containing `"` could terminate the literal early and inject
+// arbitrary AppleScript (RW-045 same family: untrusted input → exec string).
+
+describe("escapeAppleScriptString (choke point, AC-1)", () => {
+  test("escapes a double quote to \\\"", () => {
+    expect(escapeAppleScriptString('a"b')).toBe('a\\"b');
+  });
+
+  test("escapes a backslash to \\\\", () => {
+    expect(escapeAppleScriptString("a\\b")).toBe("a\\\\b");
+  });
+
+  test("escapes backslash before quote (order matters)", () => {
+    // Input `\"` must become `\\\"` (escaped backslash THEN escaped quote).
+    // If the quote were escaped first, the result `\\"` would leave a
+    // literal-terminating quote behind.
+    expect(escapeAppleScriptString('\\"')).toBe('\\\\\\"');
+  });
+
+  test("leaves a normal channel name unchanged", () => {
+    expect(escapeAppleScriptString("team-salary (running)")).toBe(
+      "team-salary (running)"
+    );
+  });
+});
+
+describe("buildOpenTabAppleScript injection safety (AC-2)", () => {
+  test("a tmuxSessionName containing a double quote stays a literal", () => {
+    const malicious = 'claude-x" \n end tell \n do shell script "touch /tmp/pwned';
+    const script = buildOpenTabAppleScript(malicious, "chan (running)", 1, 2, 3);
+    // The write-text line must embed the escaped form, not a bare quote that
+    // closes the `write text "..."` literal early.
+    expect(script).toContain('\\"'); // an escaped quote is present
+    // The raw injected statement (with surrounding quotes) must NOT appear.
+    expect(script).not.toContain('do shell script "touch /tmp/pwned"');
+  });
+
+  test("a tabTitle containing a double quote is escaped in the set-name line", () => {
+    const evil = 'x" then beep "';
+    const script = buildOpenTabAppleScript("claude-1", `${evil} (running)`, 1, 2, 3);
+    expect(script).toContain(`set name to "${escapeAppleScriptString(`${evil} (running)`)}"`);
+    // Raw, unescaped injection is absent.
+    expect(script).not.toMatch(/set name to "x" then beep/);
+  });
+
+  test("a benign session/title produces a script equal to the escaped form", () => {
+    const script = buildOpenTabAppleScript("claude-12", "team (running)", 10, 20, 30);
+    expect(script).toContain('set name to "team (running)"');
+    expect(script).toContain("set background color to {10, 20, 30}");
+  });
+});
+
+describe("buildMarkTabStoppedAppleScript injection safety (AC-2)", () => {
+  test("a tabName containing a double quote cannot break the comparison literal", () => {
+    const evil = 'x" then beep "';
+    const script = buildMarkTabStoppedAppleScript(
+      `${evil} (running)`,
+      `${evil} (stopped)`
+    );
+    expect(script).toContain(
+      `is "${escapeAppleScriptString(`${evil} (running)`)}"`
+    );
+    // Before escaping this would read `is "x" then beep ...` (raw injection).
+    expect(script).not.toMatch(/is "x" then beep/);
+  });
+
+  test("a benign channel name renders the normal comparison", () => {
+    const script = buildMarkTabStoppedAppleScript(
+      "agent-base (running)",
+      "agent-base (stopped)"
+    );
+    expect(script).toContain('is "agent-base (running)"');
+    expect(script).toContain('set name to "agent-base (stopped)"');
+  });
+});

--- a/supervisor/src/session/iterm2.ts
+++ b/supervisor/src/session/iterm2.ts
@@ -96,6 +96,77 @@ export function dimColor(hexColor: string): string {
   return `#${dr.toString(16).padStart(2, "0")}${dg.toString(16).padStart(2, "0")}${db.toString(16).padStart(2, "0")}`;
 }
 
+/**
+ * Escape a value for safe interpolation into an AppleScript double-quoted
+ * string literal. AppleScript uses backslash as the in-literal escape
+ * character, so backslash must be escaped before the double quote — otherwise
+ * a value containing `"` could terminate the literal early and inject
+ * arbitrary AppleScript (Issue #183; same family as RW-045: untrusted input →
+ * exec string). This is the single choke point for every value placed inside
+ * an osascript `-e` string literal in this module.
+ */
+export function escapeAppleScriptString(value: string): string {
+  return value.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+}
+
+/**
+ * Build the AppleScript that opens a new iTerm2 tab and attaches to the tmux
+ * session. `tmuxSessionName` and `tabTitle` are escaped at the choke point so
+ * channel/session names cannot break out of the string literals (Issue #183).
+ */
+export function buildOpenTabAppleScript(
+  tmuxSessionName: string,
+  tabTitle: string,
+  r: number,
+  g: number,
+  b: number
+): string {
+  const attachCmd = escapeAppleScriptString(
+    `${TMUX_CMD} attach -t ${tmuxSessionName}`
+  );
+  const title = escapeAppleScriptString(tabTitle);
+  return [
+    'tell application "iTerm2"',
+    "  tell current window",
+    "    create tab with default profile",
+    "    tell current session",
+    `      write text "${attachCmd}"`,
+    `      set name to "${title}"`,
+    `      set background color to {${r}, ${g}, ${b}}`,
+    "    end tell",
+    "  end tell",
+    "end tell",
+  ].join("\n");
+}
+
+/**
+ * Build the AppleScript that renames an iTerm2 tab from its "(running)" title
+ * to "(stopped)". Both the comparison and the new name are escaped at the
+ * choke point so channel names cannot break out of the literals (Issue #183).
+ */
+export function buildMarkTabStoppedAppleScript(
+  tabName: string,
+  newName: string
+): string {
+  const escTab = escapeAppleScriptString(tabName);
+  const escNew = escapeAppleScriptString(newName);
+  return [
+    'tell application "iTerm2"',
+    "  repeat with w in windows",
+    "    repeat with t in tabs of w",
+    "      try",
+    `        if name of current session of t is "${escTab}" then`,
+    "          tell current session of t",
+    `            set name to "${escNew}"`,
+    "          end tell",
+    "        end if",
+    "      end try",
+    "    end repeat",
+    "  end repeat",
+    "end tell",
+  ].join("\n");
+}
+
 export interface OpenTabOptions {
   tmuxSessionName: string;
   channelName: string;
@@ -151,18 +222,17 @@ export function openTab(opts: OpenTabOptions): void {
   // documented in Issue #73. With Supervisor's dedicated socket (mouse off
   // + mode-keys emacs) the accidental-input risk is already mitigated, so
   // we no longer enter copy-mode on attach.
-  const script = [
-    'tell application "iTerm2"',
-    "  tell current window",
-    "    create tab with default profile",
-    "    tell current session",
-    `      write text "${TMUX_CMD} attach -t ${opts.tmuxSessionName}"`,
-    `      set name to "${tabTitle}"`,
-    `      set background color to {${r}, ${g}, ${b}}`,
-    "    end tell",
-    "  end tell",
-    "end tell",
-  ].join("\n");
+  //
+  // Issue #183: tmuxSessionName / tabTitle are escaped at the
+  // escapeAppleScriptString choke point inside buildOpenTabAppleScript so a
+  // value containing `"` cannot break out of the AppleScript string literals.
+  const script = buildOpenTabAppleScript(
+    opts.tmuxSessionName,
+    tabTitle,
+    r,
+    g,
+    b
+  );
 
   try {
     // argv form (no shell): the AppleScript is passed as a single -e argument,
@@ -199,22 +269,11 @@ export function markTabStopped(channelName: string, tmuxSessionName?: string): v
     return;
   }
 
-  // Also update iTerm2 tab name via AppleScript (fire-and-forget, non-blocking)
-  const script = [
-    'tell application "iTerm2"',
-    "  repeat with w in windows",
-    "    repeat with t in tabs of w",
-    "      try",
-    `        if name of current session of t is "${tabName}" then`,
-    "          tell current session of t",
-    `            set name to "${newName}"`,
-    "          end tell",
-    "        end if",
-    "      end try",
-    "    end repeat",
-    "  end repeat",
-    "end tell",
-  ].join("\n");
+  // Also update iTerm2 tab name via AppleScript (fire-and-forget, non-blocking).
+  // Issue #183: tabName / newName are escaped at the escapeAppleScriptString
+  // choke point inside buildMarkTabStoppedAppleScript so a channelName
+  // containing `"` cannot break out of the AppleScript string literals.
+  const script = buildMarkTabStoppedAppleScript(tabName, newName);
 
   const osascriptProc = spawn("osascript", ["-e", script], {
     stdio: "ignore",


### PR DESCRIPTION
## 概要

Issue #183（#97 follow-up）。`supervisor/src/session/iterm2.ts` の `openTab` / `markTabStopped` が AppleScript のダブルクオート文字列リテラルに値を**未エスケープ補間**していた経路を、エスケープ choke point に集約して injection を防止する。

`#97` で解消したのは**シェル層**（`execFileSync`/`spawn` の argv 化）であり、`osascript -e <script>` に渡す **AppleScript ソース文字列の構築**は別レイヤーで残課題だった。値に `"` が含まれると AppleScript 文字列リテラルを抜け、任意 AppleScript 実行につながりうる（RW-045 と同系列の境界予防修繕）。

## 主な変更

- `escapeAppleScriptString(value)` を新設（choke point）。AppleScript は literal 内でバックスラッシュがエスケープ文字のため、**バックスラッシュ → ダブルクオートの順**でエスケープ。
- スクリプト構築を純粋関数 `buildOpenTabAppleScript` / `buildMarkTabStoppedAppleScript` に切り出してテスト可能化。補間値（`tabTitle` / `tmuxSessionName` / `tabName` / `newName`）をすべて choke point 経由に変更。
- `openTab` / `markTabStopped` をビルダー利用へリファクタ（挙動は不変）。

## 受入基準

| AC | 内容 | 結果 |
|---|---|---|
| AC-1 | AppleScript 補間値を choke point でエスケープ | PASS |
| AC-2 | `"` を含む channelName/sessionName で injection されない回帰テスト追加 | PASS（`iterm2.test.ts` 9 件） |
| AC-3 | bun test PASS | iterm2 suite 9/9 PASS、`tsc --noEmit` / lint-blocking-in-timers PASS |

## 統合ジャーニーAC

1. `"` / `\` を含む値が `openTab` / `markTabStopped` に渡っても、choke point でリテラルとしてエスケープされ任意実行が発生しない → AC-2 回帰テスト PASS。
2. 通常の `channelName`（`CHANNEL_MAP` 静的キー）でタブ起動・rename が回帰なく動作 → ビルダーは benign 入力で従来と同一スクリプトを生成（テストで assert）。

## テスト

```
bun test src/session/iterm2.test.ts  # 9 pass / 0 fail
bunx tsc --noEmit                     # exit 0
bun scripts/lint-blocking-in-timers.ts # PASS
```

注: 全体 `bun test` の他 7 失敗（tmux/copy-mode 統合・relay timeout・既存 SQL DDL guard）は本変更前から main で発生する環境依存の既存失敗で、本 PR とは無関係。

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * AppleScript生成機能の文字列処理を改善しました。

* **Tests**
  * AppleScript生成機能に対する包括的なテストカバレッジを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->