### PR TITLE
feat: セッション idle 自動終了しきい値を 7日→30日に延長

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -240,11 +240,11 @@ export async function startBot(token: string): Promise<void> {
   // corp #52 M3 (spec §7): auto-stop dispatch-origin sessions (branch
   // `corp-dispatch-<N>`) once their Issue carries the `done` label, after a
   // grace window the chairman can cancel by speaking. Frees the shared session
-  // slot on goal completion instead of waiting for the 7-day reaper.
+  // slot on goal completion instead of waiting for the idle reaper.
   const goalWatcher = new GoalWatcher(sessionManager, client);
   // Issue #209: nudge the owner when a live session has been running for hours
   // (long_lived, AC3) or has gone silent (quiet, AC1) — the gap between the
-  // per-turn stall heartbeat and the 7-day reaper. De-dup is internal so each
+  // per-turn stall heartbeat and the idle reaper. De-dup is internal so each
   // signal pages at most once per episode.
   const activityWatchdog = new ActivityWatchdog({
     entries: () => sessionManager.entries(),

--- a/supervisor/src/config/channels.ts
+++ b/supervisor/src/config/channels.ts
@@ -147,7 +147,7 @@ if (CHANNEL_MAP.has("claude-hub")) {
 }
 
 export const MAX_SESSIONS = 10;
-export const IDLE_TIMEOUT_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+export const IDLE_TIMEOUT_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
 export const IDLE_CHECK_INTERVAL_MS = 60 * 60 * 1000; // 1 hour
 export const GRACEFUL_KILL_TIMEOUT_MS = 15_000; // 15 seconds
 export const RESOURCE_CHECK_INTERVAL_MS = 30_000; // 30 seconds

--- a/supervisor/src/session/goal-watcher.ts
+++ b/supervisor/src/session/goal-watcher.ts
@@ -98,7 +98,7 @@ async function realFetchIssueLabels(
  * (`corp-dispatch-<N>`), and when the Issue carries the `done` label it stops
  * the session with reason `goal_complete` after a cancellable grace window. This
  * is the L4 saturation fix: completed dispatch sessions free their slot instead
- * of idling until the 7-day reaper.
+ * of idling until the idle reaper.
  *
  * Self-contained per spec §12 (no new corp→claude-hub structural coupling): it
  * reads only the branch naming convention + GitHub labels and reuses the
@@ -239,7 +239,7 @@ export class GoalWatcher {
       await this.sessionManager.stop(threadId, "goal_complete");
     } catch (err) {
       // Leave the thread untouched if the stop itself failed; the next tick (or
-      // the 7-day reaper) retries.
+      // the idle reaper) retries.
       console.error(`[GoalWatcher] Failed to stop ${threadId}:`, err);
       return;
     }

--- a/supervisor/src/session/reaper.ts
+++ b/supervisor/src/session/reaper.ts
@@ -49,8 +49,11 @@ export class Reaper {
         | undefined;
 
       if (thread?.isThread()) {
+        // Derive the day count from IDLE_TIMEOUT_MS so the message never drifts
+        // out of sync with the constant (it used to hardcode "7日").
+        const idleDays = Math.round(IDLE_TIMEOUT_MS / 1000 / 60 / 60 / 24);
         await thread.send(
-          `⏰ 7日間無操作のためセッションを自動終了しました。`
+          `⏰ ${idleDays}日間無操作のためセッションを自動終了しました。`
         );
 
         // Rename and archive. markTitleStopped also handles ♻️ resume threads,

--- a/supervisor/src/session/session-activity-watchdog.ts
+++ b/supervisor/src/session/session-activity-watchdog.ts
@@ -4,7 +4,8 @@
  * Existing safeguards each cover a *different timescale* and leave a gap:
  *   - the stall heartbeat ({@link import("./stall-heartbeat")}) is per relay turn
  *     (3 min, below the relay timeout — RELAY_TIMEOUT_MS, default 15 min),
- *   - the reaper ({@link import("./reaper").Reaper}) only acts after 7 days idle,
+ *   - the reaper ({@link import("./reaper").Reaper}) only acts after a long idle
+ *     period (IDLE_TIMEOUT_MS),
  *   - the context-budget monitor ({@link import("./context-budget")}) fires on
  *     high token counts reported by the Stop hook (#204).
  *


### PR DESCRIPTION
## 目的

セッションの idle 自動終了しきい値が短すぎるため延長する。

会長（オーナー）から「1日以上経過したら落とすルールが短すぎる」との指摘。調査の結果、実体は 1 日ではなく **Reaper の 7 日 idle タイムアウト** だったため、これを **30 日** に延長する。

## 変更点

- `IDLE_TIMEOUT_MS`: 7 days → **30 days**（`supervisor/src/config/channels.ts`）
- `reaper.ts` の Discord 通知文にハードコードされていた「7日」を `IDLE_TIMEOUT_MS` から算出するよう変更（定数と表示のドリフト防止）
- `bot.ts` / `goal-watcher.ts` / `session-activity-watchdog.ts` の "7-day reaper" コメントを duration 非依存の表現に整理

## 影響範囲・トレードオフ

- `done` ラベル付きセッションは従来どおり **GoalWatcher が 3 分猶予で回収**（本変更の影響外）
- 延びるのは「`done` 未付与で放置されたセッション」の最終回収のみ。放置枠が最長 30 日 1 スロット（全 10 枠中）を保持しうる
- 反映は **supervisor 再起動後**（定数は起動時読み込み）

## 検証

- `bunx tsc --noEmit`: clean
- 触った領域のテスト（`goal-watcher.test.ts` / `session-activity-watchdog.test.ts`）: 33 pass / 0 fail
- `tests/session/` 全体: 479 pass / 26 fail（pristine origin/main と完全同値。26 件は既存の tmux/relay 系で本変更と無関係）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * アイドル判定のタイムアウトを 7日から 30日に延長しました。
  * 自動終了の通知文が、設定値に基づく無操作日数を表示するようになりました。

* **Documentation**
  * 長時間アイドル時の案内文や説明表現を、現在の「idle reaper」表記に合わせて整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->