### PR TITLE
docs: resumeSession の doc コメントを #217 の worktree 再生成実装に合わせて更新

### DIFF
--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -669,8 +669,10 @@ export class SessionManager {
    * `projectDir` MUST be the directory the original session ran in (recorded in
    * sessions.db): `claude --resume` keys the transcript by cwd, so resuming
    * from any other directory — including a `-w` worktree — fails to find the
-   * jsonl. Worktree re-creation is intentionally out of scope; a missing
-   * `projectDir` throws so the caller can report it instead of silently
+   * jsonl. When `projectDir` is missing but a `branch` is recorded, the
+   * worktree is re-created at the same path before launching (Issue #217);
+   * only when recovery is impossible (no branch recorded, or the branch was
+   * deleted) does this throw, so the caller reports it instead of silently
    * starting a fresh conversation.
    */
   async resumeSession(


### PR DESCRIPTION
## 目的

`resumeSession` の doc コメントに、PR #218（Issue #217: resume 時の worktree 再生成）**実装前の記述**「Worktree re-creation is intentionally out of scope; a missing projectDir throws」が残存していた。

この comment rot は実害を出している: 2026-07-04 にこのコメント（と修正前の調査メモ `tmp/issue-resume-worktree.md`）を根拠に、修正済みの構造矛盾が現役バグと誤認され **重複 Issue #281 が起票された**（#281 は #217 の重複として close 済み）。

## 変更点

- `supervisor/src/session/manager.ts` の `resumeSession` doc コメント 1 箇所を現行動作に合わせて更新
  - 現行動作: `projectDir` 不在かつ `branch` 記録あり → 同一パスに worktree を再生成して起動（Issue #217）。branch 未記録 / branch 削除済みで復旧不能な場合のみ throw

## テスト方法

コメントのみの変更で挙動は不変。念のため関連テストを実行:

```
bun test tests/session/manager-resume.test.ts tests/session/worktree.test.ts
→ 39 pass / 0 fail
```

## 関連

- Issue #217 / PR #218（worktree 再生成の実装）
- Issue #281（本 comment rot が誘発した重複起票、close 済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * セッションの再開時に、作業ディレクトリがなくてもブランチ情報があればワークツリーを再作成して再開できることを明記しました。
  * 再作成できない場合のみ処理が中断されることが、より分かりやすくなりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->