### PR TITLE
feat(#206): 高コンテキストself-healing（red自動compact + ループ防止cap + observability）

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -220,19 +220,22 @@ export async function startBot(token: string): Promise<void> {
         // per-thread budget check so this path warns too. The tracker is shared
         // with the main relay path, so de-dup holds across both.
         try {
-          const budget = sessionManager.contextBudgetWarning(
+          // Issue #206: self-heal on the late-response path too (shares the
+          // per-session tracker + healer, so de-dup and the cap hold across both
+          // paths). The manager performs any auto-action; we only deliver it.
+          const outcome = await sessionManager.contextBudgetSelfHeal(
             event.threadId,
             event.contextTokens
           );
-          if (budget) {
+          if (outcome) {
             console.warn(
-              `[Bot] context-budget ${budget.level} on thread ${event.threadId} (late): ${budget.tokens} tokens`
+              `[Bot] context-budget ${outcome.level} on thread ${event.threadId} (late): ${outcome.tokens} tokens (action=${outcome.action})`
             );
-            await channel.send(budget.message);
-            if (budget.level === "red" || budget.level === "critical") {
+            await channel.send(outcome.message);
+            if (outcome.page) {
               await notifyPushover(
                 "Claude Code: コンテキスト肥大化",
-                `${channel.name ?? event.threadId} (${budget.level}, ${Math.floor(budget.tokens / 1000)}k tokens) — /session compact 推奨 (#204)`
+                `${channel.name ?? event.threadId} (${outcome.level}, ${Math.floor(outcome.tokens / 1000)}k tokens, action=${outcome.action}) — #206 self-heal`
               ).catch((err) =>
                 console.warn(`[Bot] context-budget pushover failed (late):`, err)
               );
@@ -240,7 +243,7 @@ export async function startBot(token: string): Promise<void> {
           }
         } catch (budgetErr) {
           console.warn(
-            `[Bot] context-budget check failed (late) for thread ${event.threadId}:`,
+            `[Bot] context-budget self-heal failed (late) for thread ${event.threadId}:`,
             budgetErr
           );
         }
@@ -663,19 +666,22 @@ export async function startBot(token: string): Promise<void> {
         // page Pushover for red/critical) once per band crossing. Best-effort:
         // a failure here must never affect the already-delivered response.
         try {
-          const budget = sessionManager.contextBudgetWarning(
+          // Issue #206: self-heal — auto-compact on red (capped), notify on
+          // critical. The manager performs any auto-action and returns the
+          // ready-to-post message; we only deliver it (+ page on red/critical).
+          const outcome = await sessionManager.contextBudgetSelfHeal(
             threadId,
             result.contextTokens
           );
-          if (budget) {
+          if (outcome) {
             console.warn(
-              `[Bot] context-budget ${budget.level} on thread ${threadId}: ${budget.tokens} tokens`
+              `[Bot] context-budget ${outcome.level} on thread ${threadId}: ${outcome.tokens} tokens (action=${outcome.action})`
             );
-            await thread.send(budget.message);
-            if (budget.level === "red" || budget.level === "critical") {
+            await thread.send(outcome.message);
+            if (outcome.page) {
               await notifyPushover(
                 "Claude Code: コンテキスト肥大化",
-                `${thread.name ?? threadId} (${budget.level}, ${Math.floor(budget.tokens / 1000)}k tokens) — /session compact 推奨 (#204)`
+                `${thread.name ?? threadId} (${outcome.level}, ${Math.floor(outcome.tokens / 1000)}k tokens, action=${outcome.action}) — #206 self-heal`
               ).catch((err) =>
                 console.warn(`[Bot] context-budget pushover failed:`, err)
               );
@@ -683,7 +689,7 @@ export async function startBot(token: string): Promise<void> {
           }
         } catch (budgetErr) {
           console.warn(
-            `[Bot] context-budget check failed for thread ${threadId}:`,
+            `[Bot] context-budget self-heal failed for thread ${threadId}:`,
             budgetErr
           );
         }

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -30,12 +30,40 @@ import {
 } from "./adapters";
 import {
   createContextBudgetTracker,
+  type ContextBudgetLevel,
   type ContextBudgetWarning,
 } from "./context-budget";
+import {
+  createSelfHealer,
+  type SelfHealAction,
+} from "./self-heal";
 import { compactClaudeHubExit } from "./primary-compact";
 
 const CLAUDE_PATH = resolve(homedir(), ".local", "bin", "claude");
 const TMUX_SESSION_PREFIX = "claude-";
+
+/**
+ * Non-empty intent for an auto-compact (Issue #206). RW-032: a bare `/compact`
+ * produces a bad compact, so the auto path — like the manual command — always
+ * carries an intent that preserves the working state and names the trigger.
+ */
+export const AUTO_COMPACT_INTENT =
+  "コンテキスト肥大化による tool 破損を回避するため直近の作業状態と次アクションを保持して自動圧縮 (#206)";
+
+/**
+ * Outcome of a self-heal evaluation (Issue #206). `message` is ready to post to
+ * the Discord thread (it already reflects whatever auto-action was taken), and
+ * `page` marks red/critical so the caller pages Pushover. Returned only when the
+ * session crossed up into a new band; null otherwise (no spam).
+ */
+export interface SelfHealOutcome {
+  level: ContextBudgetLevel;
+  action: SelfHealAction;
+  message: string;
+  tokens: number;
+  /** True for red/critical → caller should page Pushover. */
+  page: boolean;
+}
 
 /**
  * Authoritative liveness verdict produced by {@link SessionManager.livenessOf}
@@ -931,6 +959,101 @@ export class SessionManager {
       session.contextBudgetTracker = createContextBudgetTracker();
     }
     return session.contextBudgetTracker.check(tokens);
+  }
+
+  /**
+   * Issue #206: self-healing on top of the #204 notify-only budget warning.
+   *
+   * Reuses {@link contextBudgetWarning} (so the de-dup tracker advances exactly
+   * once) and, when a session crosses up into red, automatically relays a
+   * `/session compact` — the safe fire-and-forget primitive ({@link
+   * compactSession}). A per-session cap (RW-043) bounds how many auto-compacts
+   * fire so a rebounding context cannot loop forever; at the cap we stop and
+   * prompt manual intervention. critical stays notify-only here: the right
+   * remedy is a resume-backed restart, whose EXECUTION is deferred to a focused
+   * follow-up (RW-047 resume-timing risk + new-thread orchestration).
+   *
+   * Best-effort and self-contained: an auto-compact failure is folded into the
+   * returned message (never thrown) so the relay loop is unaffected. Returns the
+   * outcome the caller posts to the thread, or null when no band was crossed.
+   */
+  async contextBudgetSelfHeal(
+    threadId: string,
+    tokens: number | undefined
+  ): Promise<SelfHealOutcome | null> {
+    const warning = this.contextBudgetWarning(threadId, tokens);
+    if (!warning) return null;
+
+    const session = this.sessions.get(threadId);
+    // contextBudgetWarning only returns non-null when the session exists, but
+    // guard anyway so a race (stop between the two lookups) fails safe.
+    if (!session) return null;
+    if (!session.selfHealer) {
+      session.selfHealer = createSelfHealer();
+    }
+
+    const decision = session.selfHealer.decide(warning.level);
+    const page = warning.level === "red" || warning.level === "critical";
+
+    // Structured, greppable log for every band crossing (observability, AC item
+    // 4). Secrets-free: only threadId + numeric/level fields.
+    console.warn(
+      `[self-heal] thread=${threadId} level=${warning.level} tokens=${warning.tokens} action=${decision.action} count=${decision.actionCount}/${decision.cap}`
+    );
+
+    if (decision.action === "compact") {
+      try {
+        await this.compactSession(threadId, AUTO_COMPACT_INTENT);
+        return {
+          level: warning.level,
+          action: "compact",
+          tokens: warning.tokens,
+          page,
+          message:
+            `🩹 コンテキストが ${Math.floor(warning.tokens / 1000)}k に到達したため自動で ` +
+            `\`/compact\` を実行しました（${decision.actionCount}/${decision.cap} 回目, #206）。` +
+            `圧縮後も高止まりする場合は手動で \`/session compact\` するか新セッションへ切替えてください。`,
+        };
+      } catch (err) {
+        // Auto-compact failed (e.g. tmux pane gone) — fall back to the manual
+        // recommendation so the user still acts.
+        return {
+          level: warning.level,
+          action: "compact",
+          tokens: warning.tokens,
+          page,
+          message:
+            `⚠️ 自動 \`/compact\` を試みましたが失敗しました（${err instanceof Error ? err.message : String(err)}）。` +
+            `手動で \`/session compact\` を実行してください (#206)。`,
+        };
+      }
+    }
+
+    if (decision.action === "cap-reached") {
+      return {
+        level: warning.level,
+        action: "cap-reached",
+        tokens: warning.tokens,
+        page,
+        message:
+          `🛑 自動リカバリの上限（${decision.cap} 回）に達しました。これ以上は自動対応しません。` +
+          `手動で \`/session compact\` するか新セッションへ切替えてください (#206)。`,
+      };
+    }
+
+    // "notify" (critical) and "none" (yellow): keep the #204 warning text. For
+    // critical, append the manual-restart guidance (auto-restart is a follow-up).
+    const message =
+      decision.action === "notify"
+        ? `${warning.message}\n↳ 自動 restart は安全性のため手動運用です。\`/session resume\` で復帰してください (#206)。`
+        : warning.message;
+    return {
+      level: warning.level,
+      action: decision.action,
+      tokens: warning.tokens,
+      page,
+      message,
+    };
   }
 
   /**

--- a/supervisor/src/session/self-heal.ts
+++ b/supervisor/src/session/self-heal.ts
@@ -1,0 +1,111 @@
+/**
+ * Auto-recovery (self-healing) decisions for high-context child sessions
+ * (Issue #206, follow-up to #204's notify-only MVP).
+ *
+ * #204 surfaces a degraded warning when a session crosses the context-budget
+ * bands (yellow/red/critical). This module decides what *automatic* remediation
+ * to take on top of that warning:
+ *
+ *   - red      → auto `/session compact` (the safe, fire-and-forget primitive
+ *                already used by #200). Fires at a turn boundary (the Stop-hook
+ *                relay completion), so it never interrupts an in-flight turn.
+ *   - critical → notify only, for now. The right remedy at critical is a
+ *                resume-backed *restart*, but auto-restart needs new-thread
+ *                orchestration and carries the RW-047 resume-timing risk, so its
+ *                EXECUTION is deferred to a focused follow-up. critical keeps the
+ *                strong #204 warning (manual `/session resume`).
+ *   - any band → a per-session cap bounds how many auto-actions fire, so a
+ *                context that rebounds right back above the threshold after a
+ *                compact cannot loop forever (RW-043 cap mechanism). When the
+ *                cap is hit we stop auto-acting and prompt manual intervention.
+ *
+ * The planner is a tiny per-session state machine (mirrors the de-dup tracker in
+ * context-budget.ts) so it is unit-testable without a live session, and the
+ * SessionManager owns the actual side effects (compact / Discord / log).
+ */
+
+import type { ContextBudgetLevel } from "./context-budget";
+
+export type SelfHealAction =
+  /** Below the auto-action band (yellow): notify only, no remediation. */
+  | "none"
+  /** Red band: perform an automatic `/session compact`. */
+  | "compact"
+  /** Critical band: notify only (auto-restart execution deferred to follow-up). */
+  | "notify"
+  /** Per-session auto-action cap reached: stop auto-acting, prompt manual. */
+  | "cap-reached";
+
+export interface SelfHealDecision {
+  action: SelfHealAction;
+  level: ContextBudgetLevel;
+  /** Cumulative auto-actions this session has taken, AFTER this decision. */
+  actionCount: number;
+  /** The per-session cap in effect (for logging / user messaging). */
+  cap: number;
+}
+
+export interface SelfHealOptions {
+  /**
+   * Max auto-actions per session before falling back to manual (RW-043 cap).
+   * Defaults to {@link getSelfHealCap}.
+   */
+  maxAutoActions?: number;
+}
+
+export interface SelfHealer {
+  /**
+   * Decide the auto-action for a band-crossing signal. Call this ONLY when the
+   * context-budget tracker produced a warning (i.e. the session crossed up into
+   * `level`), so the de-dup already guarantees one decision per episode.
+   */
+  decide(level: ContextBudgetLevel): SelfHealDecision;
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+/**
+ * Per-session auto-action cap. Env-overridable (`CONTEXT_SELF_HEAL_MAX_ACTIONS`)
+ * for tuning/tests; default 3 — generous enough for a normally-churning session,
+ * low enough that a pathological compact↔rebound loop stops quickly.
+ */
+export function getSelfHealCap(): number {
+  return envInt("CONTEXT_SELF_HEAL_MAX_ACTIONS", 3);
+}
+
+export function createSelfHealer(options: SelfHealOptions = {}): SelfHealer {
+  const cap = options.maxAutoActions ?? getSelfHealCap();
+  let actionCount = 0;
+
+  return {
+    decide(level) {
+      // yellow: the entry band — recommend, never auto-act (avoids interrupting
+      // work for a soft signal).
+      if (level === "yellow") {
+        return { action: "none", level, actionCount, cap };
+      }
+
+      // red/critical both want remediation; enforce the cap first so a context
+      // that keeps climbing back can never drive an unbounded action loop.
+      if (actionCount >= cap) {
+        return { action: "cap-reached", level, actionCount, cap };
+      }
+
+      if (level === "red") {
+        actionCount += 1;
+        return { action: "compact", level, actionCount, cap };
+      }
+
+      // critical: auto-restart EXECUTION is deferred (RW-047 + new-thread
+      // orchestration). Notify only — and do NOT consume an auto-action, since
+      // compact is not the right remedy here and we want the cap to gate actual
+      // compacts, not critical notifications.
+      return { action: "notify", level, actionCount, cap };
+    },
+  };
+}

--- a/supervisor/src/session/types.ts
+++ b/supervisor/src/session/types.ts
@@ -1,5 +1,6 @@
 import type { ChildProcess } from "child_process";
 import type { ContextBudgetTracker } from "./context-budget";
+import type { SelfHealer } from "./self-heal";
 
 export interface SessionInfo {
   id: string;
@@ -34,6 +35,12 @@ export interface SessionInfo {
    * high-context session is warned only when it crosses up into a new band.
    */
   contextBudgetTracker?: ContextBudgetTracker;
+  /**
+   * Per-session self-heal planner (Issue #206). Lazily created alongside the
+   * tracker; decides the auto-action (compact / notify / cap-reached) for each
+   * band crossing and enforces the per-session auto-action cap (RW-043).
+   */
+  selfHealer?: SelfHealer;
 }
 
 /**

--- a/supervisor/tests/session/manager.test.ts
+++ b/supervisor/tests/session/manager.test.ts
@@ -4,11 +4,16 @@ import {
   describe,
   beforeEach,
   afterEach,
+  spyOn,
 } from "bun:test";
 import { mkdirSync } from "fs";
 import { tmpdir } from "os";
 import { resolve } from "path";
-import { SessionManager, buildClaudeFlags } from "../../src/session/manager";
+import {
+  SessionManager,
+  buildClaudeFlags,
+  AUTO_COMPACT_INTENT,
+} from "../../src/session/manager";
 import {
   createFakeEffects,
   type FakeSessionEffects,
@@ -122,6 +127,107 @@ describe("SessionManager (thread-based)", () => {
       expect(manager.contextBudgetWarning("thread-cbA", 320_000)?.level).toBe("yellow");
       // B is independent: it still gets its own first-crossing warning.
       expect(manager.contextBudgetWarning("thread-cbB", 320_000)?.level).toBe("yellow");
+    });
+  });
+
+  describe("contextBudgetSelfHeal (#206)", () => {
+    afterEach(() => {
+      delete process.env.CONTEXT_SELF_HEAL_MAX_ACTIONS;
+    });
+
+    test("null when no band is crossed (below yellow / unknown thread)", async () => {
+      await manager.start(primaryConfig, "sh-0");
+      expect(await manager.contextBudgetSelfHeal("sh-0", 100_000)).toBeNull();
+      expect(await manager.contextBudgetSelfHeal("nope", 500_000)).toBeNull();
+    });
+
+    test("yellow → notify only, no auto-compact", async () => {
+      const t = "sh-yellow";
+      await manager.start(primaryConfig, t);
+      const compactSpy = spyOn(manager, "compactSession").mockResolvedValue(
+        undefined
+      );
+      const outcome = await manager.contextBudgetSelfHeal(t, 320_000);
+      expect(outcome?.level).toBe("yellow");
+      expect(outcome?.action).toBe("none");
+      expect(outcome?.page).toBe(false);
+      expect(compactSpy).not.toHaveBeenCalled();
+      compactSpy.mockRestore();
+    });
+
+    test("AC item 1: red → auto /compact with the non-empty AUTO_COMPACT_INTENT, pages", async () => {
+      const t = "sh-red";
+      await manager.start(primaryConfig, t);
+      const compactSpy = spyOn(manager, "compactSession").mockResolvedValue(
+        undefined
+      );
+
+      const outcome = await manager.contextBudgetSelfHeal(t, 410_000);
+
+      expect(outcome?.level).toBe("red");
+      expect(outcome?.action).toBe("compact");
+      expect(outcome?.page).toBe(true);
+      expect(compactSpy).toHaveBeenCalledTimes(1);
+      // RW-032: the relayed intent is never empty.
+      expect(compactSpy.mock.calls[0]).toEqual([t, AUTO_COMPACT_INTENT]);
+      expect(AUTO_COMPACT_INTENT.trim().length).toBeGreaterThan(0);
+      expect(outcome?.message).toContain("自動");
+      compactSpy.mockRestore();
+    });
+
+    test("auto-compact failure is folded into the message, never thrown", async () => {
+      const t = "sh-red-fail";
+      await manager.start(primaryConfig, t);
+      const compactSpy = spyOn(manager, "compactSession").mockRejectedValue(
+        new Error("tmux session dead")
+      );
+
+      const outcome = await manager.contextBudgetSelfHeal(t, 410_000);
+
+      expect(outcome?.action).toBe("compact");
+      expect(outcome?.message).toContain("失敗");
+      expect(outcome?.message).toContain("tmux session dead");
+      compactSpy.mockRestore();
+    });
+
+    test("AC item 3: critical → notify only (no auto-compact), restart guidance present", async () => {
+      const t = "sh-critical";
+      await manager.start(primaryConfig, t);
+      const compactSpy = spyOn(manager, "compactSession").mockResolvedValue(
+        undefined
+      );
+
+      const outcome = await manager.contextBudgetSelfHeal(t, 850_000);
+
+      expect(outcome?.level).toBe("critical");
+      expect(outcome?.action).toBe("notify");
+      expect(outcome?.page).toBe(true);
+      expect(compactSpy).not.toHaveBeenCalled();
+      expect(outcome?.message).toContain("/session resume");
+      compactSpy.mockRestore();
+    });
+
+    test("AC item 2: rebounding red hits the cap, then stops auto-compacting", async () => {
+      process.env.CONTEXT_SELF_HEAL_MAX_ACTIONS = "1"; // healer created with cap 1
+      const t = "sh-cap";
+      await manager.start(primaryConfig, t);
+      const compactSpy = spyOn(manager, "compactSession").mockResolvedValue(
+        undefined
+      );
+
+      // 1st red crossing → compact (consumes the single slot).
+      expect((await manager.contextBudgetSelfHeal(t, 410_000))?.action).toBe(
+        "compact"
+      );
+      // Drop below yellow resets the de-dup episode so the next climb re-fires.
+      expect(await manager.contextBudgetSelfHeal(t, 100_000)).toBeNull();
+      // 2nd red crossing → cap reached, no further compact.
+      const capped = await manager.contextBudgetSelfHeal(t, 420_000);
+      expect(capped?.action).toBe("cap-reached");
+      expect(capped?.message).toContain("上限");
+
+      expect(compactSpy).toHaveBeenCalledTimes(1); // never exceeded the cap
+      compactSpy.mockRestore();
     });
   });
 

--- a/supervisor/tests/session/self-heal.test.ts
+++ b/supervisor/tests/session/self-heal.test.ts
@@ -1,0 +1,70 @@
+import { test, expect, describe } from "bun:test";
+import { createSelfHealer } from "../../src/session/self-heal";
+
+/**
+ * Unit tests for the self-heal planner (Issue #206). The planner is a per-
+ * session state machine fed band-crossing levels (from the context-budget
+ * tracker) and returns the auto-action to take.
+ *
+ * Journey AC mapping:
+ *   - item 1: red → "compact"
+ *   - item 2: a rebounding context hits the cap → "cap-reached" (no infinite loop)
+ *   - item 3: critical → "notify" (auto-restart execution deferred to follow-up)
+ */
+describe("createSelfHealer (#206)", () => {
+  test("yellow → none (notify only, no auto-action consumed)", () => {
+    const h = createSelfHealer({ maxAutoActions: 3 });
+    const d = h.decide("yellow");
+    expect(d.action).toBe("none");
+    expect(d.actionCount).toBe(0);
+  });
+
+  test("AC item 1: red → compact, increments the auto-action count", () => {
+    const h = createSelfHealer({ maxAutoActions: 3 });
+    const d = h.decide("red");
+    expect(d.action).toBe("compact");
+    expect(d.actionCount).toBe(1);
+    expect(d.cap).toBe(3);
+  });
+
+  test("AC item 3: critical → notify (restart execution deferred), no count consumed", () => {
+    const h = createSelfHealer({ maxAutoActions: 3 });
+    const d = h.decide("critical");
+    expect(d.action).toBe("notify");
+    // critical does not consume an auto-action — the cap gates compacts only.
+    expect(d.actionCount).toBe(0);
+  });
+
+  test("AC item 2: repeated red rebounds hit the cap, then stop auto-acting", () => {
+    const h = createSelfHealer({ maxAutoActions: 2 });
+    expect(h.decide("red").action).toBe("compact"); // 1
+    expect(h.decide("red").action).toBe("compact"); // 2 (cap)
+    const capped = h.decide("red"); // 3rd would exceed → cap-reached
+    expect(capped.action).toBe("cap-reached");
+    expect(capped.actionCount).toBe(2); // not incremented past the cap
+    // Stays capped on subsequent reds (no infinite loop).
+    expect(h.decide("red").action).toBe("cap-reached");
+  });
+
+  test("critical after the cap is reached → cap-reached (no further auto-action)", () => {
+    const h = createSelfHealer({ maxAutoActions: 1 });
+    expect(h.decide("red").action).toBe("compact"); // consumes the only slot
+    // Now at cap: even a critical escalation reports cap-reached, prompting
+    // manual intervention rather than silently doing nothing.
+    expect(h.decide("critical").action).toBe("cap-reached");
+  });
+
+  test("yellow never consumes the cap even when repeated", () => {
+    const h = createSelfHealer({ maxAutoActions: 1 });
+    h.decide("yellow");
+    h.decide("yellow");
+    // The single slot is still available for a real (red) action.
+    expect(h.decide("red").action).toBe("compact");
+  });
+
+  test("default cap is applied when maxAutoActions is omitted", () => {
+    const h = createSelfHealer();
+    // Default cap is 3 (env CONTEXT_SELF_HEAL_MAX_ACTIONS overridable).
+    expect(h.decide("red").cap).toBe(3);
+  });
+});


### PR DESCRIPTION
## 概要

Issue #206（#204 follow-up）。#204 の「通知のみ MVP」に **自動リカバリ（self-healing）** を追加する。子セッションが red バンド（既定 400k tokens）へ上昇したら自動で `/session compact` を発火し、高コンテキストで tool 呼び出しが破損して黙って停止する（context rot）のを予防する。

## スコープ（本 PR）

| # | 提案スコープ（issue body） | 本 PR |
|---|---|---|
| 1 | red 到達で自動 /compact | ✅ 実装（`compactSession` を発火、`AUTO_COMPACT_INTENT` 非空 = RW-032） |
| 2 | critical で resume 付き restart | ⏭️ **実行は follow-up #244 に分離**（新スレッド orchestration + RW-047 resume timing リスク）。critical は #204 の強警告 + 手動 `/session resume` 誘導を維持 |
| 3 | ループ防止 cap | ✅ 実装（per-session 自動アクション cap、既定 3、RW-043 同型） |
| 4 | observability | ✅ 構造化ログ `[self-heal] thread=.. level=.. action=.. count=N/cap` |

## 主な変更

- `src/session/self-heal.ts`（新規）: 純粋プランナー `createSelfHealer({maxAutoActions})`。band → action（red=compact / critical=notify / yellow=none）を決定し、cap 到達で `cap-reached` を返す。de-dup トラッカーと同型の per-session ステートマシンで単体テスト可能。
- `src/session/manager.ts`: `contextBudgetSelfHeal(threadId, tokens)` を追加。既存 `contextBudgetWarning` を**再利用**（トラッカーの二重前進を回避）し、red で auto-compact を実行、結果を投稿用メッセージに整形して返す。auto-compact 失敗はメッセージに畳み込み、relay loop を止めない。`AUTO_COMPACT_INTENT`（非空）を export。
- `src/bot.ts`: relay 完了経路と late-response 経路の 2 サイトを `contextBudgetSelfHeal` に切替（トラッカー・cap を両経路で共有）。
- `src/session/types.ts`: `SessionInfo.selfHealer?` を追加。

## 受入基準（journey AC）

| item | シナリオ | 結果 |
|---|---|---|
| 1 | red 到達 → 自動 /compact + 通知（intent 非空） | PASS（`self-heal.test.ts` + `manager.test.ts`: `compactSession` が `AUTO_COMPACT_INTENT` で 1 回呼ばれる） |
| 2 | compact 後もリバウンド継続 → cap で頭打ち（無限ループしない） | PASS（cap=1 で 2 回目が `cap-reached`、compact は 1 回のみ） |
| 3 | critical 到達 → restart | **本 PR は検知 + 手動 restart 誘導**。自動 restart 実行は #244。critical で `compactSession` を呼ばず `/session resume` 誘導メッセージを返すことを test で確認 |

`self-heal.test.ts` 7 pass、`manager.test.ts`（self-heal 6 ケース含む）pass、`context-budget.test.ts` pass、`relay.test.ts` / `ac-verification.test.ts` 回帰なし、`tsc --noEmit` / lint PASS。

注: 全体 `bun test` の他 6 失敗（injection guard=`db.ts` の SQL DDL / tmuxSend 統合 ×4 / relayMessage timeout）は本変更前から main で発生する環境依存の既存失敗で、本 PR の変更ファイルとは無関係。

Refs #206 / follow-up #244（critical 自動 restart 実行）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
