### PR TITLE
fix(dispatch): 新規 branch worktree の base を origin/<default> にする (#277)

### DIFF
--- a/supervisor/src/session/worktree.ts
+++ b/supervisor/src/session/worktree.ts
@@ -17,8 +17,10 @@ const execFileAsync = promisify(execFile);
  *
  * Design decisions (issue body):
  *   Q1 existing branch  → `git worktree add <path> <branch>` (checkout)
- *   Q2 unknown branch   → base = repo default branch, `git worktree add -b
- *                          <branch> --no-track <path> <base>`
+ *   Q2 unknown branch   → fetch `origin/<default>`, then base = `origin/<default>`,
+ *                          `git worktree add -b <branch> --no-track <path>
+ *                          origin/<default>` (Issue #277: base on the freshly
+ *                          fetched remote tip, not a stale local default branch)
  *   Q4 existing worktree → reuse as-is (idempotent, multi-session continue)
  *
  * Low-level git/gh calls go through {@link GitGhRunner} so the branching logic
@@ -36,6 +38,13 @@ const execFileAsync = promisify(execFile);
 
 /** Subdirectory (relative to the main repo) that holds per-branch worktrees. */
 export const WORKTREE_SUBDIR = ".claude/worktrees";
+
+/**
+ * Remote a new-branch worktree is fetched from / based on (Issue #277). corp
+ * dispatch satellites are all `origin`-remote clones, matching the issue's
+ * `git worktree add -b <branch> --no-track <path> origin/main` prescription.
+ */
+export const DEFAULT_REMOTE = "origin";
 
 /**
  * Result of inspecting an on-disk path for Q4 reuse (Issue #158).
@@ -59,6 +68,13 @@ export interface GitGhRunner {
   branchExists(mainRepoDir: string, branch: string): Promise<boolean>;
   /** Repo default branch (Q2 base for new branches). Falls back to "main". */
   defaultBranch(mainRepoDir: string): Promise<string>;
+  /**
+   * `git fetch <remote> <branch>` — refresh the remote-tracking ref before a
+   * new-branch worktree is cut from it (Issue #277). Rejects (loudly) on
+   * failure so the Q2 path can warn instead of silently basing a worktree on a
+   * stale `<remote>/<branch>`.
+   */
+  fetchRemoteBranch(mainRepoDir: string, remote: string, branch: string): Promise<void>;
   /** `git worktree add <worktreePath> <branch>` (existing branch, Q1). */
   addWorktreeFromBranch(
     mainRepoDir: string,
@@ -176,8 +192,29 @@ export async function ensureWorktree(
     return { path: worktreePath, reused: false };
   }
 
-  // Q2: unknown branch → create from the repo's default branch.
-  const base = await runner.defaultBranch(mainRepoDir);
+  // Q2: unknown branch → create from the FRESHLY-FETCHED remote default branch
+  // (Issue #277). Previously the base was the *local* default branch, which for
+  // corp dispatch worktrees could lag `origin/main` by many commits (never
+  // fetched before the worktree was cut). A session then ran on a stale base and
+  // could not see merged work. Fetch `origin/<default>` first, then base the new
+  // branch on `origin/<default>` so its HEAD equals the remote tip (behind = 0).
+  const defaultBranch = await runner.defaultBranch(mainRepoDir);
+  try {
+    await runner.fetchRemoteBranch(mainRepoDir, DEFAULT_REMOTE, defaultBranch);
+  } catch (err) {
+    // LOUD, never silent: warn that the base may be stale rather than quietly
+    // cutting a worktree from an un-refreshed remote-tracking ref (Issue #277
+    // AC-2). We still proceed on the best-available `origin/<default>` (a later
+    // `git worktree add` will itself fail loudly if that ref is absent), so a
+    // transient network blip does not hard-block a session start.
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(
+      `[worktree] git fetch ${DEFAULT_REMOTE} ${defaultBranch} failed for ${mainRepoDir}: ${reason}. ` +
+        `New worktree for branch '${trimmed}' may be based on a STALE ${DEFAULT_REMOTE}/${defaultBranch} ` +
+        `— merged work could be invisible to this session.`,
+    );
+  }
+  const base = `${DEFAULT_REMOTE}/${defaultBranch}`;
   await runner.addWorktreeNewBranch(mainRepoDir, worktreePath, trimmed, base);
   return { path: worktreePath, reused: false, baseBranch: base };
 }
@@ -301,6 +338,20 @@ export const realGitGhRunner: GitGhRunner = {
       // No remote / no <remote>/HEAD configured.
     }
     return "main";
+  },
+  async fetchRemoteBranch(mainRepoDir, remote, branch) {
+    // Issue #277: refresh `<remote>/<branch>` before a new-branch worktree is
+    // cut from it. argv array (no shell) so `remote`/`branch` are literal args
+    // and cannot inject metacharacters. A failure rejects with git's message via
+    // the error's `.stderr`; ensureWorktree's Q2 catch turns that into a loud
+    // warning instead of silently continuing on a stale base.
+    await execFileAsync("git", [
+      "-C",
+      mainRepoDir,
+      "fetch",
+      remote,
+      branch,
+    ]);
   },
   async addWorktreeFromBranch(mainRepoDir, worktreePath, branch) {
     // A failure surfaces git's message via the rejected error's `.stderr`.

--- a/supervisor/tests/session/worktree.test.ts
+++ b/supervisor/tests/session/worktree.test.ts
@@ -6,6 +6,7 @@ import {
   recreateWorktreeForExistingBranch,
   resolveWorktreePath,
   WORKTREE_SUBDIR,
+  DEFAULT_REMOTE,
   type GitGhRunner,
   type WorktreeStatus,
 } from "../../src/session/worktree";
@@ -33,6 +34,17 @@ class FakeRunner implements GitGhRunner {
   defaultBranchName = "main";
   calls: string[] = [];
 
+  // Issue #277: model a stale local default branch vs. a fresh remote tip so a
+  // test can assert the new worktree's HEAD equals origin/<default> (behind=0).
+  // `git fetch` advances the remote-tracking ref to `remoteHead`; a base of
+  // `origin/<default>` resolves to `remoteHead`, a base of the bare local
+  // `<default>` resolves to the stale `localHead`.
+  localHead = "STALE_LOCAL_SHA";
+  remoteHead = "FRESH_ORIGIN_SHA";
+  fetchShouldFail = false;
+  // worktree path → the commit SHA its HEAD points at (set by add* methods).
+  heads = new Map<string, string>();
+
   async branchExists(_dir: string, branch: string): Promise<boolean> {
     this.calls.push(`branchExists:${branch}`);
     return this.branches.has(branch);
@@ -40,6 +52,13 @@ class FakeRunner implements GitGhRunner {
   async defaultBranch(_dir: string): Promise<string> {
     this.calls.push(`defaultBranch`);
     return this.defaultBranchName;
+  }
+  async fetchRemoteBranch(_dir: string, remote: string, branch: string): Promise<void> {
+    this.calls.push(`fetch:${remote}:${branch}`);
+    if (this.fetchShouldFail) {
+      throw new Error(`fatal: unable to access '${remote}': network down`);
+    }
+    // A successful fetch means `origin/<branch>` now resolves to the fresh tip.
   }
   async addWorktreeFromBranch(_dir: string, path: string, branch: string): Promise<void> {
     this.calls.push(`addFromBranch:${branch}`);
@@ -56,6 +75,9 @@ class FakeRunner implements GitGhRunner {
     this.calls.push(`addNewBranch:${branch}:${base}`);
     this.existing.add(path);
     this.statuses.set(path, { registered: true, branch });
+    // Resolve the base ref to the SHA the new HEAD would point at: a remote
+    // `origin/<x>` base lands on the fetched tip; a bare local base is stale.
+    this.heads.set(path, base.startsWith(`${DEFAULT_REMOTE}/`) ? this.remoteHead : this.localHead);
   }
   async removeWorktree(_dir: string, path: string): Promise<void> {
     this.calls.push(`remove:${path}`);
@@ -120,14 +142,58 @@ describe("ensureWorktree", () => {
     runner = new FakeRunner();
   });
 
-  test("AC-1: unknown branch → creates worktree from default branch", async () => {
+  test("AC-1: unknown branch → creates worktree from origin/<default> (Issue #277)", async () => {
     runner.defaultBranchName = "main";
     const result = await ensureWorktree(REPO, "feature-foo", runner);
 
     expect(result.reused).toBe(false);
-    expect(result.baseBranch).toBe("main");
+    // Base is the freshly-fetched REMOTE tip, not the bare local default.
+    expect(result.baseBranch).toBe("origin/main");
     expect(result.path).toBe(resolve(REPO, WORKTREE_SUBDIR, "feature-foo"));
-    expect(runner.calls).toContain("addNewBranch:feature-foo:main");
+    expect(runner.calls).toContain("addNewBranch:feature-foo:origin/main");
+  });
+
+  test("#277 AC-1: new-branch worktree HEAD equals origin/main (behind=0), fetched BEFORE add", async () => {
+    // Simulate a stale local main that lags origin/main (the #258 scenario).
+    runner.defaultBranchName = "main";
+    runner.localHead = "STALE_LOCAL_SHA";
+    runner.remoteHead = "FRESH_ORIGIN_SHA";
+
+    const result = await ensureWorktree(REPO, "corp-dispatch-277", runner);
+
+    // The worktree HEAD must land on the fresh origin tip → behind origin/main = 0.
+    expect(runner.heads.get(result.path)).toBe(runner.remoteHead);
+    expect(runner.heads.get(result.path)).not.toBe(runner.localHead);
+    // A fetch of origin/main must have happened, and BEFORE the worktree add
+    // (otherwise the base ref would still be stale).
+    const fetchIdx = runner.calls.indexOf(`fetch:${DEFAULT_REMOTE}:main`);
+    const addIdx = runner.calls.findIndex((c) => c.startsWith("addNewBranch"));
+    expect(fetchIdx).toBeGreaterThanOrEqual(0);
+    expect(addIdx).toBeGreaterThanOrEqual(0);
+    expect(fetchIdx).toBeLessThan(addIdx);
+  });
+
+  test("#277 AC-2: git fetch failure warns LOUDLY and does not silently continue", async () => {
+    runner.defaultBranchName = "main";
+    runner.fetchShouldFail = true;
+
+    const warnings: string[] = [];
+    const origWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args.map((a) => String(a)).join(" "));
+    };
+    let result;
+    try {
+      result = await ensureWorktree(REPO, "corp-dispatch-277", runner);
+    } finally {
+      console.warn = origWarn;
+    }
+
+    // Loud: a warning mentioning the failed fetch + stale-base risk is emitted.
+    expect(warnings.some((w) => /fetch/i.test(w) && /stale/i.test(w))).toBe(true);
+    // Not a hard block: it still creates the worktree on the best-available base.
+    expect(runner.calls).toContain("addNewBranch:corp-dispatch-277:origin/main");
+    expect(result?.baseBranch).toBe("origin/main");
   });
 
   test("Q1: existing branch → checkout into worktree (no new branch)", async () => {
@@ -207,8 +273,10 @@ describe("ensureWorktree", () => {
   test("uses dynamic default branch (Q2: master/develop mixed repos)", async () => {
     runner.defaultBranchName = "develop";
     const result = await ensureWorktree(REPO, "new-feat", runner);
-    expect(result.baseBranch).toBe("develop");
-    expect(runner.calls).toContain("addNewBranch:new-feat:develop");
+    // Base tracks the remote tip of the dynamic default branch (Issue #277).
+    expect(result.baseBranch).toBe("origin/develop");
+    expect(runner.calls).toContain("fetch:origin:develop");
+    expect(runner.calls).toContain("addNewBranch:new-feat:origin/develop");
   });
 
   test("AC-4: empty / whitespace branch throws", async () => {


### PR DESCRIPTION
## 背景

corp dispatch の部署セッション worktree（`<satellite>/.claude/worktrees/corp-dispatch-<N>`）が、衛星リポの **stale な local default branch (`main`)** HEAD から切られていた。local main が origin/main から drift していると全 dispatch が古い base で走り、merge 済み機能が部署セッションから不可視になる。

実測（team_salary）: `corp-dispatch-258` の base は origin/main より **21 コミット遅れ**で、merge 済みの Epic #250（`generate-header.ts`）を含まず、旧コードへ silent fallback してヘッダーが抽象化した。本 PR はその恒久対策②。

Fixes #277

## 変更点

`supervisor/src/session/worktree.ts` の Q2（未知 branch）経路のみを修正:

- worktree 作成前に `git fetch origin <default-branch>` を実行。
- base を local ref ではなく `origin/<default-branch>` にする（`git worktree add -b <branch> --no-track <path> origin/main`）。新 branch の HEAD が remote tip と一致（behind = 0）。
- fetch 失敗時は `console.warn` で **loud に警告**し、silent に stale base で続行しない。transient なネットワーク断で session start を hard-block しないよう、best-available な `origin/<default>` で続行する（`git worktree add` 側が ref 不在なら loud に失敗）。
- `GitGhRunner` に `fetchRemoteBranch` を追加。既存の execFile argv 配列を踏襲（shell 文字列補間なし＝branch 名 injection 不可）。
- **Q1（既存 branch checkout）/ Q4（reuse）/ resume 経路（`recreateWorktreeForExistingBranch`）は不変**。

## テスト（bun test）

`supervisor/tests/session/worktree.test.ts` に回帰追加。`FakeRunner` に stale local head vs 新 origin head の分岐をモデル化。

- **#277 AC-1**: new-branch worktree の HEAD が origin/main（fresh tip）と一致し behind=0、かつ `fetch` が `worktree add` より先に走ることを検証。
- **#277 AC-2**: `git fetch` 失敗時に stale-base risk を含む warning が出て、hard-block せず best-available base で続行することを検証。

```
bun test tests/session/worktree.test.ts  → 24 pass / 0 fail
bunx tsc --noEmit                          → exit 0
```

## 統合ジャーニーAC 充足

1. **local main を origin より遅らせて新規 branch session 起動 → worktree HEAD が origin/main と一致（behind=0）**: Q2 で `git fetch origin <default>` 後に `origin/<default>` を base にするため。ユニットで stale local / fresh origin を分離し HEAD=fresh tip を決定的に検証。
2. **fetch がネットワーク失敗 → stale base で黙って続行せず警告ログを出す**: fetch を try/catch で囲み `console.warn` で loud に警告。ユニットで warning 出力を検証。

## 補足

- claude-hub は自己保守対象。作業は origin/main から切った隔離 worktree で実施（共有チェックアウトは非編集）。
- diff は base-ref 修正 + テストに限定。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 未知のブランチから worktree を作成する際、ローカルではなくリモートの既定ブランチを基準にするようになりました。
  * 作成前にリモートの既定ブランチ情報を更新し、より新しい状態を参照しやすくなりました。

* **バグ修正**
  * リモート更新に失敗しても処理を中断せず、警告を表示して継続するようになりました。
  * 既定ブランチが古い環境でも、より適切なベースから新規作成されるよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->