### PR TITLE
perf(#249): relay.ts の tmux 送信ホットパスを execFile 非同期化 (#227 PR-1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -180,6 +180,17 @@ jobs:
           TMUX_PATH: /usr/bin/tmux
         run: bun test tests/session/tmux.test.ts
 
+      # #227 (PR-1 / #249) AC-3: relay.ts's tmux send hot path must stay
+      # non-blocking after the execFileSync→execFile migration. This file mocks
+      # child_process.execFile via mock.module (process-global in Bun), so it
+      # runs as its OWN `bun test` process — same isolation rationale as the
+      # mock-isolated steps above. No `|| true`: it gates the build.
+      - name: Run mock-isolated relay non-blocking test (#227 / #249)
+        env:
+          SUPERVISOR_DB_PATH: ":memory:"
+          TMUX_PATH: /usr/bin/tmux
+        run: bun test tests/session/relay-nonblocking.test.ts
+
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v5

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -64,12 +64,15 @@ function summarizeExecError(err: unknown): {
   killed?: boolean;
   signal?: string | null;
 } {
-  const e = err as NodeJS.ErrnoException & {
-    code?: string | number;
-    killed?: boolean;
-    signal?: string | null;
-  };
-  return { code: e.code, killed: e.killed, signal: e.signal };
+  if (err && typeof err === "object") {
+    const e = err as NodeJS.ErrnoException & {
+      code?: string | number;
+      killed?: boolean;
+      signal?: string | null;
+    };
+    return { code: e.code, killed: e.killed, signal: e.signal };
+  }
+  return {};
 }
 
 function getExecStderr(err: unknown): string {
@@ -87,8 +90,11 @@ function getExecStderr(err: unknown): string {
  * (Issue #73 / RW-019) is byte-for-byte identical after the migration.
  */
 function isExecTimeout(err: unknown): boolean {
-  const e = err as NodeJS.ErrnoException & { killed?: boolean };
-  return e.code === "ETIMEDOUT" || e.killed === true;
+  if (err && typeof err === "object") {
+    const e = err as NodeJS.ErrnoException & { killed?: boolean };
+    return e.code === "ETIMEDOUT" || e.killed === true;
+  }
+  return false;
 }
 
 /**

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -1,4 +1,5 @@
-import { execFileSync } from "child_process";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import { resolve } from "path";
 import { mkdirSync, writeFileSync } from "fs";
 import { waitForRelay, type RelayResult } from "./relay-server";
@@ -10,6 +11,15 @@ import { scheduleStallHeartbeat } from "./stall-heartbeat";
 import { createPageOnce } from "./dialog-stuck-handler";
 import type { DialogStuckInfo } from "./dialog-stuck-handler";
 import { ATTACHMENT_DIR } from "./gc-attachments";
+
+/**
+ * Issue #227 (PR-1): the relay send hot path runs tmux via the *async*
+ * `execFile` so a stalled tmux server cannot freeze the Bun single event loop.
+ * The previous synchronous exec blocked the whole Supervisor for up to the
+ * per-call timeout on every send; under the dialog-watchdog's 5s poll (#222)
+ * those blocks accumulated. `promisify(execFile)` resolves to `{ stdout, stderr }`.
+ */
+const execFileAsync = promisify(execFile);
 
 /** How long to wait for Claude Code Stop hook to fire (ms) */
 const RELAY_TIMEOUT_MS = 5 * 60_000;
@@ -48,16 +58,37 @@ async function downloadAttachment(attachment: AttachmentInfo): Promise<string> {
  * We retry once after a 250ms pause so a flaky moment doesn't surface to
  * the user as a `send-keys` failure.
  */
-/** Summarize an execFileSync error without leaking message content from spawnargs. */
-function summarizeExecError(err: unknown): { code?: string; status?: number; signal?: string } {
-  const e = err as NodeJS.ErrnoException & { status?: number; signal?: string };
-  return { code: e.code, status: e.status, signal: e.signal };
+/** Summarize an execFile error without leaking message content from spawnargs. */
+function summarizeExecError(err: unknown): {
+  code?: string | number;
+  killed?: boolean;
+  signal?: string | null;
+} {
+  const e = err as NodeJS.ErrnoException & {
+    code?: string | number;
+    killed?: boolean;
+    signal?: string | null;
+  };
+  return { code: e.code, killed: e.killed, signal: e.signal };
 }
 
 function getExecStderr(err: unknown): string {
   const e = err as { stderr?: Buffer | string };
   if (!e.stderr) return "";
   return typeof e.stderr === "string" ? e.stderr : e.stderr.toString();
+}
+
+/**
+ * Detect a tmux call that was aborted by its own `timeout` option, normalising
+ * across the sync→async migration (#227). The synchronous exec threw an error
+ * with `.code === "ETIMEDOUT"`; the async `execFile` path instead kills the child
+ * with `killSignal` (default SIGTERM) and sets `.killed === true` (with
+ * `.code` left null). Accept both so `tmuxSend`'s transient-retry behavior
+ * (Issue #73 / RW-019) is byte-for-byte identical after the migration.
+ */
+function isExecTimeout(err: unknown): boolean {
+  const e = err as NodeJS.ErrnoException & { killed?: boolean };
+  return e.code === "ETIMEDOUT" || e.killed === true;
 }
 
 /**
@@ -78,11 +109,12 @@ export async function ensurePaneNotInMode(
 ): Promise<void> {
   let mode: string;
   try {
-    mode = execFileSync(
+    const { stdout } = await execFileAsync(
       TMUX_PATH,
       [...socketArgs, "display-message", "-t", sessionName, "-p", "#{pane_in_mode}"],
       { timeout: 2000 }
-    ).toString().trim();
+    );
+    mode = stdout.toString().trim();
   } catch (err) {
     console.warn(
       `[Relay] pane_in_mode check failed for ${sessionName}:`,
@@ -93,9 +125,11 @@ export async function ensurePaneNotInMode(
   if (mode !== "1") return;
   console.warn(`[Relay] pane ${sessionName} in copy-mode, cancelling before send-keys`);
   try {
-    execFileSync(TMUX_PATH, [...socketArgs, "send-keys", "-t", sessionName, "-X", "cancel"], {
-      timeout: 2000,
-    });
+    await execFileAsync(
+      TMUX_PATH,
+      [...socketArgs, "send-keys", "-t", sessionName, "-X", "cancel"],
+      { timeout: 2000 }
+    );
   } catch (err) {
     // Pane may have exited mode between check and cancel — safe to ignore.
     console.warn(
@@ -115,25 +149,26 @@ export async function tmuxSend(
   const args = [...socketArgs, "send-keys", "-t", sessionName, ...extraArgs];
   const PER_CALL_TIMEOUT = 7000;
   try {
-    execFileSync(TMUX_PATH, args, { timeout: PER_CALL_TIMEOUT });
+    await execFileAsync(TMUX_PATH, args, { timeout: PER_CALL_TIMEOUT });
     return;
   } catch (err) {
     const summary = summarizeExecError(err);
     const stderr = getExecStderr(err);
     const isModeErr = /not in a mode/i.test(stderr);
-    if (summary.code !== "ETIMEDOUT" && !isModeErr) {
+    const isTimeout = isExecTimeout(err);
+    if (!isTimeout && !isModeErr) {
       console.error(`[Relay] tmux send-keys failed:`, summary);
       throw err;
     }
-    // Transient: tmux briefly stalled (ETIMEDOUT) OR pane was in copy-mode
+    // Transient: tmux briefly stalled (timeout) OR pane was in copy-mode
     // (`not in a mode`). Exit any stuck mode and try once more.
     console.warn(
-      `[Relay] tmux send-keys transient error for ${sessionName} (${isModeErr ? "not-in-a-mode" : summary.code}), recovering...`
+      `[Relay] tmux send-keys transient error for ${sessionName} (${isModeErr ? "not-in-a-mode" : "timeout"}), recovering...`
     );
     await ensurePaneNotInMode(sessionName, socketArgs);
     await new Promise((r) => setTimeout(r, 250));
     try {
-      execFileSync(TMUX_PATH, args, { timeout: PER_CALL_TIMEOUT });
+      await execFileAsync(TMUX_PATH, args, { timeout: PER_CALL_TIMEOUT });
     } catch (retryErr) {
       console.error(
         `[Relay] tmux send-keys retry also failed for ${sessionName}:`,

--- a/supervisor/tests/session/relay-nonblocking.test.ts
+++ b/supervisor/tests/session/relay-nonblocking.test.ts
@@ -1,0 +1,107 @@
+import { test, expect, describe, mock, beforeEach } from "bun:test";
+
+/**
+ * Issue #227 (PR-1 / #249) AC-3: the relay send hot path must NOT block the Bun
+ * single event loop.
+ *
+ * `relay.ts`'s `tmuxSend` / `ensurePaneNotInMode` used synchronous
+ * `execFileSync`, so each tmux call froze the whole Supervisor for up to the
+ * per-call timeout (2–7s). Under load the dialog-watchdog poll (#222) made this
+ * cumulative. PR-1 moves them to `promisify(execFile)` + `await`, which runs the
+ * tmux subprocess in the background and yields control back to the loop.
+ *
+ * This test mocks `child_process.execFile` so the tmux call "parks" (its
+ * callback is held), then proves a *separately scheduled* macrotask
+ * (`setTimeout(0)`) runs WHILE `tmuxSend` is in flight — i.e. the event loop
+ * was free. A synchronous `execFileSync` would have run `tmuxSend` to completion
+ * before any competing timer callback could fire, so the ordering asserted here
+ * is impossible without the async conversion. This is the decisive,
+ * deterministic non-blocking proof asked for by #249 AC-3.
+ *
+ * It uses `mock.module("child_process")`, which is process-global in Bun, so it
+ * MUST run as its own isolated `bun test` step in ci.yml (same rationale as
+ * adapters-hassession.test.ts / adapters.test.ts — see PR #247 / #248).
+ */
+
+import * as childProcess from "child_process";
+
+/**
+ * Captures the callback `promisify(execFile)` hands us so the test can decide
+ * exactly when the simulated tmux subprocess "finishes". Set per-test.
+ */
+type ExecCb = (err: unknown, result: { stdout: string; stderr: string }) => void;
+let onExec: ((cb: ExecCb) => void) | null = null;
+
+// promisify(execFile) invokes the underlying fn as fn(file, args, opts, cb):
+// the callback is always the final argument. Grab it positionally so the mock
+// is robust to the (file, args, cb) vs (file, args, opts, cb) arities.
+const mockExecFile = mock((...args: unknown[]) => {
+  const cb = args[args.length - 1] as ExecCb;
+  if (onExec) {
+    onExec(cb);
+  } else {
+    cb(null, { stdout: "", stderr: "" });
+  }
+  return {} as childProcess.ChildProcess;
+});
+
+// Preserve the rest of child_process and override only execFile — relay.ts's
+// import graph (tmux.ts / relay-server.ts) still needs the real spawn/exec.
+mock.module("child_process", () => ({
+  ...childProcess,
+  execFile: mockExecFile,
+}));
+
+const { tmuxSend } = await import("../../src/session/relay");
+
+describe("relay tmux I/O is non-blocking (#227 / #249 AC-3)", () => {
+  beforeEach(() => {
+    onExec = null;
+    mockExecFile.mockClear();
+  });
+
+  test("tmuxSend yields the event loop while the tmux call is in flight", async () => {
+    const order: string[] = [];
+
+    // Park the tmux call: hold its callback instead of completing it. While
+    // parked, control MUST return to the loop if the call is truly async.
+    let release: (() => void) | null = null;
+    onExec = (cb) => {
+      order.push("exec-invoked");
+      release = () => cb(null, { stdout: "", stderr: "" });
+    };
+
+    const sent = tmuxSend("nonblock-sess", ["-l", "payload"]).then(() => {
+      order.push("tmuxSend-resolved");
+    });
+
+    // Competing macrotask scheduled AFTER kicking off tmuxSend. With a blocking
+    // execFileSync, tmuxSend would have run to completion (and its .then
+    // microtask would drain) before this 0ms timer's callback could run.
+    await new Promise<void>((resolve) =>
+      setTimeout(() => {
+        order.push("competing-task");
+        resolve();
+      }, 0)
+    );
+
+    // The tmux call started, the competing task ran, and tmuxSend is STILL
+    // parked → the loop stayed free the whole time.
+    expect(order).toContain("exec-invoked");
+    expect(order).toContain("competing-task");
+    expect(order).not.toContain("tmuxSend-resolved");
+
+    // Now let the simulated subprocess finish and confirm tmuxSend completes.
+    expect(release).not.toBeNull();
+    release!();
+    await sent;
+
+    expect(order).toEqual(["exec-invoked", "competing-task", "tmuxSend-resolved"]);
+  });
+
+  test("tmuxSend resolves via the async path with no thrown error on success", async () => {
+    // Default mock (onExec null) completes immediately with empty stdout.
+    await expect(tmuxSend("ok-sess", ["C-m"])).resolves.toBeUndefined();
+    expect(mockExecFile).toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## 概要

親 #227（tmux 同期I/O の完全非同期化）の **PR-1 / 最初の一手**。`relay.ts` の relay 送信ホットパス（`ensurePaneNotInMode` / `tmuxSend`）内の同期 `execFileSync` 4 箇所を `promisify(execFile)` + `await` へ置換し、Bun 単一イベントループの starvation を構造的に解消する。

`#222` / PR #226 では tmux 呼び出しに timeout を付与して「楔状態の無限ブロック」だけを防いだが、同期 I/O である限り各呼び出しは最大 timeout 値ぶん（2〜7s）イベントループを専有し続けた。本 PR でホットパスを非同期化する。

両関数は既に `async` で呼び出し側も `await` 済みのため、**呼び出し側への波及がゼロ**（manager / primary-compact / tmux）。

## 主な変更点

- `ensurePaneNotInMode`（display-message / send-keys -X cancel）と `tmuxSend`（初回 + リトライ）の計 4 箇所を `execFileAsync` 化。
- 送信順序（copy-mode cancel → 本文 → C-m）は `await` 連鎖で厳密に保持。
- per-call timeout は `execFile` の `timeout` オプションへ移送（挙動不変）。
- タイムアウト判定を sync→async で正規化：同期版は `code === "ETIMEDOUT"` を投げたが、async 版は `killSignal` で子プロセスを kill し `killed === true`（`code` は null）となるため、`isExecTimeout` で両方を受理。これで #73 / RW-019 の transient リトライ挙動を維持。
- `summarizeExecError` を async エラー形状（`code: string|number`, `killed`, `signal`）に追従。

## 受け入れ条件（コンポーネント・決定的）

| AC | 内容 | 結果 |
|---|---|---|
| AC-1 | `grep -c execFileSync src/session/relay.ts` = 0 | ✅ 0（コメント言及も除去） |
| AC-2 | `relay.test.ts` / `relay-send-failure.test.ts` 全 PASS（送信順序・失敗時クリーン通知を維持） | ✅ 21 pass |
| AC-3 | 非ブロック回帰 test：`execFile` を park し、`tmuxSend` 実行中に競合 `setTimeout(0)` が先行することを assert（同期では不成立＝非ブロックの決定的証明） | ✅ `relay-nonblocking.test.ts` 2 pass |
| AC-4 | `bun scripts/lint-blocking-in-timers.ts`（#27）green を維持 | ✅ green |

加えて：

- typecheck（`bunx tsc --noEmit`）exit 0
- gating-coverage lint（#248）green — `relay-nonblocking.test.ts` は `mock.module("child_process")` の process-global 汚染回避のため **専用 `bun test` step に隔離**（`adapters-hassession` / `adapters` / `tmux` と同じ隔離方針）
- 消費者回帰テスト（manager / ask-user-relay）63 pass

## 統合ジャーニーAC

不要（Issue 記載どおり）：Supervisor 内部の I/O 実装変更で、ユーザーが踏む新たな一連フローを伴わない。外形挙動は #222 と同じ「通知が遅延しない」で、検証はコンポーネント AC の relay 応答に含まれる。

## 関連

- 親: #227（PR-1）/ 上流: #222, PR #226
- 次: PR-2 #250（dialog-watchdog 5s ポーリング非同期化）

Closes #249


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * リレー機能の非ブロッキング動作に関する回帰テストをCI に追加しました。

* **Chores**
  * リレー機能の実装を非同期処理に移行しました。
  * CI パイプラインを改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->