### PR TITLE
perf(#251): TmuxAdapter interface を Promise 化 (#227 PR-3, atomic flip)

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -90,7 +90,8 @@ export async function startBot(token: string): Promise<void> {
   // signal pages at most once per episode.
   const activityWatchdog = new ActivityWatchdog({
     entries: () => sessionManager.entries(),
-    isAlive: (threadId) => sessionManager.livenessOf(threadId) === "alive",
+    isAlive: async (threadId) =>
+      (await sessionManager.livenessOf(threadId)) === "alive",
     notify: async (threadId, warning) => {
       try {
         const channel = await client.channels.fetch(threadId);
@@ -479,7 +480,7 @@ export async function startBot(token: string): Promise<void> {
         );
         return;
       }
-      const salvage = buildSalvageReply(sessionManager, threadId);
+      const salvage = await buildSalvageReply(sessionManager, threadId);
       try {
         await (message.channel as ThreadChannel).send(salvage);
       } catch (err) {
@@ -508,7 +509,7 @@ export async function startBot(token: string): Promise<void> {
           .toLowerCase();
         if (withoutMention === "status") {
           try {
-            await thread.send(buildStatusReply(sessionManager, threadId));
+            await thread.send(await buildStatusReply(sessionManager, threadId));
           } catch (err) {
             console.error(
               `[Bot] Failed to send status reply in thread ${threadId}:`,

--- a/supervisor/src/commands/session.ts
+++ b/supervisor/src/commands/session.ts
@@ -206,7 +206,7 @@ async function handleStatus(
   // (#168) + claude_session_id. Runs outside the message-relay path, so it can
   // never hijack a real work message.
   await interaction.reply({
-    content: buildStatusReply(sessionManager, channel.id),
+    content: await buildStatusReply(sessionManager, channel.id),
   });
 }
 
@@ -435,7 +435,7 @@ async function handleResume(
   // this claude session id and crosses pid + tmux reality. This is a fast-path
   // UX check — `resumeSession` re-checks under the single-flight lock to close
   // the TOCTOU (穴 C).
-  if (sessionManager.livenessOfClaudeSession(sessionId) === "alive") {
+  if ((await sessionManager.livenessOfClaudeSession(sessionId)) === "alive") {
     await interaction.reply({
       content:
         "⚠️ この session は既に稼働中です。稼働中のスレッドで操作してください（`/session list` で確認できます）。",

--- a/supervisor/src/session/adapters-fake.ts
+++ b/supervisor/src/session/adapters-fake.ts
@@ -27,19 +27,22 @@ export class FakeTmuxAdapter implements TmuxAdapter {
   /** When set, sendKeys() throws to simulate a failure during prompt confirm. */
   failOnSendKeys = false;
 
-  newSession(name: string, command: string): void {
+  // Issue #227 (PR-3): the TmuxAdapter interface methods are now async, so the
+  // fakes return Promises too. The in-memory bookkeeping stays synchronous; the
+  // `async` keyword just wraps the result so `await fake.x()` matches production.
+  async newSession(name: string, command: string): Promise<void> {
     this.sessions.set(name, { command, pid: this.pidCounter++ });
   }
 
-  killSession(name: string): void {
+  async killSession(name: string): Promise<void> {
     this.sessions.delete(name);
   }
 
-  hasSession(name: string): boolean {
+  async hasSession(name: string): Promise<boolean> {
     return this.sessions.has(name);
   }
 
-  getPid(name: string): number | null {
+  async getPid(name: string): Promise<number | null> {
     return this.sessions.get(name)?.pid ?? null;
   }
 
@@ -47,11 +50,11 @@ export class FakeTmuxAdapter implements TmuxAdapter {
     this.ensureSocketConfiguredCalls += 1;
   }
 
-  capturePane(name: string): string {
+  async capturePane(name: string): Promise<string> {
     return this.paneContent.get(name) ?? "";
   }
 
-  sendKeys(name: string, keys: string[]): void {
+  async sendKeys(name: string, keys: string[]): Promise<void> {
     this.sendKeysCalls.push({ name, keys });
     if (this.failOnSendKeys) {
       throw new Error("sendKeys failed");

--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -1,4 +1,5 @@
-import { execFileSync } from "child_process";
+import { execFile } from "child_process";
+import { promisify } from "util";
 import {
   openTab as realOpenTab,
   markTabStopped as realMarkTabStopped,
@@ -31,23 +32,28 @@ import {
  */
 
 export interface TmuxAdapter {
-  newSession(name: string, command: string): void;
-  killSession(name: string): void;
-  hasSession(name: string): boolean;
-  getPid(name: string): number | null;
+  // Issue #227 (PR-3): every tmux call below runs via the *async* `execFile`
+  // so a wedged tmux server can never block the Bun single event loop. The
+  // return types are Promise — this interface flip is atomic (TypeScript types
+  // cannot be migrated incrementally), so all consumers await. `ensureSocketConfigured`
+  // stays sync: it delegates to tmux.ts (converted separately in PR-4).
+  newSession(name: string, command: string): Promise<void>;
+  killSession(name: string): Promise<void>;
+  hasSession(name: string): Promise<boolean>;
+  getPid(name: string): Promise<number | null>;
   ensureSocketConfigured(): void;
   /**
    * Capture the visible pane content (`tmux capture-pane -p`). Returns "" on
    * error. Used by the resume flow (Issue #161) to detect Claude Code's
    * interactive "Resume from summary" prompt so it can be auto-confirmed.
    */
-  capturePane(name: string): string;
+  capturePane(name: string): Promise<string>;
   /**
    * Send raw keys to the pane (`tmux send-keys -t <name> <keys...>`).
    * Best-effort: a transient failure is swallowed (the caller's poll loop
    * retries or proceeds). Used to confirm the resume prompt with `C-m` (Enter).
    */
-  sendKeys(name: string, keys: string[]): void;
+  sendKeys(name: string, keys: string[]): Promise<void>;
 }
 
 export interface ItermAdapter {
@@ -102,7 +108,7 @@ export interface SessionEffects {
 
 // Issue #222: bound every synchronous tmux call so a wedged tmux server (whose
 // capture-pane / send-keys ETIMEDOUT rate climbs over Supervisor uptime) cannot
-// block the Node event loop indefinitely. An unbounded execFileSync stall here
+// block the Node event loop indefinitely. An unbounded synchronous tmux stall here
 // starves relay HTTP response handling, surfacing as delayed / 5-min-timed-out
 // Discord delivery rather than hard failures (the #222 symptom). 2s matches the
 // existing ceilings in dialog-watchdog.ts / relay.ts; on timeout each call below
@@ -121,35 +127,43 @@ const TMUX_NEW_SESSION_TIMEOUT_MS = 10_000;
  * already sees the ETIMEDOUT.
  */
 function warnIfTmuxTimeout(op: string, name: string, err: unknown): boolean {
-  if ((err as NodeJS.ErrnoException | undefined)?.code === "ETIMEDOUT") {
+  // Issue #227 (PR-3): after the sync→async migration a `timeout` no longer
+  // surfaces as `code === "ETIMEDOUT"` (that was the *sync* spawn shape). The
+  // async `execFile` kills the child with `killSignal` (default SIGTERM) and
+  // sets `killed === true` with `code` left null. Accept both so the #238
+  // contract (a tmux timeout means "liveness unknown" → hasSession returns
+  // true, never a false teardown) holds identically after the migration.
+  const e = err as (NodeJS.ErrnoException & { killed?: boolean }) | undefined;
+  if (e?.code === "ETIMEDOUT" || e?.killed === true) {
     console.warn(`[tmux] ${op} timed out for ${name} after ${TMUX_CALL_TIMEOUT_MS}ms`);
     return true;
   }
   return false;
 }
 
+const execFileAsync = promisify(execFile);
+
 export const realTmuxAdapter: TmuxAdapter = {
-  newSession(name, command) {
+  async newSession(name, command) {
     // Issue #147: previous `execSync(\`tmux new-session ... '${command}'\`)`
     // wrapped the entire command in single quotes. When `command` itself
     // contained single quotes (e.g. `--mcp-config '{"mcpServers":{}}'` added
     // in #104), the outer quotes closed prematurely, exposing the inner JSON
     // to bash word-splitting and quote stripping — claude received malformed
-    // arguments and exited immediately. Using execFileSync with an argv array
+    // arguments and exited immediately. Using execFile with an argv array
     // avoids shell parsing entirely: tmux receives `command` as a single
     // argument and invokes /bin/sh -c on it once, inside the new session.
-    execFileSync(TMUX_PATH, [...TMUX_ARGS, "new-session", "-d", "-s", name, command], {
+    await execFileAsync(TMUX_PATH, [...TMUX_ARGS, "new-session", "-d", "-s", name, command], {
       timeout: TMUX_NEW_SESSION_TIMEOUT_MS,
     });
   },
-  killSession(name) {
-    // PR #148 review (gemini critical): use execFileSync + argv array so an
+  async killSession(name) {
+    // PR #148 review (gemini critical): use execFile + argv array so an
     // attacker-controlled `name` cannot inject shell metacharacters via the
-    // template literal. `stdio: "ignore"` matches the previous `2>/dev/null`
-    // (silence the expected "no session" error).
+    // template literal. execFile does not inherit stdio, so the expected
+    // "no session" error is silenced as before (previous `2>/dev/null`).
     try {
-      execFileSync(TMUX_PATH, [...TMUX_ARGS, "kill-session", "-t", name], {
-        stdio: "ignore",
+      await execFileAsync(TMUX_PATH, [...TMUX_ARGS, "kill-session", "-t", name], {
         timeout: TMUX_CALL_TIMEOUT_MS,
       });
     } catch (err) {
@@ -157,10 +171,9 @@ export const realTmuxAdapter: TmuxAdapter = {
       warnIfTmuxTimeout("kill-session", name, err);
     }
   },
-  hasSession(name) {
+  async hasSession(name) {
     try {
-      execFileSync(TMUX_PATH, [...TMUX_ARGS, "has-session", "-t", name], {
-        stdio: "ignore",
+      await execFileAsync(TMUX_PATH, [...TMUX_ARGS, "has-session", "-t", name], {
         timeout: TMUX_CALL_TIMEOUT_MS,
       });
       return true;
@@ -177,15 +190,16 @@ export const realTmuxAdapter: TmuxAdapter = {
       return false;
     }
   },
-  getPid(name) {
-    // stdio: ["ignore", "pipe", "ignore"] — we need stdout to read the pid,
-    // but stderr is discarded just like the previous `2>/dev/null`.
+  async getPid(name) {
+    // execFile captures stdout (the pid) and discards stderr to the buffer
+    // (not inherited) just like the previous `2>/dev/null`.
     try {
-      const output = execFileSync(
+      const { stdout } = await execFileAsync(
         TMUX_PATH,
         [...TMUX_ARGS, "list-panes", "-t", name, "-F", "#{pane_pid}"],
-        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: TMUX_CALL_TIMEOUT_MS }
-      ).trim();
+        { encoding: "utf8", timeout: TMUX_CALL_TIMEOUT_MS }
+      );
+      const output = stdout.trim();
       const pid = parseInt(output.split("\n")[0] ?? "", 10);
       return isNaN(pid) ? null : pid;
     } catch (err) {
@@ -196,26 +210,26 @@ export const realTmuxAdapter: TmuxAdapter = {
   ensureSocketConfigured() {
     realEnsureSocketConfigured();
   },
-  capturePane(name) {
-    // stdio: ["ignore", "pipe", "ignore"] — read stdout, discard stderr (the
-    // "can't find pane" case is handled by the catch returning "").
+  async capturePane(name) {
+    // execFile reads stdout; stderr is buffered (not inherited) — the
+    // "can't find pane" case is handled by the catch returning "".
     try {
-      return execFileSync(
+      const { stdout } = await execFileAsync(
         TMUX_PATH,
         [...TMUX_ARGS, "capture-pane", "-p", "-t", name],
-        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"], timeout: TMUX_CALL_TIMEOUT_MS }
+        { encoding: "utf8", timeout: TMUX_CALL_TIMEOUT_MS }
       );
+      return stdout;
     } catch (err) {
       warnIfTmuxTimeout("capture-pane", name, err);
       return "";
     }
   },
-  sendKeys(name, keys) {
-    // execFileSync + argv array: no shell, so `keys` cannot inject
+  async sendKeys(name, keys) {
+    // execFile + argv array: no shell, so `keys` cannot inject
     // metacharacters. Best-effort — swallow transient tmux errors.
     try {
-      execFileSync(TMUX_PATH, [...TMUX_ARGS, "send-keys", "-t", name, ...keys], {
-        stdio: "ignore",
+      await execFileAsync(TMUX_PATH, [...TMUX_ARGS, "send-keys", "-t", name, ...keys], {
         timeout: TMUX_CALL_TIMEOUT_MS,
       });
     } catch (err) {

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -192,6 +192,13 @@ export interface SessionManagerOptions {
    */
   inputReadyPollAttempts?: number;
   inputReadyPollIntervalMs?: number;
+  /**
+   * Override the {@link SessionManager.watchTmuxSession} poll interval. Tests
+   * shrink this (e.g. to a few ms) to drive the async re-entry guard
+   * deterministically without waiting the production 10s (Issue #227 PR-3).
+   * Defaults to 10_000.
+   */
+  watchIntervalMs?: number;
 }
 
 export class SessionManager {
@@ -225,6 +232,7 @@ export class SessionManager {
   private readonly resumePromptPollIntervalMs: number;
   private readonly inputReadyPollAttempts: number;
   private readonly inputReadyPollIntervalMs: number;
+  private readonly watchIntervalMs: number;
 
   constructor(options: SessionManagerOptions = {}) {
     this.effects = {
@@ -245,11 +253,24 @@ export class SessionManager {
       options.inputReadyPollAttempts ?? INPUT_READY_POLL_ATTEMPTS;
     this.inputReadyPollIntervalMs =
       options.inputReadyPollIntervalMs ?? 1000;
+    this.watchIntervalMs = options.watchIntervalMs ?? 10_000;
 
     this.effects.tmux.ensureSocketConfigured();
     this.effects.relayServer.start();
-    this.recoverFromDb();
+    // Issue #227 (PR-3): recoverFromDb is async now (it awaits tmux has/kill).
+    // The constructor cannot await, so we keep the recovery promise for tests
+    // and any caller that needs to wait for startup orphan-cleanup to finish.
+    this.recovery = this.recoverFromDb();
   }
+
+  /**
+   * Startup orphan-recovery promise (Issue #227 PR-3). Resolves once
+   * {@link recoverFromDb} has finished reconciling DB `running` rows against
+   * live tmux sessions. Awaitable by tests that assert post-recovery state;
+   * production fire-and-forgets it (recovery only kills stale tmux + marks rows
+   * stopped, which races nothing the first relay depends on).
+   */
+  readonly recovery: Promise<void>;
 
   count(): number {
     return this.sessions.size;
@@ -278,13 +299,15 @@ export class SessionManager {
    *   - row.status === "running" + (pid dead OR tmux missing) → `dead`
    *     (DB says running but reality contradicts — answer is the reality)
    */
-  livenessOf(threadId: string): Liveness {
+  async livenessOf(threadId: string): Promise<Liveness> {
     const row = getSessionByThreadId(threadId);
     if (!row) return "unknown";
     if (row.status !== "running") return "dead";
     if (row.pid == null) return "dead";
     const pidAlive = this.effects.process.isAlive(row.pid);
-    const tmuxAlive = this.effects.tmux.hasSession(
+    // Issue #227 (PR-3): hasSession is async now, so livenessOf is too. All
+    // callers (salvage / resume guards) already await this verdict.
+    const tmuxAlive = await this.effects.tmux.hasSession(
       this.tmuxSessionName(threadId)
     );
     return pidAlive && tmuxAlive ? "alive" : "dead";
@@ -301,7 +324,7 @@ export class SessionManager {
    * genuinely-live session still rejects. Returns `unknown` when no row exists
    * for the id (callers treat `unknown` as "not alive → resume may proceed").
    */
-  livenessOfClaudeSession(claudeSessionId: string): Liveness {
+  async livenessOfClaudeSession(claudeSessionId: string): Promise<Liveness> {
     const row = getSessionByClaudeSessionId(claudeSessionId);
     if (!row || row.thread_id == null) return "unknown";
     return this.livenessOf(row.thread_id);
@@ -426,7 +449,7 @@ export class SessionManager {
     const tmuxName = this.tmuxSessionName(threadId);
 
     // Kill existing tmux session if any
-    this.effects.tmux.killSession(tmuxName);
+    await this.effects.tmux.killSession(tmuxName);
 
     // Build the claude command — unset ANTHROPIC_API_KEY to use Claude Max subscription
     // encodeURIComponent: Discord thread IDs are numeric today, but encode at
@@ -462,7 +485,7 @@ export class SessionManager {
 
     // Launch via tmux (provides a real TTY). Uses Supervisor's dedicated
     // -L claude-hub socket (see ./tmux.ts) so user config is not inherited.
-    this.effects.tmux.newSession(tmuxName, claudeCmd);
+    await this.effects.tmux.newSession(tmuxName, claudeCmd);
     // Apply server-wide options now that the server is definitely running.
     // The constructor's eager call is a no-op before the first new-session.
     this.effects.tmux.ensureSocketConfigured();
@@ -473,7 +496,7 @@ export class SessionManager {
     // the single-process Discord bot's event loop. Mirrors resumeSession().
     let pid: number | null = null;
     for (let i = 0; i < 5; i++) {
-      pid = this.effects.tmux.getPid(tmuxName);
+      pid = await this.effects.tmux.getPid(tmuxName);
       if (pid) break;
       await new Promise((resolve) => setTimeout(resolve, 500));
     }
@@ -601,7 +624,7 @@ export class SessionManager {
       // between the handler's check and our insert: a session that became alive
       // (or was already alive) is rejected; a stale `status='running'` row whose
       // process is dead is treated as dead and resume proceeds.
-      if (this.livenessOfClaudeSession(claudeSessionId) === "alive") {
+      if ((await this.livenessOfClaudeSession(claudeSessionId)) === "alive") {
         throw new Error(
           "この session は既に稼働中です。稼働中のスレッドで操作してください（多重 resume 防止）。"
         );
@@ -683,7 +706,7 @@ export class SessionManager {
   ): Promise<SessionInfo> {
     const sessionId = randomUUID();
     const tmuxName = this.tmuxSessionName(threadId);
-    this.effects.tmux.killSession(tmuxName);
+    await this.effects.tmux.killSession(tmuxName);
 
     const relayUrl = `http://localhost:${this.effects.relayServer.getPort()}/relay/${encodeURIComponent(threadId)}`;
     const relayUrlFile = relayUrlFilePath(projectDir);
@@ -710,12 +733,12 @@ export class SessionManager {
       `exec ${CLAUDE_PATH} ${resumeFlags.join(" ")}`,
     ].join(" && ");
 
-    this.effects.tmux.newSession(tmuxName, claudeCmd);
+    await this.effects.tmux.newSession(tmuxName, claudeCmd);
     this.effects.tmux.ensureSocketConfigured();
 
     let pid: number | null = null;
     for (let i = 0; i < 5; i++) {
-      pid = this.effects.tmux.getPid(tmuxName);
+      pid = await this.effects.tmux.getPid(tmuxName);
       if (pid) break;
       // Async wait — resumeSession is async, so unlike start()'s synchronous
       // execSync("sleep") this does not block the single-process Discord bot's
@@ -778,7 +801,7 @@ export class SessionManager {
       });
     } catch (err) {
       this.sessions.delete(threadId);
-      this.effects.tmux.killSession(tmuxName);
+      await this.effects.tmux.killSession(tmuxName);
       this.cleanupRelayUrlFile(projectDir);
       throw err;
     }
@@ -820,11 +843,11 @@ export class SessionManager {
    */
   private async confirmResumePromptIfPresent(tmuxName: string): Promise<void> {
     for (let i = 0; i < this.resumePromptPollAttempts; i++) {
-      const pane = this.effects.tmux.capturePane(tmuxName);
+      const pane = await this.effects.tmux.capturePane(tmuxName);
       if (RESUME_PROMPT_RE.test(pane)) {
         // Down moves from option 1 (summary, highlighted) to option 2 (full
         // session as-is); C-m confirms. See Issue #163.
-        this.effects.tmux.sendKeys(tmuxName, ["Down", "C-m"]);
+        await this.effects.tmux.sendKeys(tmuxName, ["Down", "C-m"]);
         return;
       }
       // Reached the normal input prompt with no picker — stop polling instead
@@ -857,8 +880,8 @@ export class SessionManager {
   async waitForInputReady(threadId: string): Promise<boolean> {
     const tmuxName = this.tmuxSessionName(threadId);
     for (let i = 0; i < this.inputReadyPollAttempts; i++) {
-      if (!this.effects.tmux.hasSession(tmuxName)) return false;
-      const pane = this.effects.tmux.capturePane(tmuxName);
+      if (!(await this.effects.tmux.hasSession(tmuxName))) return false;
+      const pane = await this.effects.tmux.capturePane(tmuxName);
       if (INPUT_READY_RE.test(pane)) return true;
       await new Promise((resolve) =>
         setTimeout(resolve, this.inputReadyPollIntervalMs)
@@ -893,7 +916,7 @@ export class SessionManager {
     const tmuxName = this.tmuxSessionName(threadId);
 
     // Check tmux session is alive
-    if (!this.effects.tmux.hasSession(tmuxName)) {
+    if (!(await this.effects.tmux.hasSession(tmuxName))) {
       return {
         text: "",
         chunks: ["⚠️ Claude Code セッションが終了しています。`/session start` で再起動してください。"],
@@ -960,7 +983,7 @@ export class SessionManager {
     }
 
     const tmuxName = this.tmuxSessionName(threadId);
-    if (!this.effects.tmux.hasSession(tmuxName)) {
+    if (!(await this.effects.tmux.hasSession(tmuxName))) {
       throw new Error("tmux session dead");
     }
 
@@ -1014,8 +1037,11 @@ export class SessionManager {
 
     // Wait for graceful shutdown, then force kill tmux session
     await new Promise<void>((resolve) => {
-      setTimeout(() => {
-        this.effects.tmux.killSession(tmuxName);
+      setTimeout(async () => {
+        // Issue #227 (PR-3): killSession is now async; await it before resolving
+        // so the graceful-kill wait still completes only after the tmux session
+        // is actually gone (ordering unchanged from the sync version).
+        await this.effects.tmux.killSession(tmuxName);
         resolve();
       }, this.gracefulKillTimeoutMs);
     });
@@ -1145,40 +1171,52 @@ export class SessionManager {
     tmuxName: string,
     sessionId: string
   ): void {
-    const interval = setInterval(() => {
-      if (!this.effects.tmux.hasSession(tmuxName)) {
-        const session = this.sessions.get(threadId);
-        console.log(
-          `[SessionManager] tmux session ${tmuxName} exited`
-        );
-        this.sessions.delete(threadId);
-        if (session) {
-          this.effects.iterm2.markTabStopped(session.channelName, tmuxName);
-          this.cleanupRelayUrlFile(session.projectDir);
-          // Issue #154: the worktree is intentionally NOT removed here. An
-          // unexpected claude exit is not an explicit teardown — removing the
-          // worktree (git worktree remove --force) would discard any
-          // uncommitted work the user did not choose to drop. Only the explicit
-          // /session stop removes it (Q3); until then it is reused on restart
-          // of the same branch (Q4).
+    // Issue #227 (PR-3): hasSession is now async (it awaits a tmux call that can
+    // take up to TMUX_CALL_TIMEOUT_MS under load). A 10s poll could therefore
+    // fire the next tick before the previous tick's check resolves, letting two
+    // ticks both observe "exited" and run teardown twice. `isChecking` is a
+    // re-entry guard: a tick that overlaps a still-running check simply skips.
+    let isChecking = false;
+    const interval = setInterval(async () => {
+      if (isChecking) return;
+      isChecking = true;
+      try {
+        if (!(await this.effects.tmux.hasSession(tmuxName))) {
+          const session = this.sessions.get(threadId);
+          console.log(
+            `[SessionManager] tmux session ${tmuxName} exited`
+          );
+          this.sessions.delete(threadId);
+          if (session) {
+            this.effects.iterm2.markTabStopped(session.channelName, tmuxName);
+            this.cleanupRelayUrlFile(session.projectDir);
+            // Issue #154: the worktree is intentionally NOT removed here. An
+            // unexpected claude exit is not an explicit teardown — removing the
+            // worktree (git worktree remove --force) would discard any
+            // uncommitted work the user did not choose to drop. Only the explicit
+            // /session stop removes it (Q3); until then it is reused on restart
+            // of the same branch (Q4).
+          }
+          updateSessionStatus(sessionId, "stopped", "tmux_exited");
+          this.clearWatcher(threadId);
         }
-        updateSessionStatus(sessionId, "stopped", "tmux_exited");
-        this.clearWatcher(threadId);
+      } finally {
+        isChecking = false;
       }
-    }, 10_000); // Check every 10 seconds
+    }, this.watchIntervalMs); // Check every 10 seconds (overridable in tests)
     this.watchers.set(threadId, interval);
   }
 
-  private recoverFromDb(): void {
+  private async recoverFromDb(): Promise<void> {
     const rows = getRunningSessions();
     for (const row of rows) {
       if (row.thread_id) {
         const tmuxName = this.tmuxSessionName(row.thread_id);
-        if (this.effects.tmux.hasSession(tmuxName)) {
+        if (await this.effects.tmux.hasSession(tmuxName)) {
           console.log(
             `[SessionManager] Found running tmux session ${tmuxName}, killing (supervisor restart)`
           );
-          this.effects.tmux.killSession(tmuxName);
+          await this.effects.tmux.killSession(tmuxName);
         }
       }
       this.cleanupRelayUrlFile(row.project_dir);

--- a/supervisor/src/session/session-activity-watchdog.ts
+++ b/supervisor/src/session/session-activity-watchdog.ts
@@ -210,9 +210,11 @@ export interface ActivityWatchdogDeps {
   entries(): IterableIterator<[string, WatchdogSession]>;
   /**
    * Authoritative liveness for a thread. Dead sessions are skipped — the reaper
-   * owns terminating them; warning about a dead session would be noise.
+   * owns terminating them; warning about a dead session would be noise. May be
+   * sync or async: `check()` awaits it, so the async `sessionManager.livenessOf`
+   * (Issue #227 PR-3) and a sync test fake both satisfy this.
    */
-  isAlive(threadId: string): boolean;
+  isAlive(threadId: string): boolean | Promise<boolean>;
   /** Deliver a warning (best-effort; throwing is caught per-session). */
   notify(threadId: string, warning: ActivityWarning): void | Promise<void>;
   thresholds?: ActivityThresholds;
@@ -280,7 +282,7 @@ export class ActivityWatchdog {
 
       let alive: boolean;
       try {
-        alive = this.deps.isAlive(threadId);
+        alive = await this.deps.isAlive(threadId);
       } catch (err) {
         console.warn(
           `[ActivityWatchdog] isAlive(${threadId}) threw:`,

--- a/supervisor/src/session/status-reply.ts
+++ b/supervisor/src/session/status-reply.ts
@@ -22,11 +22,11 @@ import { getSessionByThreadId } from "../infra/db";
  *   - dead + claude_session_id    → stopped; offer `/session resume <id>`
  *   - dead + id missing           → pre-#167 row; suggest /session start
  */
-export function buildSalvageReply(
+export async function buildSalvageReply(
   sessionManager: SessionManager,
   threadId: string
-): string {
-  const verdict = sessionManager.livenessOf(threadId);
+): Promise<string> {
+  const verdict = await sessionManager.livenessOf(threadId);
   if (verdict === "unknown") {
     return "ℹ️ このスレッドにはセッション履歴がありません。`/session start` で開始してください。";
   }
@@ -76,17 +76,17 @@ export function buildSalvageReply(
  * not "Supervisor lost tracking". Dead/unknown reuse the salvage wording so the
  * resume guidance stays identical.
  */
-export function buildStatusReply(
+export async function buildStatusReply(
   sessionManager: SessionManager,
   threadId: string
-): string {
+): Promise<string> {
   // "稼働中" only when the session is BOTH live AND tracked in memory — i.e. the
   // Supervisor can actually relay to it. If livenessOf is alive but the session
   // is no longer tracked (has() === false), the user cannot interact with it;
   // fall through to the salvage wording which says the Supervisor lost tracking
   // (gemini HIGH review, PR #179).
   if (
-    sessionManager.livenessOf(threadId) === "alive" &&
+    (await sessionManager.livenessOf(threadId)) === "alive" &&
     sessionManager.has(threadId)
   ) {
     const row = getSessionByThreadId(threadId);
@@ -99,5 +99,5 @@ export function buildStatusReply(
     );
   }
   // not tracked (lost tracking), dead, or unknown → salvage wording covers all.
-  return buildSalvageReply(sessionManager, threadId);
+  return await buildSalvageReply(sessionManager, threadId);
 }

--- a/supervisor/tests/session/adapters-hassession.test.ts
+++ b/supervisor/tests/session/adapters-hassession.test.ts
@@ -10,7 +10,7 @@ import {
 
 /**
  * Issue #238: `realTmuxAdapter.hasSession()` must NOT treat a tmux *timeout*
- * (ETIMEDOUT) as "session exited".
+ * as "session exited".
  *
  * Under tmux-server contention (Issue #222 symptom) `has-session` can time out
  * at TMUX_CALL_TIMEOUT_MS even though the session is alive. The previous catch
@@ -20,39 +20,75 @@ import {
  * unknown" — for a teardown gate we must assume alive (return true). A genuine
  * "no such session" surfaces as a non-timeout error and must still return false.
  *
- * We mock child_process.execFileSync (same approach as tmux.test.ts).
+ * Issue #227 (PR-3): the adapter now uses the *async* `execFile`, so we mock
+ * `child_process.execFile` (callback style — promisify(execFile) drives the
+ * trailing callback). Crucially the async timeout shape is `killed === true`
+ * (SIGTERM kill), NOT `code === "ETIMEDOUT"` (that was the sync spawn shape);
+ * both must be honored by `warnIfTmuxTimeout` or #238 regresses on real load.
  */
 
 import * as childProcess from "child_process";
 
-let mockExecFileSyncImpl: (...args: unknown[]) => string = () => "";
-const mockExecFileSync = mock((...args: unknown[]) =>
-  mockExecFileSyncImpl(...args)
-);
+/** Error the next execFile call should reject with (null = resolve success). */
+let mockExecFileError: unknown = null;
+
+// promisify(execFile) invokes the fn as fn(file, args, opts, cb); the callback
+// is always the final argument. We resolve `{ stdout, stderr }` on success or
+// reject with the programmed error.
+const mockExecFile = mock((...args: unknown[]) => {
+  const cb = args[args.length - 1] as (
+    err: unknown,
+    result: { stdout: string; stderr: string }
+  ) => void;
+  if (mockExecFileError) {
+    cb(mockExecFileError, { stdout: "", stderr: "" });
+  } else {
+    cb(null, { stdout: "", stderr: "" });
+  }
+  return {} as childProcess.ChildProcess;
+});
 
 // Preserve the rest of child_process (relay-server / iterm2 in adapters.ts's
-// import graph use `spawn`) and override only execFileSync.
+// import graph use `spawn`) and override only execFile.
 mock.module("child_process", () => ({
   ...childProcess,
-  execFileSync: mockExecFileSync,
+  execFile: mockExecFile,
 }));
 
 const { realTmuxAdapter } = await import("../../src/session/adapters");
 
-function makeTimeoutError(): NodeJS.ErrnoException {
+/** Sync spawn timeout shape (pre-#227): `code === "ETIMEDOUT"`. Still honored. */
+function makeEtimedoutError(): NodeJS.ErrnoException {
   const err = new Error(
-    "spawnSync /opt/homebrew/bin/tmux ETIMEDOUT"
+    "execFile /opt/homebrew/bin/tmux ETIMEDOUT"
   ) as NodeJS.ErrnoException;
   err.code = "ETIMEDOUT";
   return err;
 }
 
-describe("realTmuxAdapter.hasSession ETIMEDOUT handling (#238)", () => {
+/**
+ * Async `execFile` timeout shape (post-#227): the child is killed with the
+ * `killSignal` (SIGTERM) when the `timeout` elapses, so `killed === true` and
+ * `code` is left null. This is the realistic shape under tmux contention.
+ */
+function makeKilledTimeoutError(): NodeJS.ErrnoException & {
+  killed: boolean;
+  signal?: string;
+} {
+  const err = new Error(
+    "execFile /opt/homebrew/bin/tmux has-session timed out"
+  ) as NodeJS.ErrnoException & { killed: boolean; signal?: string };
+  err.killed = true;
+  err.signal = "SIGTERM";
+  return err;
+}
+
+describe("realTmuxAdapter.hasSession timeout handling (#238 / #227)", () => {
   let warnSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
-    mockExecFileSyncImpl = () => "";
-    mockExecFileSync.mockClear();
+    mockExecFileError = null;
+    mockExecFile.mockClear();
     warnSpy = spyOn(console, "warn").mockImplementation(() => {});
   });
 
@@ -60,32 +96,38 @@ describe("realTmuxAdapter.hasSession ETIMEDOUT handling (#238)", () => {
     warnSpy.mockRestore();
   });
 
-  test("returns true (assume alive) when has-session times out (ETIMEDOUT)", () => {
-    mockExecFileSyncImpl = () => {
-      throw makeTimeoutError();
-    };
+  test("returns true (assume alive) when has-session times out (ETIMEDOUT code)", async () => {
+    mockExecFileError = makeEtimedoutError();
 
     // Regression: a transient 2s timeout must NOT be read as an exit, otherwise
     // watchTmuxSession tears down a live session.
-    expect(realTmuxAdapter.hasSession("claude-151520552301")).toBe(true);
+    expect(await realTmuxAdapter.hasSession("claude-151520552301")).toBe(true);
     // Observability (#222): the timeout is still surfaced via console.warn.
     expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
-  test("returns false when the session genuinely does not exist (non-timeout error)", () => {
-    mockExecFileSyncImpl = () => {
-      throw new Error("can't find session: claude-dead");
-    };
+  test("returns true (assume alive) when the async execFile is killed by timeout (killed=true)", async () => {
+    // #227 regression: the async timeout shape (SIGTERM kill, killed=true, no
+    // ETIMEDOUT code) must be treated as "liveness unknown → assume alive" too,
+    // or the sync→async migration silently re-opens the #238 false-teardown.
+    mockExecFileError = makeKilledTimeoutError();
 
-    expect(realTmuxAdapter.hasSession("claude-dead")).toBe(false);
+    expect(await realTmuxAdapter.hasSession("claude-busy")).toBe(true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("returns false when the session genuinely does not exist (non-timeout error)", async () => {
+    mockExecFileError = new Error("can't find session: claude-dead");
+
+    expect(await realTmuxAdapter.hasSession("claude-dead")).toBe(false);
     // A real "no session" is not a timeout, so no timeout warning.
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  test("returns true when has-session succeeds (session present)", () => {
-    mockExecFileSyncImpl = () => "";
+  test("returns true when has-session succeeds (session present)", async () => {
+    mockExecFileError = null;
 
-    expect(realTmuxAdapter.hasSession("claude-alive")).toBe(true);
+    expect(await realTmuxAdapter.hasSession("claude-alive")).toBe(true);
     expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/supervisor/tests/session/adapters.test.ts
+++ b/supervisor/tests/session/adapters.test.ts
@@ -8,8 +8,8 @@ import {
 } from "bun:test";
 
 /**
- * Issue #147 regression tests: every realTmuxAdapter method must reach tmux
- * via execFileSync + argv array so neither `command` nor `name` flow through
+ * Issue #147 / #148 regression tests: every realTmuxAdapter method must reach
+ * tmux via execFile + argv array so neither `command` nor `name` flow through
  * the calling shell.
  *
  * Pre-fix: `execSync(\`tmux new-session ... '${command}'\`)` re-parsed
@@ -18,31 +18,68 @@ import {
  * pair closed by the inner one, leaking the JSON into bash word-splitting
  * and bricking the claude session immediately on spawn (#147).
  *
- * killSession / hasSession / getPid also accepted `name` via string
- * interpolation. PR #148 review (gemini critical) flagged that pattern as
- * a latent shell-injection vector even though current callers pass numeric
- * thread-IDs — defence-in-depth, not a current exploit.
+ * Post-fix: every method uses execFile(TMUX_PATH, [..., name, ...]) so user
+ * input cannot reach the shell at all.
  *
- * Post-fix: every method uses execFileSync(TMUX_PATH, [..., name, ...])
- * so user input cannot reach the shell at all.
+ * Issue #227 (PR-3): the adapter moved from synchronous `execFileSync` to the
+ * async `execFile` (the methods now return Promises). We mock `child_process.execFile`
+ * (callback style — promisify(execFile) drives the trailing callback) and a
+ * single mutable controller (`execFileError` / `execFileStdout` / park) shapes
+ * each call's outcome, so the tests await the adapter and assert the same argv /
+ * timeout / observability contracts as before.
  */
 
-let execFileCalls: Array<{ file: string; args: readonly string[] }> = [];
-// PR #148 review (gemini medium): mock signature typed directly to avoid
-// `unknown` + type assertion in the body.
-const mockExecFileSync = mock(
-  (file: string, args: readonly string[]): Buffer => {
-    execFileCalls.push({ file, args });
-    return Buffer.from("");
-  }
-);
+import * as childProcess from "child_process";
 
-// We re-export the rest of node:child_process untouched so other modules
-// loaded in this test process (e.g. anything importing `spawn`) keep working.
-const realChildProcess = await import("child_process");
+interface RecordedCall {
+  file: string;
+  args: readonly string[];
+  opts?: { timeout?: number };
+}
+
+let execFileCalls: RecordedCall[] = [];
+/** When set, the next execFile callback rejects with this error. */
+let execFileError: unknown = null;
+/** stdout the next execFile callback resolves with (success path). */
+let execFileStdout = "";
+/** When set true, the callback is parked (held) until `releasePark()` runs. */
+let parkNext = false;
+let parkedSettle: (() => void) | null = null;
+function releasePark(): void {
+  const s = parkedSettle;
+  parkedSettle = null;
+  s?.();
+}
+
+// promisify(execFile) invokes the fn as fn(file, args, opts, cb): the callback
+// is always the final argument, opts (with our `timeout`) is the 3rd. Resolve
+// `{ stdout, stderr }` on success or reject with the programmed error.
+const mockExecFile = mock((...callArgs: unknown[]) => {
+  const file = callArgs[0] as string;
+  const args = callArgs[1] as readonly string[];
+  const opts = callArgs[2] as { timeout?: number } | undefined;
+  const cb = callArgs[callArgs.length - 1] as (
+    err: unknown,
+    result: { stdout: string; stderr: string }
+  ) => void;
+  execFileCalls.push({ file, args, opts });
+  const settle = () => {
+    if (execFileError) cb(execFileError, { stdout: "", stderr: "" });
+    else cb(null, { stdout: execFileStdout, stderr: "" });
+  };
+  if (parkNext) {
+    parkedSettle = settle;
+  } else {
+    settle();
+  }
+  return {} as childProcess.ChildProcess;
+});
+
+// Re-export the rest of node:child_process untouched so other modules loaded in
+// this test process (e.g. anything importing `spawn`) keep working.
 mock.module("child_process", () => ({
-  ...realChildProcess,
-  execFileSync: mockExecFileSync,
+  ...childProcess,
+  execFile: mockExecFile,
 }));
 
 const { realTmuxAdapter } = await import("../../src/session/adapters");
@@ -50,14 +87,18 @@ const { TMUX_PATH, TMUX_ARGS } = await import("../../src/session/tmux");
 
 beforeEach(() => {
   execFileCalls = [];
-  mockExecFileSync.mockClear();
+  execFileError = null;
+  execFileStdout = "";
+  parkNext = false;
+  parkedSettle = null;
+  mockExecFile.mockClear();
 });
 
 describe("realTmuxAdapter.newSession (#147)", () => {
-  test("uses execFileSync with argv array (no shell parsing)", () => {
-    realTmuxAdapter.newSession("claude-test", "echo hi");
+  test("uses execFile with argv array (no shell parsing)", async () => {
+    await realTmuxAdapter.newSession("claude-test", "echo hi");
 
-    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
     expect(execFileCalls[0]?.file).toBe(TMUX_PATH);
     expect(execFileCalls[0]?.args).toEqual([
       ...TMUX_ARGS,
@@ -69,36 +110,36 @@ describe("realTmuxAdapter.newSession (#147)", () => {
     ]);
   });
 
-  test("preserves single quotes in command (the #147 regression)", () => {
+  test("preserves single quotes in command (the #147 regression)", async () => {
     // This is the exact pattern that broke Supervisor in #104:
     // --mcp-config '{"mcpServers":{}}' embedded in a longer chain.
     const command =
       `cd /tmp && exec claude --mcp-config '{"mcpServers":{}}'`;
 
-    realTmuxAdapter.newSession("claude-x", command);
+    await realTmuxAdapter.newSession("claude-x", command);
 
     // The command must appear in argv VERBATIM — no quote balancing,
     // no escape-mangling, no truncation at the inner single quote.
     expect(execFileCalls[0]?.args.at(-1)).toBe(command);
   });
 
-  test("preserves $-expansions, backticks, and brace seeds", () => {
+  test("preserves $-expansions, backticks, and brace seeds", async () => {
     // None of these should expand client-side. tmux is responsible for
     // running /bin/sh -c on this string inside the new session.
     const tricky =
       `export X=$HOME && echo \`date\` && touch {a,b,c}.txt && exec claude`;
 
-    realTmuxAdapter.newSession("claude-tricky", tricky);
+    await realTmuxAdapter.newSession("claude-tricky", tricky);
 
     expect(execFileCalls[0]?.args.at(-1)).toBe(tricky);
   });
 });
 
 describe("realTmuxAdapter.killSession (#148 review)", () => {
-  test("uses execFileSync with name as argv element (no shell)", () => {
-    realTmuxAdapter.killSession("claude-test");
+  test("uses execFile with name as argv element (no shell)", async () => {
+    await realTmuxAdapter.killSession("claude-test");
 
-    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
     expect(execFileCalls[0]?.file).toBe(TMUX_PATH);
     expect(execFileCalls[0]?.args).toEqual([
       ...TMUX_ARGS,
@@ -108,21 +149,21 @@ describe("realTmuxAdapter.killSession (#148 review)", () => {
     ]);
   });
 
-  test("neutralises shell-metacharacter injection via name", () => {
+  test("neutralises shell-metacharacter injection via name", async () => {
     // The gemini review example. With the old execSync template literal
     // this would have run `reboot` on the host. argv array passing makes
     // the whole string a single argument to tmux's -t flag.
     const malicious = `x"; reboot; #`;
 
-    realTmuxAdapter.killSession(malicious);
+    await realTmuxAdapter.killSession(malicious);
 
     expect(execFileCalls[0]?.args.at(-1)).toBe(malicious);
   });
 });
 
 describe("realTmuxAdapter.hasSession (#148 review)", () => {
-  test("returns true when execFileSync succeeds", () => {
-    expect(realTmuxAdapter.hasSession("claude-test")).toBe(true);
+  test("returns true when execFile succeeds", async () => {
+    expect(await realTmuxAdapter.hasSession("claude-test")).toBe(true);
     expect(execFileCalls[0]?.args).toEqual([
       ...TMUX_ARGS,
       "has-session",
@@ -131,185 +172,126 @@ describe("realTmuxAdapter.hasSession (#148 review)", () => {
     ]);
   });
 
-  test("returns false when execFileSync throws", () => {
-    const throwingMock = mock(
-      (_file: string, _args: readonly string[]): Buffer => {
-        throw new Error("no server running");
-      }
-    );
-    mock.module("child_process", () => ({
-      ...realChildProcess,
-      execFileSync: throwingMock,
-    }));
-
-    // Re-import so the adapter picks up the throwing mock for this test
-    // only; the mock.module call above is scoped to this test's lifetime.
-    return import("../../src/session/adapters").then(({ realTmuxAdapter: a }) => {
-      expect(a.hasSession("missing")).toBe(false);
-
-      // Restore the normal non-throwing mock for subsequent tests.
-      mock.module("child_process", () => ({
-        ...realChildProcess,
-        execFileSync: mockExecFileSync,
-      }));
-    });
+  test("returns false when execFile rejects (non-timeout)", async () => {
+    execFileError = new Error("no server running");
+    expect(await realTmuxAdapter.hasSession("missing")).toBe(false);
   });
 });
 
 describe("realTmuxAdapter.getPid (#148 review)", () => {
-  test("uses execFileSync and parses pane_pid", () => {
-    const pidMock = mock(
-      (_file: string, _args: readonly string[]): string => "12345\n"
-    );
-    mock.module("child_process", () => ({
-      ...realChildProcess,
-      execFileSync: pidMock,
-    }));
-
-    return import("../../src/session/adapters").then(({ realTmuxAdapter: a }) => {
-      expect(a.getPid("claude-test")).toBe(12345);
-      expect(pidMock).toHaveBeenCalledTimes(1);
-      const [file, args] = pidMock.mock.calls[0] ?? [];
-      expect(file).toBe(TMUX_PATH);
-      expect(args).toEqual([
-        ...TMUX_ARGS,
-        "list-panes",
-        "-t",
-        "claude-test",
-        "-F",
-        "#{pane_pid}",
-      ]);
-
-      // Restore normal mock for the rest of the file.
-      mock.module("child_process", () => ({
-        ...realChildProcess,
-        execFileSync: mockExecFileSync,
-      }));
-    });
+  test("uses execFile and parses pane_pid", async () => {
+    execFileStdout = "12345\n";
+    expect(await realTmuxAdapter.getPid("claude-test")).toBe(12345);
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+    expect(execFileCalls[0]?.file).toBe(TMUX_PATH);
+    expect(execFileCalls[0]?.args).toEqual([
+      ...TMUX_ARGS,
+      "list-panes",
+      "-t",
+      "claude-test",
+      "-F",
+      "#{pane_pid}",
+    ]);
   });
 });
 
 /**
- * Issue #222: every synchronous tmux call must be bounded by a timeout.
+ * Issue #222 (carried into #227): every tmux call must be bounded by a timeout
+ * and surface a stall via console.warn while keeping expected errors silent.
  *
- * A wedged tmux server (capture-pane / send-keys ETIMEDOUT stalls that grow
- * over Supervisor uptime) was blocking these `execFileSync` calls — and with
- * them the Node event loop — for unbounded time, starving relay HTTP response
- * handling. That surfaced as delayed / 5-min-timed-out Discord delivery rather
- * than hard failures. Bounding each call converts an indefinite hang into the
- * method's existing graceful error path (capturePane → "", hasSession → false,
- * getPid → null, sendKeys → no-op, killSession → swallow, newSession → throw).
+ * Under #227 the calls are async, but the contract is identical: each method
+ * passes a positive `timeout`, degrades to its graceful error path on failure
+ * (capturePane → "", hasSession → false, getPid → null, sendKeys → no-op,
+ * killSession → swallow, newSession → reject), and logs only on a real timeout.
  */
-describe("realTmuxAdapter tmux call timeouts (#222)", () => {
-  beforeEach(() => {
-    // Guard against earlier tests that swapped the child_process mock: make
-    // sure the call-recording mockExecFileSync is the active impl here.
-    mock.module("child_process", () => ({
-      ...realChildProcess,
-      execFileSync: mockExecFileSync,
-    }));
-  });
-
+describe("realTmuxAdapter tmux call timeouts (#222 / #227)", () => {
   function lastTimeout(): number | undefined {
-    // The mock is declared with a 2-arg signature, but Bun records every actual
-    // argument — read the 3rd (options) positionally via an unknown[] view.
-    const calls = mockExecFileSync.mock.calls as ReadonlyArray<readonly unknown[]>;
-    const opts = calls[calls.length - 1]?.[2] as { timeout?: number } | undefined;
-    return opts?.timeout;
+    return execFileCalls[execFileCalls.length - 1]?.opts?.timeout;
   }
 
-  test("newSession passes a positive timeout", () => {
-    realTmuxAdapter.newSession("claude-test", "echo hi");
+  test("newSession passes a positive timeout", async () => {
+    await realTmuxAdapter.newSession("claude-test", "echo hi");
     expect(lastTimeout()).toBeGreaterThan(0);
   });
 
-  test("killSession passes a positive timeout", () => {
-    realTmuxAdapter.killSession("claude-test");
+  test("killSession passes a positive timeout", async () => {
+    await realTmuxAdapter.killSession("claude-test");
     expect(lastTimeout()).toBeGreaterThan(0);
   });
 
-  test("hasSession passes a positive timeout", () => {
-    realTmuxAdapter.hasSession("claude-test");
+  test("hasSession passes a positive timeout", async () => {
+    await realTmuxAdapter.hasSession("claude-test");
     expect(lastTimeout()).toBeGreaterThan(0);
   });
 
-  test("getPid passes a positive timeout", () => {
-    // getPid calls .trim() on the result, so feed a string (not the default
-    // Buffer) to exercise its success path rather than masking a TypeError in
-    // its catch (gemini PR #226 review).
-    const pidMock = mock(
-      (_file: string, _args: readonly string[]): string => "12345\n"
+  test("getPid passes a positive timeout", async () => {
+    execFileStdout = "12345\n";
+    expect(await realTmuxAdapter.getPid("claude-test")).toBe(12345);
+    expect(lastTimeout()).toBeGreaterThan(0);
+  });
+
+  test("capturePane passes a positive timeout", async () => {
+    await realTmuxAdapter.capturePane("claude-test");
+    expect(lastTimeout()).toBeGreaterThan(0);
+  });
+
+  test("sendKeys passes a positive timeout", async () => {
+    await realTmuxAdapter.sendKeys("claude-test", ["C-m"]);
+    expect(lastTimeout()).toBeGreaterThan(0);
+  });
+
+  test("warns on a timeout so the degradation stays observable (#222)", async () => {
+    execFileError = Object.assign(new Error("ETIMEDOUT"), { code: "ETIMEDOUT" });
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    // Degrades to the existing error path ("") AND logs the stall.
+    expect(await realTmuxAdapter.capturePane("claude-test")).toBe("");
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("timed out");
+    warnSpy.mockRestore();
+  });
+
+  test("does NOT warn for expected non-timeout errors (no pane / no server)", async () => {
+    execFileError = new Error("can't find pane: claude-test");
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    expect(await realTmuxAdapter.capturePane("claude-test")).toBe("");
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+});
+
+/**
+ * Issue #227 (PR-3 / #251) AC-6: the tmux adapter calls must be non-blocking —
+ * a tmux call in flight must not freeze the Bun single event loop. We park the
+ * mocked execFile callback, then prove a separately scheduled `setTimeout(0)`
+ * runs WHILE `hasSession` is awaiting the parked tmux call. A synchronous
+ * execFileSync would have run hasSession to completion before any competing
+ * timer could interleave — impossible to observe without the async conversion.
+ */
+describe("realTmuxAdapter is non-blocking (#227 / #251 AC-6)", () => {
+  test("hasSession yields the event loop while the tmux call is in flight", async () => {
+    const order: string[] = [];
+    parkNext = true;
+
+    const pending = realTmuxAdapter.hasSession("claude-park").then((alive) => {
+      order.push(`hasSession-resolved:${alive}`);
+    });
+
+    // Competing macrotask scheduled after kicking off hasSession.
+    await new Promise<void>((resolve) =>
+      setTimeout(() => {
+        order.push("competing");
+        resolve();
+      }, 0)
     );
-    mock.module("child_process", () => ({
-      ...realChildProcess,
-      execFileSync: pidMock,
-    }));
-    return import("../../src/session/adapters").then(({ realTmuxAdapter: a }) => {
-      expect(a.getPid("claude-test")).toBe(12345);
-      const calls = pidMock.mock.calls as ReadonlyArray<readonly unknown[]>;
-      const opts = calls[calls.length - 1]?.[2] as { timeout?: number } | undefined;
-      expect(opts?.timeout).toBeGreaterThan(0);
-      // Restore the call-recording mock for subsequent tests.
-      mock.module("child_process", () => ({
-        ...realChildProcess,
-        execFileSync: mockExecFileSync,
-      }));
-    });
-  });
 
-  test("capturePane passes a positive timeout", () => {
-    realTmuxAdapter.capturePane("claude-test");
-    expect(lastTimeout()).toBeGreaterThan(0);
-  });
+    // The tmux call started (recorded), the competing task ran, and hasSession
+    // is STILL parked → the loop stayed free during the in-flight tmux call.
+    expect(execFileCalls).toHaveLength(1);
+    expect(order).toEqual(["competing"]);
 
-  test("sendKeys passes a positive timeout", () => {
-    realTmuxAdapter.sendKeys("claude-test", ["C-m"]);
-    expect(lastTimeout()).toBeGreaterThan(0);
-  });
-
-  test("warns on ETIMEDOUT so the degradation stays observable (#222)", () => {
-    const timeoutErr = Object.assign(new Error("ETIMEDOUT"), {
-      code: "ETIMEDOUT",
-    });
-    const timeoutMock = mock((_file: string, _args: readonly string[]): Buffer => {
-      throw timeoutErr;
-    });
-    mock.module("child_process", () => ({
-      ...realChildProcess,
-      execFileSync: timeoutMock,
-    }));
-    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
-    return import("../../src/session/adapters").then(({ realTmuxAdapter: a }) => {
-      // Degrades to the existing error path ("") AND logs the stall.
-      expect(a.capturePane("claude-test")).toBe("");
-      expect(warnSpy).toHaveBeenCalledTimes(1);
-      expect(String(warnSpy.mock.calls[0]?.[0])).toContain("timed out");
-      warnSpy.mockRestore();
-      mock.module("child_process", () => ({
-        ...realChildProcess,
-        execFileSync: mockExecFileSync,
-      }));
-    });
-  });
-
-  test("does NOT warn for expected non-timeout errors (no pane / no server)", () => {
-    const noPaneErr = new Error("can't find pane: claude-test");
-    const errMock = mock((_file: string, _args: readonly string[]): Buffer => {
-      throw noPaneErr;
-    });
-    mock.module("child_process", () => ({
-      ...realChildProcess,
-      execFileSync: errMock,
-    }));
-    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
-    return import("../../src/session/adapters").then(({ realTmuxAdapter: a }) => {
-      expect(a.capturePane("claude-test")).toBe("");
-      expect(warnSpy).not.toHaveBeenCalled();
-      warnSpy.mockRestore();
-      mock.module("child_process", () => ({
-        ...realChildProcess,
-        execFileSync: mockExecFileSync,
-      }));
-    });
+    // Release the parked call (success) and confirm hasSession resolves true.
+    releasePark();
+    await pending;
+    expect(order).toEqual(["competing", "hasSession-resolved:true"]);
   });
 });

--- a/supervisor/tests/session/manager-liveness.test.ts
+++ b/supervisor/tests/session/manager-liveness.test.ts
@@ -65,46 +65,46 @@ describe("SessionManager.livenessOf (#168)", () => {
     await manager?.shutdownAll();
   });
 
-  test("AC-3: DB 行なし → unknown", () => {
-    expect(manager.livenessOf("thread-never-existed")).toBe("unknown");
+  test("AC-3: DB 行なし → unknown", async () => {
+    expect(await manager.livenessOf("thread-never-existed")).toBe("unknown");
   });
 
-  test("AC-1: DB running + pid 死 → dead に矯正", () => {
+  test("AC-1: DB running + pid 死 → dead に矯正", async () => {
     const threadId = "thread-zombie";
     insertSession(rowFor("z1", threadId, "running", 9999));
     // pid 9999 NOT in alivePids → fake reports dead.
     // tmux session NOT created → also missing. Either signal alone forces dead.
-    expect(manager.livenessOf(threadId)).toBe("dead");
+    expect(await manager.livenessOf(threadId)).toBe("dead");
   });
 
-  test("AC-2: pid 生存 + tmux 有 → alive", () => {
+  test("AC-2: pid 生存 + tmux 有 → alive", async () => {
     const threadId = "thread-live";
     insertSession(rowFor("a1", threadId, "running", 4242));
     effects.process.alivePids.add(4242);
-    effects.tmux.newSession(tmuxNameFor(threadId), "echo ok");
-    expect(manager.livenessOf(threadId)).toBe("alive");
+    await effects.tmux.newSession(tmuxNameFor(threadId), "echo ok");
+    expect(await manager.livenessOf(threadId)).toBe("alive");
   });
 
-  test("DB running + pid 生だが tmux 無し → dead (reality wins)", () => {
+  test("DB running + pid 生だが tmux 無し → dead (reality wins)", async () => {
     // Defends the matrix: liveness=alive must require BOTH signals.
     const threadId = "thread-half-alive";
     insertSession(rowFor("h1", threadId, "running", 7777));
     effects.process.alivePids.add(7777);
     // tmux session deliberately NOT created
-    expect(manager.livenessOf(threadId)).toBe("dead");
+    expect(await manager.livenessOf(threadId)).toBe("dead");
   });
 
-  test("DB stopped → dead (DB authoritative when explicitly stopped)", () => {
+  test("DB stopped → dead (DB authoritative when explicitly stopped)", async () => {
     const threadId = "thread-stopped";
     insertSession(rowFor("s1", threadId, "stopped", 1234));
     // Even if pid+tmux happened to be reused/alive, an explicitly stopped row
     // means we should NOT call it alive — answer the stopped status.
     effects.process.alivePids.add(1234);
-    effects.tmux.newSession(tmuxNameFor(threadId), "echo ok");
-    expect(manager.livenessOf(threadId)).toBe("dead");
+    await effects.tmux.newSession(tmuxNameFor(threadId), "echo ok");
+    expect(await manager.livenessOf(threadId)).toBe("dead");
   });
 
-  test("livenessOf reads the latest row (older stopped does not mask newer running)", () => {
+  test("livenessOf reads the latest row (older stopped does not mask newer running)", async () => {
     // Cross-test with AC-4: getSessionByThreadId picks `started_at DESC LIMIT 1`,
     // so an older stopped row must not flip a newer running row to dead.
     const threadId = "thread-rerun";
@@ -115,8 +115,8 @@ describe("SessionManager.livenessOf (#168)", () => {
       rowFor("new", threadId, "running", 2222, "2026-05-31T10:00:00.000Z")
     );
     effects.process.alivePids.add(2222);
-    effects.tmux.newSession(tmuxNameFor(threadId), "echo ok");
-    expect(manager.livenessOf(threadId)).toBe("alive");
+    await effects.tmux.newSession(tmuxNameFor(threadId), "echo ok");
+    expect(await manager.livenessOf(threadId)).toBe("alive");
   });
 });
 
@@ -152,34 +152,34 @@ describe("SessionManager.livenessOfClaudeSession (#171)", () => {
     await manager?.shutdownAll();
   });
 
-  test("no row for the id → unknown (caller treats as not-alive)", () => {
-    expect(manager.livenessOfClaudeSession(CID)).toBe("unknown");
+  test("no row for the id → unknown (caller treats as not-alive)", async () => {
+    expect(await manager.livenessOfClaudeSession(CID)).toBe("unknown");
   });
 
-  test("running + pid alive + tmux present → alive", () => {
+  test("running + pid alive + tmux present → alive", async () => {
     const threadId = "thread-cid-live";
     insertSession(rowWithClaudeId("c1", threadId, CID, "running", 5151));
     effects.process.alivePids.add(5151);
-    effects.tmux.newSession(tmuxNameFor(threadId), "echo ok");
-    expect(manager.livenessOfClaudeSession(CID)).toBe("alive");
+    await effects.tmux.newSession(tmuxNameFor(threadId), "echo ok");
+    expect(await manager.livenessOfClaudeSession(CID)).toBe("alive");
   });
 
-  test("穴 A: DB status=running but pid dead → dead (stale status must not block resume)", () => {
+  test("穴 A: DB status=running but pid dead → dead (stale status must not block resume)", async () => {
     const threadId = "thread-cid-zombie";
     insertSession(rowWithClaudeId("c2", threadId, CID, "running", 6262));
     // pid 6262 NOT alive, no tmux → reality wins → dead.
-    expect(manager.livenessOfClaudeSession(CID)).toBe("dead");
+    expect(await manager.livenessOfClaudeSession(CID)).toBe("dead");
   });
 
-  test("explicitly stopped row → dead", () => {
+  test("explicitly stopped row → dead", async () => {
     const threadId = "thread-cid-stopped";
     insertSession(rowWithClaudeId("c3", threadId, CID, "stopped", 7373));
     effects.process.alivePids.add(7373);
-    effects.tmux.newSession(tmuxNameFor(threadId), "echo ok");
-    expect(manager.livenessOfClaudeSession(CID)).toBe("dead");
+    await effects.tmux.newSession(tmuxNameFor(threadId), "echo ok");
+    expect(await manager.livenessOfClaudeSession(CID)).toBe("dead");
   });
 
-  test("resolves the LATEST row for the id (older dead run does not mask a newer alive one)", () => {
+  test("resolves the LATEST row for the id (older dead run does not mask a newer alive one)", async () => {
     // A single claude session accumulates rows across resumes; the newest run is
     // what "is it alive now" cares about (getSessionByClaudeSessionId DESC LIMIT 1).
     insertSession(
@@ -189,7 +189,7 @@ describe("SessionManager.livenessOfClaudeSession (#171)", () => {
       rowWithClaudeId("new", "thread-new", CID, "running", 2222, "2026-05-31T10:00:00.000Z")
     );
     effects.process.alivePids.add(2222);
-    effects.tmux.newSession(tmuxNameFor("thread-new"), "echo ok");
-    expect(manager.livenessOfClaudeSession(CID)).toBe("alive");
+    await effects.tmux.newSession(tmuxNameFor("thread-new"), "echo ok");
+    expect(await manager.livenessOfClaudeSession(CID)).toBe("alive");
   });
 });

--- a/supervisor/tests/session/manager-resume.test.ts
+++ b/supervisor/tests/session/manager-resume.test.ts
@@ -404,8 +404,8 @@ describe("SessionManager resume single-flight & liveness (#171)", () => {
 
   test("穴 A: a genuinely-live session (pid alive + tmux present) rejects resume", async () => {
     const oldThread = "alive-old-thread";
-    effects.tmux.newSession(tmuxNameForThread(oldThread), "exec claude");
-    const oldPid = effects.tmux.getPid(tmuxNameForThread(oldThread))!;
+    await effects.tmux.newSession(tmuxNameForThread(oldThread), "exec claude");
+    const oldPid = (await effects.tmux.getPid(tmuxNameForThread(oldThread)))!;
     effects.process.alivePids.add(oldPid);
     insertSession({
       id: "live-run",
@@ -430,9 +430,9 @@ describe("SessionManager resume single-flight & liveness (#171)", () => {
     ).rejects.toThrow(/稼働中/);
     expect(manager.has("alive-new-thread")).toBe(false);
     // No new tmux session for the rejected resume (only the pre-existing one).
-    expect(effects.tmux.hasSession(tmuxNameForThread("alive-new-thread"))).toBe(
-      false
-    );
+    expect(
+      await effects.tmux.hasSession(tmuxNameForThread("alive-new-thread"))
+    ).toBe(false);
   });
 
   test("the in-flight lock is released after a successful resume (a later resume of the same id is not falsely blocked)", async () => {

--- a/supervisor/tests/session/manager.test.ts
+++ b/supervisor/tests/session/manager.test.ts
@@ -149,10 +149,10 @@ describe("SessionManager (thread-based)", () => {
     expect(manager.sessionsHealth()).toEqual([]);
   });
 
-  test("sessionsHealth() maps threadId to claude-<threadId[..12]> tmux name", () => {
+  test("sessionsHealth() maps threadId to claude-<threadId[..12]> tmux name", async () => {
     // A >12-char threadId proves the slice; AC-4 asserts this exact mapping.
     const threadId = "1234567890123456789";
-    manager.start(primaryConfig, threadId);
+    await manager.start(primaryConfig, threadId);
 
     const health = manager.sessionsHealth();
     expect(health).toHaveLength(1);
@@ -166,9 +166,9 @@ describe("SessionManager (thread-based)", () => {
     expect(row.startedAt).toBe(new Date(row.startedAt).toISOString());
   });
 
-  test("sessionsHealth() reflects all running sessions and excludes secrets", () => {
-    manager.start(primaryConfig, "thread-a");
-    manager.start(secondaryConfig, "thread-b");
+  test("sessionsHealth() reflects all running sessions and excludes secrets", async () => {
+    await manager.start(primaryConfig, "thread-a");
+    await manager.start(secondaryConfig, "thread-b");
 
     const health = manager.sessionsHealth();
     expect(health).toHaveLength(2);
@@ -556,5 +556,65 @@ describe("SessionManager.compactSession (#200)", () => {
     await expect(
       manager.compactSession("no-such-thread", "保持して圧縮")
     ).rejects.toThrow(/セッションが見つかりません/);
+  });
+});
+
+/**
+ * Issue #227 (PR-3 / #251) AC-4: `watchTmuxSession` now `await`s the async
+ * `hasSession`. A poll that takes longer than the watch interval (tmux under
+ * load) would let the next tick fire before the previous check resolves —
+ * without a guard, two ticks could both observe "exited" and run teardown
+ * twice. The `isChecking` re-entry guard must serialize the checks.
+ */
+describe("watchTmuxSession async re-entry guard (#227 / #251 AC-4)", () => {
+  test("a slow hasSession poll never double-fires teardown across overlapping ticks", async () => {
+    const localEffects = createFakeEffects();
+    const config = makeChannelConfig({ channelName: "channel-watch-guard" });
+    const threadId = "thread-watch-guard";
+    const localManager = new SessionManager({
+      effects: localEffects,
+      gracefulKillTimeoutMs: 0,
+      // Tick faster than hasSession resolves so a second tick fires while the
+      // first is still awaiting — the exact overlap the re-entry guard covers.
+      watchIntervalMs: 10,
+    });
+
+    try {
+      await localManager.start(config, threadId);
+
+      // Replace hasSession with a slow check reporting the session as GONE
+      // (false → teardown path) that records max observed concurrency. At 60ms
+      // per check vs a 10ms tick, multiple ticks elapse during one in-flight
+      // check — so maxConcurrent > 1 would prove the guard failed.
+      let concurrent = 0;
+      let maxConcurrent = 0;
+      localEffects.tmux.hasSession = async () => {
+        concurrent++;
+        maxConcurrent = Math.max(maxConcurrent, concurrent);
+        await new Promise((r) => setTimeout(r, 60));
+        concurrent--;
+        return false;
+      };
+
+      // markTabStopped fires exactly once per teardown — count it.
+      let teardownCount = 0;
+      const realMark = localEffects.iterm2.markTabStopped.bind(
+        localEffects.iterm2
+      );
+      localEffects.iterm2.markTabStopped = (channelName, tmuxSessionName) => {
+        teardownCount++;
+        realMark(channelName, tmuxSessionName);
+      };
+
+      // Let several 10ms ticks elapse across the 60ms check.
+      await new Promise((r) => setTimeout(r, 120));
+
+      // Re-entry guard held: only ONE check ran at a time...
+      expect(maxConcurrent).toBe(1);
+      // ...so teardown fired at most once despite overlapping ticks.
+      expect(teardownCount).toBeLessThanOrEqual(1);
+    } finally {
+      await localManager.shutdownAll();
+    }
   });
 });

--- a/supervisor/tests/session/salvage-reply.test.ts
+++ b/supervisor/tests/session/salvage-reply.test.ts
@@ -32,13 +32,13 @@ describe("buildSalvageReply (#169)", () => {
   // tmux name is deterministic: "claude-" + first 12 chars of threadId.
   const tmuxNameFor = (threadId: string) => `claude-${threadId.slice(0, 12)}`;
 
-  test("no DB row → reports no history and suggests /session start", () => {
-    const reply = buildSalvageReply(manager, "thread-never-seen");
+  test("no DB row → reports no history and suggests /session start", async () => {
+    const reply = await buildSalvageReply(manager, "thread-never-seen");
     expect(reply).toContain("セッション履歴がありません");
     expect(reply).toContain("/session start");
   });
 
-  test("dead session with claude_session_id → offers a resume command", () => {
+  test("dead session with claude_session_id → offers a resume command", async () => {
     const claudeId = "11111111-1111-1111-1111-111111111111";
     insertSession({
       id: "s-dead",
@@ -53,14 +53,14 @@ describe("buildSalvageReply (#169)", () => {
     });
     updateSessionStatus("s-dead", "stopped", "process_dead");
 
-    const reply = buildSalvageReply(manager, "thread-dead");
+    const reply = await buildSalvageReply(manager, "thread-dead");
     expect(reply).toContain("停止しています");
     expect(reply).toContain("process_dead");
     expect(reply).toContain(claudeId);
     expect(reply).toContain(`/session resume ${claudeId}`);
   });
 
-  test("dead session without claude_session_id → degrades to /session start (pre-#167)", () => {
+  test("dead session without claude_session_id → degrades to /session start (pre-#167)", async () => {
     insertSession({
       id: "s-noid",
       channel_name: "agent-base",
@@ -74,7 +74,7 @@ describe("buildSalvageReply (#169)", () => {
     });
     updateSessionStatus("s-noid", "stopped", "tmux_exited");
 
-    const reply = buildSalvageReply(manager, "thread-noid");
+    const reply = await buildSalvageReply(manager, "thread-noid");
     expect(reply).toContain("停止しています");
     expect(reply).toContain("未記録");
     expect(reply).toContain("/session start");
@@ -83,7 +83,7 @@ describe("buildSalvageReply (#169)", () => {
 
   // verdict === "alive": running row + pid alive + tmux session present, but
   // Supervisor lost in-memory tracking (e.g. restart). gemini review on #178.
-  test("alive (process up, Supervisor lost tracking) with id → suggests resume with the id", () => {
+  test("alive (process up, Supervisor lost tracking) with id → suggests resume with the id", async () => {
     const claudeId = "22222222-2222-2222-2222-222222222222";
     const threadId = "thread-alive";
     insertSession({
@@ -98,15 +98,15 @@ describe("buildSalvageReply (#169)", () => {
       status: "running",
     });
     effects.process.alivePids.add(5151);
-    effects.tmux.newSession(tmuxNameFor(threadId), "x");
-    expect(manager.livenessOf(threadId)).toBe("alive");
+    await effects.tmux.newSession(tmuxNameFor(threadId), "x");
+    expect(await manager.livenessOf(threadId)).toBe("alive");
 
-    const reply = buildSalvageReply(manager, threadId);
+    const reply = await buildSalvageReply(manager, threadId);
     expect(reply).toContain("管理を見失っています");
     expect(reply).toContain(`/session resume ${claudeId}`);
   });
 
-  test("alive without id → suggests start (resume is not actionable without an id)", () => {
+  test("alive without id → suggests start (resume is not actionable without an id)", async () => {
     const threadId = "thread-alivnoid";
     insertSession({
       id: "s-alive-noid",
@@ -120,10 +120,10 @@ describe("buildSalvageReply (#169)", () => {
       status: "running",
     });
     effects.process.alivePids.add(5252);
-    effects.tmux.newSession(tmuxNameFor(threadId), "x");
-    expect(manager.livenessOf(threadId)).toBe("alive");
+    await effects.tmux.newSession(tmuxNameFor(threadId), "x");
+    expect(await manager.livenessOf(threadId)).toBe("alive");
 
-    const reply = buildSalvageReply(manager, threadId);
+    const reply = await buildSalvageReply(manager, threadId);
     expect(reply).toContain("管理を見失っています");
     expect(reply).toContain("/session start");
     expect(reply).not.toContain("/session resume");
@@ -147,7 +147,7 @@ describe("buildStatusReply (#170)", () => {
 
   const tmuxNameFor = (threadId: string) => `claude-${threadId.slice(0, 12)}`;
 
-  test("alive (running + tracked) → reports 稼働中 with the id (not lost-tracking wording)", () => {
+  test("alive (running + tracked) → reports 稼働中 with the id (not lost-tracking wording)", async () => {
     const claudeId = "33333333-3333-3333-3333-333333333333";
     const threadId = "thread-st-live";
     insertSession({
@@ -162,7 +162,7 @@ describe("buildStatusReply (#170)", () => {
       status: "running",
     });
     effects.process.alivePids.add(6161);
-    effects.tmux.newSession(tmuxNameFor(threadId), "x");
+    await effects.tmux.newSession(tmuxNameFor(threadId), "x");
     // "稼働中" requires the session to also be tracked in memory (has() true),
     // not just live by pid/tmux (gemini HIGH review, PR #179). Register a
     // minimal in-memory entry — has() only checks key presence.
@@ -171,13 +171,13 @@ describe("buildStatusReply (#170)", () => {
       { threadId }
     );
 
-    const reply = buildStatusReply(manager, threadId);
+    const reply = await buildStatusReply(manager, threadId);
     expect(reply).toContain("稼働中");
     expect(reply).toContain(claudeId);
     expect(reply).not.toContain("見失って");
   });
 
-  test("alive by pid/tmux but NOT tracked in memory → lost-tracking wording, not 稼働中", () => {
+  test("alive by pid/tmux but NOT tracked in memory → lost-tracking wording, not 稼働中", async () => {
     const threadId = "thread-st-untracked";
     insertSession({
       id: "st-untracked",
@@ -191,16 +191,16 @@ describe("buildStatusReply (#170)", () => {
       status: "running",
     });
     effects.process.alivePids.add(6363);
-    effects.tmux.newSession(tmuxNameFor(threadId), "x");
+    await effects.tmux.newSession(tmuxNameFor(threadId), "x");
     // Deliberately do NOT register in the in-memory map: has() === false.
-    expect(manager.livenessOf(threadId)).toBe("alive");
+    expect(await manager.livenessOf(threadId)).toBe("alive");
 
-    const reply = buildStatusReply(manager, threadId);
+    const reply = await buildStatusReply(manager, threadId);
     expect(reply).toContain("見失って");
     expect(reply).not.toContain("稼働中です");
   });
 
-  test("dead → reuses salvage wording (停止 + resume command)", () => {
+  test("dead → reuses salvage wording (停止 + resume command)", async () => {
     const claudeId = "44444444-4444-4444-4444-444444444444";
     const threadId = "thread-st-dead";
     insertSession({
@@ -216,13 +216,13 @@ describe("buildStatusReply (#170)", () => {
     });
     updateSessionStatus("st-dead", "stopped", "process_dead");
 
-    const reply = buildStatusReply(manager, threadId);
+    const reply = await buildStatusReply(manager, threadId);
     expect(reply).toContain("停止しています");
     expect(reply).toContain(`/session resume ${claudeId}`);
   });
 
-  test("unknown (no row) → no history", () => {
-    const reply = buildStatusReply(manager, "thread-st-none");
+  test("unknown (no row) → no history", async () => {
+    const reply = await buildStatusReply(manager, "thread-st-none");
     expect(reply).toContain("セッション履歴がありません");
   });
 });


### PR DESCRIPTION
## 概要

親 #227（tmux 同期I/O の完全非同期化）の **PR-3 / core**。`TmuxAdapter` の tmux 呼び出し 6 メソッド（`newSession` / `killSession` / `hasSession` / `getPid` / `capturePane` / `sendKeys`）の戻り値を `Promise` 化し、`realTmuxAdapter` を `promisify(execFile)` ベースの async へ移行する。PR-1/2 でホットパス（relay 送信・5s poll）の同期ブロックを先に除去した後、本 PR で残りを構造的に締める。

TypeScript の interface 型のため戻り値の Promise 化は**分割不可の atomic 変更**で、全 consumer に `await` が同時波及する。

> 補足: Issue #251 の「5 メソッド」記載は `getPid` が抜けていたが、AC-1（`grep execFileSync = 0`）を満たすには `getPid` も非同期化が必須のため 6 メソッドを flip した。`ensureSocketConfigured` は adapters.ts 内で直接 `execFileSync` を使わず tmux.ts へ委譲しているため sync 維持（tmux.ts の非同期化は PR-4 範囲）。

## 主な変更点

- **adapters.ts**: 6 メソッドを async 化。`warnIfTmuxTimeout` を sync 形状（`code === "ETIMEDOUT"`）と async 形状（`killed === true` / SIGTERM kill）の**両方**を受理するよう正規化 — これがないと #238 の「timeout は生存扱い（false teardown を防ぐ）」契約が移行後に静かに退行する。
- **adapters-fake.ts**: `FakeTmuxAdapter` の 6 メソッドを async 化（bookkeeping は同期、`async` で Promise ラップ）。
- **manager.ts**: consumer 18 箇所に `await`。`watchTmuxSession` の `setInterval` コールバックを async 化 + **`isChecking` 再入ガード**（poll が interval を超過したときの重複 teardown を防止）。`recoverFromDb` を async 化（constructor は recovery promise を `this.recovery` に保持）。`livenessOf` / `livenessOfClaudeSession` も async へ波及。`watchIntervalMs` を注入可能化（再入ガードを決定的にテストするため）。
- **status-reply.ts / bot.ts / commands/session.ts**: `livenessOf` 系の async 波及に追従（`buildSalvageReply` / `buildStatusReply` も async 化）。
- **session-activity-watchdog.ts**: `isAlive` seam を `boolean | Promise<boolean>` に widen し `check()` で `await`（sync テスト fake はそのまま互換）。

## 受け入れ条件（コンポーネント・決定的）

| AC | 内容 | 結果 |
|---|---|---|
| AC-1 | `grep -c execFileSync src/session/adapters.ts` = 0 | ✅ 0 |
| AC-2 | `TmuxAdapter` 6 メソッドの戻り値型が `Promise`（型レベル担保、`tsc --noEmit` PASS） | ✅ tsc clean |
| AC-3 | manager.ts の全 consumer が await 済み（残存 sync 呼び出しで型エラーが出ない＝tsc で機械担保） | ✅ tsc clean |
| AC-4 | 再入ガード test：`hasSession` が interval 超で resolve する状況下でも teardown が二重発火しない | ✅ `manager.test.ts` — maxConcurrent=1 かつ teardown≤1 |
| AC-5 | #238 回帰（adapters-hassession、`killed=true` ケース追加）含む全 session test PASS + #27 lint green | ✅ curated 422 pass / 0 fail、#27 green |
| AC-6 | 非ブロック回帰 test：`hasSession` 実行中に別 macrotask が先行 | ✅ `adapters.test.ts`（seam park） |

mock.module を使う `adapters.test.ts` / `adapters-hassession.test.ts` は既存どおり専用 `bun test` step で隔離実行（#248 gating 済）。AC-4/AC-6 は既 gated file 内に追加（新規 gate 不要）。

## 統合ジャーニーAC

不要（Issue 記載どおり）：Supervisor 内部の I/O 実装変更で、ユーザーが踏む新たな一連フローを伴わない。外形挙動は不変。

## 規模注記（pr-size 例外）

13 file 変更。`TmuxAdapter` の interface flip が atomic（TS 型のため分割不可）であることに起因し、`pr-size.md` の「大規模リファクタリング」例外に該当する。30 file 目安内には収まっている。

## 関連

- 親: #227（PR-3）/ #238（adapters.ts 回帰基盤、PR #239/#247）
- 前: #256（PR-1, merged）, #258（PR-2, merged）/ 次: PR-4 #252（周辺 sync exec + 静的 gate）

Closes #251
