### PR TITLE
feat(#275): 孤児 dispatch セッションを idle ベースで回収する OrphanDispatchReaper

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -16,6 +16,7 @@ import {
 } from "./session/self-heal-restart";
 import { Reaper } from "./session/reaper";
 import { GoalWatcher } from "./session/goal-watcher";
+import { OrphanDispatchReaper } from "./session/orphan-dispatch-reaper";
 import { ActivityWatchdog } from "./session/session-activity-watchdog";
 import { ResourceMonitor } from "./session/resource-monitor";
 import { createSessionCommand, createSessionHandler } from "./commands/session";
@@ -242,6 +243,15 @@ export async function startBot(token: string): Promise<void> {
   // grace window the chairman can cancel by speaking. Frees the shared session
   // slot on goal completion instead of waiting for the idle reaper.
   const goalWatcher = new GoalWatcher(sessionManager, client);
+  // Issue #275 (option B): the self-contained claude-hub half of the dispatch
+  // lifecycle gap. A dispatch session (branch `corp-dispatch-<N>`) whose spawning
+  // corp CEO session exited but which never reached `done` is orphaned —
+  // GoalWatcher (done-only) skips it and the 30-day idle Reaper is far too slow,
+  // so it squats a MAX_SESSIONS slot (executor saturation). The supervisor cannot
+  // observe the corp CEO exit (corp is a separate process posting /dispatch
+  // messages), so this idle-based safety net reaps dispatch sessions idle past
+  // DISPATCH_ORPHAN_IDLE_MS while sparing any that are still actively working.
+  const orphanDispatchReaper = new OrphanDispatchReaper(sessionManager, client);
   // Issue #209: nudge the owner when a live session has been running for hours
   // (long_lived, AC3) or has gone silent (quiet, AC1) — the gap between the
   // per-turn stall heartbeat and the idle reaper. De-dup is internal so each
@@ -332,6 +342,7 @@ export async function startBot(token: string): Promise<void> {
 
     reaper.start();
     goalWatcher.start();
+    orphanDispatchReaper.start();
     activityWatchdog.start();
     resourceMonitor.start();
 
@@ -926,6 +937,7 @@ export async function startBot(token: string): Promise<void> {
     console.log("[Bot] Shutdown signal received");
     reaper.stop();
     goalWatcher.stop();
+    orphanDispatchReaper.stop();
     activityWatchdog.stop();
     resourceMonitor.stop();
     // Drain pending progress buffers before tearing down the Discord client

--- a/supervisor/src/config/channels.ts
+++ b/supervisor/src/config/channels.ts
@@ -158,3 +158,14 @@ export const MAX_MEMORY_PER_SESSION_MB = 2048; // 2GB
 // chairman time to cancel by speaking in the thread before teardown.
 export const GOAL_CHECK_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
 export const GOAL_GRACE_MS = 3 * 60 * 1000; // 3 minutes
+// OrphanDispatchReaper (Issue #275, option B): a dispatch-origin session
+// (`corp-dispatch-<N>`) whose spawning corp CEO session exited but which never
+// reached `done` is orphaned — GoalWatcher (done-only) skips it and the 30-day
+// IDLE_TIMEOUT_MS reaper is far too slow, so it squats a MAX_SESSIONS slot
+// (executor saturation). This gives dispatch sessions a much shorter idle leash
+// than IDLE_TIMEOUT_MS while leaving human / interactive sessions on the 30-day
+// reaper. Idle-based only: an actively-working dispatch session keeps
+// `lastActivityAt` fresh (bot.ts touchActivity), so it is spared (#275 AC2). The
+// idle threshold is env-overridable (`DISPATCH_ORPHAN_IDLE_MS`) for ops tuning.
+export const DISPATCH_ORPHAN_IDLE_MS = 48 * 60 * 60 * 1000; // 48 hours
+export const DISPATCH_ORPHAN_CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes

--- a/supervisor/src/session/orphan-dispatch-reaper.test.ts
+++ b/supervisor/src/session/orphan-dispatch-reaper.test.ts
@@ -1,0 +1,293 @@
+import { test, expect, describe } from "bun:test";
+import {
+  OrphanDispatchReaper,
+  selectReapableDispatch,
+  ORPHAN_REAP_REASON,
+} from "./orphan-dispatch-reaper";
+import type { SessionInfo, StopReason } from "./types";
+import type { SessionManager } from "./manager";
+import type { Client } from "discord.js";
+
+// Issue #275 (option B). OrphanDispatchReaper is GoalWatcher's sibling for the
+// *not-done, long-idle* case: it stops a dispatch-origin session (branch
+// `corp-dispatch-<N>`) whose spawning corp CEO session exited but which never
+// reached `done`, before the 30-day idle reaper would. Verifies the journey ACs:
+// AC1 (orphans don't silently pile up — they are stopped + a notice is posted),
+// AC2 (done-未達 かつ 長期idle stopped; 作業中 = active sessions spared). All deps
+// are injected so the unit tests never shell out or touch tmux.
+
+const HOUR = 60 * 60 * 1000;
+const IDLE_THRESHOLD = 48 * HOUR;
+
+function makeSession(
+  over: Partial<SessionInfo> & { threadId: string }
+): SessionInfo {
+  const now = new Date();
+  return {
+    id: over.threadId,
+    channelName: "convert-service",
+    projectDir: "/repo/.claude/worktrees/corp-dispatch-1",
+    pid: 1,
+    process: null as unknown as SessionInfo["process"],
+    startedAt: now,
+    lastActivityAt: now,
+    status: "running",
+    ...over,
+  } as SessionInfo;
+}
+
+interface StopCall {
+  threadId: string;
+  reason: StopReason;
+}
+
+function makeManager(sessions: Map<string, SessionInfo>): {
+  manager: SessionManager;
+  stopCalls: StopCall[];
+} {
+  const stopCalls: StopCall[] = [];
+  const manager = {
+    entries: () => sessions.entries(),
+    stop: async (threadId: string, reason: StopReason) => {
+      stopCalls.push({ threadId, reason });
+      // Mirror the real stop(): the session leaves the live map.
+      sessions.delete(threadId);
+    },
+  } as unknown as SessionManager;
+  return { manager, stopCalls };
+}
+
+interface ThreadStub {
+  name: string;
+  sent: string[];
+  archived: boolean;
+  renamedTo: string | null;
+}
+
+function makeClient(
+  thread?: ThreadStub,
+  opts: { cached?: boolean } = {}
+): Client {
+  const cached = opts.cached ?? true;
+  const channel = thread
+    ? {
+        isThread: () => true,
+        get name() {
+          return thread.name;
+        },
+        send: async (msg: string) => {
+          thread.sent.push(msg);
+        },
+        setName: async (n: string) => {
+          thread.renamedTo = n;
+          thread.name = n;
+        },
+        setArchived: async (v: boolean) => {
+          thread.archived = v;
+        },
+      }
+    : undefined;
+  return {
+    channels: {
+      cache: { get: () => (cached ? channel : undefined) },
+      fetch: async () => channel,
+    },
+  } as unknown as Client;
+}
+
+/** A session whose last activity was `hoursAgo` before `now`. */
+function idleSession(
+  threadId: string,
+  branch: string | undefined,
+  hoursAgo: number,
+  now: number,
+  status: SessionInfo["status"] = "running"
+): SessionInfo {
+  return makeSession({
+    threadId,
+    branch,
+    status,
+    lastActivityAt: new Date(now - hoursAgo * HOUR),
+  });
+}
+
+describe("selectReapableDispatch", () => {
+  const now = 1_000_000_000_000;
+  const opts = { idleThresholdMs: IDLE_THRESHOLD, now };
+
+  test("AC2: a not-done dispatch session idle past the threshold is selected", () => {
+    const entries = new Map<string, SessionInfo>([
+      ["t42", idleSession("t42", "corp-dispatch-42", 50, now)],
+    ]);
+    const got = selectReapableDispatch(entries.entries(), opts);
+    expect(got.map((c) => c.threadId)).toEqual(["t42"]);
+    expect(got[0]!.idleMs).toBe(50 * HOUR);
+  });
+
+  test("AC2: an active dispatch session (idle < threshold) is spared (作業中は巻き込まれない)", () => {
+    const entries = new Map<string, SessionInfo>([
+      ["t42", idleSession("t42", "corp-dispatch-42", 10, now)],
+    ]);
+    expect(selectReapableDispatch(entries.entries(), opts)).toEqual([]);
+  });
+
+  test("boundary: idle exactly at the threshold is selected (>=)", () => {
+    const entries = new Map<string, SessionInfo>([
+      ["t1", idleSession("t1", "corp-dispatch-1", 48, now)],
+    ]);
+    expect(selectReapableDispatch(entries.entries(), opts).map((c) => c.threadId)).toEqual([
+      "t1",
+    ]);
+  });
+
+  test("non-dispatch branches (conductor / work / main / none) are never selected", () => {
+    const entries = new Map<string, SessionInfo>([
+      ["conductor", idleSession("conductor", "52-m1-board", 100, now)],
+      ["main", idleSession("main", "main", 100, now)],
+      ["nobranch", idleSession("nobranch", undefined, 100, now)],
+      ["almost", idleSession("almost", "corp-dispatch-", 100, now)],
+      ["trailing", idleSession("trailing", "corp-dispatch-12a", 100, now)],
+    ]);
+    expect(selectReapableDispatch(entries.entries(), opts)).toEqual([]);
+  });
+
+  test("a session already `stopping` is skipped (no double-stop)", () => {
+    const entries = new Map<string, SessionInfo>([
+      ["t9", idleSession("t9", "corp-dispatch-9", 100, now, "stopping")],
+    ]);
+    expect(selectReapableDispatch(entries.entries(), opts)).toEqual([]);
+  });
+
+  test("mixed fleet: only the idle dispatch orphans are selected", () => {
+    const entries = new Map<string, SessionInfo>([
+      ["orphan1", idleSession("orphan1", "corp-dispatch-100", 72, now)],
+      ["active", idleSession("active", "corp-dispatch-101", 1, now)],
+      ["human", idleSession("human", "feature-x", 200, now)],
+      ["orphan2", idleSession("orphan2", "corp-dispatch-102", 49, now)],
+    ]);
+    const got = selectReapableDispatch(entries.entries(), opts).map((c) => c.threadId);
+    expect(got.sort()).toEqual(["orphan1", "orphan2"]);
+  });
+});
+
+describe("OrphanDispatchReaper.check", () => {
+  const now = 2_000_000_000_000;
+
+  test("AC1/AC2: idle dispatch orphan → stop('orphan_reaped') + notice + rename + archive", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t42", idleSession("t42", "corp-dispatch-42", 50, now)],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const thread: ThreadStub = {
+      name: "🟢 corp-dispatch-42",
+      sent: [],
+      archived: false,
+      renamedTo: null,
+    };
+    const reaper = new OrphanDispatchReaper(manager, makeClient(thread), {
+      now: () => now,
+      idleThresholdMs: IDLE_THRESHOLD,
+    });
+
+    await reaper.check();
+
+    expect(stopCalls).toEqual([{ threadId: "t42", reason: "orphan_reaped" }]);
+    expect(ORPHAN_REAP_REASON).toBe("orphan_reaped");
+    expect(thread.archived).toBe(true);
+    expect(thread.renamedTo).not.toBeNull();
+    expect(thread.sent.length).toBe(1);
+    expect(thread.sent[0]).toContain("#275");
+  });
+
+  test("AC2: an active dispatch session is left running (not stopped)", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t42", idleSession("t42", "corp-dispatch-42", 5, now)],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const reaper = new OrphanDispatchReaper(manager, makeClient(), {
+      now: () => now,
+      idleThresholdMs: IDLE_THRESHOLD,
+    });
+
+    await reaper.check();
+    expect(stopCalls).toEqual([]);
+    expect(sessions.has("t42")).toBe(true);
+  });
+
+  test("a non-dispatch idle session is not touched", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["human", idleSession("human", "feature-x", 500, now)],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const reaper = new OrphanDispatchReaper(manager, makeClient(), {
+      now: () => now,
+      idleThresholdMs: IDLE_THRESHOLD,
+    });
+
+    await reaper.check();
+    expect(stopCalls).toEqual([]);
+    expect(sessions.has("human")).toBe(true);
+  });
+
+  test("cache miss: an evicted thread is fetched from the API and still archived", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t5", idleSession("t5", "corp-dispatch-5", 60, now)],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const thread: ThreadStub = {
+      name: "🟢 corp-dispatch-5",
+      sent: [],
+      archived: false,
+      renamedTo: null,
+    };
+    const reaper = new OrphanDispatchReaper(
+      manager,
+      makeClient(thread, { cached: false }),
+      { now: () => now, idleThresholdMs: IDLE_THRESHOLD }
+    );
+
+    await reaper.check();
+    expect(stopCalls).toEqual([{ threadId: "t5", reason: "orphan_reaped" }]);
+    expect(thread.archived).toBe(true);
+  });
+
+  test("per-session error isolation: one failing stop does not abort the others", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["bad", idleSession("bad", "corp-dispatch-1", 60, now)],
+      ["good", idleSession("good", "corp-dispatch-2", 60, now)],
+    ]);
+    const stopCalls: StopCall[] = [];
+    const manager = {
+      entries: () => sessions.entries(),
+      stop: async (threadId: string, reason: StopReason) => {
+        if (threadId === "bad") throw new Error("boom");
+        stopCalls.push({ threadId, reason });
+        sessions.delete(threadId);
+      },
+    } as unknown as SessionManager;
+
+    const reaper = new OrphanDispatchReaper(manager, makeClient(), {
+      now: () => now,
+      idleThresholdMs: IDLE_THRESHOLD,
+    });
+
+    await reaper.check();
+    // "good" is still reaped despite "bad" throwing.
+    expect(stopCalls).toEqual([{ threadId: "good", reason: "orphan_reaped" }]);
+  });
+
+  test("idempotent: a second tick after reaping is a no-op (session already gone)", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t42", idleSession("t42", "corp-dispatch-42", 60, now)],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const reaper = new OrphanDispatchReaper(manager, makeClient(), {
+      now: () => now,
+      idleThresholdMs: IDLE_THRESHOLD,
+    });
+
+    await reaper.check();
+    await reaper.check();
+    expect(stopCalls.length).toBe(1);
+  });
+});

--- a/supervisor/src/session/orphan-dispatch-reaper.ts
+++ b/supervisor/src/session/orphan-dispatch-reaper.ts
@@ -1,0 +1,246 @@
+import type { SessionManager } from "./manager";
+import type { SessionInfo, StopReason } from "./types";
+import type { ThreadChannel, Client } from "discord.js";
+import { DISPATCH_BRANCH_RE } from "./goal-watcher";
+import {
+  DISPATCH_ORPHAN_IDLE_MS,
+  DISPATCH_ORPHAN_CHECK_INTERVAL_MS,
+} from "../config/channels";
+import { markTitleStopped } from "./thread-title";
+
+/**
+ * Orphan dispatch reaper (Issue #275, option B — the self-contained claude-hub
+ * half of the dispatch-session lifecycle gap).
+ *
+ * A dispatch-origin session (branch `corp-dispatch-<N>`, see
+ * {@link DISPATCH_BRANCH_RE}) is started fire-and-forget when the corp HQ posts
+ * a `/dispatch` message. When the corp CEO session that spawned it exits, the
+ * child dispatch session is NOT chain-stopped: the two are independent
+ * processes and the supervisor never observes the corp exit (corp only posts
+ * Discord messages — there is no exit signal). If that dispatch job also never
+ * reaches `done`, it falls through every existing safety net:
+ *   - {@link import("./goal-watcher").GoalWatcher} stops only `done` sessions,
+ *   - the idle {@link import("./reaper").Reaper} acts only after
+ *     IDLE_TIMEOUT_MS (30 days — far too slow), and
+ *   - {@link import("./session-activity-watchdog").ActivityWatchdog} only nudges.
+ * The orphan then squats a MAX_SESSIONS slot and starves later dispatches
+ * (executor saturation / silent stall — the #275 motivation).
+ *
+ * This reaper is GoalWatcher's sibling for the *not-done, long-idle* case: on a
+ * fixed interval it stops dispatch-origin sessions whose idle time has crossed a
+ * dispatch-specific horizon ({@link DISPATCH_ORPHAN_IDLE_MS}), which is much
+ * shorter than the general 30-day idle reaper. Human / interactive sessions
+ * (corp conductor, department channels) are left entirely on the 30-day reaper —
+ * only `corp-dispatch-<N>` sessions get the shorter leash.
+ *
+ * Selection is purely numeric (idle ms) — NOT a `gh` label call or TUI string
+ * match — mirroring ActivityWatchdog's robustness (RW-027) and adding no new
+ * corp→claude-hub structural coupling (GoalWatcher spec §12). No `done` label
+ * check is needed: a `done` session is stopped by GoalWatcher within minutes
+ * (2-min poll + 3-min grace), so it never survives to the multi-day orphan
+ * horizon. An *active* dispatch session keeps its `lastActivityAt` fresh via
+ * PostToolUse progress (bot.ts `touchActivity`), so a genuinely-working session
+ * — even the 21h #209 case — has low idle and is spared. The idle guard IS the
+ * "作業中は巻き込まれない" protection (#275 AC2 / RW-046 class): only a session
+ * with zero activity for the full horizon is reaped, and stop() reuses the exact
+ * same teardown path as the Reaper/GoalWatcher (no worktree deletion).
+ *
+ * `selectReapableDispatch` is exported as a pure function so a future on-demand
+ * trigger (a corp-secretary CLI, or a `/session reap` command) can reuse one
+ * source of truth for "which dispatch sessions are orphaned".
+ */
+
+/** Stop reason recorded when a session is reaped as an orphaned dispatch job. */
+export const ORPHAN_REAP_REASON: StopReason = "orphan_reaped";
+
+/** Minimal session shape the pure selector reads (a subset of {@link SessionInfo}). */
+export interface ReapableSession {
+  branch?: string;
+  status: SessionInfo["status"];
+  lastActivityAt: Date;
+}
+
+/** One orphaned dispatch session selected for reaping. */
+export interface OrphanReapCandidate {
+  threadId: string;
+  /** ms since the session's last recorded activity, at selection time. */
+  idleMs: number;
+}
+
+/**
+ * Pure, side-effect-free selection. From the live sessions, return the
+ * dispatch-origin ones (`corp-dispatch-<N>`) that are still `running` and whose
+ * idle time has reached `idleThresholdMs`. Everything else is spared:
+ *   - non-dispatch branches (corp conductor / work branch / `main` / no branch),
+ *   - dispatch sessions still active within the window (idle < threshold) — the
+ *     "作業中は巻き込まれない" guard (#275 AC2),
+ *   - sessions already `stopping` (avoid double-stop).
+ *
+ * Exported so both the periodic {@link OrphanDispatchReaper} and any future
+ * on-demand trigger share exactly one definition of "orphaned dispatch session".
+ */
+export function selectReapableDispatch(
+  entries: Iterable<[string, ReapableSession]>,
+  opts: { idleThresholdMs: number; now: number }
+): OrphanReapCandidate[] {
+  const out: OrphanReapCandidate[] = [];
+  for (const [threadId, session] of entries) {
+    if (session.status !== "running") continue;
+    if (!session.branch || !DISPATCH_BRANCH_RE.test(session.branch)) continue;
+    const idleMs = opts.now - session.lastActivityAt.getTime();
+    if (Number.isFinite(idleMs) && idleMs >= opts.idleThresholdMs) {
+      out.push({ threadId, idleMs });
+    }
+  }
+  return out;
+}
+
+export interface OrphanDispatchReaperDeps {
+  /** Clock injection for deterministic tests. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Poll interval. Defaults to {@link DISPATCH_ORPHAN_CHECK_INTERVAL_MS}. */
+  checkIntervalMs?: number;
+  /**
+   * Idle horizon after which a not-done dispatch session is orphan-reaped.
+   * Defaults to the `DISPATCH_ORPHAN_IDLE_MS` env override, else the
+   * {@link DISPATCH_ORPHAN_IDLE_MS} constant. Env-overridable so ops can tune
+   * the leash without a redeploy (mirrors ActivityWatchdog's env thresholds).
+   */
+  idleThresholdMs?: number;
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+/**
+ * Periodic driver (mirrors {@link import("./reaper").Reaper} /
+ * {@link import("./goal-watcher").GoalWatcher}). A thin timer + notify shell
+ * around the pure {@link selectReapableDispatch}; the interesting logic stays
+ * testable without tmux or a Discord gateway.
+ */
+export class OrphanDispatchReaper {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Re-entry guard (mirrors {@link import("./goal-watcher").GoalWatcher}). A
+   * `check()` awaits a stop() per candidate, which can outlast the poll interval
+   * under load; without this two ticks could overlap and both try to stop the
+   * same thread.
+   */
+  private isChecking = false;
+
+  private readonly now: () => number;
+  private readonly checkIntervalMs: number;
+  private readonly idleThresholdMs: number;
+
+  constructor(
+    private sessionManager: SessionManager,
+    private client: Client,
+    deps: OrphanDispatchReaperDeps = {}
+  ) {
+    this.now = deps.now ?? Date.now;
+    this.checkIntervalMs =
+      deps.checkIntervalMs ?? DISPATCH_ORPHAN_CHECK_INTERVAL_MS;
+    this.idleThresholdMs =
+      deps.idleThresholdMs ??
+      envInt("DISPATCH_ORPHAN_IDLE_MS", DISPATCH_ORPHAN_IDLE_MS);
+  }
+
+  start(): void {
+    this.timer = setInterval(() => {
+      void this.check();
+    }, this.checkIntervalMs);
+    console.log(
+      `[OrphanDispatchReaper] Started (check every ${this.checkIntervalMs / 1000 / 60}min, orphan idle ${(this.idleThresholdMs / 1000 / 60 / 60).toFixed(1)}h)`
+    );
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * One scan tick. Public so tests can drive it deterministically (the interval
+   * just calls it). Each candidate is reaped independently and any per-session
+   * error is swallowed so one bad session never aborts the tick.
+   */
+  async check(): Promise<void> {
+    if (this.isChecking) return;
+    this.isChecking = true;
+    try {
+      const candidates = selectReapableDispatch(this.sessionManager.entries(), {
+        idleThresholdMs: this.idleThresholdMs,
+        now: this.now(),
+      });
+      for (const { threadId, idleMs } of candidates) {
+        try {
+          await this.reap(threadId, idleMs);
+        } catch (err) {
+          console.error(
+            `[OrphanDispatchReaper] Error reaping thread ${threadId}:`,
+            err
+          );
+        }
+      }
+    } finally {
+      this.isChecking = false;
+    }
+  }
+
+  private async reap(threadId: string, idleMs: number): Promise<void> {
+    const idleHours = (idleMs / 1000 / 60 / 60).toFixed(1);
+    console.log(
+      `[OrphanDispatchReaper] Thread ${threadId} idle ${idleHours}h without \`done\`; orphan-reaping (orphan_reaped)`
+    );
+    try {
+      await this.sessionManager.stop(threadId, ORPHAN_REAP_REASON);
+    } catch (err) {
+      // Leave the thread untouched if the stop itself failed; the next tick (or
+      // the idle reaper) retries.
+      console.error(`[OrphanDispatchReaper] Failed to stop ${threadId}:`, err);
+      return;
+    }
+    await this.notifyThread(threadId, idleMs);
+  }
+
+  /**
+   * Post a teardown notice, mark the title stopped, and archive the thread — the
+   * same UX as the Reaper / GoalWatcher. Cache-first, then API fetch: the orphan
+   * horizon is long (days), so on a long-running supervisor — or after a restart
+   * — the thread may have been evicted from the cache; without the fetch
+   * fallback the notice / rename / archive would be silently skipped.
+   */
+  private async notifyThread(threadId: string, idleMs: number): Promise<void> {
+    try {
+      let thread = this.client.channels.cache.get(threadId) as
+        | ThreadChannel
+        | undefined;
+      if (!thread) {
+        thread = (await this.client.channels
+          .fetch(threadId)
+          .catch(() => undefined)) as ThreadChannel | undefined;
+      }
+
+      if (thread?.isThread()) {
+        const idleHours = Math.round(idleMs / 1000 / 60 / 60);
+        await thread.send(
+          `🧹 dispatch セッションが約 ${idleHours} 時間無活動（\`done\` 未到達）のため、orphan として自動終了しました（親 CEO セッション終了後の放置回収 / #275）。`
+        );
+        const stoppedName = markTitleStopped(thread.name);
+        await thread.setName(stoppedName);
+        await thread.setArchived(true);
+      }
+    } catch (err) {
+      console.error(
+        `[OrphanDispatchReaper] Failed to notify thread ${threadId}:`,
+        err
+      );
+    }
+  }
+}

--- a/supervisor/src/session/types.ts
+++ b/supervisor/src/session/types.ts
@@ -55,4 +55,4 @@ export interface SessionHealthInfo {
   lastActivityAt: string;
 }
 
-export type StopReason = "manual" | "idle_timeout" | "resource_limit" | "error" | "tmux_exited" | "supervisor_restart" | "self_heal_restart" | "goal_complete";
+export type StopReason = "manual" | "idle_timeout" | "resource_limit" | "error" | "tmux_exited" | "supervisor_restart" | "self_heal_restart" | "goal_complete" | "orphan_reaped";


### PR DESCRIPTION
## 目的

Refs #275（claude-hub 側 = **スコープ案 B**）。親 CEO(corp) セッションを終了しても、そのセッションが広げた子 dispatch セッションが**連鎖停止されず放置される**問題に対する、claude-hub 単独で完結する半分を実装する。

> ⚠️ スコープ案 A/B/C の選択（issue で「方針決定が必要」と明記）は確認が取れなかったため、**唯一 claude-hub 単独で完結する B** を自律判断で採用した。auto-close せず `Refs` に留めているので、B で #275 を close するか A（exit シグナル連鎖）の follow-up を別途起こすかは merge 判断時に選べる。

## 背景と設計判断

supervisor は corp CEO セッションの exit を**直接観測できない**（corp は別プロセスで `/dispatch` メッセージを投げるだけ・exit シグナルが無い）。そのため issue の 3 案のうち:

| 案 | 判断 |
|---|---|
| A. 親終了シグナル連鎖停止 | claude-hub 単独では CEO exit を観測不能 → corp companion の exit シグナル実装が前提（別 issue・未着手）で **end-to-end 完結不可** |
| **B. 孤児 dispatch の idle ベース回収**（本 PR） | **claude-hub 完結**。GoalWatcher/Reaper の兄弟として自作。将来 A とも合成可能 |
| C. 可視化のみ | saturation（枠占有）の症状を解消しない |

→ 唯一 claude-hub 単独で完結し、saturation を実際に解消する **B** を採用。

## 変更点

- **`supervisor/src/session/orphan-dispatch-reaper.ts`（新規）**
  - `OrphanDispatchReaper`: 一定間隔で稼働セッションを走査し、dispatch 由来（branch `corp-dispatch-<N>`）かつ `lastActivityAt` が `DISPATCH_ORPHAN_IDLE_MS` を超えた idle のものを `orphan_reaped` で停止 → Discord 通知 + rename + archive（Reaper/GoalWatcher と同 UX、同じ `stop()` 経路＝worktree 削除なし）。
  - `selectReapableDispatch`: 副作用のない純関数として export。将来の on-demand 契機（corp secretary CLI / `/session reap`）と「どれが孤児か」の単一ソースを共有する。
- **`config/channels.ts`**: `DISPATCH_ORPHAN_IDLE_MS`（既定 48h・env 上書き可）、`DISPATCH_ORPHAN_CHECK_INTERVAL_MS`（30min）を追加。
- **`session/types.ts`**: `StopReason` に `orphan_reaped` を追加（純追加）。
- **`bot.ts`**: `OrphanDispatchReaper` を construct / `start()` / shutdown で `stop()`。

## 設計上のポイント（レビュー観点）

- **純数値（idle ms）判定のみ**。`gh` label 呼び出しも TUI 文字列マッチもしない（RW-027 と同方針、corp への新規構造結合なし = GoalWatcher spec §12）。`done` セッションは GoalWatcher が数分で停止するため、多日 idle の孤児 horizon には到達せず、label 判定は不要。
- **作業中セッションは巻き込まれない**（#275 AC2 / RW-046 クラス）。active な dispatch は PostToolUse progress で `lastActivityAt` が更新される（bot.ts `touchActivity`）ため idle が小さく除外される。「activity ゼロが horizon 全域続いた」ものだけを停止する。
- **人間/対話セッションは 30 日 Reaper のまま**。短い leash は `corp-dispatch-<N>` のみに適用。
- 責務分離: 台帳 reconcile と on-demand CLI は **corp companion 側（別 issue）** の担当。

## 統合ジャーニーAC の充足（決定的検証）

headless な background watcher のため、injected-dep のユニットテストで AC を決定論的に検証（tmux/Discord/gh 不要）:

- **AC1（放置が黙って積み上がらない）**: idle 孤児 → `stop('orphan_reaped')` + Discord 通知（=停止かつ明示、silent でない）。
- **AC2（done未達かつ長期idle停止・作業中は除外）**: idle>閾値 dispatch は選択・停止（`/session list`・`tmux ls` から消える）／active dispatch・非 dispatch は spare。
- 台帳 reconcile 部分（AC1/AC2 の corp 台帳更新）は corp companion の担当のため本 PR 対象外。

## テスト / CI

- `bun test src/session/orphan-dispatch-reaper.test.ts` → **12 pass**（純関数 6 + watcher 6: reap/spare/非dispatch/cache-miss/エラー隔離/冪等）。
- `bunx tsc --noEmit` → **EXIT=0**。
- lint gate 3 種（blocking-in-timers / no-sync-exec / gating-coverage）→ **全 pass**。

## 運用者向け post-deploy 確認（任意）

`DISPATCH_ORPHAN_IDLE_MS` を短く設定した検証環境で dispatch セッションを idle 化 → 次 tick で停止し `tmux ls | grep '^claude-'` から消えること、active セッションが残ることを確認可能。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 一定時間動きのない dispatch セッションを自動で回収する監視処理を追加しました。
  * 対象セッションの停止時に、スレッド名の更新・アーカイブ・通知送信を行うようになりました。
* **Bug Fixes**
  * 監視処理の開始・停止を適切に行い、終了時の停止漏れを防止しました。
  * 条件に合うセッションのみを対象にし、重複実行や一部失敗が他の処理へ影響しないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->