### PR TITLE
perf(#252): 周辺 sync exec を execFile 非同期化 + src/session 静的gate (#227 PR-4)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,14 @@ jobs:
       - name: Lint - no blocking exec inside timer callbacks (#27)
         run: bun scripts/lint-blocking-in-timers.ts
 
+      # Issue #227 (PR-4): no synchronous child-process exec (execSync /
+      # execFileSync / spawnSync) anywhere under src/session/**. PR-1/2/3 made
+      # the hot paths async; this keeps the whole session tree sync-exec-free so
+      # a regression cannot silently reintroduce an event-loop-blocking call.
+      # AST-based, so comments citing the migration don't false-fire.
+      - name: Lint - no synchronous exec in src/session (#227 PR-4)
+        run: bun scripts/lint-no-sync-exec.ts
+
       # Issue #248 (RW-029 / F1 class): every tests/**/*.test.ts must be gated in
       # this file or justifiably excluded in scripts/lint-gating-coverage.ts.
       # Prevents a newly-added test from being silently never-run in CI.
@@ -115,6 +123,7 @@ jobs:
                    tests/session/dialog-watchdog.test.ts \
                    tests/session/relay-send-failure.test.ts \
                    tests/scripts/lint-blocking-in-timers.test.ts \
+                   tests/scripts/lint-no-sync-exec.test.ts \
                    tests/session/notify-pushover.test.ts \
                    tests/session/dialog-stuck-handler.test.ts \
                    tests/session/stall-heartbeat.test.ts \
@@ -147,7 +156,10 @@ jobs:
                    tests/session/salvage-reply.test.ts \
                    tests/session/slash-prefix.test.ts \
                    tests/session/thread-title.test.ts \
-                   tests/session/worktree.test.ts
+                   tests/session/worktree.test.ts \
+                   tests/session/keep-attachment.test.ts \
+                   tests/commands/session-keep.test.ts \
+                   tests/session/self-heal.test.ts
 
       # #238 regression: realTmuxAdapter.hasSession must treat a tmux
       # control-channel ETIMEDOUT as "alive" (assume the session survives),

--- a/supervisor/scripts/lint-no-sync-exec.ts
+++ b/supervisor/scripts/lint-no-sync-exec.ts
@@ -1,0 +1,126 @@
+#!/usr/bin/env bun
+/**
+ * Issue #227 (PR-4): block synchronous child-process exec calls anywhere under
+ * `src/session/**`.
+ *
+ * The Supervisor is a single-process Bun event loop. A `*Sync` exec
+ * (`execSync` / `execFileSync` / `spawnSync`) blocks the whole bot for the
+ * duration of the child process — under tmux-server contention that stall
+ * starves relay HTTP handling and surfaces as delayed / 5-min-timed-out Discord
+ * delivery (the #222/#227 symptom). PR-1/2/3 migrated the hot paths (relay send,
+ * the 5s dialog-watchdog poll, the core TmuxAdapter) to the async `execFile`;
+ * PR-4 finishes the peripheral worktree / iTerm2 / tmux-config calls. This gate
+ * keeps the whole `src/session/` tree sync-exec-free so a regression cannot
+ * silently reintroduce a blocking call.
+ *
+ * AST-based (not grep): a comment that merely *mentions* `execFileSync` (several
+ * files do, citing the migration) is not a CallExpression, so it is never
+ * flagged — grep would false-positive on those. Only real call expressions are
+ * reported. This is the file-scoped sibling of `lint-blocking-in-timers.ts`
+ * (#27), which scopes the same blocking-call set to timer callbacks; here the
+ * scope is "anywhere in src/session/**" instead of "inside a timer".
+ *
+ * Run: `bun scripts/lint-no-sync-exec.ts [files...]`
+ * No args → scans `src/session/`+'/'+'**'+'/*.ts'. Exits 1 on any violation.
+ */
+import ts from "typescript";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const BLOCKING_CALLS = new Set(["execSync", "execFileSync", "spawnSync"]);
+
+export interface Violation {
+  file: string;
+  line: number; // 1-based
+  column: number; // 1-based
+  callee: string;
+}
+
+/** Identifier `execSync(...)` or property access `cp.execSync(...)` / `Bun.spawnSync(...)`. */
+function blockingCalleeName(expr: ts.Expression): string | null {
+  if (ts.isIdentifier(expr) && BLOCKING_CALLS.has(expr.text)) return expr.text;
+  if (
+    ts.isPropertyAccessExpression(expr) &&
+    BLOCKING_CALLS.has(expr.name.text)
+  ) {
+    return expr.name.text;
+  }
+  return null;
+}
+
+export function lintSource(fileName: string, sourceText: string): Violation[] {
+  const sf = ts.createSourceFile(
+    fileName,
+    sourceText,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true
+  );
+  const violations: Violation[] = [];
+
+  const scan = (node: ts.Node): void => {
+    if (ts.isCallExpression(node)) {
+      const callee = blockingCalleeName(node.expression);
+      if (callee) {
+        const { line, character } = sf.getLineAndCharacterOfPosition(
+          node.getStart(sf)
+        );
+        violations.push({
+          file: fileName,
+          line: line + 1,
+          column: character + 1,
+          callee,
+        });
+      }
+    }
+    ts.forEachChild(node, scan);
+  };
+
+  scan(sf);
+  return violations;
+}
+
+if (import.meta.main) {
+  const args = process.argv.slice(2);
+  // The supervisor root is this script's parent dir, so the default scan is
+  // independent of the caller's cwd. Without this, running from the repo root
+  // would glob a nonexistent `./src/session` → 0 files → a misleading "clean"
+  // result.
+  const root = resolve(import.meta.dir, "..");
+  let entries: { display: string; abs: string }[];
+  if (args.length > 0) {
+    entries = args.map((a) => ({ display: a, abs: resolve(a) }));
+  } else {
+    const { Glob } = await import("bun");
+    const matched = [...new Glob("src/session/**/*.ts").scanSync(root)];
+    if (matched.length === 0) {
+      console.error(
+        `✖ lint-no-sync-exec: no source files found under ${root}/src/session — refusing to report clean.`
+      );
+      process.exit(1);
+    }
+    entries = matched.map((f) => ({ display: f, abs: resolve(root, f) }));
+  }
+
+  let total = 0;
+  for (const { display, abs } of entries) {
+    const text = readFileSync(abs, "utf8");
+    for (const v of lintSource(display, text)) {
+      console.error(
+        `${v.file}:${v.line}:${v.column}  synchronous '${v.callee}(...)' in src/session/** — use the async execFile/spawn instead`
+      );
+      total++;
+    }
+  }
+
+  if (total > 0) {
+    console.error(
+      `\n✖ ${total} synchronous-exec violation(s) (Issue #227 PR-4).\n` +
+        `  A *Sync exec (execSync / execFileSync / spawnSync) blocks the single-process Supervisor\n` +
+        `  event loop for the child's full duration — under tmux contention this starves relay HTTP\n` +
+        `  handling and surfaces as delayed Discord delivery (#222/#227). Use the async execFile\n` +
+        `  (promisify) or spawn (fire-and-forget) instead.`
+    );
+    process.exit(1);
+  }
+  console.log("✓ lint-no-sync-exec: no synchronous exec under src/session/**");
+}

--- a/supervisor/src/session/adapters-fake.ts
+++ b/supervisor/src/session/adapters-fake.ts
@@ -46,7 +46,11 @@ export class FakeTmuxAdapter implements TmuxAdapter {
     return this.sessions.get(name)?.pid ?? null;
   }
 
-  ensureSocketConfigured(): void {
+  // Issue #227 (PR-4): ensureSocketConfigured is async now. The counter bump
+  // runs synchronously (before the first await), so existing
+  // `ensureSocketConfiguredCalls` assertions still hold even when the call is
+  // not awaited (e.g. the constructor's fire-and-forget invocation).
+  async ensureSocketConfigured(): Promise<void> {
     this.ensureSocketConfiguredCalls += 1;
   }
 
@@ -146,7 +150,11 @@ export class FakeWorktreeAdapter implements WorktreeAdapter {
   /** When set, ensure() throws to simulate a git worktree failure. */
   failOnEnsure = false;
 
-  ensure(mainRepoDir: string, branch: string): EnsureWorktreeResult {
+  // Issue #227 (PR-4): the WorktreeAdapter interface methods are now async, so
+  // the fakes return Promises too. The in-memory bookkeeping stays synchronous;
+  // the `async` keyword just wraps the result so `await fake.x()` matches
+  // production (a `failOnEnsure` throw becomes a rejected Promise as before).
+  async ensure(mainRepoDir: string, branch: string): Promise<EnsureWorktreeResult> {
     this.ensureCalls.push({ mainRepoDir, branch });
     if (this.failOnEnsure) {
       throw new Error("git worktree add failed");
@@ -159,12 +167,12 @@ export class FakeWorktreeAdapter implements WorktreeAdapter {
     return { path, reused };
   }
 
-  remove(mainRepoDir: string, worktreePath: string): void {
+  async remove(mainRepoDir: string, worktreePath: string): Promise<void> {
     this.removeCalls.push({ mainRepoDir, worktreePath });
     this.existingPaths.delete(worktreePath);
   }
 
-  recreateForBranch(mainRepoDir: string, branch: string): boolean {
+  async recreateForBranch(mainRepoDir: string, branch: string): Promise<boolean> {
     this.recreateForBranchCalls.push({ mainRepoDir, branch });
     const path = resolveWorktreePath(mainRepoDir, branch.trim());
     if (this.existingPaths.has(path)) return true; // Q4: already present

--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -35,13 +35,14 @@ export interface TmuxAdapter {
   // Issue #227 (PR-3): every tmux call below runs via the *async* `execFile`
   // so a wedged tmux server can never block the Bun single event loop. The
   // return types are Promise — this interface flip is atomic (TypeScript types
-  // cannot be migrated incrementally), so all consumers await. `ensureSocketConfigured`
-  // stays sync: it delegates to tmux.ts (converted separately in PR-4).
+  // cannot be migrated incrementally), so all consumers await.
+  // Issue #227 (PR-4): `ensureSocketConfigured` is now async too (tmux.ts moved
+  // to the async `execFile`), so it returns Promise<void> as well.
   newSession(name: string, command: string): Promise<void>;
   killSession(name: string): Promise<void>;
   hasSession(name: string): Promise<boolean>;
   getPid(name: string): Promise<number | null>;
-  ensureSocketConfigured(): void;
+  ensureSocketConfigured(): Promise<void>;
   /**
    * Capture the visible pane content (`tmux capture-pane -p`). Returns "" on
    * error. Used by the resume flow (Issue #161) to detect Claude Code's
@@ -85,17 +86,20 @@ export interface ProcessAdapter {
  * in-memory fake so {@link SessionManager} unit tests never run git.
  */
 export interface WorktreeAdapter {
+  // Issue #227 (PR-4): the underlying git/gh calls moved to the async
+  // `execFile` (worktree.ts) so a wedged subprocess never blocks the event
+  // loop. These methods therefore return Promises and all callers await.
   /** Create or reuse the worktree for `branch` under `mainRepoDir`. */
-  ensure(mainRepoDir: string, branch: string): EnsureWorktreeResult;
+  ensure(mainRepoDir: string, branch: string): Promise<EnsureWorktreeResult>;
   /** Remove the worktree (branch is preserved). */
-  remove(mainRepoDir: string, worktreePath: string): void;
+  remove(mainRepoDir: string, worktreePath: string): Promise<void>;
   /**
    * Re-create the worktree for an *existing* branch only — resume recovery
    * (Issue #217). Returns true when the worktree exists afterwards, false when
    * the branch is gone (caller surfaces a clear error). Never creates a new
    * branch from the default branch.
    */
-  recreateForBranch(mainRepoDir: string, branch: string): boolean;
+  recreateForBranch(mainRepoDir: string, branch: string): Promise<boolean>;
 }
 
 export interface SessionEffects {
@@ -207,8 +211,8 @@ export const realTmuxAdapter: TmuxAdapter = {
       return null;
     }
   },
-  ensureSocketConfigured() {
-    realEnsureSocketConfigured();
+  async ensureSocketConfigured() {
+    await realEnsureSocketConfigured();
   },
   async capturePane(name) {
     // execFile reads stdout; stderr is buffered (not inherited) — the
@@ -240,11 +244,17 @@ export const realTmuxAdapter: TmuxAdapter = {
 };
 
 export const realItermAdapter: ItermAdapter = {
+  // Issue #227 (PR-4): realOpenTab / realMarkTabStopped became async (their
+  // internal pgrep / tmux / osascript calls moved to the async `execFile`). The
+  // ItermAdapter interface intentionally stays void: tab cosmetics are
+  // fire-and-forget and must not gate session start/stop. `void` discards the
+  // Promise; both functions catch their own errors internally (try/catch around
+  // every exec), so there is no unhandled rejection.
   openTab(opts) {
-    realOpenTab(opts);
+    void realOpenTab(opts);
   },
   markTabStopped(channelName, tmuxSessionName) {
-    realMarkTabStopped(channelName, tmuxSessionName);
+    void realMarkTabStopped(channelName, tmuxSessionName);
   },
 };
 
@@ -275,11 +285,13 @@ export const realProcessAdapter: ProcessAdapter = {
 };
 
 export const realWorktreeAdapter: WorktreeAdapter = {
+  // Issue #227 (PR-4): worktree.ts moved to the async `execFile`, so these
+  // delegate to async functions and return the Promise to the caller.
   ensure(mainRepoDir, branch) {
     return ensureWorktree(mainRepoDir, branch, realGitGhRunner);
   },
   remove(mainRepoDir, worktreePath) {
-    removeWorktree(mainRepoDir, worktreePath, realGitGhRunner);
+    return removeWorktree(mainRepoDir, worktreePath, realGitGhRunner);
   },
   recreateForBranch(mainRepoDir, branch) {
     return recreateWorktreeForExistingBranch(

--- a/supervisor/src/session/iterm2.ts
+++ b/supervisor/src/session/iterm2.ts
@@ -1,9 +1,12 @@
-import { execFileSync, spawn } from "child_process";
+import { execFile, spawn } from "child_process";
 import { readFileSync } from "fs";
 import { resolve, basename } from "path";
 import { homedir } from "os";
 import { createHash } from "crypto";
+import { promisify } from "util";
 import { TMUX_PATH, TMUX_ARGS, TMUX_CMD } from "./tmux";
+
+const execFileAsync = promisify(execFile);
 
 const PROJECT_COLORS_PATH = resolve(
   homedir(),
@@ -71,15 +74,17 @@ export function resolveColor(projectName: string): string {
   return `#${r.toString(16).padStart(2, "0")}${g.toString(16).padStart(2, "0")}${b.toString(16).padStart(2, "0")}`;
 }
 
-export function isItermRunning(): boolean {
+export async function isItermRunning(): Promise<boolean> {
   try {
-    // argv form (no shell): pgrep exits 1 when nothing matches, which
-    // execFileSync surfaces as a throw → caught below as "not running".
-    const result = execFileSync("pgrep", ["-x", "iTerm2"], {
+    // argv form (no shell): pgrep exits 1 when nothing matches, which the async
+    // execFile surfaces as a rejection → caught below as "not running". Issue
+    // #227 (PR-4): async (not a synchronous exec) so the pgrep call never blocks
+    // the single event loop.
+    const { stdout } = await execFileAsync("pgrep", ["-x", "iTerm2"], {
       encoding: "utf8",
       timeout: 3000,
-    }).trim();
-    return result.length > 0;
+    });
+    return stdout.trim().length > 0;
   } catch {
     return false;
   }
@@ -173,8 +178,8 @@ export interface OpenTabOptions {
   projectDir: string;
 }
 
-export function openTab(opts: OpenTabOptions): void {
-  if (!isItermRunning()) {
+export async function openTab(opts: OpenTabOptions): Promise<void> {
+  if (!(await isItermRunning())) {
     console.log(
       `[iTerm2] iTerm2 is not running, skipping tab creation for ${opts.channelName}`
     );
@@ -189,11 +194,13 @@ export function openTab(opts: OpenTabOptions): void {
   // Chain all five window-config commands into ONE tmux invocation via bare
   // ";" separators (tmux's own command parser treats ";" as a separator — see
   // ensureSocketConfigured in tmux.ts), cutting five process spawns to one.
-  // stdio: "ignore" matches the fire-and-forget tmux calls in adapters.ts —
-  // failures are non-fatal (the session may have already exited) and tmux's
-  // stderr must not leak to the Supervisor's terminal.
+  // Issue #227 (PR-4): async (not a synchronous exec) so a wedged tmux server
+  // cannot block the event loop. execFile buffers stdout/stderr (not inherited),
+  // matching the prior stdio: "ignore" — failures are non-fatal (the session
+  // may have already exited) and tmux's stderr must not leak to the
+  // Supervisor's terminal.
   try {
-    execFileSync(
+    await execFileAsync(
       TMUX_PATH,
       [
         ...TMUX_ARGS,
@@ -203,7 +210,7 @@ export function openTab(opts: OpenTabOptions): void {
         "set-option", "-t", opts.tmuxSessionName, "set-titles-string", "#{window_name}", ";",
         "select-pane", "-t", opts.tmuxSessionName, "-T", tabTitle,
       ],
-      { timeout: 3000, stdio: "ignore" }
+      { timeout: 3000 }
     );
   } catch {
     // tmux session may have already exited
@@ -237,8 +244,10 @@ export function openTab(opts: OpenTabOptions): void {
   try {
     // argv form (no shell): the AppleScript is passed as a single -e argument,
     // so the prior manual single-quote escaping is no longer needed (Issue
-    // #97). Matches markTabStopped's spawn(osascript, ["-e", script]).
-    execFileSync("osascript", ["-e", script], {
+    // #97). Matches markTabStopped's spawn(osascript, ["-e", script]). Issue
+    // #227 (PR-4): async (not a synchronous exec) so a slow osascript cannot
+    // block the event loop.
+    await execFileAsync("osascript", ["-e", script], {
       timeout: 5000,
     });
     console.log(`[iTerm2] Opened tab for ${opts.channelName}`);
@@ -250,7 +259,10 @@ export function openTab(opts: OpenTabOptions): void {
   }
 }
 
-export function markTabStopped(channelName: string, tmuxSessionName?: string): void {
+export async function markTabStopped(
+  channelName: string,
+  tmuxSessionName?: string
+): Promise<void> {
   const tabName = `${channelName} (running)`;
   const newName = `${channelName} (stopped)`;
   // The actual tmux session name is `claude-${threadId.slice(0,12)}` (see
@@ -259,13 +271,17 @@ export function markTabStopped(channelName: string, tmuxSessionName?: string): v
   // The fallback exists for legacy callers without a threadId in scope.
   const tmuxName = tmuxSessionName ?? `claude-${channelName}`;
 
-  // Update tmux window name if session still exists (fire-and-forget)
+  // Update tmux window name if session still exists (fire-and-forget spawn,
+  // unchanged: spawn is already async/non-blocking — #27).
   const renameProc = spawn(TMUX_PATH, [...TMUX_ARGS, "rename-window", "-t", tmuxName, newName], {
     stdio: "ignore",
   });
   setTimeout(() => renameProc.kill("SIGKILL"), 3000);
 
-  if (!isItermRunning()) {
+  // Issue #227 (PR-4): isItermRunning is async now; await it. markTabStopped is
+  // itself called fire-and-forget by realItermAdapter, so this stays
+  // non-blocking from the caller's perspective.
+  if (!(await isItermRunning())) {
     return;
   }
 

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -283,7 +283,12 @@ export class SessionManager {
       options.inputReadyPollIntervalMs ?? 1000;
     this.watchIntervalMs = options.watchIntervalMs ?? 10_000;
 
-    this.effects.tmux.ensureSocketConfigured();
+    // Issue #227 (PR-4): ensureSocketConfigured is async now. The constructor
+    // cannot await, so fire-and-forget it — it is idempotent and re-applied in
+    // start()/resume() once the tmux server is definitely up (the eager call
+    // here is a no-op before the first new-session). `void` discards the Promise;
+    // the function catches its own errors, so there is no unhandled rejection.
+    void this.effects.tmux.ensureSocketConfigured();
     this.effects.relayServer.start();
     // Issue #227 (PR-3): recoverFromDb is async now (it awaits tmux has/kill).
     // The constructor cannot await, so we keep the recovery promise for tests
@@ -455,7 +460,7 @@ export class SessionManager {
     let worktree: SessionInfo["worktree"];
     const trimmedBranch = branch?.trim();
     if (trimmedBranch) {
-      const result = this.effects.worktree.ensure(config.dir, trimmedBranch);
+      const result = await this.effects.worktree.ensure(config.dir, trimmedBranch);
       projectDir = result.path;
       worktree = {
         mainRepoDir: config.dir,
@@ -516,7 +521,7 @@ export class SessionManager {
     await this.effects.tmux.newSession(tmuxName, claudeCmd);
     // Apply server-wide options now that the server is definitely running.
     // The constructor's eager call is a no-op before the first new-session.
-    this.effects.tmux.ensureSocketConfigured();
+    await this.effects.tmux.ensureSocketConfigured();
 
     // Wait briefly for process to start. start() is async (Issue #99) so this
     // uses a non-blocking setTimeout instead of the previous
@@ -669,7 +674,7 @@ export class SessionManager {
       if (!existsSync(projectDir)) {
         const trimmedBranch = branch?.trim();
         const recovered = trimmedBranch
-          ? this.recoverWorktreeForResume(config.dir, projectDir, trimmedBranch)
+          ? await this.recoverWorktreeForResume(config.dir, projectDir, trimmedBranch)
           : false;
         if (recovered && existsSync(projectDir) && trimmedBranch) {
           // We rebuilt the worktree, so THIS resumed session now owns its
@@ -762,7 +767,7 @@ export class SessionManager {
     ].join(" && ");
 
     await this.effects.tmux.newSession(tmuxName, claudeCmd);
-    this.effects.tmux.ensureSocketConfigured();
+    await this.effects.tmux.ensureSocketConfigured();
 
     let pid: number | null = null;
     for (let i = 0; i < 5; i++) {
@@ -1183,7 +1188,7 @@ export class SessionManager {
     // cwd. Only the last session on the worktree removes it (PR #157 review,
     // CodeRabbit Major).
     if (session.worktree && !this.isWorktreePathInUse(session.worktree.path)) {
-      this.removeWorktreeBestEffort(session.worktree);
+      await this.removeWorktreeBestEffort(session.worktree);
     } else if (session.worktree) {
       console.log(
         `[SessionManager] Worktree ${session.worktree.path} still in use by another session; not removing`
@@ -1200,13 +1205,13 @@ export class SessionManager {
    * fabricating unrelated content. Failures are swallowed → false, leaving the
    * caller's existsSync re-check to decide the outcome deterministically.
    */
-  private recoverWorktreeForResume(
+  private async recoverWorktreeForResume(
     mainRepoDir: string,
     projectDir: string,
     branch: string
-  ): boolean {
+  ): Promise<boolean> {
     try {
-      const ok = this.effects.worktree.recreateForBranch(mainRepoDir, branch);
+      const ok = await this.effects.worktree.recreateForBranch(mainRepoDir, branch);
       if (ok) {
         console.log(
           `[SessionManager] Re-created worktree for branch '${branch}' to resume: ${projectDir}`
@@ -1239,12 +1244,12 @@ export class SessionManager {
    * worktree must never block session teardown, so a removal error is logged
    * and ignored. No-op when the session had no worktree.
    */
-  private removeWorktreeBestEffort(
+  private async removeWorktreeBestEffort(
     worktree: SessionInfo["worktree"]
-  ): void {
+  ): Promise<void> {
     if (!worktree) return;
     try {
-      this.effects.worktree.remove(worktree.mainRepoDir, worktree.path);
+      await this.effects.worktree.remove(worktree.mainRepoDir, worktree.path);
       console.log(
         `[SessionManager] Removed worktree ${worktree.path} (branch '${worktree.branch}' preserved)`
       );

--- a/supervisor/src/session/tmux.ts
+++ b/supervisor/src/session/tmux.ts
@@ -1,4 +1,7 @@
-import { execFileSync } from "child_process";
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
 
 export const TMUX_PATH = process.env.TMUX_PATH ?? "/opt/homebrew/bin/tmux";
 
@@ -27,7 +30,7 @@ if (!SOCKET_NAME_PATTERN.test(rawSocket)) {
 }
 export const TMUX_SOCKET = rawSocket;
 
-/** argv prefix for all execFileSync tmux calls. */
+/** argv prefix for all tmux calls (passed to the async execFile). */
 export const TMUX_ARGS: readonly string[] = ["-L", TMUX_SOCKET];
 
 /**
@@ -36,8 +39,8 @@ export const TMUX_ARGS: readonly string[] = ["-L", TMUX_SOCKET];
  * `write text`, which the interactive shell in the new tab runs on attach
  * (see {@link ./iterm2}.openTab). Safe because `TMUX_SOCKET` has been
  * validated against `SOCKET_NAME_PATTERN`. Direct tmux calls use argv via
- * `execFileSync` (Issue #97); do not introduce new template-string execSync
- * uses of this constant.
+ * the async `execFile` (Issue #97 / #227 PR-4); do not introduce new
+ * template-string exec uses of this constant.
  */
 export const TMUX_CMD = `${TMUX_PATH} -L ${TMUX_SOCKET}`;
 
@@ -68,16 +71,19 @@ export const TMUX_CMD = `${TMUX_PATH} -L ${TMUX_SOCKET}`;
  *
  * @see docs: Issue #73 / Epic #79 / Sub #80 (H1) / Sub #81 (H2)
  */
-export function ensureSocketConfigured(): void {
+export async function ensureSocketConfigured(): Promise<void> {
   try {
     // argv form (no shell): tmux's OWN command parser (not the shell) treats a
     // standalone ";" token as a separator between chained subcommands, so the
-    // three set-option calls still run in one tmux invocation. execFileSync
-    // passes argv directly, eliminating the shell parse step entirely (Issue
-    // #97). NOTE: do not "simplify" by joining these into one string — the
-    // chaining depends on ";" being its own argv element. Every token here is
-    // a hard-coded literal so there is no injection surface to begin with.
-    execFileSync(
+    // three set-option calls still run in one tmux invocation. execFile passes
+    // argv directly, eliminating the shell parse step entirely (Issue #97).
+    // Issue #227 (PR-4): async (not a synchronous exec) so a wedged tmux server
+    // cannot block the Bun single event loop. NOTE: do not "simplify" by joining these
+    // into one string — the chaining depends on ";" being its own argv element.
+    // Every token here is a hard-coded literal so there is no injection surface
+    // to begin with. execFile buffers stdout/stderr (not inherited), matching the
+    // prior stdio: "pipe" so tmux's stderr never leaks to the terminal.
+    await execFileAsync(
       TMUX_PATH,
       [
         ...TMUX_ARGS,
@@ -85,12 +91,12 @@ export function ensureSocketConfigured(): void {
         "set-option", "-g", "mode-keys", "emacs", ";",
         "set-option", "-g", "history-limit", "10000",
       ],
-      { timeout: 3000, stdio: "pipe" }
+      { timeout: 3000 }
     );
   } catch (err) {
-    // execFileSync surfaces tmux's stderr ("no server running" on the very
-    // first call, before any server exists) via err.stderr rather than
-    // err.message — check both so the expected first-call case stays silent.
+    // execFile surfaces tmux's stderr ("no server running" on the very first
+    // call, before any server exists) via err.stderr rather than err.message —
+    // check both so the expected first-call case stays silent.
     const e = err as NodeJS.ErrnoException & { stderr?: Buffer | string };
     const stderr = e?.stderr != null ? e.stderr.toString() : "";
     const msg = `${err instanceof Error ? err.message : String(err)} ${stderr}`;

--- a/supervisor/src/session/worktree.ts
+++ b/supervisor/src/session/worktree.ts
@@ -1,6 +1,9 @@
-import { execFileSync } from "child_process";
+import { execFile } from "child_process";
 import { existsSync, realpathSync } from "fs";
 import { resolve, sep } from "path";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
 
 /**
  * Per-branch git worktree management for supervisor sessions (Issue #154).
@@ -20,10 +23,15 @@ import { resolve, sep } from "path";
  *
  * Low-level git/gh calls go through {@link GitGhRunner} so the branching logic
  * in {@link ensureWorktree} is unit-testable with an in-memory fake (no real
- * git/gh). The real runner uses `execFileSync` with an argv array — never a
- * shell string — so a branch name can never inject shell metacharacters
+ * git/gh). The real runner uses the async `execFile` with an argv array — never
+ * a shell string — so a branch name can never inject shell metacharacters
  * (Q6 "git に任せる": validation is delegated to git, but the filesystem path
  * is additionally guarded against traversal and shell-injection below).
+ *
+ * Issue #227 (PR-4): every git/gh call below runs via the *async* `execFile`
+ * (not a synchronous exec) so a wedged git/gh subprocess can never block the Bun
+ * single event loop. The runner methods therefore return Promises; this is a
+ * pure sync→async migration — the Q1/Q2/Q4 branching logic is unchanged.
  */
 
 /** Subdirectory (relative to the main repo) that holds per-branch worktrees. */
@@ -44,25 +52,28 @@ export type WorktreeStatus =
   | { registered: true; branch: string | null };
 
 export interface GitGhRunner {
+  // Issue #227 (PR-4): the git/gh calls are async (`execFile`), so these return
+  // Promises. `pathExists` stays synchronous — it is a cheap `existsSync` with
+  // no subprocess to block on.
   /** True if `branch` is an existing *local branch* in the repo at `mainRepoDir`. */
-  branchExists(mainRepoDir: string, branch: string): boolean;
+  branchExists(mainRepoDir: string, branch: string): Promise<boolean>;
   /** Repo default branch (Q2 base for new branches). Falls back to "main". */
-  defaultBranch(mainRepoDir: string): string;
+  defaultBranch(mainRepoDir: string): Promise<string>;
   /** `git worktree add <worktreePath> <branch>` (existing branch, Q1). */
   addWorktreeFromBranch(
     mainRepoDir: string,
     worktreePath: string,
     branch: string,
-  ): void;
+  ): Promise<void>;
   /** `git worktree add -b <branch> --no-track <worktreePath> <base>` (Q2). */
   addWorktreeNewBranch(
     mainRepoDir: string,
     worktreePath: string,
     branch: string,
     base: string,
-  ): void;
+  ): Promise<void>;
   /** `git worktree remove <worktreePath> --force` (Q3). */
-  removeWorktree(mainRepoDir: string, worktreePath: string): void;
+  removeWorktree(mainRepoDir: string, worktreePath: string): Promise<void>;
   /** Filesystem existence check for the worktree path (Q4 reuse). */
   pathExists(path: string): boolean;
   /**
@@ -70,7 +81,7 @@ export interface GitGhRunner {
    * which branch it has checked out (Issue #158). Used to validate Q4 reuse
    * instead of trusting a bare directory existence check.
    */
-  worktreeStatus(mainRepoDir: string, worktreePath: string): WorktreeStatus;
+  worktreeStatus(mainRepoDir: string, worktreePath: string): Promise<WorktreeStatus>;
 }
 
 export interface EnsureWorktreeResult {
@@ -127,11 +138,11 @@ export function resolveWorktreePath(mainRepoDir: string, branch: string): string
  * an already-present worktree is reused (Q4), so calling this twice for the
  * same branch is safe.
  */
-export function ensureWorktree(
+export async function ensureWorktree(
   mainRepoDir: string,
   branch: string,
   runner: GitGhRunner,
-): EnsureWorktreeResult {
+): Promise<EnsureWorktreeResult> {
   const trimmed = branch.trim();
   if (!trimmed) {
     throw new Error("branch 引数が必須です");
@@ -144,7 +155,7 @@ export function ensureWorktree(
   // created directory, running claude in a non-worktree / wrong-branch cwd —
   // a silent failure. Reject those explicitly instead.
   if (runner.pathExists(worktreePath)) {
-    const status = runner.worktreeStatus(mainRepoDir, worktreePath);
+    const status = await runner.worktreeStatus(mainRepoDir, worktreePath);
     if (!status.registered) {
       throw new Error(
         `worktree 再利用先がディレクトリとして存在しますが有効な git worktree ではありません（中断した worktree remove の残骸 / 手動作成の可能性）: ${worktreePath}。手動で削除してから再実行してください。`,
@@ -160,14 +171,14 @@ export function ensureWorktree(
   }
 
   // Q1: existing local branch → checkout into a new worktree.
-  if (runner.branchExists(mainRepoDir, trimmed)) {
-    runner.addWorktreeFromBranch(mainRepoDir, worktreePath, trimmed);
+  if (await runner.branchExists(mainRepoDir, trimmed)) {
+    await runner.addWorktreeFromBranch(mainRepoDir, worktreePath, trimmed);
     return { path: worktreePath, reused: false };
   }
 
   // Q2: unknown branch → create from the repo's default branch.
-  const base = runner.defaultBranch(mainRepoDir);
-  runner.addWorktreeNewBranch(mainRepoDir, worktreePath, trimmed, base);
+  const base = await runner.defaultBranch(mainRepoDir);
+  await runner.addWorktreeNewBranch(mainRepoDir, worktreePath, trimmed, base);
   return { path: worktreePath, reused: false, baseBranch: base };
 }
 
@@ -184,11 +195,11 @@ export function ensureWorktree(
  * exists afterwards (Q4 already-present, or Q1 freshly checked out), false when
  * the branch is gone so the caller can surface a clear "cannot recover" error.
  */
-export function recreateWorktreeForExistingBranch(
+export async function recreateWorktreeForExistingBranch(
   mainRepoDir: string,
   branch: string,
   runner: GitGhRunner,
-): boolean {
+): Promise<boolean> {
   const trimmed = branch.trim();
   if (!trimmed) {
     return false;
@@ -202,8 +213,8 @@ export function recreateWorktreeForExistingBranch(
 
   // Q1: the branch still exists → check it out into a fresh worktree. A missing
   // branch falls through to `false` (no Q2 new-branch creation).
-  if (runner.branchExists(mainRepoDir, trimmed)) {
-    runner.addWorktreeFromBranch(mainRepoDir, worktreePath, trimmed);
+  if (await runner.branchExists(mainRepoDir, trimmed)) {
+    await runner.addWorktreeFromBranch(mainRepoDir, worktreePath, trimmed);
     return true;
   }
 
@@ -211,53 +222,53 @@ export function recreateWorktreeForExistingBranch(
 }
 
 /** Remove a worktree (Q3). Caller decides whether failures are fatal. */
-export function removeWorktree(
+export async function removeWorktree(
   mainRepoDir: string,
   worktreePath: string,
   runner: GitGhRunner,
-): void {
-  runner.removeWorktree(mainRepoDir, worktreePath);
+): Promise<void> {
+  await runner.removeWorktree(mainRepoDir, worktreePath);
 }
 
 /**
- * Production {@link GitGhRunner}. Every git/gh invocation uses execFileSync
- * with an argv array (no shell) so untrusted branch names are passed as a
- * single literal argument and cannot inject shell metacharacters.
+ * Production {@link GitGhRunner}. Every git/gh invocation uses the async
+ * `execFile` with an argv array (no shell) so untrusted branch names are passed
+ * as a single literal argument and cannot inject shell metacharacters. Issue
+ * #227 (PR-4): async (not a synchronous exec) so a wedged subprocess never blocks
+ * the event loop. `execFile` buffers stdout/stderr (they are not inherited),
+ * which preserves the prior `stdio` behaviour — the expected "no such ref" /
+ * "no server" errors stay off the Supervisor's terminal and a failure surfaces
+ * git's message via the rejected error's `.stderr`.
  */
 export const realGitGhRunner: GitGhRunner = {
-  branchExists(mainRepoDir, branch) {
+  async branchExists(mainRepoDir, branch) {
     try {
       // Restrict to local *branch* refs so revision expressions like `HEAD~1`
       // or `@{-1}` are not mistaken for an existing branch (which would create
       // a detached-HEAD worktree). exit 0 iff refs/heads/<branch> resolves.
-      execFileSync(
-        "git",
-        [
-          "-C",
-          mainRepoDir,
-          "show-ref",
-          "--verify",
-          "--quiet",
-          `refs/heads/${branch}`,
-        ],
-        { stdio: "ignore" },
-      );
+      await execFileAsync("git", [
+        "-C",
+        mainRepoDir,
+        "show-ref",
+        "--verify",
+        "--quiet",
+        `refs/heads/${branch}`,
+      ]);
       return true;
     } catch {
       return false;
     }
   },
-  defaultBranch(mainRepoDir) {
+  async defaultBranch(mainRepoDir) {
     // Primary: GitHub default branch (issue Q2). `:owner/:repo` is resolved by
     // gh from the repo at cwd.
     try {
-      const out = execFileSync(
+      const { stdout } = await execFileAsync(
         "gh",
         ["api", "repos/:owner/:repo", "--jq", ".default_branch"],
-        { cwd: mainRepoDir, encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
-      )
-        .toString()
-        .trim();
+        { cwd: mainRepoDir, encoding: "utf8" },
+      );
+      const out = stdout.trim();
       if (out) return out;
     } catch {
       // gh unavailable, not authenticated, or repo has no GitHub remote.
@@ -268,23 +279,21 @@ export const realGitGhRunner: GitGhRunner = {
     // gemini). The gh path above is already fork-safe; this only runs when gh
     // is unavailable.
     try {
-      const remotes = execFileSync("git", ["-C", mainRepoDir, "remote"], {
+      const { stdout } = await execFileAsync("git", ["-C", mainRepoDir, "remote"], {
         encoding: "utf8",
-        stdio: ["ignore", "pipe", "ignore"],
-      })
-        .toString()
+      });
+      const remotes = stdout
         .split("\n")
         .map((r) => r.trim())
         .filter(Boolean);
       const remote = remotes.includes("origin") ? "origin" : remotes[0];
       if (remote) {
-        const ref = execFileSync(
+        const { stdout: refOut } = await execFileAsync(
           "git",
           ["-C", mainRepoDir, "symbolic-ref", "--short", `refs/remotes/${remote}/HEAD`],
-          { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
-        )
-          .toString()
-          .trim();
+          { encoding: "utf8" },
+        );
+        const ref = refOut.trim();
         const prefix = `${remote}/`;
         if (ref.startsWith(prefix)) return ref.slice(prefix.length);
       }
@@ -293,42 +302,44 @@ export const realGitGhRunner: GitGhRunner = {
     }
     return "main";
   },
-  addWorktreeFromBranch(mainRepoDir, worktreePath, branch) {
-    // stderr is piped so a failure surfaces git's message in the thrown error.
-    execFileSync(
-      "git",
-      ["-C", mainRepoDir, "worktree", "add", worktreePath, branch],
-      { stdio: ["ignore", "pipe", "pipe"] },
-    );
+  async addWorktreeFromBranch(mainRepoDir, worktreePath, branch) {
+    // A failure surfaces git's message via the rejected error's `.stderr`.
+    await execFileAsync("git", [
+      "-C",
+      mainRepoDir,
+      "worktree",
+      "add",
+      worktreePath,
+      branch,
+    ]);
   },
-  addWorktreeNewBranch(mainRepoDir, worktreePath, branch, base) {
-    execFileSync(
-      "git",
-      [
-        "-C",
-        mainRepoDir,
-        "worktree",
-        "add",
-        "-b",
-        branch,
-        "--no-track",
-        worktreePath,
-        base,
-      ],
-      { stdio: ["ignore", "pipe", "pipe"] },
-    );
+  async addWorktreeNewBranch(mainRepoDir, worktreePath, branch, base) {
+    await execFileAsync("git", [
+      "-C",
+      mainRepoDir,
+      "worktree",
+      "add",
+      "-b",
+      branch,
+      "--no-track",
+      worktreePath,
+      base,
+    ]);
   },
-  removeWorktree(mainRepoDir, worktreePath) {
-    execFileSync(
-      "git",
-      ["-C", mainRepoDir, "worktree", "remove", worktreePath, "--force"],
-      { stdio: ["ignore", "pipe", "pipe"] },
-    );
+  async removeWorktree(mainRepoDir, worktreePath) {
+    await execFileAsync("git", [
+      "-C",
+      mainRepoDir,
+      "worktree",
+      "remove",
+      worktreePath,
+      "--force",
+    ]);
   },
   pathExists(path) {
     return existsSync(path);
   },
-  worktreeStatus(mainRepoDir, worktreePath) {
+  async worktreeStatus(mainRepoDir, worktreePath) {
     // Parse `git worktree list --porcelain`. Each worktree is a block of
     // newline-separated attribute lines, blocks separated by a blank line:
     //   worktree /abs/path
@@ -338,11 +349,14 @@ export const realGitGhRunner: GitGhRunner = {
     // worktree (Issue #158: residue / manual dir).
     let out: string;
     try {
-      out = execFileSync(
+      // Issue #227 (PR-4): async execFile so the worktree-list call never blocks
+      // the event loop. stderr is buffered (not inherited) = the old 2>/dev/null.
+      const { stdout } = await execFileAsync(
         "git",
         ["-C", mainRepoDir, "worktree", "list", "--porcelain"],
-        { encoding: "utf8", stdio: ["ignore", "pipe", "ignore"] },
-      ).toString();
+        { encoding: "utf8" },
+      );
+      out = stdout.toString();
     } catch {
       // Not a git repo / git unavailable → treat as unregistered (caller errors).
       return { registered: false };

--- a/supervisor/tests/e2e/ac-verification.test.ts
+++ b/supervisor/tests/e2e/ac-verification.test.ts
@@ -90,14 +90,15 @@ function killPane(name: string): void {
   }
 }
 
-beforeAll(() => {
+beforeAll(async () => {
   if (hasTmux) {
     try {
       execFileSync(TMUX_PATH, [...TMUX_ARGS, "start-server"], { timeout: TMUX_OP_TIMEOUT });
     } catch {
       /* new-session will start the server on demand */
     }
-    ensureSocketConfigured();
+    // Issue #227 (PR-4): ensureSocketConfigured is async now — await it.
+    await ensureSocketConfigured();
   }
   startRelayServer();
 });

--- a/supervisor/tests/e2e/dialog-stall.test.ts
+++ b/supervisor/tests/e2e/dialog-stall.test.ts
@@ -103,7 +103,7 @@ function wait(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-beforeAll(() => {
+beforeAll(async () => {
   if (!hasTmux) return;
   try {
     execFileSync(TMUX_PATH, [...TMUX_ARGS, "start-server"], {
@@ -112,7 +112,8 @@ beforeAll(() => {
   } catch {
     // server may already be running
   }
-  ensureSocketConfigured();
+  // Issue #227 (PR-4): ensureSocketConfigured is async now — await it.
+  await ensureSocketConfigured();
 });
 
 describe("Issue #57 dialog stall — E2E with real tmux", () => {

--- a/supervisor/tests/scripts/lint-no-sync-exec.test.ts
+++ b/supervisor/tests/scripts/lint-no-sync-exec.test.ts
@@ -1,0 +1,92 @@
+import { test, expect, describe } from "bun:test";
+import { lintSource } from "../../scripts/lint-no-sync-exec";
+
+/**
+ * Issue #227 (PR-4, AC-3): the static gate must flag any synchronous
+ * child-process exec (execSync / execFileSync / spawnSync) anywhere in a
+ * `src/session/**` file, and must NOT false-positive on the safe shapes —
+ * especially comments that merely mention execFileSync (several converted files
+ * cite the migration), and the async execFile/spawn replacements.
+ *
+ * It must also fail if a sync exec is *reintroduced* (the regression direction):
+ * the "flags a reintroduced execFileSync" case below is exactly that — it is the
+ * shape a future refactor that reverts PR-4 would produce.
+ */
+
+describe("lint-no-sync-exec (#227 PR-4, AC-3)", () => {
+  test("flags a top-level execFileSync (the reintroduction shape)", () => {
+    const src = `import { execFileSync } from "child_process";
+const out = execFileSync("git", ["status"], { stdio: "ignore" });`;
+    const v = lintSource("src/session/worktree.ts", src);
+    expect(v).toHaveLength(1);
+    expect(v[0]!.callee).toBe("execFileSync");
+    expect(v[0]!.line).toBe(2);
+  });
+
+  test("flags execSync and spawnSync (the full blocking set)", () => {
+    const src = `execSync("ls");
+spawnSync("tmux", ["kill-server"]);`;
+    const v = lintSource("src/session/x.ts", src);
+    expect(v.map((x) => x.callee).sort()).toEqual(["execSync", "spawnSync"]);
+  });
+
+  test("flags a sync exec nested inside a function / try block", () => {
+    const src = `export function f() {
+  try {
+    execFileSync("pgrep", ["-x", "iTerm2"]);
+  } catch {}
+}`;
+    const v = lintSource("src/session/iterm2.ts", src);
+    expect(v).toHaveLength(1);
+    expect(v[0]!.callee).toBe("execFileSync");
+    expect(v[0]!.line).toBe(3);
+  });
+
+  test("flags property-access form (cp.execFileSync / Bun.spawnSync)", () => {
+    const src = `cp.execFileSync("git", []);
+Bun.spawnSync(["ls"]);`;
+    const v = lintSource("src/session/x.ts", src);
+    expect(v.map((x) => x.callee).sort()).toEqual(["execFileSync", "spawnSync"]);
+  });
+
+  test("does NOT flag the async execFile / promisify replacement", () => {
+    const src = `import { execFile } from "child_process";
+import { promisify } from "util";
+const execFileAsync = promisify(execFile);
+export async function f() {
+  await execFileAsync("git", ["status"]);
+}`;
+    expect(lintSource("src/session/worktree.ts", src)).toHaveLength(0);
+  });
+
+  test("does NOT flag async spawn() (fire-and-forget)", () => {
+    const src = `const p = spawn("osascript", ["-e", script], { stdio: "ignore" });
+setTimeout(() => p.kill("SIGKILL"), 5000);`;
+    expect(lintSource("src/session/iterm2.ts", src)).toHaveLength(0);
+  });
+
+  test("does NOT flag a comment that merely mentions execFileSync", () => {
+    // This is the converted-file shape — AST ignores comments, grep would not.
+    const src = `// Issue #227 (PR-4): async (not execFileSync) so a wedged tmux server
+// cannot block the event loop.
+await execFileAsync("tmux", []);`;
+    expect(lintSource("src/session/tmux.ts", src)).toHaveLength(0);
+  });
+
+  test("does NOT flag a string literal that contains 'execFileSync'", () => {
+    const src = `const msg = "do not use execFileSync here";`;
+    expect(lintSource("src/session/x.ts", src)).toHaveLength(0);
+  });
+
+  test("the production src/session/** tree is clean (regression guard)", async () => {
+    const { Glob } = await import("bun");
+    const files = [...new Glob("src/session/**/*.ts").scanSync(".")];
+    expect(files.length).toBeGreaterThan(0);
+    const all = [];
+    for (const f of files) {
+      const text = await Bun.file(f).text();
+      all.push(...lintSource(f, text));
+    }
+    expect(all).toEqual([]);
+  });
+});

--- a/supervisor/tests/session/iterm2-async.test.ts
+++ b/supervisor/tests/session/iterm2-async.test.ts
@@ -5,14 +5,20 @@ import { test, expect, describe } from "bun:test";
  *
  * Before fix: markTabStopped uses execSync (blocks event loop).
  * After fix: markTabStopped uses spawn (fire-and-forget, non-blocking).
+ *
+ * Issue #227 (PR-4): markTabStopped became `async` (its `isItermRunning` gate
+ * moved to the async `execFile`). It now returns a Promise instead of void, but
+ * the non-blocking guarantee is unchanged: the synchronous portion (scheduling
+ * the rename `spawn`) runs before the first `await`, so calling it never blocks
+ * the event loop. realItermAdapter still calls it fire-and-forget (`void`).
  */
 
 describe("markTabStopped non-blocking (#27)", () => {
-  test("markTabStopped returns void (fire-and-forget)", async () => {
+  test("markTabStopped returns a Promise (fire-and-forget)", async () => {
     const { markTabStopped } = await import("../../src/session/iterm2");
     const result = markTabStopped("nonexistent-channel");
-    // fire-and-forget: returns void, no Promise to await
-    expect(result).toBeUndefined();
+    // async fire-and-forget: returns a Promise the caller may discard (`void`).
+    expect(result).toBeInstanceOf(Promise);
   });
 
   test("markTabStopped does not block event loop for >100ms", async () => {
@@ -20,8 +26,9 @@ describe("markTabStopped non-blocking (#27)", () => {
     const start = Date.now();
     markTabStopped("nonexistent-channel");
     const syncElapsed = Date.now() - start;
-    // After fix: spawn is non-blocking, should return immediately (<100ms)
-    // Before fix: execSync blocks for the osascript execution time
+    // After fix: spawn is non-blocking and the async body yields at the first
+    // await, so the synchronous return is immediate (<100ms).
+    // Before fix: execSync blocked for the osascript execution time.
     expect(syncElapsed).toBeLessThan(100);
   });
 });

--- a/supervisor/tests/session/iterm2.test.ts
+++ b/supervisor/tests/session/iterm2.test.ts
@@ -48,8 +48,10 @@ describe("dimColor", () => {
 });
 
 describe("isItermRunning", () => {
-  test("returns a boolean", () => {
-    const result = isItermRunning();
+  // Issue #227 (PR-4): isItermRunning is async now (pgrep moved to the async
+  // `execFile`), so it returns Promise<boolean> — await it before asserting.
+  test("resolves to a boolean", async () => {
+    const result = await isItermRunning();
     expect(typeof result).toBe("boolean");
   });
 });

--- a/supervisor/tests/session/relay.test.ts
+++ b/supervisor/tests/session/relay.test.ts
@@ -153,14 +153,15 @@ function paneInMode(session: string): boolean {
 // server-startup latency (which can blow through short timeouts on CI). Also
 // applies the Supervisor socket's global options (mouse off / mode-keys
 // emacs) so tests exercise the production configuration.
-beforeAll(() => {
+beforeAll(async () => {
   if (!hasTmux) return;
   try {
     execFileSync(TMUX_PATH, [...TMUX_ARGS, "start-server"], { timeout: TMUX_OP_TIMEOUT });
   } catch {
     // non-fatal; new-session will start the server on demand
   }
-  ensureSocketConfigured();
+  // Issue #227 (PR-4): ensureSocketConfigured is async now — await it.
+  await ensureSocketConfigured();
 });
 
 describe("tmuxSend integration (Issue #73 / AC-7)", () => {

--- a/supervisor/tests/session/tmux.test.ts
+++ b/supervisor/tests/session/tmux.test.ts
@@ -13,18 +13,49 @@ import {
  *
  * The function in src/session/tmux.ts swallows `no server running` (expected
  * on the very first call before any tmux server exists) and warns on any
- * other error. We verify both branches by mocking child_process.execFileSync
- * (Issue #97 switched from execSync(template) to execFileSync(argv)).
+ * other error. We verify both branches by mocking child_process.execFile
+ * (Issue #97 switched from execSync(template) to execFileSync(argv); Issue #227
+ * PR-4 then switched execFileSync → the async `execFile`, so the function is
+ * async and we mock the callback-style `execFile` that `promisify` drives).
  */
 
-let mockExecFileSyncImpl: () => string = () => "";
+import * as childProcess from "child_process";
 
-// Spy-wrapped mock so we can assert the file/argv/options passed to
-// execFileSync (#117 follow-up: gemini medium #3142222781).
-const mockExecFileSync = mock((..._args: unknown[]) => mockExecFileSyncImpl());
+/** Programmed outcome for the next execFile callback: reject with this error. */
+let execFileError: unknown = null;
+/** stdout the callback resolves with on the success path. */
+let execFileStdout = "";
 
+interface RecordedCall {
+  file: string;
+  args: readonly string[];
+  opts?: { timeout?: number };
+}
+let execFileCalls: RecordedCall[] = [];
+
+// promisify(execFile) invokes the fn as fn(file, args, opts, cb): the callback
+// is always the final argument. Resolve `{ stdout, stderr }` on success, or
+// invoke the callback with the programmed error (the error's `.stderr` carries
+// tmux's "no server running" message, matching the real execFile shape).
+const mockExecFile = mock((...callArgs: unknown[]) => {
+  const file = callArgs[0] as string;
+  const args = callArgs[1] as readonly string[];
+  const opts = callArgs[2] as { timeout?: number } | undefined;
+  const cb = callArgs[callArgs.length - 1] as (
+    err: unknown,
+    result: { stdout: string; stderr: string }
+  ) => void;
+  execFileCalls.push({ file, args, opts });
+  if (execFileError) cb(execFileError, { stdout: "", stderr: "" });
+  else cb(null, { stdout: execFileStdout, stderr: "" });
+  return {} as childProcess.ChildProcess;
+});
+
+// Re-export the rest of node:child_process untouched so other modules loaded in
+// this test process keep working.
 mock.module("child_process", () => ({
-  execFileSync: mockExecFileSync,
+  ...childProcess,
+  execFile: mockExecFile,
 }));
 
 const { ensureSocketConfigured, TMUX_PATH, TMUX_SOCKET } = await import(
@@ -35,6 +66,15 @@ function setupWarnSpy() {
   return spyOn(console, "warn").mockImplementation(() => {});
 }
 
+/** Build an Error whose `.stderr` carries tmux's message, like a real execFile reject. */
+function execFileReject(message: string): Error & { stderr: string } {
+  const e = new Error(message) as Error & { stderr: string };
+  // The real execFile reject surfaces the child's stderr on the error object;
+  // tmux prints "no server running" to stderr, not the error message itself.
+  e.stderr = message;
+  return e;
+}
+
 describe("ensureSocketConfigured unhappy-path (#85)", () => {
   // Hoisted to beforeEach/afterEach so a failing assertion never leaves a
   // stale spy attached to console.warn (#117 follow-up: gemini medium
@@ -42,8 +82,10 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
   let warnSpy: ReturnType<typeof setupWarnSpy>;
 
   beforeEach(() => {
-    mockExecFileSyncImpl = () => "";
-    mockExecFileSync.mockClear();
+    execFileError = null;
+    execFileStdout = "";
+    execFileCalls = [];
+    mockExecFile.mockClear();
     warnSpy = setupWarnSpy();
   });
 
@@ -51,12 +93,10 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
     warnSpy.mockRestore();
   });
 
-  test("warns when execFileSync throws an error other than 'no server running'", () => {
-    mockExecFileSyncImpl = () => {
-      throw new Error("EACCES: permission denied, /tmp/tmux-501");
-    };
+  test("warns when execFile rejects with an error other than 'no server running'", async () => {
+    execFileError = execFileReject("EACCES: permission denied, /tmp/tmux-501");
 
-    ensureSocketConfigured();
+    await ensureSocketConfigured();
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
     const firstCall = warnSpy.mock.calls[0]!;
@@ -64,96 +104,85 @@ describe("ensureSocketConfigured unhappy-path (#85)", () => {
     expect(firstCall[1]).toBeInstanceOf(Error);
   });
 
-  test("stays silent when execFileSync throws 'no server running' (first-call case)", () => {
-    mockExecFileSyncImpl = () => {
-      throw new Error("no server running on /tmp/tmux-501/claude-hub");
-    };
+  test("stays silent when execFile rejects with 'no server running' (first-call case)", async () => {
+    execFileError = execFileReject("no server running on /tmp/tmux-501/claude-hub");
 
-    ensureSocketConfigured();
+    await ensureSocketConfigured();
 
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  test("stays silent when execFileSync succeeds", () => {
-    mockExecFileSyncImpl = () => "";
+  test("stays silent when execFile succeeds", async () => {
+    execFileStdout = "";
 
-    ensureSocketConfigured();
-
-    expect(warnSpy).not.toHaveBeenCalled();
-  });
-
-  test("matches 'no server running' regex case-insensitively", () => {
-    mockExecFileSyncImpl = () => {
-      throw new Error("No Server Running");
-    };
-
-    ensureSocketConfigured();
+    await ensureSocketConfigured();
 
     expect(warnSpy).not.toHaveBeenCalled();
   });
 
-  test("re-runs and re-warns on every invocation (no memoisation by design)", () => {
-    mockExecFileSyncImpl = () => {
-      throw new Error("EBUSY: tmux socket is locked");
-    };
+  test("matches 'no server running' regex case-insensitively", async () => {
+    execFileError = execFileReject("No Server Running");
 
-    ensureSocketConfigured();
-    ensureSocketConfigured();
-    ensureSocketConfigured();
+    await ensureSocketConfigured();
+
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  test("re-runs and re-warns on every invocation (no memoisation by design)", async () => {
+    execFileError = execFileReject("EBUSY: tmux socket is locked");
+
+    await ensureSocketConfigured();
+    await ensureSocketConfigured();
+    await ensureSocketConfigured();
 
     expect(warnSpy).toHaveBeenCalledTimes(3);
   });
 
-  test("preserves the original Error instance in the warning payload", () => {
-    const customError = new Error("ENOSPC: no space left on device");
-    mockExecFileSyncImpl = () => {
-      throw customError;
-    };
+  test("preserves the original Error instance in the warning payload", async () => {
+    const customError = execFileReject("ENOSPC: no space left on device");
+    execFileError = customError;
 
-    ensureSocketConfigured();
+    await ensureSocketConfigured();
 
     expect(warnSpy.mock.calls[0]![1]).toBe(customError);
   });
 
-  test("passes raw non-Error thrown value through to console.warn", () => {
+  test("passes raw non-Error rejected value through to console.warn", async () => {
     // Plain object: not an Error instance, and String(err) === "[object Object]"
     // which does NOT match /no server running/i, so the isNoServer guard
     // correctly falls through to the warn branch (#117 follow-up: coderabbit
     // minor #3142223332).
     const thrown = { code: "EPERM", path: "/tmp/tmux-501" };
-    mockExecFileSyncImpl = () => {
-      throw thrown;
-    };
+    execFileError = thrown;
 
-    ensureSocketConfigured();
+    await ensureSocketConfigured();
 
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(warnSpy.mock.calls[0]![1]).toBe(thrown);
   });
 
-  test("invokes execFileSync with the expected tmux file, argv and options", () => {
-    mockExecFileSyncImpl = () => "";
+  test("invokes execFile with the expected tmux file, argv and options", async () => {
+    execFileStdout = "";
 
-    ensureSocketConfigured();
+    await ensureSocketConfigured();
 
-    expect(mockExecFileSync).toHaveBeenCalledTimes(1);
-    const call = mockExecFileSync.mock.calls[0]!;
-    const file = call[0] as string;
-    const argv = call[1] as string[];
-    const opts = call[2] as { timeout?: number; stdio?: string };
+    expect(mockExecFile).toHaveBeenCalledTimes(1);
+    const call = execFileCalls[0]!;
 
     // argv form (Issue #97): file is the tmux binary; the exact argv asserts
     // both that every option token is a discrete element AND that the two ";"
     // separators sit between the three set-option groups (an exact match, so a
     // mis-placed or extra separator fails — `arrayContaining` would not catch
     // that).
-    expect(file).toBe(TMUX_PATH);
-    expect(argv).toEqual([
+    expect(call.file).toBe(TMUX_PATH);
+    expect(call.args).toEqual([
       "-L", TMUX_SOCKET,
       "set-option", "-g", "mouse", "off", ";",
       "set-option", "-g", "mode-keys", "emacs", ";",
       "set-option", "-g", "history-limit", "10000",
     ]);
-    expect(opts).toMatchObject({ timeout: 3000, stdio: "pipe" });
+    // PR-4: stdio: "pipe" is gone (execFile buffers by default); the timeout is
+    // unchanged.
+    expect(call.opts).toMatchObject({ timeout: 3000 });
   });
 });

--- a/supervisor/tests/session/worktree.test.ts
+++ b/supervisor/tests/session/worktree.test.ts
@@ -19,6 +19,10 @@ import {
  *   - AC-4 (empty branch → error):                   "rejects ..."
  */
 
+// Issue #227 (PR-4): GitGhRunner's git/gh methods are async now (the production
+// runner uses the async `execFile`). The fake mirrors that — the in-memory
+// bookkeeping stays synchronous, the `async` keyword just wraps the result so
+// `await ensureWorktree(...)` matches production. `pathExists` stays sync.
 class FakeRunner implements GitGhRunner {
   existing = new Set<string>(); // worktree paths that already exist (Q4)
   branches = new Set<string>(); // refs that resolve (Q1)
@@ -29,31 +33,31 @@ class FakeRunner implements GitGhRunner {
   defaultBranchName = "main";
   calls: string[] = [];
 
-  branchExists(_dir: string, branch: string): boolean {
+  async branchExists(_dir: string, branch: string): Promise<boolean> {
     this.calls.push(`branchExists:${branch}`);
     return this.branches.has(branch);
   }
-  defaultBranch(_dir: string): string {
+  async defaultBranch(_dir: string): Promise<string> {
     this.calls.push(`defaultBranch`);
     return this.defaultBranchName;
   }
-  addWorktreeFromBranch(_dir: string, path: string, branch: string): void {
+  async addWorktreeFromBranch(_dir: string, path: string, branch: string): Promise<void> {
     this.calls.push(`addFromBranch:${branch}`);
     this.existing.add(path);
     // Creating a worktree registers it on `branch` (models real git).
     this.statuses.set(path, { registered: true, branch });
   }
-  addWorktreeNewBranch(
+  async addWorktreeNewBranch(
     _dir: string,
     path: string,
     branch: string,
     base: string,
-  ): void {
+  ): Promise<void> {
     this.calls.push(`addNewBranch:${branch}:${base}`);
     this.existing.add(path);
     this.statuses.set(path, { registered: true, branch });
   }
-  removeWorktree(_dir: string, path: string): void {
+  async removeWorktree(_dir: string, path: string): Promise<void> {
     this.calls.push(`remove:${path}`);
     this.existing.delete(path);
     this.statuses.delete(path);
@@ -61,7 +65,7 @@ class FakeRunner implements GitGhRunner {
   pathExists(path: string): boolean {
     return this.existing.has(path);
   }
-  worktreeStatus(_dir: string, path: string): WorktreeStatus {
+  async worktreeStatus(_dir: string, path: string): Promise<WorktreeStatus> {
     this.calls.push(`worktreeStatus:${path}`);
     return this.statuses.get(path) ?? { registered: false };
   }
@@ -116,9 +120,9 @@ describe("ensureWorktree", () => {
     runner = new FakeRunner();
   });
 
-  test("AC-1: unknown branch → creates worktree from default branch", () => {
+  test("AC-1: unknown branch → creates worktree from default branch", async () => {
     runner.defaultBranchName = "main";
-    const result = ensureWorktree(REPO, "feature-foo", runner);
+    const result = await ensureWorktree(REPO, "feature-foo", runner);
 
     expect(result.reused).toBe(false);
     expect(result.baseBranch).toBe("main");
@@ -126,9 +130,9 @@ describe("ensureWorktree", () => {
     expect(runner.calls).toContain("addNewBranch:feature-foo:main");
   });
 
-  test("Q1: existing branch → checkout into worktree (no new branch)", () => {
+  test("Q1: existing branch → checkout into worktree (no new branch)", async () => {
     runner.branches.add("existing-branch");
-    const result = ensureWorktree(REPO, "existing-branch", runner);
+    const result = await ensureWorktree(REPO, "existing-branch", runner);
 
     expect(result.reused).toBe(false);
     expect(result.baseBranch).toBeUndefined();
@@ -136,12 +140,12 @@ describe("ensureWorktree", () => {
     expect(runner.calls.some((c) => c.startsWith("addNewBranch"))).toBe(false);
   });
 
-  test("AC-3 / Q4: existing valid worktree on the expected branch → reuse, no git add", () => {
+  test("AC-3 / Q4: existing valid worktree on the expected branch → reuse, no git add", async () => {
     const path = resolveWorktreePath(REPO, "feature-foo");
     runner.existing.add(path);
     runner.statuses.set(path, { registered: true, branch: "feature-foo" });
 
-    const result = ensureWorktree(REPO, "feature-foo", runner);
+    const result = await ensureWorktree(REPO, "feature-foo", runner);
 
     expect(result.reused).toBe(true);
     expect(result.path).toBe(path);
@@ -152,79 +156,80 @@ describe("ensureWorktree", () => {
 
   // --- #158: reuse must be validated, never silently assumed -------------
 
-  test("#158 AC-1: path exists but is NOT a registered worktree (residue) → explicit error, no silent reuse", () => {
+  test("#158 AC-1: path exists but is NOT a registered worktree (residue) → explicit error, no silent reuse", async () => {
     const path = resolveWorktreePath(REPO, "feature-foo");
     runner.existing.add(path); // dir present on disk...
     // ...but no status entry → worktreeStatus reports {registered:false}.
 
-    expect(() => ensureWorktree(REPO, "feature-foo", runner)).toThrow(
+    await expect(ensureWorktree(REPO, "feature-foo", runner)).rejects.toThrow(
       /git worktree ではありません|残骸/,
     );
     // Must not fall through to creating/reusing.
     expect(runner.calls.some((c) => c.startsWith("add"))).toBe(false);
   });
 
-  test("#158 AC-1: path is a worktree but checked out on a DIFFERENT branch → explicit error", () => {
+  test("#158 AC-1: path is a worktree but checked out on a DIFFERENT branch → explicit error", async () => {
     const path = resolveWorktreePath(REPO, "feature-foo");
     runner.existing.add(path);
     runner.statuses.set(path, { registered: true, branch: "some-other-branch" });
 
-    expect(() => ensureWorktree(REPO, "feature-foo", runner)).toThrow(
+    await expect(ensureWorktree(REPO, "feature-foo", runner)).rejects.toThrow(
       /branch.*一致|期待 branch/,
     );
     expect(runner.calls.some((c) => c.startsWith("add"))).toBe(false);
   });
 
-  test("#158: a detached-HEAD worktree (no branch) → explicit error, not silent reuse", () => {
+  test("#158: a detached-HEAD worktree (no branch) → explicit error, not silent reuse", async () => {
     const path = resolveWorktreePath(REPO, "feature-foo");
     runner.existing.add(path);
     runner.statuses.set(path, { registered: true, branch: null });
 
-    expect(() => ensureWorktree(REPO, "feature-foo", runner)).toThrow();
+    await expect(ensureWorktree(REPO, "feature-foo", runner)).rejects.toThrow();
     expect(runner.calls.some((c) => c.startsWith("add"))).toBe(false);
   });
 
-  test("#158 AC-2: valid worktree on the expected branch → reuse succeeds (no regression)", () => {
+  test("#158 AC-2: valid worktree on the expected branch → reuse succeeds (no regression)", async () => {
     const path = resolveWorktreePath(REPO, "feat/foo-bar");
     runner.existing.add(path);
     runner.statuses.set(path, { registered: true, branch: "feat/foo-bar" });
 
-    const result = ensureWorktree(REPO, "feat/foo-bar", runner);
+    const result = await ensureWorktree(REPO, "feat/foo-bar", runner);
     expect(result.reused).toBe(true);
     expect(result.path).toBe(path);
   });
 
-  test("is idempotent: second ensure of the same branch reuses", () => {
-    ensureWorktree(REPO, "feature-foo", runner); // creates
-    const second = ensureWorktree(REPO, "feature-foo", runner);
+  test("is idempotent: second ensure of the same branch reuses", async () => {
+    await ensureWorktree(REPO, "feature-foo", runner); // creates
+    const second = await ensureWorktree(REPO, "feature-foo", runner);
     expect(second.reused).toBe(true);
   });
 
-  test("uses dynamic default branch (Q2: master/develop mixed repos)", () => {
+  test("uses dynamic default branch (Q2: master/develop mixed repos)", async () => {
     runner.defaultBranchName = "develop";
-    const result = ensureWorktree(REPO, "new-feat", runner);
+    const result = await ensureWorktree(REPO, "new-feat", runner);
     expect(result.baseBranch).toBe("develop");
     expect(runner.calls).toContain("addNewBranch:new-feat:develop");
   });
 
-  test("AC-4: empty / whitespace branch throws", () => {
-    expect(() => ensureWorktree(REPO, "", runner)).toThrow(/必須/);
-    expect(() => ensureWorktree(REPO, "   ", runner)).toThrow(/必須/);
+  test("AC-4: empty / whitespace branch throws", async () => {
+    // ensureWorktree is async now → a thrown error becomes a rejected Promise.
+    await expect(ensureWorktree(REPO, "", runner)).rejects.toThrow(/必須/);
+    await expect(ensureWorktree(REPO, "   ", runner)).rejects.toThrow(/必須/);
   });
 
-  test("trims surrounding whitespace from branch name", () => {
-    const result = ensureWorktree(REPO, "  feature-foo  ", runner);
+  test("trims surrounding whitespace from branch name", async () => {
+    const result = await ensureWorktree(REPO, "  feature-foo  ", runner);
     expect(result.path).toBe(resolve(REPO, WORKTREE_SUBDIR, "feature-foo"));
   });
 });
 
 describe("removeWorktree", () => {
-  test("delegates to the runner (Q3)", () => {
+  test("delegates to the runner (Q3)", async () => {
     const runner = new FakeRunner();
     const path = resolveWorktreePath(REPO, "feature-foo");
     runner.existing.add(path);
 
-    removeWorktree(REPO, path, runner);
+    await removeWorktree(REPO, path, runner);
 
     expect(runner.calls).toContain(`remove:${path}`);
     expect(runner.pathExists(path)).toBe(false);
@@ -244,18 +249,18 @@ describe("recreateWorktreeForExistingBranch (#217)", () => {
     runner = new FakeRunner();
   });
 
-  test("Q4: worktree path already present → true, no git add", () => {
+  test("Q4: worktree path already present → true, no git add", async () => {
     const path = resolveWorktreePath(REPO, "feat-217");
     runner.existing.add(path);
-    expect(recreateWorktreeForExistingBranch(REPO, "feat-217", runner)).toBe(
+    expect(await recreateWorktreeForExistingBranch(REPO, "feat-217", runner)).toBe(
       true,
     );
     expect(runner.calls.some((c) => c.startsWith("add"))).toBe(false);
   });
 
-  test("Q1: existing branch, missing worktree → checks out from branch, true", () => {
+  test("Q1: existing branch, missing worktree → checks out from branch, true", async () => {
     runner.branches.add("feat-217");
-    expect(recreateWorktreeForExistingBranch(REPO, "feat-217", runner)).toBe(
+    expect(await recreateWorktreeForExistingBranch(REPO, "feat-217", runner)).toBe(
       true,
     );
     expect(runner.calls).toContain("addFromBranch:feat-217");
@@ -263,16 +268,16 @@ describe("recreateWorktreeForExistingBranch (#217)", () => {
     expect(runner.calls.some((c) => c.startsWith("addNewBranch"))).toBe(false);
   });
 
-  test("branch gone → false WITHOUT creating a new branch (no Q2)", () => {
-    expect(recreateWorktreeForExistingBranch(REPO, "deleted", runner)).toBe(
+  test("branch gone → false WITHOUT creating a new branch (no Q2)", async () => {
+    expect(await recreateWorktreeForExistingBranch(REPO, "deleted", runner)).toBe(
       false,
     );
     expect(runner.calls).toContain("branchExists:deleted");
     expect(runner.calls.some((c) => c.startsWith("add"))).toBe(false);
   });
 
-  test("empty / whitespace branch → false, no git calls", () => {
-    expect(recreateWorktreeForExistingBranch(REPO, "   ", runner)).toBe(false);
+  test("empty / whitespace branch → false, no git calls", async () => {
+    expect(await recreateWorktreeForExistingBranch(REPO, "   ", runner)).toBe(false);
     expect(runner.calls.length).toBe(0);
   });
 });


### PR DESCRIPTION
## 概要

親 #227（tmux 同期I/O の完全非同期化）の **PR-4 / 仕上げ**。ホットパス（PR-1 relay #256 / PR-2 watchdog #258 / PR-3 TmuxAdapter #259、いずれも merged）の非同期化後に残る**非ポーリングの周辺同期 exec**を締め、Supervisor の `src/session/**` 全体から同期 exec を排除する。いずれも純粋な sync→async 変換で、worktree 作成/削除等のロジックは不変。

## 主な変更点

- **worktree.ts**: `GitGhRunner` の git/gh 5 メソッド + `ensureWorktree` / `recreateWorktreeForExistingBranch` / `removeWorktree` を `promisify(execFile)` で async 化（`pathExists` は `existsSync` で sync 維持）。**削除/作成ロジックは一切変更なし**。
- **iterm2.ts**: `isItermRunning` / `openTab` / `markTabStopped` を内部 async 化（3 execFileSync → execFile）。`markTabStopped` の `spawn` 経路は不変。
- **tmux.ts**: `ensureSocketConfigured` を async 化。
- **adapters.ts**: `WorktreeAdapter`（ensure/remove/recreateForBranch）と `TmuxAdapter.ensureSocketConfigured` を Promise 化。`ItermAdapter` は best-effort のため `void` のまま維持し、`realItermAdapter` から fire-and-forget（関数が内部 catch するので unhandled rejection なし）→ manager.ts への iterm2 波及ゼロ。
- **adapters-fake.ts**: Fake worktree / ensureSocketConfigured を async 化（カウンタ加算は同期実行されるため既存 assert を維持）。
- **manager.ts**: worktree / ensureSocketConfigured の全 await site に `await`。constructor は await 不可のため `void this.effects.tmux.ensureSocketConfigured()` の fire-and-forget（idempotent・start で再適用）。

## 受け入れ条件（コンポーネント・決定的）

| AC | 内容 | 結果 |
|---|---|---|
| AC-1 | `grep -rc execFileSync src/session/{worktree,iterm2,tmux}.ts` 全て 0 | ✅ 0/0/0（`src/session/**` 全体でも call site 0） |
| AC-2 | worktree.test.ts + start/stop フロー test PASS | ✅ worktree+manager 118 pass / 0 fail |
| AC-3 | 静的 gate：`src/session/**` に execFileSync が残らないことを検査 | ✅ 新設 `scripts/lint-no-sync-exec.ts`（AST ベース）+ test。CI typecheck job と gating list に結線。**negative fixture で exit 1 を確認** |
| AC-4 | `bunx tsc --noEmit` / #27 lint green | ✅ tsc exit 0 / #27 green / gating-coverage green |

mock.module を使う test（tmux/adapters/adapters-hassession/relay-nonblocking/lint-no-sync-exec）は専用 `bun test` step で隔離（process-global 汚染回避、#248 gating 準拠）。`tmux.test.ts` は async `execFile` を callback 形式で mock する形へ書き換え（argv/timeout assert は不変）。

## 統合ジャーニーAC

不要（Issue 記載どおり）：Supervisor 内部の I/O 実装変更で、ユーザーが踏む新たな一連フローを伴わない。start/stop の外形挙動は不変。

## 規模注記（pr-size 例外）

16 file（14 modified + 2 new）。`WorktreeAdapter` / `ensureSocketConfigured` の interface flip が atomic（TS 型のため分割不可）であることに起因し、`pr-size.md` の「大規模リファクタリング」例外に該当する。30 file 目安内。

## #227 完了

本 PR で #227 の AC「tmux 呼び出しが同期ブロックしない（イベントループを専有しない）ことをテストで担保」を **src/session 全体で達成**。新設の静的 gate が今後の sync exec 再混入を CI で機械的に防ぐ（RW-029 型の silent 戻り防止）。

## 関連

- 親: #227（PR-4 / 完）/ 前: #256, #258, #259（PR-1/2/3, merged）

Closes #252


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * `src/session/**` 配下での同期的な子プロセス実行を検出するローカルリントルールを追加しました。

* **改善**
  * tmux、git worktree、iTerm2 の各操作を非同期処理に変更しました。イベントループのブロッキングを解消し、アプリケーションの応答性が向上します。

* **テスト**
  * 非同期処理対応に合わせてテストスイートを拡充・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->