### PR TITLE
test(#238): hasSession ETIMEDOUT 回帰テストを CI gating に追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,20 @@ jobs:
                    tests/hijoguchi-routing/p0.test.ts \
                    tests/e2e/ac-verification.test.ts
 
+      # #238 regression: realTmuxAdapter.hasSession must treat a tmux
+      # control-channel ETIMEDOUT as "alive" (assume the session survives),
+      # never as a silent teardown. This file is the unit gate for that fix
+      # (PR #239). It uses mock.module("child_process"), which is
+      # process-global in Bun and would leak into the curated list above, so it
+      # runs as its OWN `bun test` process. No `|| true` — it must gate the
+      # build (RW-029: a silently-green CI is worse than a red one). Not run
+      # with --coverage so it does not overwrite the lcov.info produced above.
+      - name: Run mock-isolated session tests (#238 hasSession ETIMEDOUT)
+        env:
+          SUPERVISOR_DB_PATH: ":memory:"
+          TMUX_PATH: /usr/bin/tmux
+        run: bun test tests/session/adapters-hassession.test.ts
+
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## 目的

#238（`hasSession` の tmux ETIMEDOUT を session 終了と誤判定する bug、PR #239 で fix 済）の**回帰テストを CI で実際に gate する**。今日のライブ検証（corp `/session start`）で #238 の false-teardown を実機再現したのを受け、「検証を CI に焼き込む」ための変更。

## 変更点

- `.github/workflows/ci.yml` の Unit Tests job に **独立した `bun test` step** を追加し、`tests/session/adapters-hassession.test.ts`（#238 回帰テスト）を gate する。

### なぜ別 step か

`adapters-hassession.test.ts` は `mock.module("child_process")` を使う。Bun の `mock.module` は**プロセスグローバル**で、既存 gating list（curated な決定論的ファイル群）と同一 `bun test` 呼び出しに混ぜると他ファイルを汚染する（ローカル実測: 3 ファイル同居で 2 fail/2 error、単独なら 3 pass）。よって**独立プロセス**で実行する。

- `|| true` は付けない（RW-029: silently-green CI を作らない）。失敗すれば job が赤になる。
- `--coverage` なしで実行し、上の step が出力する `lcov.info` を上書きしない。

## 設計判断: watchTmuxSession の追加テストは作らなかった

当初 handoff には「`watchTmuxSession` の false-teardown 回帰テスト」も候補に挙げていたが、調査の結論として **#238 のバグと修正は 100% `realTmuxAdapter.hasSession`（アダプタ層）にあり**、`watchTmuxSession` は `if (!hasSession) teardown` の自明な consumer で一度も誤っていない。`hasSession=true` を注入して「teardown しない」を確認するテストはトートロジーで、かつ 10 秒 `setInterval` の fake-timer 基盤を新設する高コスト（当 repo 未導入）。価値が見合わないため作らない（RW-035 / thin-scaffolding）。

代わりに、ライブ検証で判明した**真に価値あるギャップ**＝ orphan GC 盲点を #246 として起票した。

## テスト

- ローカル: `bun test tests/session/adapters-hassession.test.ts` → 3 pass / 0 fail。
- 本 PR の CI で新 step が実際に走り gate することを確認する。

## 関連

- Closes なし（#238 は既に closed）。#238 / PR #239 の回帰防止を補完。
- Follow-up: #246（orphan GC 盲点）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * モック関連のセッションテストを独立した実行ステップに分離し、テストの信頼性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->