### PR TITLE
fix(#267): claudeHubExit の非メンション誤応答を PreToolUse 機械ゲートで防止

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -189,6 +189,21 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/hijoguchi-record-activity.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/hijoguchi-record-channel-context.sh"
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "mcp__plugin_discord_discord__(reply|react|edit_message)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/hijoguchi-discord-gate.sh"
           }
         ]
       }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -226,6 +226,9 @@ jobs:
       - name: Run routing matrix (25 cases, P0×12 gating)
         run: bash scripts/test-hijoguchi-routing.sh
 
+      - name: Run claudeHubExit mechanical mention gate tests (#267)
+        run: bash scripts/test-hijoguchi-discord-gate.sh
+
   # E2E verification of the Discord ↔ Supervisor ↔ Claude Code relay chain.
   # Covers AC-4/5/6/7 hermetically (tmux + mock claude + relay-server HTTP).
   # AC-1/2/3 require a live Discord bot token and are documented as manual

--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -89,6 +89,17 @@ claudeHubExit Bot は `~/.claude/channels/discord/access.json` で access 制御
 - **Primary**: claude-hub の保守チャンネル。常時やり取りが発生するため mention 不要で allowFrom も空
 - **Non-primary**: 他プロジェクト thread。基本 Channel-Supervisor が担当するため claudeHubExit は普段応答しないが、Supervisor 障害時に owner が mention して問い合わせる経路として残す。非 owner からの mention は silent drop される
 
+### 機械ゲート（#267 backstop）
+
+access.json の `requireMention` と `scripts/hijoguchi-system-prompt.md` の沈黙ルールは「メッセージが LLM に届く／届いた後に LLM が沈黙を選ぶ」前提のため、いずれかが破れると claudeHubExit が非 primary で誤応答する（#230 の system-prompt ゲートが #267 で再破綻：Channel-Supervisor のセッションスレッドに届いた非メンション `/resume-session` に 👀 + 返信した）。
+
+これを LLM 判断に依存しない形で塞ぐため、**PreToolUse の機械ゲート**を追加した（投稿の直前で決定的に DENY する）:
+
+- `scripts/hijoguchi-record-channel-context.sh`（UserPromptSubmit）: 受信した Discord メッセージごとに「chat_id」と「自分宛メンション有無」を `${CLAUDE_HUB_STATE_DIR}/channel-ctx/<chat_id>` に記録する（記録のみ・常に exit 0）。
+- `scripts/hijoguchi-discord-gate.sh`（PreToolUse: `reply`/`react`/`edit_message`）: 投稿先が **primary 以外** かつ **直近の受信が非メンション**なら **exit 2 で DENY**。primary は常時許可、非 primary はメンション時のみ許可（= 条件1/2 を機械化）。記録欠如は fail-closed で DENY。
+- いずれも `CLAUDE_HUB_HIJOGUCHI_SESSION=1` の claudeHubExit セッションにのみ適用（`start-hijoguchi.sh` が `HIJOGUCHI_CHANNEL_ID` / `HIJOGUCHI_BOT_MENTION` を `env` 前置で in-session hook へ転送）。
+- 仕様メモ: 非 primary では **本文に明示の mention タグ**を要求する（plugin の reply-implicit mention は本文に現れないため honor しない＝ #230 条件2 より厳格な fail-safe）。回帰テスト: `scripts/test-hijoguchi-discord-gate.sh`。
+
 ### 反映
 
 access.json は毎メッセージ読み込まれるため、編集は即反映。Bot 再起動不要。

--- a/scripts/hijoguchi-discord-gate.sh
+++ b/scripts/hijoguchi-discord-gate.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# PreToolUse hook: the ENFORCING half of the claudeHubExit mechanical mention
+# gate (#267). DENIES (exit 2) a Discord post tool (reply / react / edit) when
+# the target chat is NOT the primary channel AND the last incoming message there
+# did not mention the bot. This mechanically enforces #230 (respond only in the
+# primary channel or when @mentioned) WITHOUT depending on the LLM honoring the
+# behavioral system-prompt rule — which is exactly what failed in #267 (the
+# launchd claudeHubExit reacted + replied to a non-mention message inside a
+# Channel-Supervisor session thread).
+#
+# Mention context is written per chat_id by scripts/hijoguchi-record-channel-
+# context.sh (UserPromptSubmit). PreToolUse deny is a documented, deterministic
+# mechanism (exit 2 blocks the tool call), unlike UserPromptSubmit suppression.
+#
+# Registered in .claude/settings.json (PreToolUse, matcher = the discord post
+# tools). Scoped in-code to CLAUDE_HUB_HIJOGUCHI_SESSION=1.
+#
+# Decision: exit 0 = allow, exit 2 = deny (stderr reason is surfaced to Claude).
+set -u
+
+INPUT="$(cat 2>/dev/null)" || exit 0
+
+# Out of scope: only gate the dedicated claudeHubExit session.
+[ "${CLAUDE_HUB_HIJOGUCHI_SESSION:-0}" = "1" ] || exit 0
+
+TOOL="$(printf '%s' "${INPUT}" | jq -r '.tool_name // empty' 2>/dev/null)" || exit 0
+case "${TOOL}" in
+  mcp__plugin_discord_discord__reply|mcp__plugin_discord_discord__react|mcp__plugin_discord_discord__edit_message) : ;;
+  *) exit 0 ;;  # not a Discord post tool → nothing to gate
+esac
+
+CHAT_ID="$(printf '%s' "${INPUT}" | jq -r '.tool_input.chat_id // empty' 2>/dev/null)"
+# No target chat → cannot classify a Discord post → fail-closed DENY. reply /
+# react / edit_message all require chat_id, so a legitimate call always has one;
+# a call without it would fail anyway, so denying loses no real functionality
+# while closing a "no chat_id ⇒ allow" bypass.
+if [ -z "${CHAT_ID}" ]; then
+  echo "[hijoguchi-gate] BLOCKED ${TOOL}: missing chat_id (cannot classify; fail-closed)." >&2
+  exit 2
+fi
+
+PRIMARY="${HIJOGUCHI_CHANNEL_ID:-}"
+# Misconfigured (primary unknown): fail-closed DENY rather than silently
+# disabling the backstop — a silent fail-open would let #267 recur unnoticed.
+# start-hijoguchi.sh refuses to launch without this env AND forwards it via the
+# `env` prefix, so this branch is defensive; if it ever fires, claudeHubExit goes
+# (loudly) silent until the env is fixed, which is strictly preferred over a
+# silent return to the buggy behaviour.
+if [ -z "${PRIMARY}" ]; then
+  echo "[hijoguchi-gate] BLOCKED ${TOOL}: HIJOGUCHI_CHANNEL_ID unset (fail-closed backstop)." >&2
+  exit 2
+fi
+
+# Primary channel → always allowed (#230 condition 1).
+[ "${CHAT_ID}" = "${PRIMARY}" ] && exit 0
+
+# Non-primary → allowed only if the last incoming message there mentioned the
+# bot (#230 condition 2). Missing record = fail-closed DENY.
+STATE_DIR="${CLAUDE_HUB_STATE_DIR:-${HOME}/.claude-hub-state}"
+MENTIONED="$(cat "${STATE_DIR}/channel-ctx/${CHAT_ID}" 2>/dev/null || true)"
+if [ "${MENTIONED}" = "1" ]; then
+  exit 0
+fi
+
+echo "[hijoguchi-gate] BLOCKED ${TOOL} to a non-primary channel without an @mention (#267 mechanical gate; reply only in the primary channel or when mentioned)." >&2
+exit 2

--- a/scripts/hijoguchi-record-channel-context.sh
+++ b/scripts/hijoguchi-record-channel-context.sh
@@ -1,0 +1,69 @@
+#!/bin/bash
+# UserPromptSubmit hook: record, per incoming Discord chat_id, whether the
+# message mentioned the claudeHubExit bot. Half of the MECHANICAL mention gate
+# (#267) that replaces the behavioral system-prompt rule which re-broke #230.
+#
+# The companion PreToolUse hook (scripts/hijoguchi-discord-gate.sh) reads these
+# records to DENY a reply/react in a non-primary channel that was not mentioned.
+# We split recording (here) from denying (there) because UserPromptSubmit
+# blocking of `--channels`-injected prompts is not a documented guarantee, but
+# PreToolUse deny is — so the reliable mechanical decision happens at PreToolUse,
+# and this hook only needs to FIRE (which it provably does — the sibling
+# idle-stamp hook relies on the same path) and write state.
+#
+# Registered in .claude/settings.json (UserPromptSubmit, no matcher → fires on
+# every prompt). Scoped in-code to CLAUDE_HUB_HIJOGUCHI_SESSION=1 so an ordinary
+# `claude` opened in ~/claude-hub never writes gate state. ALWAYS exits 0: a
+# failure here must never block the prompt path (fail-safe; the gate hook is the
+# enforcing layer and is fail-closed on a MISSING record).
+set -u
+
+# Drain stdin first so the producer never blocks, capturing it for parsing.
+INPUT="$(cat 2>/dev/null)" || exit 0
+
+# Scope to the hijoguchi session only.
+[ "${CLAUDE_HUB_HIJOGUCHI_SESSION:-0}" = "1" ] || exit 0
+
+STATE_DIR="${CLAUDE_HUB_STATE_DIR:-${HOME}/.claude-hub-state}"
+CTX_DIR="${STATE_DIR}/channel-ctx"
+
+# Extract the prompt text (UserPromptSubmit payload `.prompt`). Bad/missing JSON
+# is non-fatal: just nothing to record.
+PROMPT="$(printf '%s' "${INPUT}" | jq -r '.prompt // empty' 2>/dev/null)" || exit 0
+[ -n "${PROMPT}" ] || exit 0
+
+# Only act on a Discord channel envelope injected by the plugin transport, i.e.
+#   <channel source="plugin:discord:discord" chat_id="..." ...>
+case "${PROMPT}" in
+  *'source="plugin:discord:discord"'*) : ;;
+  *) exit 0 ;;
+esac
+
+# Pull the chat_id (Discord snowflake) out of the envelope tag.
+CHAT_ID="$(printf '%s' "${PROMPT}" | grep -oE 'chat_id="[0-9]+"' | head -1 | tr -dc '0-9')"
+[ -n "${CHAT_ID}" ] || exit 0
+
+# Mentioned iff the body contains the bot's mention tag (HIJOGUCHI_BOT_MENTION,
+# e.g. "<@123...>"). Empty env → treat as not-mentioned (fail-closed: the gate
+# will then require primary or deny). The `case` pattern is a quoted substring
+# match; the tag is "<@<digits>>", none of which are shell glob metacharacters
+# (* ? [ ]), so it cannot match too broadly.
+MENTIONED=0
+BOT_MENTION="${HIJOGUCHI_BOT_MENTION:-}"
+if [ -n "${BOT_MENTION}" ]; then
+  case "${PROMPT}" in
+    *"${BOT_MENTION}"*) MENTIONED=1 ;;
+  esac
+fi
+
+mkdir -p "${CTX_DIR}" 2>/dev/null || exit 0
+# Atomic publish (temp + mv) so the gate never reads a torn value. This records
+# only the MOST RECENT message per chat_id; the --channels plugin enqueues and
+# delivers messages serially (one prompt → one turn) and this hook fires at
+# submit time, so the record reflects the message being handled in the current
+# turn. Cross-message interleaving on one chat_id is therefore not expected.
+TMP="${CTX_DIR}/.${CHAT_ID}.$$"
+if printf '%s' "${MENTIONED}" > "${TMP}" 2>/dev/null; then
+  mv -f "${TMP}" "${CTX_DIR}/${CHAT_ID}" 2>/dev/null || rm -f "${TMP}" 2>/dev/null || true
+fi
+exit 0

--- a/scripts/start-hijoguchi.sh
+++ b/scripts/start-hijoguchi.sh
@@ -210,8 +210,14 @@ fi
 # hook — the hook would then always skip and the idle timer would never warm,
 # resetting the session on a fixed schedule regardless of activity. `env` sets
 # the vars on the claude process directly, independent of server state.
-CLAUDE_CMD=$(printf 'env CLAUDE_HUB_HIJOGUCHI_SESSION=1 CLAUDE_HUB_STATE_DIR=%q LAST_MSG_TS_FILE=%q ' \
-  "${CLAUDE_HUB_STATE_DIR}" "${LAST_MSG_TS_FILE}")
+# HIJOGUCHI_CHANNEL_ID / HIJOGUCHI_BOT_MENTION are forwarded explicitly (not via
+# export) for the same reason as the activity-tracking vars above: when the tmux
+# server pre-exists, the claude pane inherits the server's cached env, so the
+# in-session mechanical mention gate (#267: hijoguchi-discord-gate.sh /
+# hijoguchi-record-channel-context.sh) would not see them and would fail open /
+# misclassify. The `env` prefix sets them on the claude process directly.
+CLAUDE_CMD=$(printf 'env CLAUDE_HUB_HIJOGUCHI_SESSION=1 CLAUDE_HUB_STATE_DIR=%q LAST_MSG_TS_FILE=%q HIJOGUCHI_CHANNEL_ID=%q HIJOGUCHI_BOT_MENTION=%q ' \
+  "${CLAUDE_HUB_STATE_DIR}" "${LAST_MSG_TS_FILE}" "${HIJOGUCHI_CHANNEL_ID}" "${HIJOGUCHI_BOT_MENTION}")
 CLAUDE_CMD+=$(printf '%q ' "${CLAUDE_ARGV[@]}")
 
 # Opt-in introspection for tests: print the fully-built launch command (incl.

--- a/scripts/test-hijoguchi-discord-gate.sh
+++ b/scripts/test-hijoguchi-discord-gate.sh
@@ -1,0 +1,236 @@
+#!/bin/bash
+# Unit tests for the claudeHubExit Discord mention gate (#267).
+#
+# Two hooks implement a MECHANICAL gate that does NOT depend on the LLM honoring
+# the behavioral system-prompt rule (which broke in #267, re-breaking #230):
+#
+#   scripts/hijoguchi-record-channel-context.sh  (UserPromptSubmit)
+#     Records, per incoming Discord chat_id, whether the message mentioned the
+#     bot — into ${CLAUDE_HUB_STATE_DIR}/channel-ctx/<chat_id> (1 = mentioned).
+#
+#   scripts/hijoguchi-discord-gate.sh            (PreToolUse: reply/react/edit)
+#     DENIES (exit 2) a Discord post when the target chat is non-primary AND the
+#     last incoming message there did not mention the bot. Allows primary always
+#     and non-primary only when mentioned (= #230 condition 1 / 2, mechanically).
+#
+# Run standalone: bash scripts/test-hijoguchi-discord-gate.sh
+# Exits 0 on all-pass, 1 on any failure.
+# shellcheck disable=SC2329
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+RECORD="${SCRIPT_DIR}/hijoguchi-record-channel-context.sh"
+GATE="${SCRIPT_DIR}/hijoguchi-discord-gate.sh"
+
+PRIMARY="100000000000000001"      # stands in for HIJOGUCHI_CHANNEL_ID
+NONPRIM="200000000000000002"      # a project / session-thread channel
+BOT_MENTION="<@900000000000000009>"
+
+fail=0
+run() {
+  local name="$1"; shift
+  if "$@"; then echo "PASS ${name}"; else echo "FAIL ${name}"; fail=1; fi
+}
+
+# Fresh isolated state dir per invocation of the helpers.
+new_state() {
+  STATE="$(mktemp -d)"
+  export CLAUDE_HUB_STATE_DIR="${STATE}"
+}
+
+# Build a UserPromptSubmit hook payload whose prompt is a discord channel
+# envelope. $1=chat_id $2=body
+prompt_payload() {
+  local chat="$1" body="$2"
+  local env="<channel source=\"plugin:discord:discord\" chat_id=\"${chat}\" message_id=\"m1\" user=\"u\" ts=\"t\">
+${body}
+</channel>"
+  jq -n --arg p "${env}" '{hook_event_name:"UserPromptSubmit", prompt:$p}'
+}
+
+# Build a PreToolUse payload. $1=tool_name $2=chat_id
+tool_payload() {
+  local tool="$1" chat="$2"
+  jq -n --arg t "${tool}" --arg c "${chat}" \
+    '{hook_event_name:"PreToolUse", tool_name:$t, tool_input:{chat_id:$c, text:"x"}}'
+}
+
+ctx_file() { echo "${CLAUDE_HUB_STATE_DIR}/channel-ctx/$1"; }
+
+# ----- record-context hook -----
+
+# hijoguchi + non-primary + NO mention -> ctx=0
+rc1_nonprimary_no_mention() {
+  new_state
+  CLAUDE_HUB_HIJOGUCHI_SESSION=1 HIJOGUCHI_BOT_MENTION="${BOT_MENTION}" \
+    bash "${RECORD}" <<<"$(prompt_payload "${NONPRIM}" "hello supervisor tmux")" || return 1
+  [ "$(cat "$(ctx_file "${NONPRIM}")" 2>/dev/null)" = "0" ]
+}
+
+# hijoguchi + non-primary + mention -> ctx=1
+rc2_nonprimary_mention() {
+  new_state
+  CLAUDE_HUB_HIJOGUCHI_SESSION=1 HIJOGUCHI_BOT_MENTION="${BOT_MENTION}" \
+    bash "${RECORD}" <<<"$(prompt_payload "${NONPRIM}" "hey ${BOT_MENTION} please look")" || return 1
+  [ "$(cat "$(ctx_file "${NONPRIM}")" 2>/dev/null)" = "1" ]
+}
+
+# non-hijoguchi session -> nothing written
+rc3_non_hijoguchi_noop() {
+  new_state
+  CLAUDE_HUB_HIJOGUCHI_SESSION=0 HIJOGUCHI_BOT_MENTION="${BOT_MENTION}" \
+    bash "${RECORD}" <<<"$(prompt_payload "${NONPRIM}" "hello")" || return 1
+  [ ! -e "$(ctx_file "${NONPRIM}")" ]
+}
+
+# plain (non-channel) prompt -> nothing written
+rc4_non_channel_noop() {
+  new_state
+  CLAUDE_HUB_HIJOGUCHI_SESSION=1 HIJOGUCHI_BOT_MENTION="${BOT_MENTION}" \
+    bash "${RECORD}" <<<'{"hook_event_name":"UserPromptSubmit","prompt":"just a normal prompt"}' || return 1
+  [ -z "$(find "${CLAUDE_HUB_STATE_DIR}/channel-ctx" -type f 2>/dev/null)" ]
+}
+
+# record hook must always exit 0 even on garbage stdin
+rc5_always_exit0() {
+  new_state
+  CLAUDE_HUB_HIJOGUCHI_SESSION=1 HIJOGUCHI_BOT_MENTION="${BOT_MENTION}" \
+    bash "${RECORD}" <<<'not json at all'
+}
+
+# HIJOGUCHI_BOT_MENTION unset + mention tag present in body -> records 0
+# (fail-closed: without the configured tag a mention cannot be confirmed, so the
+# gate will later deny rather than wrongly allow).
+rc6_bot_mention_unset_records_zero() {
+  new_state
+  CLAUDE_HUB_HIJOGUCHI_SESSION=1 \
+    bash "${RECORD}" <<<"$(prompt_payload "${NONPRIM}" "hey ${BOT_MENTION} please look")" || return 1
+  [ "$(cat "$(ctx_file "${NONPRIM}")" 2>/dev/null)" = "0" ]
+}
+
+# ----- gate hook -----
+
+gate() { # env... ; $1=tool $2=chat ; returns hook exit code
+  CLAUDE_HUB_HIJOGUCHI_SESSION="${HJ:-1}" HIJOGUCHI_CHANNEL_ID="${PRIMARY}" \
+    bash "${GATE}" <<<"$(tool_payload "$1" "$2")"
+}
+
+# reply to PRIMARY -> allow (exit 0)
+g1_primary_allow() {
+  new_state
+  gate "mcp__plugin_discord_discord__reply" "${PRIMARY}"
+}
+
+# reply to non-primary, ctx=0 (recorded, NOT mentioned) -> deny (exit 2)
+g2_nonprimary_unmentioned_deny() {
+  new_state
+  mkdir -p "${STATE}/channel-ctx"; echo 0 > "$(ctx_file "${NONPRIM}")"
+  CLAUDE_HUB_HIJOGUCHI_SESSION=1 HIJOGUCHI_CHANNEL_ID="${PRIMARY}" CLAUDE_HUB_STATE_DIR="${STATE}" \
+    bash "${GATE}" <<<"$(tool_payload mcp__plugin_discord_discord__reply "${NONPRIM}")"
+  [ $? -eq 2 ]
+}
+
+# reply to non-primary, ctx=1 (mentioned) -> allow (exit 0)
+g3_nonprimary_mentioned_allow() {
+  new_state
+  mkdir -p "${STATE}/channel-ctx"; echo 1 > "$(ctx_file "${NONPRIM}")"
+  gate "mcp__plugin_discord_discord__reply" "${NONPRIM}"
+}
+
+# reply to non-primary, NO ctx file -> deny (fail-closed, exit 2)
+g4_nonprimary_noctx_failclosed() {
+  new_state
+  CLAUDE_HUB_HIJOGUCHI_SESSION=1 HIJOGUCHI_CHANNEL_ID="${PRIMARY}" \
+    bash "${GATE}" <<<"$(tool_payload mcp__plugin_discord_discord__reply "${NONPRIM}")"
+  [ $? -eq 2 ]
+}
+
+# react to non-primary, ctx=0 -> deny (exit 2)
+g5_react_nonprimary_deny() {
+  new_state
+  mkdir -p "${STATE}/channel-ctx"; echo 0 > "$(ctx_file "${NONPRIM}")"
+  CLAUDE_HUB_HIJOGUCHI_SESSION=1 HIJOGUCHI_CHANNEL_ID="${PRIMARY}" \
+    bash "${GATE}" <<<"$(tool_payload mcp__plugin_discord_discord__react "${NONPRIM}")"
+  [ $? -eq 2 ]
+}
+
+# non-hijoguchi session -> allow (out of scope, exit 0)
+g6_non_hijoguchi_allow() {
+  new_state
+  HJ=0 gate "mcp__plugin_discord_discord__reply" "${NONPRIM}"
+}
+
+# non-discord tool -> allow (exit 0)
+g7_other_tool_allow() {
+  new_state
+  CLAUDE_HUB_HIJOGUCHI_SESSION=1 HIJOGUCHI_CHANNEL_ID="${PRIMARY}" \
+    bash "${GATE}" <<<'{"hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"ls"}}'
+}
+
+# empty HIJOGUCHI_CHANNEL_ID -> fail-closed deny (exit 2): the backstop must not
+# silently disable itself on misconfig.
+g8_primary_unset_failclosed() {
+  new_state
+  CLAUDE_HUB_HIJOGUCHI_SESSION=1 HIJOGUCHI_CHANNEL_ID="" CLAUDE_HUB_STATE_DIR="${STATE}" \
+    bash "${GATE}" <<<"$(tool_payload mcp__plugin_discord_discord__reply "${NONPRIM}")"
+  [ $? -eq 2 ]
+}
+
+# discord post tool with NO chat_id -> fail-closed deny (exit 2).
+g9_missing_chatid_failclosed() {
+  new_state
+  CLAUDE_HUB_HIJOGUCHI_SESSION=1 HIJOGUCHI_CHANNEL_ID="${PRIMARY}" CLAUDE_HUB_STATE_DIR="${STATE}" \
+    bash "${GATE}" <<<'{"hook_event_name":"PreToolUse","tool_name":"mcp__plugin_discord_discord__reply","tool_input":{"text":"x"}}'
+  [ $? -eq 2 ]
+}
+
+# edit_message to non-primary, ctx=0 -> deny (exit 2) (same policy as reply/react).
+g10_edit_nonprimary_deny() {
+  new_state
+  mkdir -p "${STATE}/channel-ctx"; echo 0 > "$(ctx_file "${NONPRIM}")"
+  CLAUDE_HUB_HIJOGUCHI_SESSION=1 HIJOGUCHI_CHANNEL_ID="${PRIMARY}" CLAUDE_HUB_STATE_DIR="${STATE}" \
+    bash "${GATE}" <<<"$(tool_payload mcp__plugin_discord_discord__edit_message "${NONPRIM}")"
+  [ $? -eq 2 ]
+}
+
+# ----- end-to-end: reproduce #267 incident then prove it is blocked -----
+# Non-primary corp session-thread, no mention -> record -> gate reply -> DENY.
+e1_incident_blocked() {
+  new_state
+  CLAUDE_HUB_HIJOGUCHI_SESSION=1 HIJOGUCHI_BOT_MENTION="${BOT_MENTION}" \
+    bash "${RECORD}" <<<"$(prompt_payload "${NONPRIM}" "/resume-session ~/.claude/sessions/x.tmp")" || return 1
+  CLAUDE_HUB_HIJOGUCHI_SESSION=1 HIJOGUCHI_CHANNEL_ID="${PRIMARY}" \
+    bash "${GATE}" <<<"$(tool_payload mcp__plugin_discord_discord__reply "${NONPRIM}")"
+  [ $? -eq 2 ]
+}
+
+# ----- syntax -----
+s1_record_syntax() { bash -n "${RECORD}"; }
+s2_gate_syntax()   { bash -n "${GATE}"; }
+
+run "s1 record syntax"                 s1_record_syntax
+run "s2 gate syntax"                   s2_gate_syntax
+run "rc1 non-primary no-mention -> 0"  rc1_nonprimary_no_mention
+run "rc2 non-primary mention -> 1"     rc2_nonprimary_mention
+run "rc3 non-hijoguchi no-op"          rc3_non_hijoguchi_noop
+run "rc4 non-channel no-op"            rc4_non_channel_noop
+run "rc5 record always exit 0"         rc5_always_exit0
+run "rc6 bot-mention unset -> 0"       rc6_bot_mention_unset_records_zero
+run "g1 primary allow"                 g1_primary_allow
+run "g2 non-primary unmentioned deny"  g2_nonprimary_unmentioned_deny
+run "g3 non-primary mentioned allow"   g3_nonprimary_mentioned_allow
+run "g4 non-primary no-ctx fail-closed" g4_nonprimary_noctx_failclosed
+run "g5 react non-primary deny"        g5_react_nonprimary_deny
+run "g6 non-hijoguchi allow"           g6_non_hijoguchi_allow
+run "g7 other tool allow"              g7_other_tool_allow
+run "g8 primary-unset fail-closed"     g8_primary_unset_failclosed
+run "g9 missing chat_id fail-closed"   g9_missing_chatid_failclosed
+run "g10 edit_message non-primary deny" g10_edit_nonprimary_deny
+run "e1 #267 incident blocked"         e1_incident_blocked
+
+if [ "${fail}" -eq 0 ]; then
+  echo "ALL TESTS PASSED"
+  exit 0
+fi
+echo "SOME TESTS FAILED"
+exit 1


### PR DESCRIPTION
## 概要

Issue #267 を **(1) claudeHubExit の非メンション誤応答** に絞って対処する。`#230` の system-prompt（behavioral）ゲートが再破綻し、launchd の **claudeHubExit 本体**が Channel-Supervisor のセッションスレッド（`duplicate_channel2 · Corp CEO`）に届いた**非メンションの `/resume-session`** に reaction + 返信した。

調査でセッション transcript（`edf6a5be`、#230 ゲートテキスト一致・cwd `~/claude-hub/supervisor`）から応答主体を確定。issue 記載の別 ID（`1487744…`）は誤認だった。

## 根本原因

`access.json` の `requireMention` と `hijoguchi-system-prompt.md` の沈黙ルールは「届く / 届いた後に LLM が沈黙を選ぶ」前提で、いずれかが破れると誤応答する。これは「気をつける型」対策の再破綻（rework-prevention / thin-scaffolding）。

## 対策（LLM 判断に依存しない機械ゲート）

| hook | event | 役割 |
|---|---|---|
| `hijoguchi-record-channel-context.sh` | UserPromptSubmit | 受信 Discord メッセージごとに chat_id とメンション有無を `${CLAUDE_HUB_STATE_DIR}/channel-ctx/<chat_id>` に記録（記録のみ・常に exit 0・atomic write） |
| `hijoguchi-discord-gate.sh` | PreToolUse（`reply`/`react`/`edit_message`） | 投稿直前に判定。**非 primary かつ非メンション → exit 2 で DENY**。primary 常時許可 / 非 primary はメンション時のみ / 設定・chat_id 欠如は **fail-closed** |

- `UserPromptSubmit` の block は channel 注入メッセージへの完全沈黙が公式 docs で保証されない（claude-code-guide 検証）。決定的な `PreToolUse` deny を採用。
- いずれも `CLAUDE_HUB_HIJOGUCHI_SESSION=1` のみ適用。`start-hijoguchi.sh` が `HIJOGUCHI_CHANNEL_ID` / `HIJOGUCHI_BOT_MENTION` を `env` 前置で in-session hook へ転送。
- 仕様メモ: 非 primary では**本文の明示 mention タグ**を要求（plugin の reply-implicit mention は本文に現れないため honor しない＝ #230 条件2 より厳格な fail-safe）。

## テスト

`scripts/test-hijoguchi-discord-gate.sh`（**19 ケース / 19 PASS**、CI `ci.yml` で enforce）。

| AC | 内容 | 期待 | 判定 |
|---|---|---|---|
| AC-1 | 非 primary + 非メンション reply（= #267 再現） | DENY(2) | PASS (g2/e1) |
| AC-2 | primary reply | ALLOW(0) | PASS (g1) |
| AC-3 | 非 primary + メンション | ALLOW(0) | PASS (g3) |
| AC-4 | fail-closed（no-ctx / primary 未設定 / chat_id 欠如） | DENY(2) | PASS (g4/g8/g9) |
| AC-5 | hijoguchi セッション限定 | allow / no-write | PASS (g6/rc3) |

shellcheck clean / pre-git-check PASS / real ID ハードコードなし。code-review（must/should/nit 計9件）反映済（fail-open 2 箇所を fail-closed 化 + テスト追加 + atomic write）。

## デプロイ手順（マージ後）

稼働中 claudeHubExit を再起動して初めてゲートが有効化される:

```
launchctl kickstart -k gui/$(id -u)/com.claude-hub.hijoguchi
```

## スコープ外（別 issue）

「Channel-Supervisor の反応がない」症状（再起動直後の tmux socket レースで中継不通）は別根本原因のため **#268** に分離。

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Discord メンションゲート機能を追加。一次チャネル以外では明示的な `@mention` がない限り、ボットの投稿（返信・リアクション・メッセージ編集）をブロックするようになりました。

* **ドキュメント**
  * 新しい運用ルール「機械ゲート」について説明を追加。メンション記録とゲート判定の仕組みを文書化しました。

* **テスト**
  * メンションゲート機能を検証する回帰テストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->