### PR TITLE
feat(#158): worktree再利用時に登録worktree+branch一致を検証しsilent reuse防止

### DIFF
--- a/supervisor/src/session/worktree.ts
+++ b/supervisor/src/session/worktree.ts
@@ -1,5 +1,5 @@
 import { execFileSync } from "child_process";
-import { existsSync } from "fs";
+import { existsSync, realpathSync } from "fs";
 import { resolve, sep } from "path";
 
 /**
@@ -29,6 +29,20 @@ import { resolve, sep } from "path";
 /** Subdirectory (relative to the main repo) that holds per-branch worktrees. */
 export const WORKTREE_SUBDIR = ".claude/worktrees";
 
+/**
+ * Result of inspecting an on-disk path for Q4 reuse (Issue #158).
+ *
+ *   - `{ registered: false }`  the path exists but is NOT a path registered in
+ *     `git worktree list` — i.e. residue from an interrupted `git worktree
+ *     remove`, or a manually-created directory. Reusing it would run claude in
+ *     a non-worktree dir (silent failure).
+ *   - `{ registered: true, branch }`  the path is a registered worktree;
+ *     `branch` is the checked-out local branch, or `null` for a detached HEAD.
+ */
+export type WorktreeStatus =
+  | { registered: false }
+  | { registered: true; branch: string | null };
+
 export interface GitGhRunner {
   /** True if `branch` is an existing *local branch* in the repo at `mainRepoDir`. */
   branchExists(mainRepoDir: string, branch: string): boolean;
@@ -51,6 +65,12 @@ export interface GitGhRunner {
   removeWorktree(mainRepoDir: string, worktreePath: string): void;
   /** Filesystem existence check for the worktree path (Q4 reuse). */
   pathExists(path: string): boolean;
+  /**
+   * Inspect whether `worktreePath` is a *registered* git worktree and, if so,
+   * which branch it has checked out (Issue #158). Used to validate Q4 reuse
+   * instead of trusting a bare directory existence check.
+   */
+  worktreeStatus(mainRepoDir: string, worktreePath: string): WorktreeStatus;
 }
 
 export interface EnsureWorktreeResult {
@@ -118,8 +138,24 @@ export function ensureWorktree(
   }
   const worktreePath = resolveWorktreePath(mainRepoDir, trimmed);
 
-  // Q4: existing worktree → reuse.
+  // Q4: existing worktree → reuse, but only after validating it is a real
+  // worktree on the expected branch (Issue #158). A bare existence check would
+  // happily reuse an interrupted-`worktree remove` residue or a manually
+  // created directory, running claude in a non-worktree / wrong-branch cwd —
+  // a silent failure. Reject those explicitly instead.
   if (runner.pathExists(worktreePath)) {
+    const status = runner.worktreeStatus(mainRepoDir, worktreePath);
+    if (!status.registered) {
+      throw new Error(
+        `worktree 再利用先がディレクトリとして存在しますが有効な git worktree ではありません（中断した worktree remove の残骸 / 手動作成の可能性）: ${worktreePath}。手動で削除してから再実行してください。`,
+      );
+    }
+    if (status.branch !== trimmed) {
+      const actual = status.branch ?? "(detached HEAD)";
+      throw new Error(
+        `worktree 再利用先が期待 branch '${trimmed}' と一致しません（実際: '${actual}'）: ${worktreePath}。手動で確認・修正してから再実行してください。`,
+      );
+    }
     return { path: worktreePath, reused: true };
   }
 
@@ -292,4 +328,58 @@ export const realGitGhRunner: GitGhRunner = {
   pathExists(path) {
     return existsSync(path);
   },
+  worktreeStatus(mainRepoDir, worktreePath) {
+    // Parse `git worktree list --porcelain`. Each worktree is a block of
+    // newline-separated attribute lines, blocks separated by a blank line:
+    //   worktree /abs/path
+    //   HEAD <sha>
+    //   branch refs/heads/<name>     (omitted / replaced by `detached`)
+    // A path present on disk but absent from this listing is not a registered
+    // worktree (Issue #158: residue / manual dir).
+    let out: string;
+    try {
+      out = execFileSync(
+        "git",
+        ["-C", mainRepoDir, "worktree", "list", "--porcelain"],
+        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
+      ).toString();
+    } catch {
+      // Not a git repo / git unavailable → treat as unregistered (caller errors).
+      return { registered: false };
+    }
+
+    const target = realpathOrResolve(worktreePath);
+    for (const block of out.split(/\n\s*\n/)) {
+      const lines = block.split("\n");
+      const wtLine = lines.find((l) => l.startsWith("worktree "));
+      if (!wtLine) continue;
+      const wtPath = realpathOrResolve(wtLine.slice("worktree ".length).trim());
+      if (wtPath !== target) continue;
+
+      const branchLine = lines.find((l) => l.startsWith("branch "));
+      if (branchLine) {
+        const ref = branchLine.slice("branch ".length).trim();
+        const branch = ref.startsWith("refs/heads/")
+          ? ref.slice("refs/heads/".length)
+          : ref;
+        return { registered: true, branch };
+      }
+      // No `branch` line (`detached` present, or bare HEAD): no checked-out branch.
+      return { registered: true, branch: null };
+    }
+    return { registered: false };
+  },
 };
+
+/**
+ * Normalize a path for comparison against `git worktree list` output, which
+ * records canonical (symlink-resolved) absolute paths. Falls back to `resolve`
+ * when the path cannot be realpath'd (e.g. it no longer exists).
+ */
+function realpathOrResolve(p: string): string {
+  try {
+    return realpathSync(resolve(p));
+  } catch {
+    return resolve(p);
+  }
+}

--- a/supervisor/tests/session/worktree.test.ts
+++ b/supervisor/tests/session/worktree.test.ts
@@ -7,6 +7,7 @@ import {
   resolveWorktreePath,
   WORKTREE_SUBDIR,
   type GitGhRunner,
+  type WorktreeStatus,
 } from "../../src/session/worktree";
 
 /**
@@ -21,6 +22,10 @@ import {
 class FakeRunner implements GitGhRunner {
   existing = new Set<string>(); // worktree paths that already exist (Q4)
   branches = new Set<string>(); // refs that resolve (Q1)
+  // Q4 validation (#158): path → registered-worktree status. Defaults to
+  // "not a registered worktree" (residue) when a path exists on disk but was
+  // not created by the fake's add* methods.
+  statuses = new Map<string, WorktreeStatus>();
   defaultBranchName = "main";
   calls: string[] = [];
 
@@ -35,6 +40,8 @@ class FakeRunner implements GitGhRunner {
   addWorktreeFromBranch(_dir: string, path: string, branch: string): void {
     this.calls.push(`addFromBranch:${branch}`);
     this.existing.add(path);
+    // Creating a worktree registers it on `branch` (models real git).
+    this.statuses.set(path, { registered: true, branch });
   }
   addWorktreeNewBranch(
     _dir: string,
@@ -44,13 +51,19 @@ class FakeRunner implements GitGhRunner {
   ): void {
     this.calls.push(`addNewBranch:${branch}:${base}`);
     this.existing.add(path);
+    this.statuses.set(path, { registered: true, branch });
   }
   removeWorktree(_dir: string, path: string): void {
     this.calls.push(`remove:${path}`);
     this.existing.delete(path);
+    this.statuses.delete(path);
   }
   pathExists(path: string): boolean {
     return this.existing.has(path);
+  }
+  worktreeStatus(_dir: string, path: string): WorktreeStatus {
+    this.calls.push(`worktreeStatus:${path}`);
+    return this.statuses.get(path) ?? { registered: false };
   }
 }
 
@@ -123,15 +136,62 @@ describe("ensureWorktree", () => {
     expect(runner.calls.some((c) => c.startsWith("addNewBranch"))).toBe(false);
   });
 
-  test("AC-3 / Q4: existing worktree → reuse, no git add", () => {
+  test("AC-3 / Q4: existing valid worktree on the expected branch → reuse, no git add", () => {
     const path = resolveWorktreePath(REPO, "feature-foo");
     runner.existing.add(path);
+    runner.statuses.set(path, { registered: true, branch: "feature-foo" });
 
     const result = ensureWorktree(REPO, "feature-foo", runner);
 
     expect(result.reused).toBe(true);
     expect(result.path).toBe(path);
     expect(runner.calls.some((c) => c.startsWith("add"))).toBe(false);
+    // Reuse is validated, not assumed (#158).
+    expect(runner.calls).toContain(`worktreeStatus:${path}`);
+  });
+
+  // --- #158: reuse must be validated, never silently assumed -------------
+
+  test("#158 AC-1: path exists but is NOT a registered worktree (residue) → explicit error, no silent reuse", () => {
+    const path = resolveWorktreePath(REPO, "feature-foo");
+    runner.existing.add(path); // dir present on disk...
+    // ...but no status entry → worktreeStatus reports {registered:false}.
+
+    expect(() => ensureWorktree(REPO, "feature-foo", runner)).toThrow(
+      /git worktree ではありません|残骸/,
+    );
+    // Must not fall through to creating/reusing.
+    expect(runner.calls.some((c) => c.startsWith("add"))).toBe(false);
+  });
+
+  test("#158 AC-1: path is a worktree but checked out on a DIFFERENT branch → explicit error", () => {
+    const path = resolveWorktreePath(REPO, "feature-foo");
+    runner.existing.add(path);
+    runner.statuses.set(path, { registered: true, branch: "some-other-branch" });
+
+    expect(() => ensureWorktree(REPO, "feature-foo", runner)).toThrow(
+      /branch.*一致|期待 branch/,
+    );
+    expect(runner.calls.some((c) => c.startsWith("add"))).toBe(false);
+  });
+
+  test("#158: a detached-HEAD worktree (no branch) → explicit error, not silent reuse", () => {
+    const path = resolveWorktreePath(REPO, "feature-foo");
+    runner.existing.add(path);
+    runner.statuses.set(path, { registered: true, branch: null });
+
+    expect(() => ensureWorktree(REPO, "feature-foo", runner)).toThrow();
+    expect(runner.calls.some((c) => c.startsWith("add"))).toBe(false);
+  });
+
+  test("#158 AC-2: valid worktree on the expected branch → reuse succeeds (no regression)", () => {
+    const path = resolveWorktreePath(REPO, "feat/foo-bar");
+    runner.existing.add(path);
+    runner.statuses.set(path, { registered: true, branch: "feat/foo-bar" });
+
+    const result = ensureWorktree(REPO, "feat/foo-bar", runner);
+    expect(result.reused).toBe(true);
+    expect(result.path).toBe(path);
   });
 
   test("is idempotent: second ensure of the same branch reuses", () => {


### PR DESCRIPTION
## 概要

Issue #158（PR #157 の gemini medium 指摘 follow-up）。`ensureWorktree` の Q4（既存 worktree 再利用）が **ディレクトリ存在チェック（`existsSync`）だけ**で判定していたため、`<projectDir>/.claude/worktrees/<branch>/` に「ディレクトリは存在するが有効な git worktree ではない」残骸（中断した `git worktree remove` の残骸 / 手動作成）があると reuse を真と誤判定し、branch 不一致・非 worktree の cwd で claude を起動する **silent failure** になりえた。

## 主な変更

- `GitGhRunner` に `worktreeStatus(mainRepoDir, worktreePath): WorktreeStatus` を追加。実装は `git worktree list --porcelain` を解析し、パスが登録済み worktree か、checkout 中の branch を返す（detached HEAD は `branch: null`）。
- `ensureWorktree` の Q4 で、reuse 前に **(1) 登録済み worktree か (2) checkout 中 branch が期待値と一致するか** を検証。非 worktree / branch 不一致 / detached HEAD は明示エラーにして再利用を拒否（silent reuse=0）。失敗は既存設計どおり `launchStart` 経由でスレッドへ伝播。
- 実パス比較は `realpathSync` で symlink 正規化（macOS の `/var`→`/private/var` 等、porcelain の canonical path と一致させる）。
- `FakeRunner` に `worktreeStatus` を実装（add 時に status 登録 / remove 時に削除）。

## 受入基準（journey AC）

| シナリオ | 検証 | 結果 |
|---|---|---|
| 非 worktree 残骸を指定 → 明示エラー（silent reuse=0） | Fake で status 未登録ケース | PASS |
| branch 不一致の worktree → 明示エラー | Fake で別 branch | PASS |
| detached HEAD → 明示エラー | Fake で `branch:null` | PASS |
| 期待 branch を指す有効 worktree → reuse 成功（回帰なし） | Fake で一致ケース | PASS |

`tests/session/worktree.test.ts` 22 pass / 0 fail、manager 系含め 80 pass、`tsc --noEmit` / lint PASS。

## スコープ補足

本 PR は issue 本文どおり `ensureWorktree` に限定。`recreateWorktreeForExistingBranch`（resume recovery）の Q4 も同型だが、recovery はセマンティクスが異なる（stop で worktree 削除済み前提）ため別途要否を判断。意図的に本 PR では触らない。

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)
