### PR TITLE
feat(ci): test gating-coverage lint で tests/ の gate 漏れを機械検知 (#248)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,12 @@ jobs:
       - name: Lint - no blocking exec inside timer callbacks (#27)
         run: bun scripts/lint-blocking-in-timers.ts
 
+      # Issue #248 (RW-029 / F1 class): every tests/**/*.test.ts must be gated in
+      # this file or justifiably excluded in scripts/lint-gating-coverage.ts.
+      # Prevents a newly-added test from being silently never-run in CI.
+      - name: Lint - CI test gating coverage (#248)
+        run: bun scripts/lint-gating-coverage.ts
+
   unit-test:
     name: Unit Tests
     runs-on: ubuntu-latest
@@ -115,7 +121,33 @@ jobs:
                    tests/session/context-budget.test.ts \
                    tests/session/session-activity-watchdog.test.ts \
                    tests/hijoguchi-routing/p0.test.ts \
-                   tests/e2e/ac-verification.test.ts
+                   tests/e2e/ac-verification.test.ts \
+                   tests/scripts/lint-gating-coverage.test.ts \
+                   tests/commands/session-compact.test.ts \
+                   tests/commands/session-start-access.test.ts \
+                   tests/commands/session-start-branch.test.ts \
+                   tests/commands/session-thread-title.test.ts \
+                   tests/config/access-policy.test.ts \
+                   tests/config/check-access-policy.test.ts \
+                   tests/discord/in-memory-client.test.ts \
+                   tests/discord/real-client.test.ts \
+                   tests/guards/access-enforcement-wired.test.ts \
+                   tests/hooks/ask-user-relay.test.ts \
+                   tests/hooks/auto-approve-permission.test.ts \
+                   tests/hooks/progress-relay.test.ts \
+                   tests/scripts/cleanup-idle-claude.test.ts \
+                   tests/scripts/setup-agent-base.test.ts \
+                   tests/session/ask-user-relay.test.ts \
+                   tests/session/dispatch.test.ts \
+                   tests/session/dispatch-run.test.ts \
+                   tests/session/dispatch-integration.test.ts \
+                   tests/session/latency-logger.test.ts \
+                   tests/session/manager-input-ready.test.ts \
+                   tests/session/progress-buffer.test.ts \
+                   tests/session/salvage-reply.test.ts \
+                   tests/session/slash-prefix.test.ts \
+                   tests/session/thread-title.test.ts \
+                   tests/session/worktree.test.ts
 
       # #238 regression: realTmuxAdapter.hasSession must treat a tmux
       # control-channel ETIMEDOUT as "alive" (assume the session survives),
@@ -130,6 +162,23 @@ jobs:
           SUPERVISOR_DB_PATH: ":memory:"
           TMUX_PATH: /usr/bin/tmux
         run: bun test tests/session/adapters-hassession.test.ts
+
+      # adapters.test.ts and tmux.test.ts each call mock.module("child_process"),
+      # which is process-global in Bun and pollutes any file sharing the process
+      # (running the three mock.module files together yields cross-file failures).
+      # So each gets its OWN `bun test` process — same isolation rationale as the
+      # #238 step above (#248: these were previously ungated → never run in CI).
+      - name: Run mock-isolated adapters tests (#248)
+        env:
+          SUPERVISOR_DB_PATH: ":memory:"
+          TMUX_PATH: /usr/bin/tmux
+        run: bun test tests/session/adapters.test.ts
+
+      - name: Run mock-isolated tmux tests (#248)
+        env:
+          SUPERVISOR_DB_PATH: ":memory:"
+          TMUX_PATH: /usr/bin/tmux
+        run: bun test tests/session/tmux.test.ts
 
       - name: Upload coverage to Codecov
         if: always()
@@ -190,7 +239,7 @@ jobs:
         env:
           SUPERVISOR_DB_PATH: ":memory:"
           TMUX_PATH: /usr/bin/tmux
-        run: bun test tests/e2e/ac-verification.test.ts tests/session/relay.test.ts
+        run: bun test tests/e2e/ac-verification.test.ts tests/session/relay.test.ts tests/e2e/dialog-stall.test.ts
         working-directory: supervisor
 
   # Local-only tests (require tmux/Claude CLI or local config):

--- a/supervisor/scripts/lint-gating-coverage.ts
+++ b/supervisor/scripts/lint-gating-coverage.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env bun
+/**
+ * Issue #248 (RW-029 / F1 class): CI gating-coverage lint.
+ *
+ * ci.yml runs the Unit/E2E suites from an explicit WHITELIST of files passed to
+ * `bun test` (deterministic on purpose — it avoids Bun's process-global
+ * `mock.module` pollution leaking between files). The weakness of a whitelist:
+ * a newly-added test file under `tests/` that nobody remembers to add is
+ * SILENTLY never run in CI. That is exactly how #238's regression test slipped
+ * (PR #247 — the F1 that motivated this issue) and how the shell-exec-safety
+ * security guard (#159 / RW-045) sits red-but-ungated today. Same failure class
+ * as RW-029: a silently-green CI is worse than a red one.
+ *
+ * This lint scans every test file under `tests/` and requires each to be either:
+ *   1. gated   — passed as an argument to some `bun test` step in ci.yml, or
+ *   2. excluded — listed in EXCLUSIONS below WITH a non-empty reason.
+ * Any other test file fails the build (a new gate omission). To stop the
+ * exclusion list from rotting into a silent dumping ground, an entry with an
+ * empty reason, or one that points at a file that no longer exists, also fails.
+ *
+ * Run: `bun scripts/lint-gating-coverage.ts` (from supervisor/). Exits 1 on any
+ * violation. Scope is intentionally the `tests/` tree only — colocated tests
+ * living under `src/` are out of scope for this issue (tracked separately).
+ */
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+/** A test file intentionally NOT gated in ci.yml. Each MUST carry a real reason. */
+export interface Exclusion {
+  file: string;
+  reason: string;
+}
+
+/**
+ * Files deliberately excluded from CI gating. Adding an entry is a conscious
+ * decision that must be justified here — "I forgot to gate it" is not a reason,
+ * such files belong in ci.yml instead.
+ */
+export const EXCLUSIONS: Exclusion[] = [
+  {
+    file: "tests/session/iterm2.test.ts",
+    reason:
+      "local-only: needs ~/.claude/scripts/project-colors.json (macOS iTerm2 tab colours), absent on CI ubuntu — see ci.yml 'Local-only tests' note.",
+  },
+  {
+    file: "tests/session/iterm2-async.test.ts",
+    reason:
+      "macOS-only timing: markTabStopped shells out to real `osascript`, which blocks >100ms on a Mac and fails the non-blocking assertion. Not deterministic across runners.",
+  },
+  {
+    file: "tests/guards/shell-exec-safety.test.ts",
+    reason:
+      "RED on main: src/infra/db.ts:45 ALTER TABLE interpolation lacks a `// shell-safe:` justification (#159 / RW-045 guard). Gating is blocked until the justification is added — tracked in #253.",
+  },
+];
+
+/**
+ * Pull every `tests/...*.test.ts` token out of the *command* lines of ci.yml.
+ *
+ * Comment lines (YAML `#`) are dropped first so that a file merely *mentioned*
+ * in a comment (e.g. the "Local-only tests" note) is never mistaken for gated —
+ * only paths inside an actual `run:` shell body count.
+ */
+export function extractGatedFiles(ciYaml: string): Set<string> {
+  const gated = new Set<string>();
+  for (const rawLine of ciYaml.split("\n")) {
+    if (rawLine.trimStart().startsWith("#")) continue; // skip comments
+    for (const m of rawLine.matchAll(/tests\/[A-Za-z0-9_./-]+\.test\.ts/g)) {
+      gated.add(m[0]);
+    }
+  }
+  return gated;
+}
+
+export interface CoverageReport {
+  /** In tests/ but neither gated nor excluded — a silent gate omission. */
+  ungated: string[];
+  /** Exclusion entries with a blank reason (silent exclusion). */
+  emptyReason: string[];
+  /** Exclusion entries whose file no longer exists (rotted list). */
+  staleExclusions: string[];
+  /** Excluded AND gated — the exclusion is now redundant (warning only). */
+  redundant: string[];
+}
+
+export function analyzeCoverage(args: {
+  testFiles: string[];
+  gated: Set<string>;
+  exclusions: Exclusion[];
+  /** Existence probe (injectable for tests); defaults to "always exists". */
+  fileExists?: (file: string) => boolean;
+}): CoverageReport {
+  const { testFiles, gated, exclusions } = args;
+  const exists = args.fileExists ?? (() => true);
+  const excludedSet = new Set(exclusions.map((e) => e.file));
+
+  return {
+    ungated: testFiles
+      .filter((f) => !gated.has(f) && !excludedSet.has(f))
+      .sort(),
+    emptyReason: exclusions
+      .filter((e) => e.reason.trim() === "")
+      .map((e) => e.file),
+    staleExclusions: exclusions.filter((e) => !exists(e.file)).map((e) => e.file),
+    redundant: exclusions.filter((e) => gated.has(e.file)).map((e) => e.file),
+  };
+}
+
+/** True when the report contains a build-failing violation (redundant is warn-only). */
+export function hasFailure(r: CoverageReport): boolean {
+  return (
+    r.ungated.length > 0 ||
+    r.emptyReason.length > 0 ||
+    r.staleExclusions.length > 0
+  );
+}
+
+if (import.meta.main) {
+  const root = resolve(import.meta.dir, ".."); // supervisor/
+  const ciPath = resolve(root, "../.github/workflows/ci.yml");
+
+  const ciYaml = readFileSync(ciPath, "utf8");
+  const gated = extractGatedFiles(ciYaml);
+
+  const { Glob } = await import("bun");
+  const testFiles = [...new Glob("tests/**/*.test.ts").scanSync(root)].sort();
+  if (testFiles.length === 0) {
+    console.error(
+      `✖ lint-gating-coverage: no test files found under ${root}/tests — refusing to report clean.`,
+    );
+    process.exit(1);
+  }
+
+  const report = analyzeCoverage({
+    testFiles,
+    gated,
+    exclusions: EXCLUSIONS,
+    fileExists: (f) => existsSync(resolve(root, f)),
+  });
+
+  for (const f of report.redundant) {
+    console.error(
+      `⚠ ${f}: in EXCLUSIONS but also gated in ci.yml — drop the exclusion entry.`,
+    );
+  }
+
+  if (!hasFailure(report)) {
+    console.log(
+      `✓ lint-gating-coverage: ${testFiles.length} test file(s) — ${gated.size} gated, ${EXCLUSIONS.length} excluded, 0 ungated.`,
+    );
+    process.exit(0);
+  }
+
+  for (const f of report.ungated) {
+    console.error(
+      `${f}: not gated in ci.yml and not in EXCLUSIONS — add it to a 'bun test' step or justify it in scripts/lint-gating-coverage.ts.`,
+    );
+  }
+  for (const f of report.emptyReason) {
+    console.error(`${f}: EXCLUSIONS entry has an empty reason — state why it is not gated.`);
+  }
+  for (const f of report.staleExclusions) {
+    console.error(`${f}: EXCLUSIONS entry points at a missing file — remove the stale entry.`);
+  }
+
+  console.error(
+    `\n✖ gating-coverage violation(s) (Issue #248).\n` +
+      `  A test that is neither gated in ci.yml nor justifiably excluded is never run in CI —\n` +
+      `  it can rot to red without anyone noticing (RW-029: a silently-green CI is worse than a red one).`,
+  );
+  process.exit(1);
+}

--- a/supervisor/tests/scripts/lint-gating-coverage.test.ts
+++ b/supervisor/tests/scripts/lint-gating-coverage.test.ts
@@ -1,0 +1,135 @@
+import { test, expect, describe } from "bun:test";
+import { existsSync } from "fs";
+import { resolve } from "path";
+import {
+  analyzeCoverage,
+  extractGatedFiles,
+  hasFailure,
+  EXCLUSIONS,
+  type Exclusion,
+} from "../../scripts/lint-gating-coverage";
+
+/**
+ * Issue #248: the gating-coverage lint must (AC-1) fail when a test file is
+ * neither gated in ci.yml nor excluded, (AC-2) pass when every existing test
+ * file under tests/ is gated or excluded, and (AC-3) fail when an exclusion
+ * entry has no reason. The final "real repo" test makes AC-2 a live regression
+ * guard against future gate omissions.
+ */
+
+describe("extractGatedFiles", () => {
+  test("collects every tests/*.test.ts passed to a bun test step", () => {
+    const yaml = `      - name: Run tests
+        run: |
+          bun test --coverage \\
+                   tests/session/relay.test.ts \\
+                   tests/infra/db.test.ts
+      - name: Isolated
+        run: bun test tests/session/adapters-hassession.test.ts`;
+    const gated = extractGatedFiles(yaml);
+    expect(gated.has("tests/session/relay.test.ts")).toBe(true);
+    expect(gated.has("tests/infra/db.test.ts")).toBe(true);
+    expect(gated.has("tests/session/adapters-hassession.test.ts")).toBe(true);
+    expect(gated.size).toBe(3);
+  });
+
+  test("ignores a test file mentioned only in a comment (not a real run arg)", () => {
+    // The "Local-only tests" note must NOT be read as gating.
+    const yaml = `      # Local-only: tests/session/iterm2.test.ts needs project-colors.json
+      - name: Run tests
+        run: bun test tests/session/relay.test.ts`;
+    const gated = extractGatedFiles(yaml);
+    expect(gated.has("tests/session/relay.test.ts")).toBe(true);
+    expect(gated.has("tests/session/iterm2.test.ts")).toBe(false);
+  });
+});
+
+describe("analyzeCoverage", () => {
+  const exclusions: Exclusion[] = [
+    { file: "tests/session/iterm2.test.ts", reason: "local-only config" },
+  ];
+
+  test("AC-1: a file neither gated nor excluded is reported as ungated", () => {
+    const r = analyzeCoverage({
+      testFiles: ["tests/session/new-feature.test.ts", "tests/session/relay.test.ts"],
+      gated: new Set(["tests/session/relay.test.ts"]),
+      exclusions,
+    });
+    expect(r.ungated).toEqual(["tests/session/new-feature.test.ts"]);
+    expect(hasFailure(r)).toBe(true);
+  });
+
+  test("AC-2: every file gated or excluded → no violation", () => {
+    const r = analyzeCoverage({
+      testFiles: ["tests/session/relay.test.ts", "tests/session/iterm2.test.ts"],
+      gated: new Set(["tests/session/relay.test.ts"]),
+      exclusions,
+    });
+    expect(r.ungated).toEqual([]);
+    expect(hasFailure(r)).toBe(false);
+  });
+
+  test("AC-3: an exclusion with a blank reason fails", () => {
+    const r = analyzeCoverage({
+      testFiles: ["tests/session/x.test.ts"],
+      gated: new Set<string>(),
+      exclusions: [{ file: "tests/session/x.test.ts", reason: "   " }],
+    });
+    expect(r.emptyReason).toEqual(["tests/session/x.test.ts"]);
+    expect(hasFailure(r)).toBe(true);
+  });
+
+  test("a stale exclusion (missing file) fails", () => {
+    const r = analyzeCoverage({
+      testFiles: [],
+      gated: new Set<string>(),
+      exclusions: [{ file: "tests/session/deleted.test.ts", reason: "gone" }],
+      fileExists: () => false,
+    });
+    expect(r.staleExclusions).toEqual(["tests/session/deleted.test.ts"]);
+    expect(hasFailure(r)).toBe(true);
+  });
+
+  test("an exclusion that is also gated is flagged redundant (warning, not failure)", () => {
+    const r = analyzeCoverage({
+      testFiles: ["tests/session/relay.test.ts"],
+      gated: new Set(["tests/session/relay.test.ts"]),
+      exclusions: [{ file: "tests/session/relay.test.ts", reason: "was excluded once" }],
+    });
+    expect(r.redundant).toEqual(["tests/session/relay.test.ts"]);
+    expect(hasFailure(r)).toBe(false);
+  });
+});
+
+describe("real repository (AC-2 regression guard)", () => {
+  test("every tests/**/*.test.ts is gated in ci.yml or justifiably excluded", async () => {
+    const root = resolve(import.meta.dir, "../.."); // supervisor/
+    const ciYaml = await Bun.file(resolve(root, "../.github/workflows/ci.yml")).text();
+    const gated = extractGatedFiles(ciYaml);
+
+    const { Glob } = await import("bun");
+    const testFiles = [...new Glob("tests/**/*.test.ts").scanSync(root)].sort();
+    expect(testFiles.length).toBeGreaterThan(0);
+
+    const report = analyzeCoverage({
+      testFiles,
+      gated,
+      exclusions: EXCLUSIONS,
+      fileExists: (f) => existsSync(resolve(root, f)),
+    });
+
+    // Surface the offending files in the assertion message, not just a count.
+    expect({
+      ungated: report.ungated,
+      emptyReason: report.emptyReason,
+      staleExclusions: report.staleExclusions,
+    }).toEqual({ ungated: [], emptyReason: [], staleExclusions: [] });
+  });
+
+  test("this lint's own test file is gated (no self-exemption)", async () => {
+    const root = resolve(import.meta.dir, "../..");
+    const ciYaml = await Bun.file(resolve(root, "../.github/workflows/ci.yml")).text();
+    const gated = extractGatedFiles(ciYaml);
+    expect(gated.has("tests/scripts/lint-gating-coverage.test.ts")).toBe(true);
+  });
+});


### PR DESCRIPTION
## 目的（#248）

ci.yml の Unit/E2E は **明示ホワイトリスト方式**で `bun test` に渡すファイルを列挙している（決定論性 + Bun の `mock.module` プロセスグローバル汚染回避のため意図的）。この方式は安全な反面、「テストを追加したが gating list へ入れ忘れる」と **silent に未 gate 化**する弱点がある。PR #247 で #238 の回帰テストが未収録だった F1、および本 PR で発覚した `shell-exec-safety.test.ts` の silent RED が実例。RW-029（silently-green な CI は red より悪い）と同型クラス。

`tests/` 配下の全テストが **(1) ci.yml で gating 済 / (2) 理由付き除外** のいずれかであることを保証する lint を追加する。

## 変更点

- **`supervisor/scripts/lint-gating-coverage.ts`**: ci.yml の `run:` 行から `bun test` 引数を抽出（コメント行の言及は除外）し、gating でも除外でもない `tests/**/*.test.ts` を検知。除外リストは**理由必須**、stale（実体消失）・redundant（gating済なのに除外残存）も検知。
- **`supervisor/tests/scripts/lint-gating-coverage.test.ts`**: 純関数の単体テスト（AC-1/2/3）＋**実リポ回帰ガード**（既存全テストが gating/除外に収まることを恒久検証）＋ lint 自身の test が gate 必須であることの検証。
- **`.github/workflows/ci.yml`**: 既存 ungated 31 件を全分類。
  - 決定的 25 件 → curated unit list へ gate
  - `tests/e2e/dialog-stall.test.ts` → e2e job へ gate
  - `tests/session/adapters.test.ts` / `tests/session/tmux.test.ts` → `mock.module` 汚染のため**各々独立 step**（3 件同居で相互汚染を実測確認）
  - typecheck job に lint step 追加

## 除外リスト（理由付き）

| ファイル | 理由 |
|---|---|
| `tests/session/iterm2.test.ts` | local-only（`~/.claude/scripts/project-colors.json` 依存、CI ubuntu に不在） |
| `tests/session/iterm2-async.test.ts` | macOS の実 `osascript` がブロックし `<100ms` 非ブロック assert に失敗。ランナー間で非決定的 |
| `tests/guards/shell-exec-safety.test.ts` | **main で既に RED**（`src/infra/db.ts:45` の ALTER TABLE 補間が未正当化、#159/RW-045 ガード）。修正まで gating 不可 → #253 で追跡 |

## 副産物（重要）

`shell-exec-safety.test.ts`（シェルインジェクション回帰ガード）が gate 漏れで silent RED 化していたことを本 lint が炙り出した。db.ts 修正はセキュリティ判断を要し本 PR の範囲外のため、**follow-up #253** を起票。

## AC 検証（決定的）

| AC | 検証 | 結果 |
|---|---|---|
| AC-1 | gating/除外いずれにも無い `*.test.ts` を追加 → lint fail | exit 1 ✅ |
| AC-2 | 既存全 `*.test.ts` で lint pass | `bun scripts/lint-gating-coverage.ts` exit 0（57件: 54 gated / 3 excluded / 0 ungated）✅ |
| AC-3 | 除外エントリの理由が空 → fail | 単体テスト ✅ |

その他: curated unit list 50 件同居 **611 pass / 3 skip / 0 fail**、隔離 `adapters` 16 / `tmux` 8 pass、e2e trio（dialog-stall 含）27 pass、`bunx tsc --noEmit` green、lint 単体テスト 9 pass。

## 統合ジャーニーAC

不要・理由: CI lint の追加でありユーザー操作フローを持たない。lint 自体のユニットテスト + 実リポ回帰ガードで決定的に検証する。

Closes #248

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * テスト実行プロセスの信頼性を向上させるための検証機構を追加しました。複数のテストファイルを CI ワークフローに統合し、テスト実行の漏れを検知する品質チェックツールを導入しました。

* **Chores**
  * CI/CD パイプラインの堅牢性を強化し、テスト カバレッジの管理を自動化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->