### PR TITLE
feat(#273): Supervisor session lifecycle E2E を CI に結線 (#144 Phase 5)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -242,8 +242,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install tmux
-        run: sudo apt-get update && sudo apt-get install -y tmux
+      - name: Install tmux + jq
+        # jq is required by tests/e2e/fixtures/claude-mock.sh for safe JSON
+        # encoding of the relay POST (the session-lifecycle E2E step below).
+        run: sudo apt-get update && sudo apt-get install -y tmux jq
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -267,6 +269,20 @@ jobs:
           SUPERVISOR_DB_PATH: ":memory:"
           TMUX_PATH: /usr/bin/tmux
         run: bun test tests/e2e/ac-verification.test.ts tests/session/relay.test.ts tests/e2e/dialog-stall.test.ts
+        working-directory: supervisor
+
+      # Supervisor ↔ tmux session lifecycle E2E (Issue #144 / #273). Runs as its
+      # OWN `bun test` process — same isolation rationale as the mock-isolated
+      # session tests above. The env below is what makes the suite ACTUALLY run
+      # (it self-skips without both vars). Test-only socket `claude-hub-test`
+      # keeps it isolated from any prod `claude-hub` server (RW-019).
+      - name: Run session lifecycle E2E
+        env:
+          SUPERVISOR_DB_PATH: ":memory:"
+          TMUX_PATH: /usr/bin/tmux
+          SUPERVISOR_TMUX_SOCKET: claude-hub-test
+          SUPERVISOR_CLAUDE_PATH: ${{ github.workspace }}/supervisor/tests/e2e/fixtures/claude-mock.sh
+        run: bun test tests/e2e/session-lifecycle.test.ts
         working-directory: supervisor
 
   # Local-only tests (require tmux/Claude CLI or local config):

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -40,8 +40,20 @@ import {
 } from "./self-heal";
 import { compactClaudeHubExit } from "./primary-compact";
 
-const CLAUDE_PATH = resolve(homedir(), ".local", "bin", "claude");
+const DEFAULT_CLAUDE_PATH = resolve(homedir(), ".local", "bin", "claude");
 const TMUX_SESSION_PREFIX = "claude-";
+
+/**
+ * Resolve the `claude` executable path at use-time (not module-load-time) so the
+ * lifecycle E2E (Issue #144/#273) can point it at `fixtures/claude-mock.sh` via
+ * `SUPERVISOR_CLAUDE_PATH` set on the `bun test` process. `SUPERVISOR_CLAUDE_PATH`
+ * is operator-controlled (same trust level as `SUPERVISOR_TMUX_SOCKET`); callers
+ * embed the result quoted in the tmux command line so paths with spaces are safe.
+ */
+function claudePath(): string {
+  const envPath = process.env.SUPERVISOR_CLAUDE_PATH;
+  return envPath && envPath.length > 0 ? resolve(envPath) : DEFAULT_CLAUDE_PATH;
+}
 
 /**
  * Non-empty intent for an auto-compact (Issue #206). RW-032: a bare `/compact`
@@ -424,6 +436,15 @@ export class SessionManager {
   }
 
   private tmuxSessionName(threadId: string): string {
+    return SessionManager.tmuxSessionNameFor(threadId);
+  }
+
+  /**
+   * Public, deterministic mapping from threadId → tmux session name. Exposed so
+   * callers (e.g. the lifecycle E2E, Issue #144/#273) don't re-derive the
+   * `claude-<threadId12>` formula and silently break when it changes.
+   */
+  static tmuxSessionNameFor(threadId: string): string {
     // Use a short prefix + first 12 chars of threadId for tmux session name
     return `${TMUX_SESSION_PREFIX}${threadId.slice(0, 12)}`;
   }
@@ -541,7 +562,9 @@ export class SessionManager {
       // `--session-id <uuid>` only on fresh start; resume uses `--resume <id>`
       // (the two are mutually exclusive). claudeSessionId is a randomUUID() so
       // it is shell-safe to embed here.
-      `exec ${CLAUDE_PATH} --session-id ${claudeSessionId} ${buildClaudeFlags(config).join(" ")}`,
+      // Quote claudePath() so SUPERVISOR_CLAUDE_PATH values containing spaces
+      // (e.g. a test fixture under "/Users/Test User/...") don't word-split.
+      `exec "${claudePath()}" --session-id ${claudeSessionId} ${buildClaudeFlags(config).join(" ")}`,
     ].join(" && ");
 
     // Launch via tmux (provides a real TTY). Uses Supervisor's dedicated
@@ -791,7 +814,8 @@ export class SessionManager {
       `mkdir -p "${relayUrlDir}"`,
       `printf "%s" "${relayUrl}" > "${relayUrlFile}"`,
       `cd "${projectDir}"`,
-      `exec ${CLAUDE_PATH} ${resumeFlags.join(" ")}`,
+      // Quote claudePath() (space-safe); resume path mirrors start's exec above.
+      `exec "${claudePath()}" ${resumeFlags.join(" ")}`,
     ].join(" && ");
 
     await this.effects.tmux.newSession(tmuxName, claudeCmd);

--- a/supervisor/tests/e2e/session-lifecycle.test.ts
+++ b/supervisor/tests/e2e/session-lifecycle.test.ts
@@ -126,7 +126,11 @@ beforeAll(async () => {
 afterAll(async () => {
   if (!enabled) return;
   try {
-    await manager.shutdownAll();
+    // Guard: beforeAll may have thrown before `manager` was assigned (e.g. the
+    // SessionManager constructor failing), leaving it undefined here (gemini
+    // PR #274 review). shutdownAll is still best-effort; the tmux kill below runs
+    // regardless so a half-initialised run can't leak the test server.
+    if (manager) await manager.shutdownAll();
   } catch {
     // best-effort; still kill the tmux server below.
   }

--- a/supervisor/tests/e2e/session-lifecycle.test.ts
+++ b/supervisor/tests/e2e/session-lifecycle.test.ts
@@ -1,0 +1,278 @@
+// Supervisor ↔ tmux session lifecycle E2E (Issue #144 / #273).
+//
+// Drives the real SessionManager lifecycle against real tmux:
+//   SessionManager.start → real tmux (-L claude-hub-test) → claude-mock.sh
+//   → Stop-hook POST → relay-server → SessionManager.sendMessage result
+//   → SessionManager.stop tears the tmux session down.
+//
+// This closes the gap the existing CI E2E (tests/e2e/ac-verification.test.ts)
+// does NOT cover: ac-verification exercises the raw tmux/relay *primitives*
+// directly, but never drives SessionManager's own start/relay/stop lifecycle.
+// We test SessionManager directly (not via the Discord-routing layer) so the
+// suite has no dependency on bot.ts / slash wiring — that glue stays covered by
+// unit tests. See PR #146 (closed) rationale on why the wireBotHandlers duplicate
+// was dropped.
+//
+// Required env (the suite self-skips when missing so dev machines without tmux,
+// or that don't want to spawn real sessions, are unaffected):
+//   - SUPERVISOR_TMUX_SOCKET=claude-hub-test   (isolates from prod `claude-hub`)
+//   - SUPERVISOR_CLAUDE_PATH=<abs path to fixtures/claude-mock.sh>
+// CI (.github/workflows/ci.yml, e2e job) injects both.
+
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import { execFileSync } from "child_process";
+import { resolve, dirname, join } from "path";
+import { fileURLToPath } from "url";
+import { tmpdir } from "os";
+import {
+  mkdtempSync,
+  rmSync,
+  mkdirSync,
+  writeFileSync,
+  existsSync,
+  realpathSync,
+} from "fs";
+
+import { SessionManager } from "../../src/session/manager";
+import { TMUX_PATH, TMUX_ARGS, TMUX_SOCKET } from "../../src/session/tmux";
+import { FakeItermAdapter } from "../../src/session/adapters-fake";
+import type { ChannelConfig } from "../../src/config/channels";
+
+const TMUX_OP_TIMEOUT = 10_000;
+const REQUIRED_SOCKET = "claude-hub-test";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const FIXTURE_PATH = resolve(__dirname, "fixtures/claude-mock.sh");
+
+function tmuxAvailable(): boolean {
+  try {
+    execFileSync(TMUX_PATH, ["-V"], { stdio: "ignore", timeout: 2000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Resolve both sides through realpath so a SUPERVISOR_CLAUDE_PATH that is a
+// symlink or a relative path still activates the suite when it points at the
+// right fixture (CodeRabbit PR #145 review).
+function realPathOrSelf(p: string): string {
+  try {
+    return realpathSync(p);
+  } catch {
+    return p;
+  }
+}
+
+const hasTmux = tmuxAvailable();
+const correctSocket = TMUX_SOCKET === REQUIRED_SOCKET;
+const envClaudePath = process.env.SUPERVISOR_CLAUDE_PATH;
+const fixtureExists = existsSync(FIXTURE_PATH);
+const correctClaudePath =
+  envClaudePath !== undefined &&
+  fixtureExists &&
+  existsSync(envClaudePath) &&
+  realPathOrSelf(envClaudePath) === realPathOrSelf(FIXTURE_PATH);
+const enabled = hasTmux && correctSocket && correctClaudePath;
+
+if (!enabled) {
+  // eslint-disable-next-line no-console
+  console.log(
+    `[session-lifecycle.test] skipping (hasTmux=${hasTmux}, ` +
+      `socket=${TMUX_SOCKET} required=${REQUIRED_SOCKET}, ` +
+      `claudePath=${envClaudePath ?? "<unset>"} required=${FIXTURE_PATH}, ` +
+      `fixtureExists=${fixtureExists})`,
+  );
+}
+
+const itE2E = enabled ? test : test.skip;
+
+let workDir: string;
+let projectDir: string;
+let manager: SessionManager;
+let config: ChannelConfig;
+
+beforeAll(async () => {
+  if (!enabled) return;
+  // Project directory the SessionManager cd's into. Real tmux invocation needs
+  // it to exist and be writable for the relay-url file.
+  workDir = mkdtempSync(join(tmpdir(), "session-lifecycle-"));
+  projectDir = join(workDir, "project");
+  mkdirSync(projectDir, { recursive: true });
+  writeFileSync(join(projectDir, "README.md"), "# session lifecycle fixture\n");
+
+  // Start the tmux server on the test socket explicitly so cleanup is symmetric.
+  try {
+    execFileSync(TMUX_PATH, [...TMUX_ARGS, "start-server"], {
+      timeout: TMUX_OP_TIMEOUT,
+    });
+  } catch {
+    // new-session will start the server on demand.
+  }
+
+  // Real tmux + real relay-server (the byte flow under test) but a fake iTerm2
+  // adapter so no windows open on the dev's machine and CI Linux runners work.
+  manager = new SessionManager({
+    effects: { iterm2: new FakeItermAdapter() },
+  });
+  config = {
+    channelName: "session-lifecycle-test",
+    dir: projectDir,
+    displayName: "Session Lifecycle Test",
+  };
+});
+
+afterAll(async () => {
+  if (!enabled) return;
+  try {
+    await manager.shutdownAll();
+  } catch {
+    // best-effort; still kill the tmux server below.
+  }
+  // Hard-kill the test tmux server so leftover panes from a flaky run don't
+  // poison the next invocation. Scoped to the test socket only (RW-019).
+  try {
+    execFileSync(TMUX_PATH, [...TMUX_ARGS, "kill-server"], {
+      timeout: TMUX_OP_TIMEOUT,
+    });
+  } catch {
+    // server already gone
+  }
+  if (workDir) {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+describe("Supervisor session lifecycle E2E (Issue #144 / #273)", () => {
+  itE2E(
+    "AC-1: SessionManager.start spawns a live tmux session under the canonical name",
+    async () => {
+      const threadId = makeThreadId(1);
+      try {
+        await manager.start(config, threadId);
+
+        expect(manager.has(threadId)).toBe(true);
+
+        // Use the public API rather than re-deriving the formula so a future
+        // rename surfaces here as a test failure (gemini PR #145 review).
+        const tmuxName = SessionManager.tmuxSessionNameFor(threadId);
+        expect(listTmuxSessions()).toContain(tmuxName);
+
+        // Pane is up; the mock-claude greeting is timing-dependent so we only
+        // assert non-empty bytes here. AC-2 verifies the relay round-trip.
+        expect(capturePane(tmuxName).length).toBeGreaterThan(0);
+      } finally {
+        await stopIfActive(threadId);
+      }
+    },
+    20_000,
+  );
+
+  itE2E(
+    "AC-2: sendMessage round-trips through claude-mock.sh and the relay server",
+    async () => {
+      const threadId = makeThreadId(2);
+      try {
+        await manager.start(config, threadId);
+
+        const result = await manager.sendMessage(threadId, "ping-from-lifecycle");
+
+        expect(result.error, `relay error: ${result.error ?? ""}`).toBeFalsy();
+        // Match on substring rather than the full mock template so claude-mock.sh's
+        // greeting prefix can evolve without breaking this AC.
+        const echoed =
+          (result.text ?? "").includes("ping-from-lifecycle") ||
+          result.chunks.some((c) => c.includes("ping-from-lifecycle"));
+        expect(echoed, `no round-trip echo in ${JSON.stringify(result)}`).toBe(
+          true,
+        );
+      } finally {
+        await stopIfActive(threadId);
+      }
+    },
+    30_000,
+  );
+
+  itE2E(
+    "AC-3: SessionManager.stop tears the tmux session down",
+    async () => {
+      const threadId = makeThreadId(3);
+      // No try/finally — AC-3's purpose IS the stop path; the cleanup helper at
+      // the end is a no-op once stop has already succeeded.
+      await manager.start(config, threadId);
+      const tmuxName = SessionManager.tmuxSessionNameFor(threadId);
+      expect(listTmuxSessions()).toContain(tmuxName);
+
+      await manager.stop(threadId, "manual");
+      expect(manager.has(threadId)).toBe(false);
+
+      await waitFor(
+        () => (!listTmuxSessions().includes(tmuxName) ? true : null),
+        5_000,
+        100,
+      );
+      expect(listTmuxSessions()).not.toContain(tmuxName);
+      await stopIfActive(threadId);
+    },
+    30_000,
+  );
+});
+
+// ---- helpers ----
+
+function listTmuxSessions(): string[] {
+  try {
+    return execFileSync(
+      TMUX_PATH,
+      [...TMUX_ARGS, "list-sessions", "-F", "#{session_name}"],
+      { timeout: TMUX_OP_TIMEOUT },
+    )
+      .toString()
+      .split("\n")
+      .filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function capturePane(session: string): string {
+  try {
+    return execFileSync(
+      TMUX_PATH,
+      [...TMUX_ARGS, "capture-pane", "-p", "-t", session],
+      { timeout: TMUX_OP_TIMEOUT },
+    ).toString();
+  } catch {
+    return "";
+  }
+}
+
+// `T extends NonNullable<unknown>` rules out null/undefined as valid poll
+// results so a timeout (returns null) can never collide with a polled null.
+async function waitFor<T extends NonNullable<unknown>>(
+  poll: () => T | null,
+  timeoutMs: number,
+  intervalMs: number,
+): Promise<T | null> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const v = poll();
+    if (v !== null) return v;
+    await new Promise((r) => setTimeout(r, intervalMs));
+  }
+  return null;
+}
+
+function makeThreadId(suffix: number): string {
+  return `lifecycle-${process.pid}-${Date.now()}-${suffix}`;
+}
+
+async function stopIfActive(threadId: string): Promise<void> {
+  if (!manager.has(threadId)) return;
+  try {
+    await manager.stop(threadId, "manual");
+  } catch {
+    // afterAll's shutdownAll is the safety net; ignore here.
+  }
+}


### PR DESCRIPTION
Closes #273. Refs #144 (Phase 5)。PR #146 (closed) の作り直し。

## 概要

Discord ↔ Supervisor ↔ tmux ライフサイクル E2E を CI に載せる (#144) にあたり、PR #146 が採った `wireBotHandlers` 経由の設計を**採らず**、`SessionManager` を直接駆動する実 tmux ライフサイクル E2E を追加し、`ci.yml` に結線した。

### なぜ wireBotHandlers を採らないか（AgentTeams の結論・案A）

PR #146 の `wireBotHandlers`/`handler.ts` は本番 `bot.ts` から未 import の duplicate で、テストがそれを叩くため本番経路を保証しなかった（devils-advocate 指摘）。本番経路を E2E で叩くには `bot.ts`(986 LoC) + `commands/session.ts`(~400 LoC) を IDiscordClient 駆動へ書き換える高 blast-radius なリファクタが必要になる。

本 PR は代わりに **SessionManager 層**で lifecycle を検証する。既存 CI E2E (`tests/e2e/ac-verification.test.ts`) は raw tmux/relay プリミティブを直接叩くだけで、**SessionManager 自身の start/relay/stop ライフサイクルは CI 未カバー**だった。そのギャップを、本番 Discord bot を触らずに埋める。Discord-routing glue は従来どおり unit test でカバー。

## 変更点

| ファイル | 変更 |
|---|---|
| `supervisor/src/session/manager.ts` | `CLAUDE_PATH` 定数 → `claudePath()` at-use-time 化（start/resume 両 exec に適用、`SUPERVISOR_CLAUDE_PATH` で fixture 注入可・値はクォートしスペース安全）。`tmuxSessionNameFor()` を public static 化（E2E が session 名を再計算せず参照）。本番 default 挙動は不変 |
| `supervisor/tests/e2e/session-lifecycle.test.ts`（新規） | start→relay round-trip→stop の 3 AC を実 tmux + `claude-mock.sh` で検証。env 不在時 self-skip |
| `.github/workflows/ci.yml` | e2e ジョブに `session-lifecycle` ステップを env 注入付きで追加（self-skip 解消）+ `jq` install |

## 統合ジャーニーAC との対応

| #273 AC | 本 PR |
|---|---|
| SessionManager.start が tmux session 起動 | ✅ AC-1 |
| sendMessage が claude-mock + relay を round-trip | ✅ AC-2 |
| stop が tmux session 破棄 | ✅ AC-3 |
| E2E が CI で skip されず実行 | ✅ ci.yml 結線 + env 注入 |

## 検証

```
bunx tsc --noEmit                       # 0 errors
# env 注入で E2E 実行
SUPERVISOR_TMUX_SOCKET=claude-hub-test \
SUPERVISOR_CLAUDE_PATH=$(pwd)/tests/e2e/fixtures/claude-mock.sh \
bun test tests/e2e/session-lifecycle.test.ts   # 3 pass / 0 fail / 45.5s
# env 不在（デフォルト Unit Tests ジョブ相当）
bun test tests/e2e/session-lifecycle.test.ts   # 0 pass / 3 skip / 0 fail
bun test tests/session/manager.test.ts         # 51 pass / 0 fail（変更ファイル直接）
bun scripts/lint-gating-coverage.ts            # 新テスト gated（0 ungated）
bun scripts/lint-no-sync-exec.ts               # clean
```

full `bun test` の失敗（tmux/relay/adapters の execFile モック系）は `mock.module` の process-global leakage による**既存の isolation artifact**（main=27 fail / 本ブランチ=26 fail、CI は各々を独立プロセスで実行）。個別 isolation 実行では全て pass。

## RW 整合性

- **RW-019**: test 専用 socket `claude-hub-test` を本番 `claude-hub` と分離。`kill-server` も test socket 限定
- **RW-005/RW-008**: `afterAll` で `shutdownAll` + `kill-server` + workDir 削除、各 AC の finally で `stopIfActive`
- **RW-046（#146 の compile 破綻教訓）**: `CLAUDE_PATH`→`claudePath()` を start/resume の**両** exec に適用し未定義参照を残さない（tsc 0 errors で実証）
