### PR TITLE
feat(#262): GoalWatcher で done ラベル到達時に dispatch セッションを自動停止 (M3)

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -15,6 +15,7 @@ import {
   manualRestartGuidance,
 } from "./session/self-heal-restart";
 import { Reaper } from "./session/reaper";
+import { GoalWatcher } from "./session/goal-watcher";
 import { ActivityWatchdog } from "./session/session-activity-watchdog";
 import { ResourceMonitor } from "./session/resource-monitor";
 import { createSessionCommand, createSessionHandler } from "./commands/session";
@@ -236,6 +237,11 @@ export async function startBot(token: string): Promise<void> {
     });
   }
   const reaper = new Reaper(sessionManager, client);
+  // corp #52 M3 (spec §7): auto-stop dispatch-origin sessions (branch
+  // `corp-dispatch-<N>`) once their Issue carries the `done` label, after a
+  // grace window the chairman can cancel by speaking. Frees the shared session
+  // slot on goal completion instead of waiting for the 7-day reaper.
+  const goalWatcher = new GoalWatcher(sessionManager, client);
   // Issue #209: nudge the owner when a live session has been running for hours
   // (long_lived, AC3) or has gone silent (quiet, AC1) — the gap between the
   // per-turn stall heartbeat and the 7-day reaper. De-dup is internal so each
@@ -325,6 +331,7 @@ export async function startBot(token: string): Promise<void> {
     }
 
     reaper.start();
+    goalWatcher.start();
     activityWatchdog.start();
     resourceMonitor.start();
 
@@ -918,6 +925,7 @@ export async function startBot(token: string): Promise<void> {
   const shutdown = async () => {
     console.log("[Bot] Shutdown signal received");
     reaper.stop();
+    goalWatcher.stop();
     activityWatchdog.stop();
     resourceMonitor.stop();
     // Drain pending progress buffers before tearing down the Discord client

--- a/supervisor/src/config/channels.ts
+++ b/supervisor/src/config/channels.ts
@@ -152,3 +152,9 @@ export const IDLE_CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 export const GRACEFUL_KILL_TIMEOUT_MS = 15_000; // 15 seconds
 export const RESOURCE_CHECK_INTERVAL_MS = 30_000; // 30 seconds
 export const MAX_MEMORY_PER_SESSION_MB = 2048; // 2GB
+// GoalWatcher (corp #52 M3, spec §7): poll dispatch sessions' Issue labels for
+// `done` and auto-stop after a grace window. 2-min poll keeps gh well under any
+// rate limit (only dispatch sessions are polled); the 3-min grace gives the
+// chairman time to cancel by speaking in the thread before teardown.
+export const GOAL_CHECK_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
+export const GOAL_GRACE_MS = 3 * 60 * 1000; // 3 minutes

--- a/supervisor/src/session/goal-watcher.test.ts
+++ b/supervisor/src/session/goal-watcher.test.ts
@@ -1,0 +1,243 @@
+import { test, expect, describe } from "bun:test";
+import { GoalWatcher, DISPATCH_BRANCH_RE } from "./goal-watcher";
+import type { SessionInfo, StopReason } from "./types";
+import type { SessionManager } from "./manager";
+import type { Client } from "discord.js";
+
+// M3 / Issue #262 (corp #52). GoalWatcher is the reaper's sibling: it auto-stops
+// a *dispatch-origin* session (branch `corp-dispatch-<N>`) once its Issue carries
+// the `done` label, after a grace window that the chairman can cancel by speaking
+// in the thread. Verifies spec AC-4 (done→stop), AC-5 (grace cancel), AC-6 (corp
+// excluded), AC-7 (Issue close alone ≠ stop). All deps are injected so the unit
+// tests never shell out to gh or touch tmux.
+
+function makeSession(
+  over: Partial<SessionInfo> & { threadId: string }
+): SessionInfo {
+  const now = new Date();
+  return {
+    id: over.threadId,
+    channelName: "convert-service",
+    projectDir: "/repo/.claude/worktrees/corp-dispatch-1",
+    pid: 1,
+    process: null as unknown as SessionInfo["process"],
+    startedAt: now,
+    lastActivityAt: now,
+    status: "running",
+    ...over,
+  } as SessionInfo;
+}
+
+interface StopCall {
+  threadId: string;
+  reason: StopReason;
+}
+
+function makeManager(sessions: Map<string, SessionInfo>): {
+  manager: SessionManager;
+  stopCalls: StopCall[];
+} {
+  const stopCalls: StopCall[] = [];
+  const manager = {
+    entries: () => sessions.entries(),
+    stop: async (threadId: string, reason: StopReason) => {
+      stopCalls.push({ threadId, reason });
+      // Mirror the real stop(): the session leaves the live map.
+      sessions.delete(threadId);
+    },
+  } as unknown as SessionManager;
+  return { manager, stopCalls };
+}
+
+interface ThreadStub {
+  name: string;
+  sent: string[];
+  archived: boolean;
+  renamedTo: string | null;
+}
+
+function makeClient(thread?: ThreadStub): Client {
+  const channel = thread
+    ? {
+        isThread: () => true,
+        get name() {
+          return thread.name;
+        },
+        send: async (msg: string) => {
+          thread.sent.push(msg);
+        },
+        setName: async (n: string) => {
+          thread.renamedTo = n;
+          thread.name = n;
+        },
+        setArchived: async (v: boolean) => {
+          thread.archived = v;
+        },
+      }
+    : undefined;
+  return {
+    channels: { cache: { get: () => channel } },
+  } as unknown as Client;
+}
+
+describe("DISPATCH_BRANCH_RE", () => {
+  test("captures the Issue number from a dispatch branch", () => {
+    expect("corp-dispatch-372".match(DISPATCH_BRANCH_RE)?.[1]).toBe("372");
+  });
+
+  test("rejects non-dispatch branches (corp conductor / work branches)", () => {
+    expect("52-m1-board-p2".match(DISPATCH_BRANCH_RE)).toBeNull();
+    expect("main".match(DISPATCH_BRANCH_RE)).toBeNull();
+    expect("corp-dispatch-".match(DISPATCH_BRANCH_RE)).toBeNull();
+    expect("corp-dispatch-12a".match(DISPATCH_BRANCH_RE)).toBeNull();
+    expect("xcorp-dispatch-1".match(DISPATCH_BRANCH_RE)).toBeNull();
+  });
+});
+
+describe("GoalWatcher.check", () => {
+  test("AC-4: `done` label → after grace window → stop('goal_complete') + archive", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t372", makeSession({ threadId: "t372", branch: "corp-dispatch-372" })],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const thread: ThreadStub = {
+      name: "🟢 corp-dispatch-372",
+      sent: [],
+      archived: false,
+      renamedTo: null,
+    };
+    let clock = 1000;
+    const watcher = new GoalWatcher(manager, makeClient(thread), {
+      fetchIssueLabels: async () => ["done"],
+      now: () => clock,
+      graceMs: 100,
+    });
+
+    // First tick: `done` seen → grace window opens, no stop yet.
+    await watcher.check();
+    expect(stopCalls).toEqual([]);
+
+    // Within grace: still no stop.
+    clock = 1050;
+    await watcher.check();
+    expect(stopCalls).toEqual([]);
+
+    // Grace elapsed: stop once with goal_complete, thread archived.
+    clock = 1101;
+    await watcher.check();
+    expect(stopCalls).toEqual([{ threadId: "t372", reason: "goal_complete" }]);
+    expect(thread.archived).toBe(true);
+    expect(thread.renamedTo).not.toBeNull();
+    expect(thread.sent.length).toBe(1);
+  });
+
+  test("AC-5: a thread message during the grace window cancels the stop", async () => {
+    const session = makeSession({
+      threadId: "t1",
+      branch: "corp-dispatch-1",
+      lastActivityAt: new Date(5000),
+    });
+    const sessions = new Map<string, SessionInfo>([["t1", session]]);
+    const { manager, stopCalls } = makeManager(sessions);
+    let clock = 0;
+    const watcher = new GoalWatcher(manager, makeClient(), {
+      fetchIssueLabels: async () => ["done"],
+      now: () => clock,
+      graceMs: 100,
+    });
+
+    // Grace opens.
+    await watcher.check();
+    expect(stopCalls).toEqual([]);
+
+    // Chairman speaks in the thread → lastActivityAt advances past detection.
+    session.lastActivityAt = new Date(9000);
+
+    // Grace elapsed, but the activity cancels the auto-stop.
+    clock = 1000;
+    await watcher.check();
+    expect(stopCalls).toEqual([]);
+  });
+
+  test("AC-7: Issue without `done` is never stopped, even across the grace window", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t9", makeSession({ threadId: "t9", branch: "corp-dispatch-9" })],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    let clock = 0;
+    const watcher = new GoalWatcher(manager, makeClient(), {
+      // A merged/closed Issue still only carries phase labels — never `done`.
+      fetchIssueLabels: async () => ["staging-ready", "deployed"],
+      now: () => clock,
+      graceMs: 100,
+    });
+
+    await watcher.check();
+    clock = 1000;
+    await watcher.check();
+    clock = 2000;
+    await watcher.check();
+    expect(stopCalls).toEqual([]);
+  });
+
+  test("AC-6: corp conductor (branchless) and work-branch sessions are excluded", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["corp", makeSession({ threadId: "corp", branch: undefined })],
+      ["work", makeSession({ threadId: "work", branch: "52-m1-board-p2" })],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    let fetchCalls = 0;
+    let clock = 0;
+    const watcher = new GoalWatcher(manager, makeClient(), {
+      fetchIssueLabels: async () => {
+        fetchCalls++;
+        return ["done"];
+      },
+      now: () => clock,
+      graceMs: 100,
+    });
+
+    await watcher.check();
+    clock = 1000;
+    await watcher.check();
+    expect(stopCalls).toEqual([]);
+    // Non-dispatch branches must never even trigger a label lookup.
+    expect(fetchCalls).toBe(0);
+  });
+
+  test("fail-soft: a label-fetch error never throws and never stops a live session", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t1", makeSession({ threadId: "t1", branch: "corp-dispatch-1" })],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const watcher = new GoalWatcher(manager, makeClient(), {
+      fetchIssueLabels: async () => {
+        throw new Error("gh rate limited");
+      },
+      graceMs: 0,
+    });
+
+    await watcher.check(); // must resolve, not reject
+    expect(stopCalls).toEqual([]);
+  });
+
+  test("stops only once: a removed session is not re-stopped on the next tick", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t1", makeSession({ threadId: "t1", branch: "corp-dispatch-1" })],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    let clock = 0;
+    const watcher = new GoalWatcher(manager, makeClient(), {
+      fetchIssueLabels: async () => ["done"],
+      now: () => clock,
+      graceMs: 50,
+    });
+
+    await watcher.check(); // open grace
+    clock = 100;
+    await watcher.check(); // stop (session removed by manager.stop)
+    clock = 200;
+    await watcher.check(); // session gone → nothing more
+    expect(stopCalls).toEqual([{ threadId: "t1", reason: "goal_complete" }]);
+  });
+});

--- a/supervisor/src/session/goal-watcher.test.ts
+++ b/supervisor/src/session/goal-watcher.test.ts
@@ -56,7 +56,11 @@ interface ThreadStub {
   renamedTo: string | null;
 }
 
-function makeClient(thread?: ThreadStub): Client {
+function makeClient(
+  thread?: ThreadStub,
+  opts: { cached?: boolean } = {}
+): Client {
+  const cached = opts.cached ?? true;
   const channel = thread
     ? {
         isThread: () => true,
@@ -76,7 +80,12 @@ function makeClient(thread?: ThreadStub): Client {
       }
     : undefined;
   return {
-    channels: { cache: { get: () => channel } },
+    channels: {
+      // When `cached` is false the thread is absent from the cache (eviction /
+      // restart) and only the API fetch resolves it (PR #270 gemini HIGH).
+      cache: { get: () => (cached ? channel : undefined) },
+      fetch: async () => channel,
+    },
   } as unknown as Client;
 }
 
@@ -128,6 +137,33 @@ describe("GoalWatcher.check", () => {
     expect(stopCalls).toEqual([{ threadId: "t372", reason: "goal_complete" }]);
     expect(thread.archived).toBe(true);
     expect(thread.renamedTo).not.toBeNull();
+    expect(thread.sent.length).toBe(1);
+  });
+
+  test("AC-4 (cache miss): an evicted thread is fetched from the API and still archived", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t5", makeSession({ threadId: "t5", branch: "corp-dispatch-5" })],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const thread: ThreadStub = {
+      name: "🟢 corp-dispatch-5",
+      sent: [],
+      archived: false,
+      renamedTo: null,
+    };
+    let clock = 0;
+    // cached: false → cache.get returns undefined, only channels.fetch resolves it.
+    const watcher = new GoalWatcher(manager, makeClient(thread, { cached: false }), {
+      fetchIssueLabels: async () => ["done"],
+      now: () => clock,
+      graceMs: 50,
+    });
+
+    await watcher.check(); // open grace
+    clock = 100;
+    await watcher.check(); // stop + notify via API-fetched thread
+    expect(stopCalls).toEqual([{ threadId: "t5", reason: "goal_complete" }]);
+    expect(thread.archived).toBe(true);
     expect(thread.sent.length).toBe(1);
   });
 

--- a/supervisor/src/session/goal-watcher.ts
+++ b/supervisor/src/session/goal-watcher.ts
@@ -1,0 +1,262 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import type { SessionManager } from "./manager";
+import type { ThreadChannel, Client } from "discord.js";
+import { GOAL_CHECK_INTERVAL_MS, GOAL_GRACE_MS } from "../config/channels";
+import { markTitleStopped } from "./thread-title";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Dispatch-origin branch shape (corp #52 / spec §7). The corp HQ posts
+ * `/dispatch corp-dispatch-<N> <N> ...`, so a session running on a branch that
+ * matches this pattern is a dispatch job whose lifecycle we own; its single
+ * capture group is the GitHub Issue number. The corp conductor session (no
+ * branch, or a work branch like `52-m1-board`) deliberately does NOT match, so
+ * it is excluded from auto-stop (spec AC-6).
+ */
+export const DISPATCH_BRANCH_RE = /^corp-dispatch-(\d+)$/;
+
+/**
+ * The single terminal phase label (spec §8). Its presence — NOT Issue close —
+ * is the auto-stop trigger (spec §7 / AC-7): devcycle closes the Issue when the
+ * PR merges, but production deploy + prod E2E still run afterward, so closing
+ * must not kill the session. The playbook adds `done` only at the true end.
+ */
+const DONE_LABEL = "done";
+
+export interface GoalWatcherDeps {
+  /**
+   * Fetch the GitHub label names for Issue `issueNumber`, resolved from the git
+   * remote at `repoDir`. Injected so unit tests never shell out. The real
+   * implementation is fail-soft (returns `[]` on any gh error) — a transient
+   * rate-limit / auth blip must never stop a live session.
+   */
+  fetchIssueLabels?: (repoDir: string, issueNumber: number) => Promise<string[]>;
+  /** Clock injection for deterministic grace-window tests. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Poll interval. Defaults to {@link GOAL_CHECK_INTERVAL_MS}. */
+  checkIntervalMs?: number;
+  /** Grace window after `done` is first seen before stopping. Defaults to {@link GOAL_GRACE_MS}. */
+  graceMs?: number;
+}
+
+/** State of an open grace window for one thread after `done` was first seen. */
+interface PendingStop {
+  /** Injected-clock time when `done` was first observed. */
+  detectedAt: number;
+  /** Snapshot of the session's `lastActivityAt` at detection; a later value means the chairman spoke. */
+  activityAtDetection: number;
+}
+
+/**
+ * Real label fetch via `gh issue view`. Mirrors worktree.ts: async `execFile`
+ * with an argv array (no shell), repo resolved from `cwd`. Fail-soft: any error
+ * (gh missing / unauthenticated / no GitHub remote / issue unreadable) yields
+ * `[]` so the watcher treats it as "not done yet" rather than stopping blindly.
+ */
+async function realFetchIssueLabels(
+  repoDir: string,
+  issueNumber: number
+): Promise<string[]> {
+  try {
+    const { stdout } = await execFileAsync(
+      "gh",
+      [
+        "issue",
+        "view",
+        String(issueNumber),
+        "--json",
+        "labels",
+        "--jq",
+        ".labels[].name",
+      ],
+      { cwd: repoDir, encoding: "utf8" }
+    );
+    return stdout
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Reaper's sibling for goal-driven teardown (corp #52 M3, spec §7). On a fixed
+ * interval it scans live sessions, keeps only the dispatch-origin ones
+ * (`corp-dispatch-<N>`), and when the Issue carries the `done` label it stops
+ * the session with reason `goal_complete` after a cancellable grace window. This
+ * is the L4 saturation fix: completed dispatch sessions free their slot instead
+ * of idling until the 7-day reaper.
+ *
+ * Self-contained per spec §12 (no new corp→claude-hub structural coupling): it
+ * reads only the branch naming convention + GitHub labels and reuses the
+ * existing `sessionManager.stop`.
+ */
+export class GoalWatcher {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Re-entry guard (mirrors {@link SessionManager}'s watchTmuxSession). Each
+   * `check()` awaits one gh call per dispatch session, which can outlast the
+   * poll interval under load; without this two ticks could overlap and both
+   * decide to stop the same thread.
+   */
+  private isChecking = false;
+  /** threadId → open grace window. */
+  private readonly pending = new Map<string, PendingStop>();
+
+  private readonly fetchIssueLabels: NonNullable<
+    GoalWatcherDeps["fetchIssueLabels"]
+  >;
+  private readonly now: () => number;
+  private readonly checkIntervalMs: number;
+  private readonly graceMs: number;
+
+  constructor(
+    private sessionManager: SessionManager,
+    private client: Client,
+    deps: GoalWatcherDeps = {}
+  ) {
+    this.fetchIssueLabels = deps.fetchIssueLabels ?? realFetchIssueLabels;
+    this.now = deps.now ?? Date.now;
+    this.checkIntervalMs = deps.checkIntervalMs ?? GOAL_CHECK_INTERVAL_MS;
+    this.graceMs = deps.graceMs ?? GOAL_GRACE_MS;
+  }
+
+  start(): void {
+    this.timer = setInterval(() => {
+      void this.check();
+    }, this.checkIntervalMs);
+    console.log(
+      `[GoalWatcher] Started (check every ${this.checkIntervalMs / 1000 / 60}min, grace ${this.graceMs / 1000 / 60}min)`
+    );
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * One scan tick. Public so tests can drive it deterministically (the interval
+   * just calls it). Each dispatch session is evaluated independently and any
+   * per-session error is swallowed so one bad session never aborts the tick.
+   */
+  async check(): Promise<void> {
+    if (this.isChecking) return;
+    this.isChecking = true;
+    try {
+      // Snapshot entries first: stop() mutates the live map, so iterating a
+      // stable array avoids any iterator-vs-deletion ambiguity mid-tick.
+      const sessions = Array.from(this.sessionManager.entries());
+      const liveDispatch = new Set<string>();
+
+      for (const [threadId, session] of sessions) {
+        const match = session.branch?.match(DISPATCH_BRANCH_RE);
+        if (!match) continue; // not a dispatch session (corp / work branch) → AC-6
+        liveDispatch.add(threadId);
+        try {
+          await this.evaluate(threadId, session, Number(match[1]));
+        } catch (err) {
+          // Fail-soft per session: log and keep scanning the rest.
+          console.error(
+            `[GoalWatcher] Error evaluating thread ${threadId}:`,
+            err
+          );
+        }
+      }
+
+      // Drop grace state for threads that are no longer live dispatch sessions
+      // (stopped here or elsewhere) so `pending` cannot leak across ticks.
+      for (const threadId of [...this.pending.keys()]) {
+        if (!liveDispatch.has(threadId)) this.pending.delete(threadId);
+      }
+    } finally {
+      this.isChecking = false;
+    }
+  }
+
+  private async evaluate(
+    threadId: string,
+    session: { branch?: string; lastActivityAt: Date; channelName: string; projectDir: string; worktree?: { mainRepoDir: string } },
+    issueNumber: number
+  ): Promise<void> {
+    const repoDir = session.worktree?.mainRepoDir ?? session.projectDir;
+    const labels = await this.fetchIssueLabels(repoDir, issueNumber);
+
+    if (!labels.includes(DONE_LABEL)) {
+      // Not done (or `done` was removed) → close any open grace window. Also
+      // covers AC-7: a closed-but-not-`done` Issue keeps the session alive.
+      this.pending.delete(threadId);
+      return;
+    }
+
+    const entry = this.pending.get(threadId);
+    if (!entry) {
+      // First sighting of `done` → open a cancellable grace window (AC-5).
+      this.pending.set(threadId, {
+        detectedAt: this.now(),
+        activityAtDetection: session.lastActivityAt.getTime(),
+      });
+      return;
+    }
+
+    // A thread message since detection means the chairman is still working →
+    // cancel the auto-stop (AC-5). Re-opens fresh on the next tick if `done`
+    // persists and the thread goes quiet again.
+    if (session.lastActivityAt.getTime() > entry.activityAtDetection) {
+      this.pending.delete(threadId);
+      return;
+    }
+
+    if (this.now() - entry.detectedAt >= this.graceMs) {
+      await this.stopSession(threadId, session.channelName);
+      this.pending.delete(threadId);
+    }
+  }
+
+  private async stopSession(
+    threadId: string,
+    channelName: string
+  ): Promise<void> {
+    console.log(
+      `[GoalWatcher] Thread ${threadId} (${channelName}) reached \`done\`; auto-stopping (goal_complete)`
+    );
+    try {
+      await this.sessionManager.stop(threadId, "goal_complete");
+    } catch (err) {
+      // Leave the thread untouched if the stop itself failed; the next tick (or
+      // the 7-day reaper) retries.
+      console.error(`[GoalWatcher] Failed to stop ${threadId}:`, err);
+      return;
+    }
+    await this.notifyThread(threadId);
+  }
+
+  /**
+   * Post a completion notice, mark the title stopped, and archive the thread —
+   * the same teardown UX as the Reaper, so a goal-completed thread is visually
+   * closed (AC-4: it disappears from `/session list` and is archived).
+   */
+  private async notifyThread(threadId: string): Promise<void> {
+    try {
+      const thread = this.client.channels.cache.get(threadId) as
+        | ThreadChannel
+        | undefined;
+
+      if (thread?.isThread()) {
+        await thread.send(
+          `✅ ゴール（\`done\` ラベル）到達のためセッションを自動終了しました。`
+        );
+        const stoppedName = markTitleStopped(thread.name);
+        await thread.setName(stoppedName);
+        await thread.setArchived(true);
+      }
+    } catch (err) {
+      console.error(`[GoalWatcher] Failed to notify thread ${threadId}:`, err);
+    }
+  }
+}

--- a/supervisor/src/session/goal-watcher.ts
+++ b/supervisor/src/session/goal-watcher.ts
@@ -25,6 +25,16 @@ export const DISPATCH_BRANCH_RE = /^corp-dispatch-(\d+)$/;
  */
 const DONE_LABEL = "done";
 
+/**
+ * Hard timeout for the `gh issue view` call (PR #270 gemini MEDIUM). Without it
+ * a hung gh (network stall, SSH/GPG prompt, rate-limit wedge) would leave its
+ * promise pending forever, which keeps {@link GoalWatcher.check}'s `isChecking`
+ * re-entry guard stuck `true` and disables every future tick. On timeout
+ * `execFile` kills the child and rejects, so the fail-soft `catch` returns `[]`
+ * and the watcher keeps running.
+ */
+const GH_FETCH_TIMEOUT_MS = 15_000;
+
 export interface GoalWatcherDeps {
   /**
    * Fetch the GitHub label names for Issue `issueNumber`, resolved from the git
@@ -71,7 +81,7 @@ async function realFetchIssueLabels(
         "--jq",
         ".labels[].name",
       ],
-      { cwd: repoDir, encoding: "utf8" }
+      { cwd: repoDir, encoding: "utf8", timeout: GH_FETCH_TIMEOUT_MS }
     );
     return stdout
       .split("\n")
@@ -243,9 +253,19 @@ export class GoalWatcher {
    */
   private async notifyThread(threadId: string): Promise<void> {
     try {
-      const thread = this.client.channels.cache.get(threadId) as
+      // Cache-first, then API fetch (PR #270 gemini HIGH). `done` is detected
+      // long after the thread was created (label poll + grace window), so on a
+      // long-running supervisor — or after a restart — the thread may have been
+      // evicted from the cache. Without the fetch fallback the completion notice
+      // / rename / archive would be silently skipped, failing AC-4.
+      let thread = this.client.channels.cache.get(threadId) as
         | ThreadChannel
         | undefined;
+      if (!thread) {
+        thread = (await this.client.channels
+          .fetch(threadId)
+          .catch(() => undefined)) as ThreadChannel | undefined;
+      }
 
       if (thread?.isThread()) {
         await thread.send(

--- a/supervisor/src/session/types.ts
+++ b/supervisor/src/session/types.ts
@@ -55,4 +55,4 @@ export interface SessionHealthInfo {
   lastActivityAt: string;
 }
 
-export type StopReason = "manual" | "idle_timeout" | "resource_limit" | "error" | "tmux_exited" | "supervisor_restart" | "self_heal_restart";
+export type StopReason = "manual" | "idle_timeout" | "resource_limit" | "error" | "tmux_exited" | "supervisor_restart" | "self_heal_restart" | "goal_complete";


### PR DESCRIPTION
## 概要

corp #52（dispatch ボード＋セッションライフサイクル Epic）の **M3 / L4（飽和対策）**。
reaper 兄弟の `GoalWatcher` を追加し、dispatch 由来セッション（branch が
`corp-dispatch-<N>`）の Issue が `done` ラベルに到達したら、猶予窓のあとに
`sessionManager.stop(threadId, "goal_complete")` で自動停止する。完了済み
dispatch セッションが 7 日 reaper を待たずにスロットを解放する。

設計の真実源: corp `docs/specs/2026-06-21-corp-dispatch-board-and-session-lifecycle-design.md` §7 / 計画 §M3(P5)。

親: miyashita337/corp#52 ／ Closes #262

## 主な変更

- **`supervisor/src/session/goal-watcher.ts`**（新規）
  - `setInterval` で生存セッションを poll。`^corp-dispatch-(\d+)$` のみ対象（corp コンダクタ＝branch なし/作業 branch は除外）
  - `gh issue view N --json labels` で `done` を検知（`execFile` argv・no-shell、worktree.ts と同型）。**fail-soft**: gh エラー時は `[]` を返し停止しない
  - **猶予窓**: `done` 初検知で窓を開き、その間にスレッド発言（`lastActivityAt` 前進）があればキャンセル
  - 再入ガード（`watchTmuxSession` と同型）。停止後は reaper と同じく完了通知＋title stopped＋archive
  - 依存（gh 取得・clock・interval・grace）を注入可能にし単体テストを純粋化
- **`types.ts`**: `StopReason` に `"goal_complete"` 追加
- **`config/channels.ts`**: `GOAL_CHECK_INTERVAL_MS`(2分) / `GOAL_GRACE_MS`(3分)
- **`bot.ts`**: GoalWatcher の start / shutdown を配線（reaper と同型）

## 設計判断

- **トリガーは `done` ラベルのみ（Issue close ではない）**: devcycle は PR merge で Issue が閉じても本番デプロイ＋本番 E2E が残るため、close で殺すと途中停止になる（spec §7 / AC-7）
- **corp は対象外**: branch が `corp-dispatch-N` でない常駐コンダクタはラベル取得すらしない（spec AC-6）
- **自己完結**（spec §12・memory `claude-hub-not-dispatchable`）: corp→claude-hub の新規構造結合を増やさず、branch 命名規約＋GitHub poll＋既存 `stop` のみで成立

## テスト / 検証

- `supervisor/src/session/goal-watcher.test.ts`（単体 8 件）
  - AC-4: `done`→猶予後 `goal_complete` stop＋archive
  - AC-5: 猶予中のスレッド発言で停止キャンセル
  - AC-6: corp（branchless）/ 作業 branch はラベル取得すらせず除外
  - AC-7: `done` 無し（close のみ）では停止しない
  - ＋ fail-soft（gh エラーで throw も停止もしない）／ 単発停止（削除済みセッションを再停止しない）／ regex
- `bunx tsc --noEmit` クリーン
- `bun test`: 全体 723 pass（残 fail は既存の `realTmuxAdapter`・relay 環境依存テストで本変更と無関係）
- pre-commit（blocking-in-timers lint）PASS

## 補足

- 実装は claude-hub 共有ツリーを汚さないよう隔離 worktree のローカル PDCA で実施（claude-hub は dispatch 非対象）。
- go-live 時の挙動: GoalWatcher は supervisor 常駐に同梱され、起動時に自動で start。実 dispatch セッションが `done` に達したときのみ作用する。
