### PR TITLE
perf(#250): dialog-watchdog の 5s ポーリング tmux I/O を execFile 非同期化 (#227 PR-2)

### DIFF
--- a/supervisor/src/session/dialog-watchdog.ts
+++ b/supervisor/src/session/dialog-watchdog.ts
@@ -1,4 +1,5 @@
-import { execFileSync } from "child_process";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import { TMUX_PATH, TMUX_ARGS } from "./tmux";
 import {
   detectDialog,
@@ -43,6 +44,15 @@ const MAX_BACKOFF_MS = 30_000;
  * tick (which would otherwise trigger backoff prematurely).
  */
 const CAPTURE_TIMEOUT_MS = 3_000;
+
+/**
+ * Issue #227 (PR-2): the watchdog polls every relay-in-flight session every 5s
+ * on the shared `-L claude-hub` tmux server. Running capture/send via the
+ * *async* `execFile` keeps each poll off the Bun event loop, so N concurrent
+ * watchdogs no longer accumulate N synchronous blocks per tick (the dominant
+ * starvation source #227 named). `promisify(execFile)` resolves `{ stdout, stderr }`.
+ */
+const execFileAsync = promisify(execFile);
 
 /**
  * Compute the next poll interval. On a successful capture, reset to `base`;
@@ -90,11 +100,14 @@ export interface DialogWatchdogOptions {
   /** Override max auto-accept attempts — tests can drop to 1 for speed. */
   maxAutoAcceptAttempts?: number;
   /** Inject a custom capture function — tests pass a fake to avoid spawning
-   *  tmux. Defaults to {@link captureViaTmux}. */
-  capture?: (sessionName: string) => string;
+   *  tmux. Defaults to {@link captureViaTmux}. May be sync or async: the tick
+   *  awaits it, so a sync fake (returning a string) stays compatible while the
+   *  production default is now async (Issue #227 PR-2). */
+  capture?: (sessionName: string) => string | Promise<string>;
   /** Inject a custom send-keys function — tests pass a recorder to assert
-   *  the right keys were sent. Defaults to {@link sendKeysViaTmux}. */
-  sendKeys?: (sessionName: string, keys: string[]) => void;
+   *  the right keys were sent. Sync or async; the tick awaits it
+   *  (Issue #227 PR-2). Defaults to {@link sendKeysViaTmux}. */
+  sendKeys?: (sessionName: string, keys: string[]) => void | Promise<void>;
   /**
    * Inject the timer primitives that space out poll ticks. Tests pass a
    * virtual clock to drive ticks in deterministic virtual time, eliminating
@@ -119,13 +132,14 @@ export interface DialogWatchdog {
   stop(): void;
 }
 
-function captureViaTmux(sessionName: string): string {
+async function captureViaTmux(sessionName: string): Promise<string> {
   try {
-    return execFileSync(
+    const { stdout } = await execFileAsync(
       TMUX_PATH,
       [...TMUX_ARGS, "capture-pane", "-p", "-t", sessionName],
       { timeout: CAPTURE_TIMEOUT_MS }
-    ).toString();
+    );
+    return stdout.toString();
   } catch (err) {
     // Pane gone / server stopped: the session ended — return empty so detect
     // returns null and the watchdog stays at its base interval until it is
@@ -141,10 +155,10 @@ function captureViaTmux(sessionName: string): string {
   }
 }
 
-function sendKeysViaTmux(sessionName: string, keys: string[]): void {
+async function sendKeysViaTmux(sessionName: string, keys: string[]): Promise<void> {
   for (const key of keys) {
     try {
-      execFileSync(
+      await execFileAsync(
         TMUX_PATH,
         [...TMUX_ARGS, "send-keys", "-t", sessionName, key],
         { timeout: 2000 }
@@ -213,7 +227,7 @@ export function startDialogWatchdog(
     try {
       let pane: string;
       try {
-        pane = capture(tmuxSessionName);
+        pane = await capture(tmuxSessionName);
       } catch (err) {
         // capture-pane failed — typically ETIMEDOUT while the shared tmux
         // server is overloaded by many concurrent watchdogs (Issue #222).
@@ -257,7 +271,7 @@ export function startDialogWatchdog(
           `[Dialog] auto-accepted: ${match.kind} (attempt ${consecutiveAttempts}/${maxAutoAcceptAttempts}) on ${tmuxSessionName}`
         );
         try {
-          sendKeys(tmuxSessionName, keys);
+          await sendKeys(tmuxSessionName, keys);
         } catch (err) {
           console.warn(
             `[Dialog] auto-accept send-keys threw for ${tmuxSessionName}:`,

--- a/supervisor/tests/session/dialog-watchdog.test.ts
+++ b/supervisor/tests/session/dialog-watchdog.test.ts
@@ -158,7 +158,9 @@ describe("dialog-watchdog", () => {
       pollIntervalMs: SHORT_TICK_MS,
       maxAutoAcceptAttempts: 1,
       capture: () => "rm dangerous\nDo you want to proceed? (y/N)\n",
-      sendKeys: (_, keys) => sentKeys.push(keys),
+      sendKeys: (_, keys) => {
+        sentKeys.push(keys);
+      },
       setTimer: clock.setTimer,
       clearTimer: clock.clearTimer,
     });
@@ -181,7 +183,9 @@ describe("dialog-watchdog", () => {
       maxAutoAcceptAttempts: 1,
       capture: () =>
         "● How is Claude doing this session? (optional)\n  1: Bad    2: Fine   3: Good   0: Dismiss\n",
-      sendKeys: (_, keys) => sentKeys.push(keys),
+      sendKeys: (_, keys) => {
+        sentKeys.push(keys);
+      },
       onAutoAccept: (m) => accepts.push(m),
       setTimer: clock.setTimer,
       clearTimer: clock.clearTimer,
@@ -426,5 +430,73 @@ describe("dialog-watchdog tmux backoff (#222)", () => {
     await clock.advance(SHORT_TICK_MS * 4);
     watchdog.stop();
     expect(accepts.length).toBe(0);
+  });
+});
+
+/**
+ * Issue #227 (PR-2 / #250) AC-3: the watchdog's poll tick must NOT block the
+ * Bun single event loop while a tmux `capture-pane` / `send-keys` is in flight.
+ * PR-2 moved `captureViaTmux` / `sendKeysViaTmux` to async `execFile` and made
+ * the tick `await` the (now-async) capture/send seams.
+ *
+ * This exercises the public injection seam with REAL timers (no virtual clock):
+ * the first capture "parks" (its promise is held), and we prove a separately
+ * scheduled `setTimeout(0)` runs WHILE the tick is suspended at `await
+ * capture(...)`. A synchronous capture would have driven the whole tick to
+ * completion before any competing timer callback could interleave, so the
+ * ordering asserted here is impossible without the async conversion.
+ */
+describe("dialog-watchdog poll is non-blocking (#227 / #250 AC-3)", () => {
+  test("a poll tick yields the event loop while capture is in flight", async () => {
+    const order: string[] = [];
+    let captureCount = 0;
+    let releaseCapture: ((text: string) => void) | null = null;
+
+    const watchdog = startDialogWatchdog({
+      tmuxSessionName: "nonblock",
+      pollIntervalMs: 1, // first tick fires almost immediately (real timer)
+      maxAutoAcceptAttempts: 1,
+      capture: () => {
+        captureCount++;
+        if (captureCount === 1) {
+          // Park: the tick suspends here until the test releases it. While
+          // suspended the loop must stay free if capture is truly awaited.
+          return new Promise<string>((resolve) => {
+            order.push("capture-invoked");
+            releaseCapture = (text) => resolve(text);
+          });
+        }
+        // Later ticks: clean pane, resolve immediately (no dangling promise).
+        return "";
+      },
+      sendKeys: () => {
+        order.push("sendKeys");
+      },
+    });
+
+    // Let the first tick start and park inside capture.
+    await new Promise<void>((r) => setTimeout(r, 15));
+    // Competing macrotask: with a blocking sync capture, the tick would have
+    // finished before this 0ms timer could interleave.
+    await new Promise<void>((r) =>
+      setTimeout(() => {
+        order.push("competing");
+        r();
+      }, 0)
+    );
+
+    // capture started + competing ran, and the tick is STILL parked (no
+    // sendKeys yet) → the event loop stayed free during the tmux call.
+    expect(order).toContain("capture-invoked");
+    expect(order).toContain("competing");
+    expect(order).not.toContain("sendKeys");
+
+    // Release with a known dialog so the tick resumes and reaches await sendKeys.
+    expect(releaseCapture).not.toBeNull();
+    releaseCapture!("Permission required\n  ❯ Yes\n    No\n");
+    await new Promise<void>((r) => setTimeout(r, 15));
+    expect(order).toContain("sendKeys");
+
+    watchdog.stop();
   });
 });


### PR DESCRIPTION
## 概要

親 #227（tmux 同期I/O の完全非同期化）の **PR-2**。`dialog-watchdog.ts` は relay 中の各セッションを **5 秒毎にポーリング**し、`captureViaTmux` / `sendKeysViaTmux` が同期 `execFileSync` を使っていた。同時セッション数ぶんの同期ブロックが毎 tick 累積する構造で、#227 が名指しした**最大の starvation 源**。本 PR でこれを async `execFile` 化する。

`tick` は既に `async`、capture / send は注入 seam を持つため、デフォルト実装の async 化 + tick 内 `await` で対応できる。

## 主な変更点

- `captureViaTmux` / `sendKeysViaTmux` を `promisify(execFile)` ベースの async 実装へ置換。
- 注入 seam の型を `string | Promise<string>` / `void | Promise<void>` に widen。`tick` で `await capture(...)` / `await sendKeys(...)`。既存の sync fake はそのまま互換。
- per-call timeout は `execFile` の `timeout` オプションへ移送（挙動不変）。

## 非対象（scope 分離）

- capture 失敗時の **exponential backoff**（劣化サーバを 5s 毎に叩かない）は #227 の follow-up 候補で別 issue。本 PR は純粋な同期→非同期化に限定（RW-035 の scope creep 回避）。既存の `nextPollInterval` backoff ロジックはそのまま維持。

## 受け入れ条件（コンポーネント・決定的）

| AC | 内容 | 結果 |
|---|---|---|
| AC-1 | `grep -c execFileSync src/session/dialog-watchdog.ts` = 0 | ✅ 0 |
| AC-2 | watchdog 関連 test（dialog-watchdog / dialog-stuck-handler / stall-heartbeat / dialog-detect）が async 注入で全 PASS | ✅ 43 pass |
| AC-3 | 非ブロック回帰 test：注入 capture を park し、tick 実行中に競合 `setTimeout(0)` が先行 + parked 中は sendKeys 未発火を assert（同期では不成立） | ✅ pass |
| AC-4 | `bun scripts/lint-blocking-in-timers.ts`（#27）green 維持 | ✅ green |

加えて：typecheck exit 0（`push()` を返していた fake 2 件を void 化 — union 型で void-return leniency が効かないため）、gating-coverage（#248）green、relay 消費者テスト pass。

AC-3 は watchdog の注入 seam（capture/sendKeys）を使うため `mock.module` 不要 → 既存の gated file 内に追加（新規 CI step なし）。

## 統合ジャーニーAC

不要（Issue 記載どおり）：Supervisor 内部のポーリング I/O 実装変更で、ユーザーが踏む新たな一連フローを伴わない。外形挙動は不変。

## 関連

- 親: #227（PR-2）/ 上流: #222
- 前: #256（PR-1, merged）/ 次: PR-3 #251（TmuxAdapter interface Promise 化）

Closes #250
