### PR TITLE
feat(#244): 高コンテキスト critical 時の resume 付き自動 restart を実行

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -159,7 +159,8 @@ jobs:
                    tests/session/worktree.test.ts \
                    tests/session/keep-attachment.test.ts \
                    tests/commands/session-keep.test.ts \
-                   tests/session/self-heal.test.ts
+                   tests/session/self-heal.test.ts \
+                   tests/session/self-heal-restart.test.ts
 
       # #238 regression: realTmuxAdapter.hasSession must treat a tmux
       # control-channel ETIMEDOUT as "alive" (assume the session survives),

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -9,7 +9,11 @@ import {
   type ThreadChannel,
   type TextChannel,
 } from "discord.js";
-import { SessionManager } from "./session/manager";
+import { SessionManager, type SelfHealOutcome } from "./session/manager";
+import {
+  executeSelfHealRestart,
+  manualRestartGuidance,
+} from "./session/self-heal-restart";
 import { Reaper } from "./session/reaper";
 import { ActivityWatchdog } from "./session/session-activity-watchdog";
 import { ResourceMonitor } from "./session/resource-monitor";
@@ -47,6 +51,149 @@ import {
   runDispatch,
 } from "./session/dispatch";
 import { buildThreadTitle } from "./session/thread-title";
+
+/** Shared context for delivering a self-heal outcome to a thread (Issue #206/#244). */
+interface SelfHealCtx {
+  thread: ThreadChannel;
+  threadId: string;
+  sessionManager: SessionManager;
+  client: Client;
+}
+
+/**
+ * Deliver a self-heal outcome to its Discord thread (Issue #206), executing the
+ * resume-backed restart when the planner chose it (Issue #244). Shared by the
+ * main relay tail and the late-response path so both behave identically. The
+ * outcome message is always posted first — for a restart it is the immediate
+ * "restarting…" announce, which matters because the resume picker poll can take
+ * minutes before the new thread is live.
+ */
+async function deliverSelfHealOutcome(
+  outcome: SelfHealOutcome,
+  ctx: SelfHealCtx
+): Promise<void> {
+  const { thread, threadId } = ctx;
+  console.warn(
+    `[Bot] context-budget ${outcome.level} on thread ${threadId}: ${outcome.tokens} tokens (action=${outcome.action})`
+  );
+  await thread.send(outcome.message);
+  if (outcome.action === "restart" && outcome.restart) {
+    await runSelfHealRestart(outcome, ctx);
+  }
+  if (outcome.page) {
+    await notifyPushover(
+      "Claude Code: コンテキスト肥大化",
+      `${thread.name ?? threadId} (${outcome.level}, ${Math.floor(outcome.tokens / 1000)}k tokens, action=${outcome.action}) — self-heal`
+    ).catch((err) =>
+      console.warn(`[Bot] context-budget pushover failed:`, err)
+    );
+  }
+}
+
+/**
+ * Drive the resume-backed restart for a critical-context session (Issue #244):
+ * resolve the channel config + parent text channel, then hand the real Discord /
+ * SessionManager side effects to {@link executeSelfHealRestart} (which owns the
+ * stop→create→resume ordering and the degrade-to-manual path). Defaults ON; the
+ * `CONTEXT_SELF_HEAL_RESTART=0` env is an emergency off-switch that degrades to
+ * manual `/session resume` guidance without a redeploy.
+ */
+async function runSelfHealRestart(
+  outcome: SelfHealOutcome,
+  ctx: SelfHealCtx
+): Promise<void> {
+  const { thread, threadId, sessionManager, client } = ctx;
+  const r = outcome.restart;
+  if (!r) return;
+
+  const flag = process.env.CONTEXT_SELF_HEAL_RESTART;
+  if (flag === "0" || flag === "false") {
+    await thread
+      .send(
+        manualRestartGuidance(
+          r.claudeSessionId,
+          "自動 restart は無効化されています (CONTEXT_SELF_HEAL_RESTART=0)"
+        )
+      )
+      .catch((err) =>
+        console.warn(`[Bot] self-heal restart (disabled) notice failed:`, err)
+      );
+    return;
+  }
+
+  const config = CHANNEL_MAP.get(r.channelName);
+  const parent = thread.parent;
+  if (
+    !config ||
+    !parent ||
+    !parent.isTextBased() ||
+    parent.isDMBased() ||
+    !("threads" in parent)
+  ) {
+    await thread
+      .send(
+        manualRestartGuidance(
+          r.claudeSessionId,
+          "新スレッドを作成できない構成のため"
+        )
+      )
+      .catch((err) =>
+        console.warn(`[Bot] self-heal restart (no-thread) notice failed:`, err)
+      );
+    return;
+  }
+  const textChannel = parent as TextChannel;
+
+  const result = await executeSelfHealRestart({
+    claudeSessionId: r.claudeSessionId,
+    tokens: outcome.tokens,
+    stopOld: () => sessionManager.stop(threadId, "self_heal_restart"),
+    createThread: async () => {
+      // Sequence suffix only when another session is already live on the same
+      // branch (mirrors handleResume / dispatch).
+      const sameBranchCount = sessionManager
+        .listRunningByChannel(r.channelName)
+        .filter((s) => s.branch === (r.branch ?? undefined)).length;
+      const threadName = buildThreadTitle(
+        "resume",
+        r.branch,
+        config.displayName,
+        sameBranchCount + 1
+      );
+      const nt = await textChannel.threads.create({
+        name: threadName,
+        autoArchiveDuration: 10080, // 7 days
+      });
+      return { id: nt.id, mention: `<#${nt.id}>` };
+    },
+    resume: async (newThreadId) => {
+      await sessionManager.resumeSession(
+        config,
+        newThreadId,
+        r.claudeSessionId,
+        r.projectDir,
+        r.branch
+      );
+    },
+    notifyOld: async (m) => {
+      await thread.send(m);
+    },
+    notifyNew: async (id, m) => {
+      const c = await client.channels.fetch(id);
+      if (c?.isThread()) await c.send(m);
+    },
+  });
+
+  if (!result.ok) {
+    console.warn(
+      `[Bot] self-heal restart degraded for thread ${threadId}: ${result.error ?? "unknown"}`
+    );
+  } else {
+    console.log(
+      `[Bot] self-heal restart: thread ${threadId} → ${result.newThreadId}`
+    );
+  }
+}
 
 export async function startBot(token: string): Promise<void> {
   // Issue #255: page-ability check at boot. If Pushover creds are missing, the
@@ -226,26 +373,21 @@ export async function startBot(token: string): Promise<void> {
         // per-thread budget check so this path warns too. The tracker is shared
         // with the main relay path, so de-dup holds across both.
         try {
-          // Issue #206: self-heal on the late-response path too (shares the
+          // Issue #206/#244: self-heal on the late-response path too (shares the
           // per-session tracker + healer, so de-dup and the cap hold across both
-          // paths). The manager performs any auto-action; we only deliver it.
+          // paths). The manager decides; deliverSelfHealOutcome posts the message
+          // and drives the resume-backed restart when chosen.
           const outcome = await sessionManager.contextBudgetSelfHeal(
             event.threadId,
             event.contextTokens
           );
           if (outcome) {
-            console.warn(
-              `[Bot] context-budget ${outcome.level} on thread ${event.threadId} (late): ${outcome.tokens} tokens (action=${outcome.action})`
-            );
-            await channel.send(outcome.message);
-            if (outcome.page) {
-              await notifyPushover(
-                "Claude Code: コンテキスト肥大化",
-                `${channel.name ?? event.threadId} (${outcome.level}, ${Math.floor(outcome.tokens / 1000)}k tokens, action=${outcome.action}) — #206 self-heal`
-              ).catch((err) =>
-                console.warn(`[Bot] context-budget pushover failed (late):`, err)
-              );
-            }
+            await deliverSelfHealOutcome(outcome, {
+              thread: channel,
+              threadId: event.threadId,
+              sessionManager,
+              client,
+            });
           }
         } catch (budgetErr) {
           console.warn(
@@ -672,26 +814,21 @@ export async function startBot(token: string): Promise<void> {
         // page Pushover for red/critical) once per band crossing. Best-effort:
         // a failure here must never affect the already-delivered response.
         try {
-          // Issue #206: self-heal — auto-compact on red (capped), notify on
-          // critical. The manager performs any auto-action and returns the
-          // ready-to-post message; we only deliver it (+ page on red/critical).
+          // Issue #206/#244: self-heal — auto-compact on red (capped),
+          // resume-backed restart on critical. The manager decides;
+          // deliverSelfHealOutcome posts the message, drives the restart when
+          // chosen, and pages Pushover on red/critical.
           const outcome = await sessionManager.contextBudgetSelfHeal(
             threadId,
             result.contextTokens
           );
           if (outcome) {
-            console.warn(
-              `[Bot] context-budget ${outcome.level} on thread ${threadId}: ${outcome.tokens} tokens (action=${outcome.action})`
-            );
-            await thread.send(outcome.message);
-            if (outcome.page) {
-              await notifyPushover(
-                "Claude Code: コンテキスト肥大化",
-                `${thread.name ?? threadId} (${outcome.level}, ${Math.floor(outcome.tokens / 1000)}k tokens, action=${outcome.action}) — #206 self-heal`
-              ).catch((err) =>
-                console.warn(`[Bot] context-budget pushover failed:`, err)
-              );
-            }
+            await deliverSelfHealOutcome(outcome, {
+              thread,
+              threadId,
+              sessionManager,
+              client,
+            });
           }
         } catch (budgetErr) {
           console.warn(

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -36,6 +36,7 @@ import {
 import {
   createSelfHealer,
   type SelfHealAction,
+  type SelfHealer,
 } from "./self-heal";
 import { compactClaudeHubExit } from "./primary-compact";
 
@@ -63,6 +64,20 @@ export interface SelfHealOutcome {
   tokens: number;
   /** True for red/critical → caller should page Pushover. */
   page: boolean;
+  /**
+   * Present only when {@link action} is `"restart"` (Issue #244). The manager
+   * cannot create a Discord thread, so it hands the caller (bot.ts) everything
+   * the resume-backed restart needs, captured BEFORE the old session is stopped.
+   * `claudeSessionId` is guaranteed non-empty here (the restart branch downgrades
+   * to `"notify"` when it is missing), so the caller can always build a valid
+   * `/session resume <id>` even on the degrade path.
+   */
+  restart?: {
+    claudeSessionId: string;
+    channelName: string;
+    projectDir: string;
+    branch: string | null;
+  };
 }
 
 /**
@@ -234,6 +249,19 @@ export class SessionManager {
   private sessions = new Map<string, SessionInfo>();
   /** Map<threadId, intervalHandle> — watchdogs to clear on stop/shutdown */
   private watchers = new Map<string, ReturnType<typeof setInterval>>();
+  /**
+   * Map<claudeSessionId, SelfHealer> — the per-CONVERSATION self-heal planner
+   * (Issue #206/#244). Keyed by claude session id, NOT threadId, so the
+   * auto-action cap survives a self-heal restart: a critical restart stops the
+   * old session and `claude --resume`s the SAME id into a fresh thread, which
+   * reloads the full ~800k context and would re-cross critical immediately. A
+   * fresh per-thread planner would reset the cap and restart forever (RW-043);
+   * keying by claude session id makes compacts AND restarts share ONE bounded
+   * budget across the whole conversation's restart chain (AC item 2). Entries
+   * are removed on a terminal stop / tmux exit (but NOT on a self_heal_restart
+   * stop, which must carry the count forward to the resumed session).
+   */
+  private readonly selfHealers = new Map<string, SelfHealer>();
   /**
    * threadIds with a start currently in flight (review #185 gemini HIGH).
    * Since {@link start} is async (it awaits the PID poll), the dup-check and
@@ -1001,6 +1029,13 @@ export class SessionManager {
    * remedy is a resume-backed restart, whose EXECUTION is deferred to a focused
    * follow-up (RW-047 resume-timing risk + new-thread orchestration).
    *
+   * critical now resolves to a resume-backed restart (Issue #244): the planner
+   * returns `restart` and this hands the caller (bot.ts) the session identity
+   * (claude session id / channel / cwd / branch) it needs to drive the
+   * stop→new-thread→resume orchestration, captured BEFORE any stop. When the
+   * claude session id is not yet known the restart degrades to the manual
+   * `/session resume` guidance (action `notify`) rather than acting blindly.
+   *
    * Best-effort and self-contained: an auto-compact failure is folded into the
    * returned message (never thrown) so the relay loop is unaffected. Returns the
    * outcome the caller posts to the thread, or null when no band was crossed.
@@ -1016,11 +1051,20 @@ export class SessionManager {
     // contextBudgetWarning only returns non-null when the session exists, but
     // guard anyway so a race (stop between the two lookups) fails safe.
     if (!session) return null;
-    if (!session.selfHealer) {
-      session.selfHealer = createSelfHealer();
+
+    // Resolve the per-CONVERSATION planner, keyed by claude session id so the
+    // auto-action cap survives a self-heal restart (see {@link selfHealers}).
+    // Fall back to threadId only when the id was not captured (a session that
+    // never responded) — such a session can't be resumed anyway, so the
+    // restart branch below degrades to manual.
+    const healerKey = session.claudeSessionId ?? threadId;
+    let healer = this.selfHealers.get(healerKey);
+    if (!healer) {
+      healer = createSelfHealer();
+      this.selfHealers.set(healerKey, healer);
     }
 
-    const decision = session.selfHealer.decide(warning.level);
+    const decision = healer.decide(warning.level);
     const page = warning.level === "red" || warning.level === "critical";
 
     // Structured, greppable log for every band crossing (observability, AC item
@@ -1069,18 +1113,50 @@ export class SessionManager {
       };
     }
 
-    // "notify" (critical) and "none" (yellow): keep the #204 warning text. For
-    // critical, append the manual-restart guidance (auto-restart is a follow-up).
-    const message =
-      decision.action === "notify"
-        ? `${warning.message}\n↳ 自動 restart は安全性のため手動運用です。\`/session resume\` で復帰してください (#206)。`
-        : warning.message;
+    if (decision.action === "restart") {
+      // Capture the session identity NOW — bot.ts stops this session before
+      // resuming, after which `this.sessions.get(threadId)` is gone (#244).
+      const claudeSessionId = session.claudeSessionId;
+      if (claudeSessionId) {
+        return {
+          level: warning.level,
+          action: "restart",
+          tokens: warning.tokens,
+          page,
+          message:
+            `🔄 コンテキストが ${Math.floor(warning.tokens / 1000)}k（critical）に到達したため、` +
+            `会話を引き継いで自動 restart します（${decision.actionCount}/${decision.cap} 回目, #244）。`,
+          restart: {
+            claudeSessionId,
+            channelName: session.channelName,
+            projectDir: session.projectDir,
+            branch: session.branch ?? null,
+          },
+        };
+      }
+      // No claude session id captured yet → resume has nothing to target. Degrade
+      // to the manual-restart guidance instead of acting blindly (#244, no silent
+      // failure). `notify` is delivered as-is by the caller (no restart payload).
+      return {
+        level: warning.level,
+        action: "notify",
+        tokens: warning.tokens,
+        page,
+        message:
+          `${warning.message}\n↳ 自動 restart は session id 未取得のため実行できませんでした。` +
+          `\`/session list\` で session_id を確認し \`/session resume <session_id>\` で復帰してください (#244)。`,
+      };
+    }
+
+    // "none" (yellow) — keep the #204 notify-only warning text. (red→compact,
+    // critical→restart, and cap-reached all returned above; a degraded restart
+    // returns "notify" inline above with its own guidance.)
     return {
       level: warning.level,
       action: decision.action,
       tokens: warning.tokens,
       page,
-      message,
+      message: warning.message,
     };
   }
 
@@ -1176,6 +1252,14 @@ export class SessionManager {
 
     this.clearWatcher(threadId);
     this.sessions.delete(threadId);
+    // Issue #244: drop the per-conversation self-heal planner on a TERMINAL stop
+    // so its cap does not leak. A `self_heal_restart` stop is NOT terminal — the
+    // conversation is about to be `claude --resume`d into a fresh thread, so the
+    // planner (and its accumulated auto-action count) must carry forward to bound
+    // the restart chain (AC item 2). All other reasons end the conversation here.
+    if (reason !== "self_heal_restart") {
+      this.selfHealers.delete(session.claudeSessionId ?? threadId);
+    }
     this.effects.iterm2.markTabStopped(session.channelName, tmuxName);
     updateSessionStatus(session.id, "stopped", reason);
     this.cleanupRelayUrlFile(session.projectDir);
@@ -1282,6 +1366,9 @@ export class SessionManager {
       clearInterval(handle);
     }
     this.watchers.clear();
+    // Defensive — stop("manual") already drops each, but clear any orphan left
+    // by a failed-then-unresumed self_heal_restart (Issue #244).
+    this.selfHealers.clear();
     this.effects.relayServer.stop();
     console.log("[SessionManager] All sessions stopped.");
   }
@@ -1318,6 +1405,10 @@ export class SessionManager {
           if (session) {
             this.effects.iterm2.markTabStopped(session.channelName, tmuxName);
             this.cleanupRelayUrlFile(session.projectDir);
+            // Issue #244: an unexpected exit ends this conversation generation —
+            // drop its self-heal planner so the cap map does not leak. A later
+            // manual /session resume legitimately starts a fresh planner.
+            this.selfHealers.delete(session.claudeSessionId ?? threadId);
             // Issue #154: the worktree is intentionally NOT removed here. An
             // unexpected claude exit is not an explicit teardown — removing the
             // worktree (git worktree remove --force) would discard any

--- a/supervisor/src/session/self-heal-restart.ts
+++ b/supervisor/src/session/self-heal-restart.ts
@@ -1,0 +1,150 @@
+/**
+ * Resume-backed auto-restart orchestration for a critical-context session
+ * (Issue #244, the follow-up #206 deferred).
+ *
+ * When the self-heal planner decides `restart` (context crossed into the
+ * critical band, under the per-session cap), this drives the recovery:
+ *
+ *   1. stop the old (critical) session  — frees the claude session id so the
+ *      resume's liveness re-check sees it as dead and proceeds.
+ *   2. create a fresh Discord thread     — a clean view; the old thread is left
+ *      with a pointer to it.
+ *   3. `claude --resume <id>` into it     — carries the FULL conversation history
+ *      across (resumeSession in SessionManager).
+ *   4. link the new thread from the old   — so the user can follow the move.
+ *
+ * Every Discord / SessionManager side effect is injected so this is unit-testable
+ * with fakes (mirrors runDispatch's `createThread` callback). The function NEVER
+ * throws: it runs on the best-effort relay tail, and any failure degrades to the
+ * manual `/session resume <id>` guidance posted in the old thread — a silent
+ * failure here would strand the user at an unusable 800k-token session (RW-047
+ * resume-timing flake is exactly such a failure, so it must degrade loudly).
+ */
+
+export interface SelfHealRestartDeps {
+  /** The claude session id to resume (carried in the outcome before the stop). */
+  claudeSessionId: string;
+  /** Context tokens at the crossing (for the user-facing messages). */
+  tokens: number;
+  /**
+   * Stop the old session. Must complete before resume so the claude session's
+   * liveness flips to dead (else resumeSession rejects "already running").
+   * Throwing → degrade.
+   */
+  stopOld: () => Promise<void>;
+  /**
+   * Create the fresh Discord thread the session resumes into. `mention` is a
+   * thread reference (`<#id>`) for the link posted back to the old thread.
+   * Throwing → degrade.
+   */
+  createThread: () => Promise<{ id: string; mention: string }>;
+  /** Resume the claude session into the new thread. Throwing (incl. RW-047 timeout) → degrade. */
+  resume: (newThreadId: string) => Promise<void>;
+  /** Post a message into the OLD (critical) thread. Best-effort; failure is swallowed. */
+  notifyOld: (message: string) => Promise<void>;
+  /** Post the welcome into the NEW thread on success. Best-effort; failure is swallowed. */
+  notifyNew?: (newThreadId: string, message: string) => Promise<void>;
+}
+
+export interface SelfHealRestartResult {
+  /** True only when the resume into the new thread succeeded. */
+  ok: boolean;
+  /** Set on success: the thread the session was resumed into. */
+  newThreadId?: string;
+  /** True when restart could not complete and we fell back to manual guidance. */
+  degraded?: boolean;
+  /** Failure detail (developer-facing); never surfaced raw to users. */
+  error?: string;
+}
+
+/**
+ * Manual-recovery guidance posted to the old thread when auto-restart cannot
+ * complete. Always names the concrete `/session resume <id>` so the user has a
+ * one-step recovery — no silent failure (#244 AC item 3).
+ */
+export function manualRestartGuidance(
+  claudeSessionId: string,
+  reason: string
+): string {
+  return (
+    `⚠️ コンテキストが critical に到達しましたが、自動 restart に失敗しました（${reason}）。\n` +
+    `手動で \`/session resume ${claudeSessionId}\` を実行して会話を引き継いで復帰してください (#244)。`
+  );
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+export async function executeSelfHealRestart(
+  deps: SelfHealRestartDeps
+): Promise<SelfHealRestartResult> {
+  const { claudeSessionId, tokens } = deps;
+
+  // Best-effort post helper: the degrade path MUST reach the user, so a
+  // notifyOld failure here is logged and swallowed rather than masking the
+  // original error or throwing out of the relay tail.
+  const degrade = async (
+    reason: string,
+    err: unknown
+  ): Promise<SelfHealRestartResult> => {
+    try {
+      await deps.notifyOld(manualRestartGuidance(claudeSessionId, reason));
+    } catch (notifyErr) {
+      console.warn(
+        `[self-heal-restart] failed to post degrade guidance: ${errMsg(notifyErr)}`
+      );
+    }
+    return { ok: false, degraded: true, error: errMsg(err) };
+  };
+
+  // 1. Stop the old session (frees the claude session for resume).
+  try {
+    await deps.stopOld();
+  } catch (err) {
+    return degrade("旧セッションの停止に失敗", err);
+  }
+
+  // 2. Create the fresh thread.
+  let thread: { id: string; mention: string };
+  try {
+    thread = await deps.createThread();
+  } catch (err) {
+    return degrade("新スレッドの作成に失敗", err);
+  }
+
+  // 3. Resume into the new thread (RW-047: a timing failure throws here).
+  try {
+    await deps.resume(thread.id);
+  } catch (err) {
+    return degrade("resume に失敗", err);
+  }
+
+  // 4. Success — link the new thread from the old, welcome in the new.
+  const k = Math.floor(tokens / 1000);
+  try {
+    await deps.notifyOld(
+      `🔄 コンテキストが ${k}k（critical）に到達したため、会話を引き継いで自動 restart しました → ${thread.mention} (#244)。\n` +
+        `このスレッドはここで終了します。続きは新スレッドで操作してください。`
+    );
+  } catch (err) {
+    console.warn(
+      `[self-heal-restart] resumed but failed to link new thread in old: ${errMsg(err)}`
+    );
+  }
+  if (deps.notifyNew) {
+    try {
+      await deps.notifyNew(
+        thread.id,
+        `♻️ 高コンテキスト self-heal により前スレッドから自動復帰しました（resume, #244）。\n` +
+          `前回の会話を引き継いでいます。このスレッドにメッセージを送ると中継されます。`
+      );
+    } catch (err) {
+      console.warn(
+        `[self-heal-restart] resumed but failed to welcome new thread: ${errMsg(err)}`
+      );
+    }
+  }
+
+  return { ok: true, newThreadId: thread.id };
+}

--- a/supervisor/src/session/self-heal.ts
+++ b/supervisor/src/session/self-heal.ts
@@ -9,19 +9,25 @@
  *   - red      → auto `/session compact` (the safe, fire-and-forget primitive
  *                already used by #200). Fires at a turn boundary (the Stop-hook
  *                relay completion), so it never interrupts an in-flight turn.
- *   - critical → notify only, for now. The right remedy at critical is a
- *                resume-backed *restart*, but auto-restart needs new-thread
- *                orchestration and carries the RW-047 resume-timing risk, so its
- *                EXECUTION is deferred to a focused follow-up. critical keeps the
- *                strong #204 warning (manual `/session resume`).
- *   - any band → a per-session cap bounds how many auto-actions fire, so a
- *                context that rebounds right back above the threshold after a
- *                compact cannot loop forever (RW-043 cap mechanism). When the
- *                cap is hit we stop auto-acting and prompt manual intervention.
+ *   - critical → resume-backed *restart* in a fresh thread (#244, the follow-up
+ *                #206 deferred). The planner only DECIDES `restart`; the actual
+ *                orchestration (stop → new thread → `claude --resume`) lives in
+ *                self-heal-restart.ts / bot.ts because it needs Discord. A
+ *                restart that cannot proceed (or fails) degrades to the manual
+ *                `/session resume` guidance — never a silent failure (RW-047).
+ *   - any band → a cap bounds how many auto-actions fire, so a context that
+ *                rebounds right back above the threshold after a compact OR a
+ *                restart cannot loop forever (RW-043 cap mechanism). compact and
+ *                restart share ONE cap (合算); once it is hit we stop auto-acting
+ *                and prompt manual intervention.
  *
- * The planner is a tiny per-session state machine (mirrors the de-dup tracker in
- * context-budget.ts) so it is unit-testable without a live session, and the
- * SessionManager owns the actual side effects (compact / Discord / log).
+ * The planner is a tiny state machine (mirrors the de-dup tracker in
+ * context-budget.ts) so it is unit-testable without a live session. The
+ * SessionManager owns the actual side effects (compact / Discord / log) AND owns
+ * the planner's lifetime: it keys one planner per claude session id (not per
+ * thread), so the cap survives a self-heal restart — `claude --resume` reloads
+ * the full context and would re-cross critical, and a fresh planner would let it
+ * restart forever (#244 AC item 2). See SessionManager.selfHealers.
  */
 
 import type { ContextBudgetLevel } from "./context-budget";
@@ -31,7 +37,13 @@ export type SelfHealAction =
   | "none"
   /** Red band: perform an automatic `/session compact`. */
   | "compact"
-  /** Critical band: notify only (auto-restart execution deferred to follow-up). */
+  /** Critical band: perform a resume-backed restart in a fresh thread (#244). */
+  | "restart"
+  /**
+   * Critical band but the restart could not be executed (e.g. the claude
+   * session id was never captured): notify only and prompt manual
+   * `/session resume` — the #244 degrade path, never a silent failure.
+   */
   | "notify"
   /** Per-session auto-action cap reached: stop auto-acting, prompt manual. */
   | "cap-reached";
@@ -101,11 +113,13 @@ export function createSelfHealer(options: SelfHealOptions = {}): SelfHealer {
         return { action: "compact", level, actionCount, cap };
       }
 
-      // critical: auto-restart EXECUTION is deferred (RW-047 + new-thread
-      // orchestration). Notify only — and do NOT consume an auto-action, since
-      // compact is not the right remedy here and we want the cap to gate actual
-      // compacts, not critical notifications.
-      return { action: "notify", level, actionCount, cap };
+      // critical: a resume-backed restart in a fresh thread (#244). Consumes an
+      // auto-action so the per-session cap bounds compacts AND restarts together
+      // (RW-043, 合算): a context that keeps rebounding to critical can restart
+      // at most `cap` times (combined with any compacts) before we stop and
+      // prompt manual intervention (AC item 2 — no infinite restart loop).
+      actionCount += 1;
+      return { action: "restart", level, actionCount, cap };
     },
   };
 }

--- a/supervisor/src/session/types.ts
+++ b/supervisor/src/session/types.ts
@@ -1,6 +1,5 @@
 import type { ChildProcess } from "child_process";
 import type { ContextBudgetTracker } from "./context-budget";
-import type { SelfHealer } from "./self-heal";
 
 export interface SessionInfo {
   id: string;
@@ -35,12 +34,6 @@ export interface SessionInfo {
    * high-context session is warned only when it crosses up into a new band.
    */
   contextBudgetTracker?: ContextBudgetTracker;
-  /**
-   * Per-session self-heal planner (Issue #206). Lazily created alongside the
-   * tracker; decides the auto-action (compact / notify / cap-reached) for each
-   * band crossing and enforces the per-session auto-action cap (RW-043).
-   */
-  selfHealer?: SelfHealer;
 }
 
 /**
@@ -62,4 +55,4 @@ export interface SessionHealthInfo {
   lastActivityAt: string;
 }
 
-export type StopReason = "manual" | "idle_timeout" | "resource_limit" | "error" | "tmux_exited" | "supervisor_restart";
+export type StopReason = "manual" | "idle_timeout" | "resource_limit" | "error" | "tmux_exited" | "supervisor_restart" | "self_heal_restart";

--- a/supervisor/tests/session/manager.test.ts
+++ b/supervisor/tests/session/manager.test.ts
@@ -190,9 +190,9 @@ describe("SessionManager (thread-based)", () => {
       compactSpy.mockRestore();
     });
 
-    test("AC item 3: critical → notify only (no auto-compact), restart guidance present", async () => {
+    test("#244: critical → restart, hands back the session identity (no auto-compact)", async () => {
       const t = "sh-critical";
-      await manager.start(primaryConfig, t);
+      const info = await manager.start(primaryConfig, t);
       const compactSpy = spyOn(manager, "compactSession").mockResolvedValue(
         undefined
       );
@@ -200,11 +200,50 @@ describe("SessionManager (thread-based)", () => {
       const outcome = await manager.contextBudgetSelfHeal(t, 850_000);
 
       expect(outcome?.level).toBe("critical");
-      expect(outcome?.action).toBe("notify");
+      expect(outcome?.action).toBe("restart");
       expect(outcome?.page).toBe(true);
       expect(compactSpy).not.toHaveBeenCalled();
-      expect(outcome?.message).toContain("/session resume");
+      // The restart payload carries everything bot.ts needs to resume, captured
+      // before the stop (claude session id is pinned at start, #167).
+      expect(outcome?.restart?.claudeSessionId).toBe(info.claudeSessionId!);
+      expect(outcome?.restart?.channelName).toBe(primaryConfig.channelName);
+      expect(outcome?.restart?.projectDir).toBe(info.projectDir);
       compactSpy.mockRestore();
+    });
+
+    test("#244 AC item 2: the auto-action cap survives a self_heal_restart (keyed by claude session id), bounding the restart chain", async () => {
+      process.env.CONTEXT_SELF_HEAL_MAX_ACTIONS = "1"; // one auto-action total
+      // Dedicated manager with a no-op resume prompt poll so resumeSession does
+      // not pay the production picker wait.
+      const m = new SessionManager({
+        effects,
+        gracefulKillTimeoutMs: 0,
+        resumePromptPollAttempts: 0,
+      });
+      try {
+        const tA = "sh-rs-A";
+        const a = await m.start(primaryConfig, tA);
+        const cid = a.claudeSessionId!;
+
+        // 1st critical on the original session → restart (consumes the only slot).
+        const first = await m.contextBudgetSelfHeal(tA, 850_000);
+        expect(first?.action).toBe("restart");
+        expect(first?.restart?.claudeSessionId).toBe(cid);
+
+        // Self-heal restart stops the old session WITHOUT dropping the planner…
+        await m.stop(tA, "self_heal_restart");
+        // …and resumes the SAME claude session id into a fresh thread.
+        const tB = "sh-rs-B";
+        await m.resumeSession(primaryConfig, tB, cid, primaryConfig.dir);
+
+        // The resumed session reloads the full context and re-crosses critical.
+        // Because the planner is keyed by claude session id, the cap is already
+        // spent → cap-reached, NOT another restart (no infinite restart loop).
+        const second = await m.contextBudgetSelfHeal(tB, 860_000);
+        expect(second?.action).toBe("cap-reached");
+      } finally {
+        await m.shutdownAll();
+      }
     });
 
     test("AC item 2: rebounding red hits the cap, then stops auto-compacting", async () => {

--- a/supervisor/tests/session/self-heal-restart.test.ts
+++ b/supervisor/tests/session/self-heal-restart.test.ts
@@ -1,0 +1,142 @@
+import { test, expect, describe } from "bun:test";
+import {
+  executeSelfHealRestart,
+  manualRestartGuidance,
+  type SelfHealRestartDeps,
+} from "../../src/session/self-heal-restart";
+
+/**
+ * Unit tests for the resume-backed auto-restart orchestration (Issue #244).
+ * Every Discord / SessionManager side effect is injected, so these drive the
+ * exact ordering and the degrade paths without a live session.
+ *
+ * Journey AC mapping:
+ *   - item 1: critical → restart fires once, resumes into a NEW thread, links it
+ *             from the old thread.
+ *   - item 3: a failing restart (stop / create / resume) degrades to manual
+ *             `/session resume <id>` guidance — never silent (silent failure = 0).
+ *  (item 2 — the per-session cap that stops infinite restarts — is at the
+ *   planner level: see self-heal.test.ts.)
+ */
+
+const SID = "11111111-2222-3333-4444-555555555555";
+
+function makeDeps(
+  overrides: Partial<SelfHealRestartDeps> = {}
+): {
+  deps: SelfHealRestartDeps;
+  calls: { stop: number; create: number; resume: string[]; old: string[]; new: string[] };
+} {
+  const calls = { stop: 0, create: 0, resume: [] as string[], old: [] as string[], new: [] as string[] };
+  const deps: SelfHealRestartDeps = {
+    claudeSessionId: SID,
+    tokens: 850_000,
+    stopOld: async () => {
+      calls.stop += 1;
+    },
+    createThread: async () => {
+      calls.create += 1;
+      return { id: "new-thread-1", mention: "<#new-thread-1>" };
+    },
+    resume: async (id) => {
+      calls.resume.push(id);
+    },
+    notifyOld: async (m) => {
+      calls.old.push(m);
+    },
+    notifyNew: async (_id, m) => {
+      calls.new.push(m);
+    },
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+describe("executeSelfHealRestart (#244)", () => {
+  test("AC item 1: success — stop → create → resume(new) → link old + welcome new", async () => {
+    const { deps, calls } = makeDeps();
+    const res = await executeSelfHealRestart(deps);
+
+    expect(res.ok).toBe(true);
+    expect(res.newThreadId).toBe("new-thread-1");
+    expect(res.degraded).toBeUndefined();
+    // ordering: stopped, created, resumed into the freshly created thread id.
+    expect(calls.stop).toBe(1);
+    expect(calls.create).toBe(1);
+    expect(calls.resume).toEqual(["new-thread-1"]);
+    // old thread got a link to the new thread; new thread got a welcome.
+    expect(calls.old.length).toBe(1);
+    expect(calls.old[0]).toContain("<#new-thread-1>");
+    expect(calls.old[0]).toContain("#244");
+    expect(calls.new.length).toBe(1);
+  });
+
+  test("AC item 3: resume failure (RW-047 timing) → degrade to manual /session resume, no throw", async () => {
+    const { deps, calls } = makeDeps({
+      resume: async () => {
+        throw new Error("resume picker timed out");
+      },
+    });
+    const res = await executeSelfHealRestart(deps);
+
+    expect(res.ok).toBe(false);
+    expect(res.degraded).toBe(true);
+    expect(res.error).toContain("resume picker timed out");
+    // The old thread was told exactly how to recover manually — silent failure = 0.
+    expect(calls.old.length).toBe(1);
+    expect(calls.old[0]).toContain(`/session resume ${SID}`);
+    // No welcome was posted to a thread we failed to resume into.
+    expect(calls.new.length).toBe(0);
+  });
+
+  test("AC item 3: stop failure → degrade, resume never attempted", async () => {
+    const { deps, calls } = makeDeps({
+      stopOld: async () => {
+        throw new Error("tmux won't die");
+      },
+    });
+    const res = await executeSelfHealRestart(deps);
+
+    expect(res.ok).toBe(false);
+    expect(res.degraded).toBe(true);
+    expect(calls.create).toBe(0);
+    expect(calls.resume).toEqual([]);
+    expect(calls.old[0]).toContain(`/session resume ${SID}`);
+  });
+
+  test("AC item 3: thread-create failure → degrade, resume never attempted", async () => {
+    const { deps, calls } = makeDeps({
+      createThread: async () => {
+        throw new Error("discord 503");
+      },
+    });
+    const res = await executeSelfHealRestart(deps);
+
+    expect(res.ok).toBe(false);
+    expect(res.degraded).toBe(true);
+    expect(calls.resume).toEqual([]);
+    expect(calls.old[0]).toContain(`/session resume ${SID}`);
+  });
+
+  test("degrade guidance failing to post does NOT throw out of the relay tail", async () => {
+    const { deps } = makeDeps({
+      resume: async () => {
+        throw new Error("boom");
+      },
+      notifyOld: async () => {
+        throw new Error("discord down too");
+      },
+    });
+    // Must resolve to a degraded result, not reject.
+    const res = await executeSelfHealRestart(deps);
+    expect(res.ok).toBe(false);
+    expect(res.degraded).toBe(true);
+  });
+
+  test("manualRestartGuidance always names the concrete resume command", () => {
+    const g = manualRestartGuidance(SID, "テスト理由");
+    expect(g).toContain(`/session resume ${SID}`);
+    expect(g).toContain("テスト理由");
+    expect(g).toContain("#244");
+  });
+});

--- a/supervisor/tests/session/self-heal.test.ts
+++ b/supervisor/tests/session/self-heal.test.ts
@@ -7,9 +7,10 @@ import { createSelfHealer } from "../../src/session/self-heal";
  * tracker) and returns the auto-action to take.
  *
  * Journey AC mapping:
- *   - item 1: red → "compact"
- *   - item 2: a rebounding context hits the cap → "cap-reached" (no infinite loop)
- *   - item 3: critical → "notify" (auto-restart execution deferred to follow-up)
+ *   - item 1: critical → "restart" (resume-backed restart, #244)
+ *   - item 2: a rebounding context hits the shared cap → "cap-reached" so
+ *             compacts AND restarts together cannot loop forever
+ *   - item 3: the restart execution / degrade is covered in self-heal-restart.test.ts
  */
 describe("createSelfHealer (#206)", () => {
   test("yellow → none (notify only, no auto-action consumed)", () => {
@@ -27,12 +28,14 @@ describe("createSelfHealer (#206)", () => {
     expect(d.cap).toBe(3);
   });
 
-  test("AC item 3: critical → notify (restart execution deferred), no count consumed", () => {
+  test("AC item 1: critical → restart, consumes an auto-action (#244)", () => {
     const h = createSelfHealer({ maxAutoActions: 3 });
     const d = h.decide("critical");
-    expect(d.action).toBe("notify");
-    // critical does not consume an auto-action — the cap gates compacts only.
-    expect(d.actionCount).toBe(0);
+    expect(d.action).toBe("restart");
+    // #244: unlike the old notify-only behaviour, a restart consumes a slot so
+    // the shared cap bounds restarts too (RW-043).
+    expect(d.actionCount).toBe(1);
+    expect(d.cap).toBe(3);
   });
 
   test("AC item 2: repeated red rebounds hit the cap, then stop auto-acting", () => {
@@ -46,11 +49,22 @@ describe("createSelfHealer (#206)", () => {
     expect(h.decide("red").action).toBe("cap-reached");
   });
 
+  test("AC item 2: compact and restart share ONE cap (合算), then cap-reached", () => {
+    const h = createSelfHealer({ maxAutoActions: 2 });
+    expect(h.decide("red").action).toBe("compact"); // 1 (compact)
+    expect(h.decide("critical").action).toBe("restart"); // 2 (restart) — same cap
+    const capped = h.decide("critical"); // 3rd would exceed → cap-reached
+    expect(capped.action).toBe("cap-reached");
+    expect(capped.actionCount).toBe(2);
+    // No infinite restart loop: stays capped on subsequent criticals.
+    expect(h.decide("critical").action).toBe("cap-reached");
+  });
+
   test("critical after the cap is reached → cap-reached (no further auto-action)", () => {
     const h = createSelfHealer({ maxAutoActions: 1 });
     expect(h.decide("red").action).toBe("compact"); // consumes the only slot
     // Now at cap: even a critical escalation reports cap-reached, prompting
-    // manual intervention rather than silently doing nothing.
+    // manual intervention rather than restarting forever.
     expect(h.decide("critical").action).toBe("cap-reached");
   });
 


### PR DESCRIPTION
## 概要

Issue #244（Epic #207 / #206 follow-up）。#206 が安全性のため deferred した
**critical（既定 800k tokens）到達時の resume 付き自動 restart** を実装する。

#206 では red→自動 compact までを実装し、critical は通知のみ（手動 `/session resume` 誘導）だった。
本 PR は critical で「現セッション stop → 新スレッド作成 → `claude --resume` で会話を引き継いで復帰」を
自動実行し、失敗時は手動復帰へ degrade する。

## 主な変更

| ファイル | 変更 |
|---|---|
| `src/session/self-heal.ts` | planner を critical→`restart` に拡張。compact と restart が **1 つの cap を共有**（合算, RW-043） |
| `src/session/self-heal-restart.ts`（新） | Discord 非依存の orchestration。stop→新スレッド→resume→旧スレッドへリンク。**never throw**、失敗は手動 `/session resume` へ degrade |
| `src/session/manager.ts` | self-heal planner を **claudeSessionId でキー**し `self_heal_restart` stop を跨いで cap を保持。restart 判定＋必要情報（claude session id/channel/cwd/branch）を返す |
| `src/bot.ts` | 2 つの self-heal 呼び出し箇所を `deliverSelfHealOutcome` に集約し restart を結線。緊急 off-switch `CONTEXT_SELF_HEAL_RESTART=0`（既定 ON） |
| `src/session/types.ts` | `StopReason` に `self_heal_restart` 追加、`selfHealer` を `SessionInfo` から manager へ移動 |
| `.github/workflows/ci.yml` | 新規テストを gating list に登録 |

## 設計上のポイント

- **無限 restart 防止（AC item 2）**: `claude --resume` は全文脈（~800k）を再ロードするため、resume 直後に再び critical を跨ぐ。planner を thread ではなく **claudeSessionId でキー**することで、auto-action cap が restart 連鎖を跨いで保持され、cap 到達で自動 restart を停止し手動誘導へ切り替える（RW-043 同型のループ防止）。
- **silent failure 0（AC item 3）**: stop / スレッド作成 / resume（RW-047 の resume timing flake 含む）いずれの失敗も、旧スレッドへ具体的な `/session resume <id>` 手動手順を出して degrade する。orchestration は決して throw せず relay tail を壊さない。
- **境界での安全側**: restart は default ON だが env で即時無効化可能。

## テスト

決定的単体テスト **80 pass**（`bun test` の自動 gate 対象）:

- `self-heal.test.ts`: critical→restart（item1）、compact+restart 合算 cap→cap-reached（item2）
- `self-heal-restart.test.ts`（新）: 成功時 stop→create→resume→link（item1）、stop/create/resume 各失敗→手動 degrade・no throw（item3）
- `manager.test.ts`: critical→restart で session identity を返す／**self_heal_restart stop を跨いで cap 保持**（resumeSession を fake adapters で通し、再 critical が cap-reached になることを検証, item2 の核心）

typecheck（`bunx tsc --noEmit`）green。

## 統合ジャーニーAC 検証状況

| AC | 検証 |
|---|---|
| item1: critical→restart 1 回・新スレッド復帰・旧スレッドへリンク | 単体（planner/orchestration/manager）で決定的検証済。**ライブ Discord での新スレッド応答・`fetch_messages` 確認は staged 検証が必要** |
| item2: cap で自動 restart 停止（無限 restart しない） | ✅ 決定的（cross-resume cap テスト） |
| item3: resume 失敗→手動誘導へ degrade（silent 0） | ✅ 決定的（失敗注入テスト） |

> 補足: item1 のライブ検証は稼働中 Supervisor + Discord での実 session 増大が要るため本 PR では unit 検証に留め、staged 検証はマージ後の実機ドッグフードで実施する。

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)
