### PR TITLE
fix(#255): dispatch 長尺ターンの relay false タイムアウトを解消（A+B+C+E）

### DIFF
--- a/supervisor/hooks/ask-user-relay.sh
+++ b/supervisor/hooks/ask-user-relay.sh
@@ -63,13 +63,16 @@ if [ -z "$QUESTION" ]; then
 fi
 
 # Forward to the supervisor and wait for the user's reply. --max-time matches
-# the relay-server's DEFAULT_ASK_TIMEOUT_MS plus a small buffer for the round
-# trip; the server itself enforces the real timeout.
+# the relay-server's DEFAULT_ASK_TIMEOUT_MS (300s since Issue #255) plus a small
+# buffer for the round trip; the server itself enforces the real timeout.
+# INVARIANT: this MUST stay >= DEFAULT_ASK_TIMEOUT_MS/1000, or curl gives up
+# before the server and the user's late reply is wasted. relay-server.test.ts
+# locks `--max-time*1000 >= DEFAULT_ASK_TIMEOUT_MS`.
 RESPONSE=$(jq -n --arg q "$QUESTION" '{question: $q}' | \
   curl -s -X POST "$ASK_URL" \
     -H "Content-Type: application/json" \
     -d @- \
-    --max-time 130)
+    --max-time 310)
 CURL_EXIT=$?
 
 if [ $CURL_EXIT -ne 0 ] || [ -z "$RESPONSE" ]; then

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -17,7 +17,7 @@ import { createSessionCommand, createSessionHandler } from "./commands/session";
 import { CHANNEL_MAP, MAX_SESSIONS } from "./config/channels";
 import type { AttachmentInfo } from "./session/relay";
 import { buildDialogStuckHandler } from "./session/dialog-stuck-handler";
-import { notifyPushover } from "./session/notify-pushover";
+import { notifyPushover, warnIfPushoverUnconfigured } from "./session/notify-pushover";
 import { updateSessionClaudeId } from "./infra/db";
 import {
   buildSalvageReply,
@@ -49,6 +49,11 @@ import {
 import { buildThreadTitle } from "./session/thread-title";
 
 export async function startBot(token: string): Promise<void> {
+  // Issue #255: page-ability check at boot. If Pushover creds are missing, the
+  // stall heartbeat / dialog watchdog pages silently drop, so warn the operator
+  // up front instead of leaving it to be noticed only when a stall fails to page.
+  warnIfPushoverUnconfigured();
+
   const client = new Client({
     intents: [
       GatewayIntentBits.Guilds,

--- a/supervisor/src/session/dialog-detect.ts
+++ b/supervisor/src/session/dialog-detect.ts
@@ -9,7 +9,8 @@
  * permission dialogs but cannot intercept these other dialog families.
  *
  * Without detection, the relay silently times out at RELAY_TIMEOUT_MS
- * (5 min) and the user perceives the bot as dead. This module exposes a
+ * (default 15 min, env-tunable) and the user perceives the bot as dead.
+ * This module exposes a
  * pure function `detectDialog(paneText)` that callers (relay watchdog,
  * tests) can invoke against `tmux capture-pane -p` output.
  *

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -937,8 +937,8 @@ export class SessionManager {
    * Issue #200: relay a `/compact <intent>` into the session's TUI as a
    * fire-and-forget send. Unlike {@link sendMessage}, this does NOT wait for a
    * relay (Stop-hook) response: the `/compact` built-in compacts context and
-   * does not POST to the relay server, so waiting would only burn the 5-min
-   * RELAY_TIMEOUT_MS. The caller acks immediately.
+   * does not POST to the relay server, so waiting would only burn
+   * RELAY_TIMEOUT_MS (default 15 min). The caller acks immediately.
    *
    * `intent` is always non-empty by contract (the command layer substitutes a
    * default) — a bare `/compact` is never sent (RW-032: bad-compact prevention).

--- a/supervisor/src/session/notify-pushover.ts
+++ b/supervisor/src/session/notify-pushover.ts
@@ -30,6 +30,22 @@ function readEnv(): PushoverEnv {
 }
 
 /**
+ * Issue #255: surface a *startup* warning when Pushover is unconfigured, so the
+ * operator learns at boot that stall / dialog paging is disabled — rather than
+ * discovering it only when a stall silently fails to page (the #255
+ * observability gap, where many `[Pushover] skipped` lines went unnoticed
+ * because nothing flagged the missing credentials up front). Returns `true` when
+ * both credentials are present. `env` is injectable for tests.
+ */
+export function warnIfPushoverUnconfigured(env: PushoverEnv = readEnv()): boolean {
+  if (env.token && env.userKey) return true;
+  console.warn(
+    "[Pushover] startup: PUSHOVER_TOKEN / PUSHOVER_USER_KEY not set — stall/dialog paging is disabled (Issue #255)"
+  );
+  return false;
+}
+
+/**
  * Send a Pushover notification. Returns `true` only when the API accepted the
  * message (`status: 1`). Returns `false` when credentials are absent or the
  * request fails — both are logged, never thrown.

--- a/supervisor/src/session/relay-server.ts
+++ b/supervisor/src/session/relay-server.ts
@@ -66,12 +66,28 @@ interface PendingAsk {
 const pendingRequests = new Map<string, PendingRequest>();
 const pendingAsks = new Map<string, PendingAsk>();
 
-// /ask/:threadId default timeout. Mirrors the 120s budget from the example in
-// Issue #12 body so users have time to type a real answer on mobile Discord.
-const DEFAULT_ASK_TIMEOUT_MS = 120_000;
+// /ask/:threadId default timeout. Issue #255: raised 120s → 300s. The incident
+// dropped an AskUserQuestion after only 2 min unanswered, so a 会長 answering on
+// mobile Discord lost the question. INVARIANT: the curl `--max-time` in
+// hooks/ask-user-relay.sh MUST stay >= this / 1000 (otherwise curl gives up
+// before the server, and the late reply is wasted). A test in
+// relay-server.test.ts reads the hook and locks `--max-time*1000 >= DEFAULT`.
+export const DEFAULT_ASK_TIMEOUT_MS = 300_000;
 // Cap user-supplied timeouts so a malformed hook payload can't pin a request
 // indefinitely. 10 minutes is well above any realistic Discord round-trip.
-const MAX_ASK_TIMEOUT_MS = 600_000;
+export const MAX_ASK_TIMEOUT_MS = 600_000;
+
+/**
+ * Issue #255: user-facing notice when the relay gives up waiting for the Stop
+ * hook. The old text ("⚠️ Claude Code からの応答がタイムアウトしました。")
+ * asserted the session had died. In practice the session is usually still
+ * *alive* — a long dispatch turn merely exceeded the relay ceiling — and the
+ * Stop hook's late POST is forwarded via the late-response path. Word it so the
+ * user does not think the turn was lost. The `error` field stays
+ * "Response timeout" for callers / tests that key on it.
+ */
+export const RELAY_TIMEOUT_USER_MESSAGE =
+  "⏳ 制限時間内に応答が返りませんでした。セッションは稼働中の可能性があり、完了すると結果を追って転送します。しばらく待っても返らない場合は再送してください。";
 
 let server: ReturnType<typeof Bun.serve> | null = null;
 let relayPort = 0;
@@ -412,7 +428,7 @@ export function waitForRelay(
   return new Promise<RelayResult>((resolve) => {
     const timer = setTimeout(() => {
       pendingRequests.delete(threadId);
-      resolve({ text: "", chunks: ["⚠️ Claude Code からの応答がタイムアウトしました。"], error: "Response timeout" });
+      resolve({ text: "", chunks: [RELAY_TIMEOUT_USER_MESSAGE], error: "Response timeout" });
     }, timeoutMs);
 
     pendingRequests.set(threadId, { resolve, timer });

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -7,7 +7,7 @@ import { persistAttachments } from "./attachment-store";
 import { TMUX_PATH, TMUX_ARGS } from "./tmux";
 import { createLatencyTracker } from "./latency-logger";
 import { startDialogWatchdog } from "./dialog-watchdog";
-import { scheduleStallHeartbeat } from "./stall-heartbeat";
+import { scheduleStallHeartbeat, DEFAULT_STALL_DELAY_MS } from "./stall-heartbeat";
 import { createPageOnce } from "./dialog-stuck-handler";
 import type { DialogStuckInfo } from "./dialog-stuck-handler";
 import { ATTACHMENT_DIR } from "./gc-attachments";
@@ -21,8 +21,42 @@ import { ATTACHMENT_DIR } from "./gc-attachments";
  */
 const execFileAsync = promisify(execFile);
 
-/** How long to wait for Claude Code Stop hook to fire (ms) */
-const RELAY_TIMEOUT_MS = 5 * 60_000;
+/**
+ * How long to wait for the Claude Code Stop hook to POST the response (ms).
+ *
+ * Issue #255: the old fixed 5-min ceiling was *shorter* than a normal dispatch
+ * agent turn (multi-`bash`/`gh` research easily runs 10-20 min). The relay then
+ * gave up on a *live* session and surfaced a false "応答がタイムアウト", even
+ * though the Stop hook eventually POSTs and the late-response path forwards it.
+ * The default is raised and made tunable via the `RELAY_TIMEOUT_MS` env (ms).
+ *
+ * Invariant: the effective timeout MUST stay strictly above
+ * {@link DEFAULT_STALL_DELAY_MS} so the 3-min stall heartbeat still fires
+ * *while* the relay is waiting (it pages the user that a long turn is in
+ * progress). {@link RELAY_TIMEOUT_FLOOR_MS} enforces this in code, replacing the
+ * comment-only contract that previously lived in stall-heartbeat.ts.
+ */
+export const DEFAULT_RELAY_TIMEOUT_MS = 15 * 60_000;
+/** Lowest effective relay timeout: keeps the stall heartbeat strictly earlier. */
+export const RELAY_TIMEOUT_FLOOR_MS = DEFAULT_STALL_DELAY_MS + 60_000;
+/** Upper bound so a malformed env can't pin a relay for an unbounded time. */
+export const RELAY_TIMEOUT_CEILING_MS = 60 * 60_000;
+
+/**
+ * Resolve the relay timeout from `env.RELAY_TIMEOUT_MS` (ms), falling back to
+ * {@link DEFAULT_RELAY_TIMEOUT_MS} for absent / non-numeric / non-positive
+ * values, then clamping into [floor, ceiling]. Pure + exported so a unit test
+ * can lock the default, the clamp, and the stall-heartbeat invariant.
+ */
+export function readRelayTimeoutMs(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.RELAY_TIMEOUT_MS;
+  const parsed = raw !== undefined ? Number(raw) : NaN;
+  const value =
+    Number.isFinite(parsed) && parsed > 0 ? parsed : DEFAULT_RELAY_TIMEOUT_MS;
+  return Math.min(RELAY_TIMEOUT_CEILING_MS, Math.max(RELAY_TIMEOUT_FLOOR_MS, value));
+}
+
+const RELAY_TIMEOUT_MS = readRelayTimeoutMs();
 
 export interface AttachmentInfo {
   url: string;
@@ -245,7 +279,8 @@ export async function sendToPane(
  * polls the pane every 5s. Dialogs that slip past `--dangerously-skip-
  * permissions` (Plan mode confirmation, AskUserQuestion, MCP elicitation,
  * Bash interactive y/n) cause the TUI to stall silently — without
- * detection the relay simply times out at RELAY_TIMEOUT_MS (5 min). The
+ * detection the relay simply times out at RELAY_TIMEOUT_MS (default 15 min,
+ * env-tunable since Issue #255). The
  * watchdog auto-accepts known kinds and, if the dialog persists, fires
  * `onDialogStuck` so the caller can post a heartbeat to Discord.
  */

--- a/supervisor/src/session/session-activity-watchdog.ts
+++ b/supervisor/src/session/session-activity-watchdog.ts
@@ -3,7 +3,7 @@
  *
  * Existing safeguards each cover a *different timescale* and leave a gap:
  *   - the stall heartbeat ({@link import("./stall-heartbeat")}) is per relay turn
- *     (3 min, below the 5-min relay timeout),
+ *     (3 min, below the relay timeout — RELAY_TIMEOUT_MS, default 15 min),
  *   - the reaper ({@link import("./reaper").Reaper}) only acts after 7 days idle,
  *   - the context-budget monitor ({@link import("./context-budget")}) fires on
  *     high token counts reported by the Stop hook (#204).

--- a/supervisor/src/session/stall-heartbeat.ts
+++ b/supervisor/src/session/stall-heartbeat.ts
@@ -14,9 +14,11 @@
  * without coupling to Claude Code's churning TUI (RW-027).
  */
 
-// MUST stay below RELAY_TIMEOUT_MS in relay.ts (5 min): the stall heartbeat
+// MUST stay below the effective relay timeout (relay.ts): the stall heartbeat
 // has to fire *while* the relay is still waiting, otherwise the relay times
-// out first and the heartbeat never pages.
+// out first and the heartbeat never pages. Since Issue #255 the relay timeout
+// is env-tunable, so relay.ts derives RELAY_TIMEOUT_FLOOR_MS from this value to
+// enforce `stall < relay` in code rather than relying on this comment alone.
 export const DEFAULT_STALL_DELAY_MS = 3 * 60_000;
 
 export interface StallHeartbeat {

--- a/supervisor/tests/session/notify-pushover.test.ts
+++ b/supervisor/tests/session/notify-pushover.test.ts
@@ -1,5 +1,8 @@
-import { test, expect, describe, mock } from "bun:test";
-import { notifyPushover } from "../../src/session/notify-pushover";
+import { test, expect, describe, mock, spyOn } from "bun:test";
+import {
+  notifyPushover,
+  warnIfPushoverUnconfigured,
+} from "../../src/session/notify-pushover";
 
 describe("notifyPushover", () => {
   test("skips (returns false) when credentials are unset", async () => {
@@ -72,5 +75,37 @@ describe("notifyPushover", () => {
       fetchImpl: fetchSpy as unknown as typeof fetch,
     });
     expect(ok).toBe(false);
+  });
+});
+
+// Issue #255 (proposal C): warn at startup when Pushover is unconfigured so the
+// operator knows paging is disabled, rather than discovering it only when a
+// stall silently fails to page.
+describe("warnIfPushoverUnconfigured (Issue #255)", () => {
+  test("returns true and stays quiet when both credentials are set", () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const ok = warnIfPushoverUnconfigured({ token: "tok", userKey: "usr" });
+      expect(ok).toBe(true);
+      expect(warnSpy).toHaveBeenCalledTimes(0);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test.each([
+    ["both unset", {}],
+    ["only token", { token: "tok" }],
+    ["only userKey", { userKey: "usr" }],
+  ])("returns false and warns when %s", (_label, env) => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const ok = warnIfPushoverUnconfigured(env);
+      expect(ok).toBe(false);
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0]![0])).toContain("paging is disabled");
+    } finally {
+      warnSpy.mockRestore();
+    }
   });
 });

--- a/supervisor/tests/session/relay-server.test.ts
+++ b/supervisor/tests/session/relay-server.test.ts
@@ -1,4 +1,6 @@
 import { test, expect, describe, afterEach } from "bun:test";
+import { readFileSync } from "fs";
+import { resolve } from "path";
 import {
   startRelayServer,
   stopRelayServer,
@@ -7,6 +9,9 @@ import {
   onLateResponse,
   onProgress,
   onSessionsQuery,
+  RELAY_TIMEOUT_USER_MESSAGE,
+  DEFAULT_ASK_TIMEOUT_MS,
+  MAX_ASK_TIMEOUT_MS,
   type LateResponseEvent,
   type ProgressEvent,
 } from "../../src/session/relay-server";
@@ -93,6 +98,21 @@ describe("relay-server", () => {
     startRelayServer();
 
     const result = await waitForRelay("thread-timeout", 100);
+    expect(result.error).toBe("Response timeout");
+  });
+
+  // Issue #255 (proposal B): the timeout chunk must NOT assert the session died
+  // — it is usually still alive and the late-response path forwards the result.
+  test("timeout chunk reassures the session may still be running (Issue #255)", async () => {
+    startRelayServer();
+
+    const result = await waitForRelay("thread-timeout-msg", 100);
+    expect(result.chunks).toEqual([RELAY_TIMEOUT_USER_MESSAGE]);
+    // Wording acceptance: mentions the session may still be running.
+    expect(result.chunks[0]).toContain("稼働中");
+    // Must drop the old "応答がタイムアウトしました" dead-session assertion.
+    expect(result.chunks[0]).not.toContain("応答がタイムアウトしました");
+    // `error` stays machine-stable for callers that key on it.
     expect(result.error).toBe("Response timeout");
   });
 
@@ -387,5 +407,36 @@ describe("relay-server", () => {
       body: JSON.stringify({}),
     });
     expect(res.status).toBe(404);
+  });
+});
+
+// Issue #255 (proposal E): the AskUserQuestion relay timeout was raised
+// 120s → 300s so a 会長 answering on mobile Discord isn't dropped after 2 min.
+// The server default and the curl `--max-time` in hooks/ask-user-relay.sh are a
+// coupled pair (RW-035-style implicit contract); lock both here so they can't
+// drift apart and re-break the late reply.
+describe("ask timeout (Issue #255, proposal E)", () => {
+  test("DEFAULT_ASK_TIMEOUT_MS is raised to at least 300s and stays <= MAX", () => {
+    expect(DEFAULT_ASK_TIMEOUT_MS).toBeGreaterThanOrEqual(300_000);
+    expect(DEFAULT_ASK_TIMEOUT_MS).toBeLessThanOrEqual(MAX_ASK_TIMEOUT_MS);
+  });
+
+  test("ask-user-relay.sh --max-time covers the server default (curl must not give up first)", () => {
+    const hookPath = resolve(
+      import.meta.dir,
+      "../../hooks/ask-user-relay.sh",
+    );
+    const hook = readFileSync(hookPath, "utf8");
+    const match = hook.match(/--max-time\s+(\d+)/);
+    expect(match).not.toBeNull();
+    const maxTimeSeconds = Number(match![1]);
+    // INVARIANT (lower bound): curl budget (s) * 1000 must be >= the server
+    // default (ms), otherwise curl aborts before the user can answer and the
+    // reply is wasted.
+    expect(maxTimeSeconds * 1000).toBeGreaterThanOrEqual(DEFAULT_ASK_TIMEOUT_MS);
+    // INVARIANT (upper bound): curl must not wait beyond the server's hard cap —
+    // the server can never answer later than MAX_ASK_TIMEOUT_MS, so a larger
+    // --max-time would just hang the hook with no chance of a reply.
+    expect(maxTimeSeconds * 1000).toBeLessThanOrEqual(MAX_ASK_TIMEOUT_MS);
   });
 });

--- a/supervisor/tests/session/relay.test.ts
+++ b/supervisor/tests/session/relay.test.ts
@@ -8,7 +8,12 @@ import {
   tmuxSend,
   ensurePaneNotInMode,
   flattenForSendKeys,
+  readRelayTimeoutMs,
+  DEFAULT_RELAY_TIMEOUT_MS,
+  RELAY_TIMEOUT_FLOOR_MS,
+  RELAY_TIMEOUT_CEILING_MS,
 } from "../../src/session/relay";
+import { DEFAULT_STALL_DELAY_MS } from "../../src/session/stall-heartbeat";
 import { TMUX_ARGS, ensureSocketConfigured } from "../../src/session/tmux";
 
 // Issue #210: the newline-flatten regex was double-escaped (`/[\\r\\n]+/`) so it
@@ -271,4 +276,50 @@ describe("relayMessage send failure (#74)", () => {
       expect(result.text).toBe("");
     }
   );
+});
+
+// Issue #255 (proposal A): the relay timeout is env-tunable with a raised
+// default, but must always stay above the stall heartbeat so a long *live*
+// dispatch turn is paged (3 min) before — never instead of — the relay giving
+// up. readRelayTimeoutMs is the single choke point that enforces this.
+describe("readRelayTimeoutMs (Issue #255)", () => {
+  test("default (env unset) is the raised 15-min default", () => {
+    expect(readRelayTimeoutMs({})).toBe(DEFAULT_RELAY_TIMEOUT_MS);
+    expect(DEFAULT_RELAY_TIMEOUT_MS).toBe(15 * 60_000);
+  });
+
+  test("invariant: default and floor both stay strictly above the stall delay", () => {
+    // If this ever inverts, the stall heartbeat would never fire before the
+    // relay timed out — the exact silent-stall regression #255 guards against.
+    expect(RELAY_TIMEOUT_FLOOR_MS).toBeGreaterThan(DEFAULT_STALL_DELAY_MS);
+    expect(DEFAULT_RELAY_TIMEOUT_MS).toBeGreaterThan(DEFAULT_STALL_DELAY_MS);
+  });
+
+  test("a valid positive env value (within bounds) is honored", () => {
+    expect(readRelayTimeoutMs({ RELAY_TIMEOUT_MS: "600000" })).toBe(600_000);
+  });
+
+  test("a value below the floor is clamped up to the floor", () => {
+    // 1s would put the relay below the 3-min stall heartbeat.
+    expect(readRelayTimeoutMs({ RELAY_TIMEOUT_MS: "1000" })).toBe(
+      RELAY_TIMEOUT_FLOOR_MS,
+    );
+  });
+
+  test("a value above the ceiling is clamped down to the ceiling", () => {
+    expect(readRelayTimeoutMs({ RELAY_TIMEOUT_MS: "999999999" })).toBe(
+      RELAY_TIMEOUT_CEILING_MS,
+    );
+  });
+
+  test.each([
+    ["non-numeric", "abc"],
+    ["zero", "0"],
+    ["negative", "-5"],
+    ["empty", ""],
+  ])("falls back to the default for %s env values", (_label, raw) => {
+    expect(readRelayTimeoutMs({ RELAY_TIMEOUT_MS: raw })).toBe(
+      DEFAULT_RELAY_TIMEOUT_MS,
+    );
+  });
 });


### PR DESCRIPTION
## 概要

調査 Issue #255（dispatch 長尺ターンで relay が 5分 false タイムアウト）の提案 **A / B / C / E** を claude-hub 側で実装する。「生存中のセッションに対し relay が先に諦め false な『応答がタイムアウト』を出す」体験を主因として解消する。

Closes #255

## 変更点

| 提案 | 内容 | 主な変更 |
|---|---|---|
| **A** | relay timeout を可変化＋延長（5分→15分 default） | `relay.ts`: `readRelayTimeoutMs(env)` を choke point に `RELAY_TIMEOUT_MS` env 対応。`stall(3分) < relay` の不変条件を floor=`DEFAULT_STALL_DELAY_MS+60s` で**コード担保**（従来は comment のみ）。ceiling=60分、不正値は default。 |
| **B** | timeout 文言修正 | `relay-server.ts`: `RELAY_TIMEOUT_USER_MESSAGE` を export 化し「セッションは稼働中の可能性／完了後に転送」へ。死亡断定を排除。`error` は `Response timeout` のまま（機械的 caller 互換）。 |
| **C** | Pushover 未設定の起動時 warn | `notify-pushover.ts`: `warnIfPushoverUnconfigured(env)` を追加し `bot.ts` の `startBot` 先頭に結線。stall ページ silent drop の可観測性ギャップを解消。 |
| **E** | AskUserQuestion /ask の timeout 延長（120秒→300秒） | `relay-server.ts`: `DEFAULT_ASK_TIMEOUT_MS=300_000`。`hooks/ask-user-relay.sh` の `curl --max-time` を 130→310 と **lockstep** で更新。突合テストで `server ≤ curl ≤ MAX` の cross-file 不変条件を固定（RW-035 型の暗黙契約 drift を防止）。 |

### 対象外（明示）
- **提案 D**（tmux 過負荷の event-loop starvation）は既存 **Epic #227** / PR #249-252 に委譲。
- **提案 E のうち「dispatch 時に AskUserQuestion を抑制」**は corp 側の autonomy-first ポリシー／prompt 設計の領域のため claude-hub 対象外。本 PR は claude-hub スコープの「/ask timeout 延長」のみ実装。
- team_salary の Playwright 環境問題（記事公開失敗の実体, #236）は team_salary 側。

## 統合ジャーニーAC

| # | 操作 | 期待結果 | 検証手段 |
|---|---|---|---|
| A | 5分超の長尺ターンを dispatch | relay は false timeout を出さず待機継続（default 15分・`RELAY_TIMEOUT_MS` で可変）。stall(3分)>relay の逆転は env でも不可能 | `readRelayTimeoutMs` unit test（default/clamp/invalid + 不変条件 6 ケース） |
| B | relay が制限時間に達する | 文言が「稼働中の可能性／完了後に転送」へ変化、`error` は `Response timeout` を維持 | timeout result の chunk が新文言かつ `稼働中` を含む test |
| C | Pushover 未設定で Supervisor を起動 | 起動時に1行 warn（`paging is disabled`） | `warnIfPushoverUnconfigured` test（4 ケース）+ `startBot` 結線 |
| E | AskUserQuestion を Discord 越しに出す | /ask が 120秒ではなく 300秒待つ。curl も連動し server より先に諦めない | `DEFAULT_ASK_TIMEOUT_MS>=300s` + hook `--max-time` 突合 test（server≤curl≤MAX） |

## テスト

- 新規回帰テスト: `relay.test.ts` / `relay-server.test.ts` / `notify-pushover.test.ts`（対象 3 ファイル **65 pass / 0 fail**）。
- `bunx tsc --noEmit`: **clean（exit 0）**。
- 全体 `bun test`: 666 pass。残り 6 fail は **本 PR 起因ではない**既存事象（`shell-exec injection guard` は `src/infra/db.ts:45` で main からの既存 fail を baseline 確認済み、他 5 件は実 tmux サーバ依存の integration テスト）。

## レビュー

`code-review-orchestrator` による事前レビュー実施済み。**must 指摘なし**。`should`（hook `--max-time` 上限の test 追加）+ stale な「5分」コメント 4 箇所（本変更で事実誤りになったもの）を本 PR 内で修正済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
