### PR TITLE
feat: dispatch の headless executor モード（claude -p 化, Epic #285 Phase 2）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,10 @@ jobs:
                    tests/session/dispatch.test.ts \
                    tests/session/dispatch-run.test.ts \
                    tests/session/dispatch-integration.test.ts \
+                   tests/session/dispatch-headless.test.ts \
+                   tests/session/adapters-executor.test.ts \
+                   tests/session/manager-headless.test.ts \
+                   tests/session/headless-liveness.test.ts \
                    tests/session/latency-logger.test.ts \
                    tests/session/manager-input-ready.test.ts \
                    tests/session/progress-buffer.test.ts \

--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -87,6 +87,45 @@ Channel-Supervisor 経由で起動する Claude Code セッションは、デフ
 
 「lazy load」は Claude Code 公式に仕組みが存在しないため、本実装では「default disable + 必要な channel だけ opt-in」で代替する。設定変更の検証は `bash scripts/list-mcp-load-time.sh --quick` で前後比較できる。
 
+## Headless executor モード (`DISPATCH_EXECUTOR_MODE`, Epic #285 Phase 2)
+
+`/dispatch`（corp からの自動起動）で始まる部署セッションは、既定では tmux 内の対話 TUI（`tmux new-session -d` で `claude` を起動し、`waitForInputReady` で Ink TUI の描画を待って send-keys で初期コマンドを注入）で動く。この経路は RW-019（copy-mode で send-keys が silent drop）や RW-025/RW-047（TUI 表示文字列マッチのタイミング依存）といった手戻りクラスの温床になる。
+
+dispatch は「Issue 番号とコマンドを与えて完走させる」バッチ的ワークロードで対話 TUI である必要がないため、**headless モード**を opt-in で用意している。headless では tmux も Ink TUI も使わず、`claude -p "<初期コマンド>"` を子プロセスとして spawn し、stdout を捕捉して部署スレッドへ投稿する。TUI 依存の故障モードが構造的に消える。
+
+### 有効化（opt-in・逃げ道）
+
+| env | 値 | 挙動 |
+|---|---|---|
+| `DISPATCH_EXECUTOR_MODE` | 未設定（既定） / `tmux` | 現行の tmux 対話 TUI 経路（変更なし） |
+| `DISPATCH_EXECUTOR_MODE` | `headless` | dispatch を `claude -p` の子プロセスで実行し stdout をスレッド返却 |
+| `DISPATCH_HEADLESS_TIMEOUT_MS` | 正の整数（既定 `7200000` = 2h） | headless 子プロセスの wall-clock 上限。超過で SIGTERM → スレッドにタイムアウト明示 |
+
+- 完全に **opt-in**: `headless` 以外の値（未設定・空・大文字 `HEADLESS` 等）はすべて `tmux` にフォールバックする（`resolveExecutorMode`、fail-safe）。
+- 対話セッション（`/session start`、primary channel）は headless 化しない。人間との対話は TUI のまま。
+- Supervisor の plist `EnvironmentVariables` に `DISPATCH_EXECUTOR_MODE=headless` を追加 → `launchctl bootout`+`bootstrap` で反映（他の env 同様、`kickstart -k` では env 再読込されない点に注意）。
+
+### 起動フラグ（TUI 専用フラグの除外）
+
+headless の argv は `buildHeadlessClaudeFlags()`（`supervisor/src/session/manager.ts`）が生成する。tmux 経路の `buildClaudeFlags()` は bash コマンド文字列への埋め込み用に値を pre-quote しているため**再利用せず**、shell を通さない argv 配列として組み立てる（`--mcp-config '{...}'` の literal quote 混入を防ぐ）。TUI 表示名 `--name` は除外。`claude --help`（v2.1.201）で確認したフラグ: `-p`/`--print`、`--output-format text`、`--dangerously-skip-permissions`、`--no-chrome`、`--strict-mcp-config`、`--mcp-config`、`--session-id`。
+
+### ライフサイクル / 誤回収防止
+
+- 子プロセス spawn 時に session を登録（MAX_SESSIONS 枠・`/session list` に反映）、exit で close（DB を `stopped` 化、reason は `headless_exited` / タイムアウトは `headless_timeout`、worktree は best-effort 削除）。
+- headless セッションは自己終了（子プロセス exit が権威的な liveness）で relay 進捗を出さないため、tmux idle 前提の **OrphanDispatchReaper / GoalWatcher は `executor:"headless"` を skip** する（idle 誤回収・done ラベル起因の stop() レースを回避）。wedge した子は上記 `DISPATCH_HEADLESS_TIMEOUT_MS` で回収する。
+
+### 観測ログ
+
+- 起動: `[SessionManager] Started <channel> headless (PID: ..., thread: ..., cmd: /impl <N>)`
+- 終了: `[SessionManager] Headless session for thread <id> closed (reason: headless_exited|headless_timeout, exit: <code>)`
+- bot 側: `[Bot] Headless dispatch completed in channel <ch> (thread=..., exit=..., timedOut=...)`
+- 非ゼロ exit / タイムアウト / exit 0 だが stdout 空 は、いずれも**スレッドに明示投稿**する（サイレント成功にしない）。
+
+### 段階導入（WARN-first dogfood の写像）
+
+1. `DISPATCH_EXECUTOR_MODE=headless` を opt-in で有効化し、agent-base 向け dispatch（no-template / pdca）で数日 dogfood。
+2. 故障モードを観測ログで確認。問題なければ既定を headless に昇格し、tmux は明示指定の逃げ道として残す。
+
 ## Access Policy (claudeHubExit)
 
 claudeHubExit Bot は `~/.claude/channels/discord/access.json` で access 制御される。Issue #47 以降、以下の方針で運用する。

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -51,6 +51,7 @@ import {
   DISPATCH_PREFIX,
   parseDispatchCommand,
   runDispatch,
+  resolveExecutorMode,
 } from "./session/dispatch";
 import { buildThreadTitle } from "./session/thread-title";
 
@@ -524,12 +525,24 @@ export async function startBot(token: string): Promise<void> {
     );
 
     const textChannel = message.channel as TextChannel;
+    // Epic #285 Phase 2: headless is opt-in via DISPATCH_EXECUTOR_MODE=headless.
+    // Default (unset) keeps the current tmux path unchanged.
+    const executorMode = resolveExecutorMode();
     const result = await runDispatch({
       config,
       branch,
       issueNumber,
       command,
       sessionManager,
+      executorMode,
+      // Headless streams its formatted output back through this poster (the tmux
+      // path never calls it — it posts its own welcome below).
+      postToThread: async (tId: string, content: string) => {
+        const thread = await client.channels.fetch(tId);
+        if (thread?.isThread()) {
+          await thread.send(content);
+        }
+      },
       createThread: async (b: string) => {
         // Sequence suffix only when another session is already live on the same
         // branch (mirrors handleStart / RW-046 same-branch multi-session).
@@ -550,7 +563,7 @@ export async function startBot(token: string): Promise<void> {
       },
     });
 
-    if (result.ok) {
+    if (result.ok && result.mode === "tmux") {
       try {
         const thread = await client.channels.fetch(result.threadId);
         if (thread?.isThread()) {
@@ -567,6 +580,13 @@ export async function startBot(token: string): Promise<void> {
           err
         );
       }
+    } else if (result.ok) {
+      // Headless: runDispatch already posted the start notice + formatted output
+      // to the thread. Log the job outcome so a non-zero exit / timeout is
+      // visible in the supervisor log too (the thread carries the detail).
+      console.log(
+        `[Bot] Headless dispatch completed in channel ${channelName} (thread=${result.threadId}, exit=${result.exitCode}, timedOut=${result.timedOut})`
+      );
     } else {
       console.error(
         `[Bot] Dispatch failed (stage=${result.stage}) in channel ${channelName}: ${result.error}`

--- a/supervisor/src/session/adapters-fake.ts
+++ b/supervisor/src/session/adapters-fake.ts
@@ -1,4 +1,7 @@
 import type {
+  ExecutorAdapter,
+  HeadlessRunOptions,
+  HeadlessRunResult,
   ItermAdapter,
   ProcessAdapter,
   RelayServerAdapter,
@@ -187,12 +190,43 @@ export class FakeWorktreeAdapter implements WorktreeAdapter {
   }
 }
 
+export class FakeExecutorAdapter implements ExecutorAdapter {
+  /** Every runHeadless() invocation, so tests can assert argv / cwd / env (AC-1). */
+  runHeadlessCalls: HeadlessRunOptions[] = [];
+  /**
+   * Result returned by runHeadless(). Tests overwrite it to drive the exit-code
+   * / timeout / empty-output branches of the dispatch orchestrator.
+   */
+  result: HeadlessRunResult = {
+    exitCode: 0,
+    stdout: "",
+    stderr: "",
+    timedOut: false,
+  };
+  /** pid handed to onSpawn (incremented per call so concurrent runs differ). */
+  spawnPid = 20_000;
+  /** When set, runHeadless throws to simulate a spawn failure (binary missing). */
+  failOnSpawn = false;
+
+  async runHeadless(opts: HeadlessRunOptions): Promise<HeadlessRunResult> {
+    this.runHeadlessCalls.push(opts);
+    if (this.failOnSpawn) {
+      // Mirror Bun.spawn's synchronous throw when the executable is not found:
+      // the child never started, so onSpawn is NOT called (no session to register).
+      throw new Error("spawn claude ENOENT");
+    }
+    opts.onSpawn?.(this.spawnPid++);
+    return this.result;
+  }
+}
+
 export interface FakeSessionEffects extends SessionEffects {
   tmux: FakeTmuxAdapter;
   iterm2: FakeItermAdapter;
   relayServer: FakeRelayServerAdapter;
   process: FakeProcessAdapter;
   worktree: FakeWorktreeAdapter;
+  executor: FakeExecutorAdapter;
 }
 
 export function createFakeEffects(): FakeSessionEffects {
@@ -202,5 +236,6 @@ export function createFakeEffects(): FakeSessionEffects {
     relayServer: new FakeRelayServerAdapter(),
     process: new FakeProcessAdapter(),
     worktree: new FakeWorktreeAdapter(),
+    executor: new FakeExecutorAdapter(),
   };
 }

--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -1,4 +1,4 @@
-import { execFile } from "child_process";
+import { execFile, spawn } from "child_process";
 import { promisify } from "util";
 import {
   openTab as realOpenTab,
@@ -354,46 +354,84 @@ export const realWorktreeAdapter: WorktreeAdapter = {
 };
 
 export const realExecutorAdapter: ExecutorAdapter = {
-  // Bun.spawn (not child_process) so the pid is available synchronously for
-  // onSpawn and the streams read without a maxBuffer ceiling — the tmux path's
-  // execFile helpers above cannot expose the pid before exit. Runtime is Bun
-  // (see supervisor/CLAUDE.md), so this is the project-native process API.
-  async runHeadless({ claudePath, args, cwd, env, timeoutMs, onSpawn }) {
-    const proc = Bun.spawn([claudePath, ...args], {
-      cwd,
-      // Bun.spawn REPLACES the environment (it does not merge with process.env),
-      // so the caller passes a complete env; keys whose value is undefined are
-      // omitted, which is how ANTHROPIC_API_KEY gets unset (use Claude Max).
-      env,
-      stdout: "pipe",
-      stderr: "pipe",
-      stdin: "ignore",
+  // child_process.spawn (async, so lint-no-sync-exec is satisfied) with
+  // `detached: true` so the child leads its own process GROUP. On timeout we
+  // kill the whole group (`process.kill(-pid)`), not just the direct child:
+  // `claude -p` spawns tool subprocesses (git / gh / bash), and if any survive
+  // they keep the stdout pipe open, so the 'close' event — and this promise —
+  // would hang until they exit (observed as a Linux-CI deadlock with an
+  // orphaned grandchild). Group SIGKILL closes the pipes promptly.
+  runHeadless({ claudePath, args, cwd, env, timeoutMs, onSpawn }) {
+    return new Promise<HeadlessRunResult>((resolve, reject) => {
+      let child;
+      try {
+        child = spawn(claudePath, args, {
+          cwd,
+          // Passed through as-is (keys with undefined value are dropped by Node),
+          // so ANTHROPIC_API_KEY is unset here → use the Claude Max subscription.
+          env,
+          detached: true,
+          stdio: ["ignore", "pipe", "pipe"],
+        });
+      } catch (err) {
+        reject(err);
+        return;
+      }
+
+      const pid = child.pid;
+      if (pid == null) {
+        reject(new Error("failed to spawn headless claude (no pid)"));
+        return;
+      }
+      onSpawn?.(pid);
+
+      let stdout = "";
+      let stderr = "";
+      child.stdout?.setEncoding("utf8");
+      child.stderr?.setEncoding("utf8");
+      child.stdout?.on("data", (d: string) => {
+        stdout += d;
+      });
+      child.stderr?.on("data", (d: string) => {
+        stderr += d;
+      });
+
+      let timedOut = false;
+      let settled = false;
+      const timer = setTimeout(() => {
+        timedOut = true;
+        try {
+          // Negative pid → the whole process group (claude + its tool children).
+          // SIGKILL because a wedged run may ignore SIGTERM.
+          process.kill(-pid, "SIGKILL");
+        } catch {
+          // Group already gone / not a leader — fall back to the direct child.
+          try {
+            child.kill("SIGKILL");
+          } catch {
+            // Nothing more we can do; 'close' will still settle the promise.
+          }
+        }
+      }, timeoutMs);
+
+      child.on("error", (err) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        reject(err);
+      });
+      // 'close' fires once the process exited AND its stdio streams closed. With
+      // the group kill above, grandchildren die too, so this is not delayed.
+      child.on("close", (code) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        // On a timeout kill the numeric code reflects the signal, not a
+        // meaningful "job failed with code N" — report null so the caller
+        // renders it as a timeout rather than a numeric non-zero exit.
+        resolve({ exitCode: timedOut ? null : code, stdout, stderr, timedOut });
+      });
     });
-    onSpawn?.(proc.pid);
-
-    let timedOut = false;
-    const timer = setTimeout(() => {
-      timedOut = true;
-      // SIGTERM the child; its exit resolves `proc.exited` and closes the
-      // streams, so the reads below unblock with whatever was buffered.
-      proc.kill();
-    }, timeoutMs);
-
-    try {
-      // Drain both streams concurrently, then await exit. Reading before
-      // awaiting exit avoids a pipe-buffer deadlock on large output.
-      const [stdout, stderr] = await Promise.all([
-        new Response(proc.stdout).text(),
-        new Response(proc.stderr).text(),
-      ]);
-      const exitCode = await proc.exited;
-      // On a timeout kill the reported exit code reflects the signal, which is
-      // not a meaningful "the job failed with code N" — report null so the
-      // caller renders it as a timeout, not a numeric non-zero exit.
-      return { exitCode: timedOut ? null : exitCode, stdout, stderr, timedOut };
-    } finally {
-      clearTimeout(timer);
-    }
   },
 };
 

--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -102,12 +102,63 @@ export interface WorktreeAdapter {
   recreateForBranch(mainRepoDir: string, branch: string): Promise<boolean>;
 }
 
+/**
+ * Result of one headless `claude -p` run (Epic #285 Phase 2). Captured after the
+ * child exits so the dispatch orchestrator can format stdout for the department
+ * thread. A non-zero `exitCode` is DATA, not an error — the caller surfaces it to
+ * the thread (AC-5, no silent success); {@link ExecutorAdapter.runHeadless} only
+ * throws when the child could not be spawned at all (binary/cwd missing).
+ */
+export interface HeadlessRunResult {
+  /** Child exit code, or `null` when it was killed (e.g. the timeout fired). */
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  /** True when the run was killed because it exceeded {@link HeadlessRunOptions.timeoutMs}. */
+  timedOut: boolean;
+}
+
+export interface HeadlessRunOptions {
+  /** Absolute path to the `claude` binary (resolved by the caller). */
+  claudePath: string;
+  /**
+   * argv passed AFTER the binary — includes `-p <initialCommand>`, the headless
+   * flag set, and `--session-id <uuid>`. Passed as an array (no shell) so the
+   * prompt and JSON `--mcp-config` value cannot be re-parsed by a shell.
+   */
+  args: string[];
+  /** Working directory for the child (the branch worktree, or the channel dir). */
+  cwd: string;
+  /** Full environment for the child (the caller builds it; it is NOT merged). */
+  env: Record<string, string | undefined>;
+  /** Wall-clock ceiling; on expiry the child is killed and `timedOut` is set. */
+  timeoutMs: number;
+  /**
+   * Invoked exactly once with the child pid immediately after spawn (before the
+   * child exits). Lets {@link import("./manager").SessionManager} register the
+   * session for slot accounting / liveness while the long run is still in flight.
+   */
+  onSpawn?: (pid: number) => void;
+}
+
+/**
+ * Headless executor (Epic #285 Phase 2). Runs `claude -p "<command>"` as a child
+ * process and returns its captured output — the structural seam that lets the
+ * dispatch path bypass the tmux Ink TUI (and its {@link waitForInputReady}
+ * string-match timing class, RW-025 / RW-047) for batch dispatch workloads. Unit
+ * tests inject a fake so they never spawn a real `claude`.
+ */
+export interface ExecutorAdapter {
+  runHeadless(opts: HeadlessRunOptions): Promise<HeadlessRunResult>;
+}
+
 export interface SessionEffects {
   tmux: TmuxAdapter;
   iterm2: ItermAdapter;
   relayServer: RelayServerAdapter;
   process: ProcessAdapter;
   worktree: WorktreeAdapter;
+  executor: ExecutorAdapter;
 }
 
 // Issue #222: bound every synchronous tmux call so a wedged tmux server (whose
@@ -302,10 +353,55 @@ export const realWorktreeAdapter: WorktreeAdapter = {
   },
 };
 
+export const realExecutorAdapter: ExecutorAdapter = {
+  // Bun.spawn (not child_process) so the pid is available synchronously for
+  // onSpawn and the streams read without a maxBuffer ceiling — the tmux path's
+  // execFile helpers above cannot expose the pid before exit. Runtime is Bun
+  // (see supervisor/CLAUDE.md), so this is the project-native process API.
+  async runHeadless({ claudePath, args, cwd, env, timeoutMs, onSpawn }) {
+    const proc = Bun.spawn([claudePath, ...args], {
+      cwd,
+      // Bun.spawn REPLACES the environment (it does not merge with process.env),
+      // so the caller passes a complete env; keys whose value is undefined are
+      // omitted, which is how ANTHROPIC_API_KEY gets unset (use Claude Max).
+      env,
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+    onSpawn?.(proc.pid);
+
+    let timedOut = false;
+    const timer = setTimeout(() => {
+      timedOut = true;
+      // SIGTERM the child; its exit resolves `proc.exited` and closes the
+      // streams, so the reads below unblock with whatever was buffered.
+      proc.kill();
+    }, timeoutMs);
+
+    try {
+      // Drain both streams concurrently, then await exit. Reading before
+      // awaiting exit avoids a pipe-buffer deadlock on large output.
+      const [stdout, stderr] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+      ]);
+      const exitCode = await proc.exited;
+      // On a timeout kill the reported exit code reflects the signal, which is
+      // not a meaningful "the job failed with code N" — report null so the
+      // caller renders it as a timeout, not a numeric non-zero exit.
+      return { exitCode: timedOut ? null : exitCode, stdout, stderr, timedOut };
+    } finally {
+      clearTimeout(timer);
+    }
+  },
+};
+
 export const realSessionEffects: SessionEffects = {
   tmux: realTmuxAdapter,
   iterm2: realItermAdapter,
   relayServer: realRelayServerAdapter,
   process: realProcessAdapter,
   worktree: realWorktreeAdapter,
+  executor: realExecutorAdapter,
 };

--- a/supervisor/src/session/dispatch.ts
+++ b/supervisor/src/session/dispatch.ts
@@ -33,9 +33,30 @@
  */
 
 import { resolveWorktreePath } from "./worktree";
+import { formatForDiscord } from "./output-formatter";
 
 /** Literal trigger token. Exposed so external callers (corp) can match it. */
 export const DISPATCH_PREFIX = "/dispatch";
+
+/**
+ * Dispatch executor backend (Epic #285 Phase 2). `"tmux"` is the current
+ * interactive-TUI path (start → waitForInputReady → sendMessage); `"headless"`
+ * runs `claude -p` and returns captured stdout. Opt-in and fail-safe: anything
+ * other than the exact literal `"headless"` resolves to `"tmux"`, so the default
+ * (env unset) is unchanged (AC-4).
+ */
+export type DispatchExecutorMode = "tmux" | "headless";
+
+/**
+ * Resolve the executor mode from the environment (Epic #285 / #287). Read at the
+ * bot boundary and passed explicitly into {@link runDispatch} so the orchestrator
+ * stays pure/testable. Only the exact string `"headless"` enables headless.
+ */
+export function resolveExecutorMode(
+  env: Record<string, string | undefined> = process.env,
+): DispatchExecutorMode {
+  return env.DISPATCH_EXECUTOR_MODE === "headless" ? "headless" : "tmux";
+}
 
 /**
  * Dispatch goal selector — the optional 3rd token of
@@ -169,6 +190,19 @@ export function parseDispatchCommand(content: string): ParsedDispatch {
 }
 
 /**
+ * Captured result of a headless dispatch run (Epic #285 Phase 2). Structurally a
+ * subset of the manager's HeadlessSessionResult, so a SessionManager satisfies
+ * this seam without importing the concrete type.
+ */
+export interface DispatchHeadlessOutcome {
+  /** Child exit code, or null when killed (e.g. timeout). */
+  exitCode: number | null;
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+}
+
+/**
  * Minimal SessionManager surface the dispatch orchestrator needs. Keeping it
  * structural lets tests inject a fake without the real tmux/claude stack.
  */
@@ -188,7 +222,31 @@ export interface DispatchSessionManager {
    */
   waitForInputReady(threadId: string): Promise<boolean>;
   sendMessage(threadId: string, message: string): Promise<unknown>;
+  /**
+   * Headless executor path (Epic #285 Phase 2 / #287). Runs `claude -p
+   * "<initialCommand>"` in the branch worktree to completion and resolves with
+   * the captured output. Optional so a tmux-only fake still satisfies the
+   * interface; {@link runDispatch} verifies it is present before taking the
+   * headless branch (no silent fallback).
+   */
+  runHeadless?(
+    config: unknown,
+    threadId: string,
+    initialCommand: string,
+    branch?: string,
+  ): Promise<DispatchHeadlessOutcome>;
 }
+
+/**
+ * Post a single (already Discord-safe) message to the dispatch thread. Injected
+ * so the headless path can stream its formatted output back without runDispatch
+ * importing discord.js. Each `content` is <= Discord's 2000-char limit (the
+ * caller chunks via {@link formatForDiscord}).
+ */
+export type DispatchThreadPoster = (
+  threadId: string,
+  content: string,
+) => Promise<void>;
 
 /** Creates the Discord thread the session runs in and returns its id. */
 export type DispatchThreadFactory = (
@@ -202,11 +260,39 @@ export interface RunDispatchArgs {
   command: DispatchCommand;
   sessionManager: DispatchSessionManager;
   createThread: DispatchThreadFactory;
+  /**
+   * Executor backend (Epic #285 Phase 2). Defaults to `"tmux"` (current
+   * behaviour). `"headless"` requires `sessionManager.runHeadless` and
+   * {@link postToThread} to be present. Injected explicitly (bot.ts derives it
+   * from `DISPATCH_EXECUTOR_MODE` via {@link resolveExecutorMode}) so the
+   * orchestrator stays pure.
+   */
+  executorMode?: DispatchExecutorMode;
+  /**
+   * Posts the headless run's formatted output back to the dispatch thread.
+   * Required for the headless path; unused by the tmux path (bot.ts posts its
+   * own welcome there).
+   */
+  postToThread?: DispatchThreadPoster;
 }
 
 export type RunDispatchResult =
-  | { ok: true; threadId: string; injected: string }
-  | { ok: false; stage: "thread" | "start" | "inject"; error: string };
+  | {
+      ok: true;
+      /** `"tmux"` (default, unchanged) or `"headless"` (Epic #285 Phase 2). */
+      mode: "tmux" | "headless";
+      threadId: string;
+      injected: string;
+      /** Headless only: child exit code (null when killed / timed out). */
+      exitCode?: number | null;
+      /** Headless only: true when the run hit the executor timeout. */
+      timedOut?: boolean;
+    }
+  | {
+      ok: false;
+      stage: "thread" | "start" | "inject" | "output";
+      error: string;
+    };
 
 /**
  * Orchestrate a validated dispatch: create the thread, start the session in the
@@ -225,6 +311,12 @@ export async function runDispatch(
 ): Promise<RunDispatchResult> {
   const { config, branch, issueNumber, command, sessionManager, createThread } =
     args;
+
+  // Epic #285 Phase 2: opt-in headless path. Default (env unset → "tmux") keeps
+  // the interactive-TUI flow below entirely unchanged (AC-4).
+  if ((args.executorMode ?? "tmux") === "headless") {
+    return runDispatchHeadless(args);
+  }
 
   let threadId: string;
   try {
@@ -268,7 +360,167 @@ export async function runDispatch(
     return { ok: false, stage: "inject", error: errMsg(err) };
   }
 
-  return { ok: true, threadId, injected: initialCommand };
+  return { ok: true, mode: "tmux", threadId, injected: initialCommand };
+}
+
+/**
+ * Headless dispatch orchestration (Epic #285 Phase 2 / #287). Creates the
+ * thread, posts a start notice, runs `claude -p "<initialCommand>"` to
+ * completion, then posts the formatted stdout back to the thread. Every terminal
+ * state posts SOMETHING — non-zero exit, timeout, and empty-but-successful
+ * output are all surfaced explicitly (AC-5 / agent-output-quality #1: no silent
+ * success, no silent fallback).
+ *
+ * `ok` reports whether the DISPATCH was orchestrated (thread made, run executed,
+ * output posted) — a failed *job* (non-zero exit) is still `ok:true` because its
+ * failure was delivered to the thread; `exitCode` / `timedOut` carry the job
+ * outcome for the caller to log. `ok:false` is reserved for orchestration
+ * failures (thread creation, spawn, posting, or missing headless wiring).
+ */
+async function runDispatchHeadless(
+  args: RunDispatchArgs,
+): Promise<RunDispatchResult> {
+  const { config, branch, issueNumber, command, sessionManager, createThread } =
+    args;
+  const postToThread = args.postToThread;
+  const initialCommand = `/${command} ${issueNumber}`;
+
+  // Fail-closed: headless requires both the manager capability and a poster. A
+  // missing wire is a config error, surfaced (not silently downgraded to tmux).
+  if (!sessionManager.runHeadless || !postToThread) {
+    return {
+      ok: false,
+      stage: "start",
+      error:
+        "headless executor is not wired (sessionManager.runHeadless / postToThread missing)",
+    };
+  }
+
+  let threadId: string;
+  try {
+    const thread = await createThread(branch);
+    threadId = thread.id;
+  } catch (err) {
+    return { ok: false, stage: "thread", error: errMsg(err) };
+  }
+
+  // Start notice (best-effort: a failed notice must not abort the actual run).
+  try {
+    await postToThread(
+      threadId,
+      `🤖 headless 実行を開始します: \`${initialCommand}\`（ブランチ \`${branch}\`）`,
+    );
+  } catch (err) {
+    console.warn(
+      `[Dispatch] headless start notice failed for thread ${threadId}: ${errMsg(err)}`,
+    );
+  }
+
+  let outcome: DispatchHeadlessOutcome;
+  try {
+    outcome = await sessionManager.runHeadless(
+      config,
+      threadId,
+      initialCommand,
+      branch,
+    );
+  } catch (err) {
+    // Spawn / worktree failure — surface to the thread AND the caller.
+    const error = errMsg(err);
+    try {
+      await postToThread(
+        threadId,
+        `❌ headless 実行を開始できませんでした: ${error}`,
+      );
+    } catch (postErr) {
+      console.warn(
+        `[Dispatch] failed to post headless start-error for thread ${threadId}: ${errMsg(postErr)}`,
+      );
+    }
+    return { ok: false, stage: "start", error };
+  }
+
+  const posted = await postHeadlessOutcome(
+    threadId,
+    initialCommand,
+    outcome,
+    postToThread,
+  );
+  if (!posted.ok) {
+    return { ok: false, stage: "output", error: posted.error };
+  }
+
+  return {
+    ok: true,
+    mode: "headless",
+    threadId,
+    injected: initialCommand,
+    exitCode: outcome.exitCode,
+    timedOut: outcome.timedOut,
+  };
+}
+
+/** How many trailing chars of stderr to echo on failure (keep the thread lean). */
+const STDERR_TAIL_LEN = 1500;
+
+function stderrTail(stderr: string): string {
+  const trimmed = stderr.trim();
+  return trimmed.length > STDERR_TAIL_LEN
+    ? `…${trimmed.slice(-STDERR_TAIL_LEN)}`
+    : trimmed;
+}
+
+/**
+ * Render a headless outcome into Discord-safe chunks and post them (Epic #285
+ * Phase 2 / #287, AC-2 / AC-5). Distinguishes four terminal states, none of
+ * which is silent:
+ *   - timeout       → ⏱️ notice + any partial stdout + stderr tail
+ *   - non-zero exit → ❌ notice (with exit code) + stdout + stderr tail
+ *   - exit 0, empty → ⚠️ explicit "succeeded but produced no output"
+ *   - exit 0, text  → the formatted stdout
+ * Returns `{ ok:false, error }` only when posting itself throws.
+ */
+async function postHeadlessOutcome(
+  threadId: string,
+  initialCommand: string,
+  outcome: DispatchHeadlessOutcome,
+  postToThread: DispatchThreadPoster,
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const chunks: string[] = [];
+  const stdout = outcome.stdout.trim();
+  const stderr = stderrTail(outcome.stderr);
+
+  if (outcome.timedOut) {
+    chunks.push(
+      `⏱️ headless 実行がタイムアウトしました（\`${initialCommand}\`）。以下は打ち切り時点の出力です:`,
+    );
+    if (stdout) chunks.push(...formatForDiscord(outcome.stdout));
+    else chunks.push("（stdout は空でした）");
+    if (stderr) chunks.push(...formatForDiscord(`stderr:\n${stderr}`));
+  } else if (outcome.exitCode !== 0) {
+    chunks.push(
+      `❌ headless 実行が非ゼロ終了しました（exit ${outcome.exitCode}, \`${initialCommand}\`）:`,
+    );
+    if (stdout) chunks.push(...formatForDiscord(outcome.stdout));
+    if (stderr) chunks.push(...formatForDiscord(`stderr:\n${stderr}`));
+    if (!stdout && !stderr) chunks.push("（stdout / stderr ともに空でした）");
+  } else if (!stdout) {
+    // exit 0 but nothing on stdout — never present this as success (#1).
+    chunks.push(
+      `⚠️ headless 実行は正常終了 (exit 0) しましたが stdout が空でした（\`${initialCommand}\`）。ジョブが本当に完了したかログを確認してください。`,
+    );
+  } else {
+    chunks.push(...formatForDiscord(outcome.stdout));
+  }
+
+  try {
+    for (const chunk of chunks) {
+      await postToThread(threadId, chunk);
+    }
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: errMsg(err) };
+  }
 }
 
 function errMsg(err: unknown): string {

--- a/supervisor/src/session/goal-watcher.ts
+++ b/supervisor/src/session/goal-watcher.ts
@@ -165,6 +165,11 @@ export class GoalWatcher {
       const liveDispatch = new Set<string>();
 
       for (const [threadId, session] of sessions) {
+        // Headless dispatch sessions self-terminate on their child's exit (Epic
+        // #285 Phase 2): SessionManager.finishHeadless owns their teardown, so a
+        // label-driven stop() here would race that and could SIGTERM a run that
+        // is already exiting. Leave them entirely to the headless lifecycle.
+        if (session.executor === "headless") continue;
         const match = session.branch?.match(DISPATCH_BRANCH_RE);
         if (!match) continue; // not a dispatch session (corp / work branch) → AC-6
         liveDispatch.add(threadId);

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -27,6 +27,7 @@ import {
 import {
   realSessionEffects,
   type SessionEffects,
+  type HeadlessRunResult,
 } from "./adapters";
 import {
   createContextBudgetTracker,
@@ -191,6 +192,105 @@ export function buildClaudeFlags(config: ChannelConfig): string[] {
 }
 
 /**
+ * Default wall-clock ceiling for a headless `claude -p` run (Epic #285 Phase 2).
+ * A dispatch job (`/impl`, `/pdca`) can legitimately run for many minutes, so
+ * this is generous; it exists to bound a genuinely wedged child so it cannot
+ * squat a MAX_SESSIONS slot forever (the "誤放置" half of #288). The idle
+ * reapers deliberately do NOT reap headless sessions — a self-terminating child
+ * with its own timeout is the authoritative liveness bound, not tmux idle time —
+ * so this ceiling is that bound. Env-overridable for ops tuning (mirrors
+ * DISPATCH_ORPHAN_IDLE_MS) without a redeploy.
+ */
+export const HEADLESS_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours
+
+function headlessTimeoutMs(): number {
+  const raw = process.env.DISPATCH_HEADLESS_TIMEOUT_MS;
+  if (!raw) return HEADLESS_TIMEOUT_MS;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : HEADLESS_TIMEOUT_MS;
+}
+
+/**
+ * Build the argv for a headless `claude -p` run (Epic #285 Phase 2 / #286).
+ *
+ * This intentionally does NOT reuse {@link buildClaudeFlags}: that helper
+ * pre-quotes its values for embedding in the tmux path's bash *command string*
+ * (e.g. `--name "channel"` and `--mcp-config '{...}'` carry literal quotes so a
+ * shell round-trip parses them correctly). Headless spawns with an argv *array*
+ * and no shell (Bun.spawn), so those literal quotes would become part of the
+ * value — `--mcp-config '{"mcpServers":{}}'` would be an invalid config path.
+ * Here every token is a clean, unquoted argv element.
+ *
+ * Reuses the same config-driven decisions as buildClaudeFlags (chromeEnabled,
+ * mcpProfile) but drops `--name`, whose only effect is the Ink TUI display name
+ * (TUI-only, per #286). Flags verified against `claude --help` (v2.1.201):
+ * `-p`/`--print`, `--output-format`, `--dangerously-skip-permissions`,
+ * `--no-chrome`, `--strict-mcp-config`, `--mcp-config`, `--session-id`.
+ *
+ * `initialCommand` is the first prompt (e.g. `/impl 42`) — a fixed literal built
+ * from the validated selector + issue number, never free user text.
+ */
+export function buildHeadlessClaudeFlags(
+  config: ChannelConfig,
+  initialCommand: string,
+): string[] {
+  const args = [
+    "-p",
+    initialCommand,
+    // text is the default -p format, but pin it explicitly so a future default
+    // change cannot silently turn stdout into JSON the formatter would post raw.
+    "--output-format",
+    "text",
+    "--dangerously-skip-permissions",
+  ];
+
+  if (config.chromeEnabled !== true) {
+    args.push("--no-chrome");
+  }
+
+  const profile = config.mcpProfile ?? "none";
+  if (profile === "none") {
+    // Raw JSON (no surrounding quotes): argv is passed literally, no shell.
+    args.push("--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}');
+  }
+
+  return args;
+}
+
+/**
+ * Environment for a headless child (Epic #285 Phase 2). Bun.spawn REPLACES the
+ * environment, so this returns a COMPLETE env derived from the supervisor's:
+ *   - ANTHROPIC_API_KEY removed → use the Claude Max subscription (mirrors the
+ *     tmux path's `unset ANTHROPIC_API_KEY`),
+ *   - PATH prefixed with the same dirs the tmux path exports, so tools the run
+ *     shells out to (git / gh / bun) resolve regardless of the supervisor's PATH.
+ * SUPERVISOR_RELAY_URL is intentionally NOT set: headless captures stdout
+ * directly, so the PostToolUse progress-relay hook has nothing to POST to.
+ */
+function buildHeadlessEnv(): Record<string, string | undefined> {
+  const env: Record<string, string | undefined> = { ...process.env };
+  delete env.ANTHROPIC_API_KEY;
+  const extraPath = [
+    resolve(homedir(), ".local/bin"),
+    resolve(homedir(), ".bun/bin"),
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+    "/usr/bin",
+    "/bin",
+  ].join(":");
+  env.PATH = env.PATH ? `${extraPath}:${env.PATH}` : extraPath;
+  return env;
+}
+
+/** Outcome of {@link SessionManager.runHeadless}. */
+export interface HeadlessSessionResult extends HeadlessRunResult {
+  /** Supervisor session-row id (for correlating with sessions.db). */
+  sessionId: string;
+  /** The pinned `--session-id` value handed to the child. */
+  claudeSessionId: string;
+}
+
+/**
  * Compute the runtime-dir path that holds the relay URL for a given project
  * cwd. Sanitises by stripping every leading `/` and replacing any character
  * outside `[A-Za-z0-9._-]` with `_`, so each session's URL lives in its own
@@ -310,6 +410,7 @@ export class SessionManager {
         options.effects?.relayServer ?? realSessionEffects.relayServer,
       process: options.effects?.process ?? realSessionEffects.process,
       worktree: options.effects?.worktree ?? realSessionEffects.worktree,
+      executor: options.effects?.executor ?? realSessionEffects.executor,
     };
     this.gracefulKillTimeoutMs =
       options.gracefulKillTimeoutMs ?? GRACEFUL_KILL_TIMEOUT_MS;
@@ -650,6 +751,178 @@ export class SessionManager {
     }, 0);
 
     return info;
+  }
+
+  /**
+   * Start and run a dispatch job headlessly (Epic #285 Phase 2 / #287): spawn
+   * `claude -p "<initialCommand>"` in the branch worktree and resolve with the
+   * captured stdout/stderr/exit once the child exits. Unlike {@link start}, there
+   * is NO tmux session, NO Ink TUI, and NO waitForInputReady/sendMessage — the
+   * whole TUI-timing failure class (RW-025 / RW-047) is structurally absent.
+   *
+   * The session is registered in the live map the instant the child spawns (via
+   * the adapter's onSpawn callback) so slot accounting (MAX_SESSIONS) and the
+   * status endpoints see it during the run, and closed on exit ({@link
+   * finishHeadless}). The reapers deliberately skip `executor:"headless"`
+   * sessions (orphan-dispatch-reaper.ts / goal-watcher.ts) because a headless
+   * session self-terminates — its child process, bounded by the run timeout, is
+   * the authoritative liveness signal, not tmux idle time.
+   *
+   * Guards mirror {@link start} (MAX_SESSIONS, thread/pending collision,
+   * projectDir existence). A spawn failure propagates (no session is registered,
+   * onSpawn never fired) so the caller can surface it (no silent fallback).
+   */
+  async runHeadless(
+    config: ChannelConfig,
+    threadId: string,
+    initialCommand: string,
+    branch?: string,
+  ): Promise<HeadlessSessionResult> {
+    // Same single-flight guards as start(): runHeadless is another async entry
+    // that registers a session, so it must respect the identical MAX_SESSIONS /
+    // dup / pending checks or a race could bypass them (review #185 class).
+    if (this.sessions.size + this.pendingStarts.size >= MAX_SESSIONS) {
+      throw new Error(`最大セッション数 (${MAX_SESSIONS}) に達しています`);
+    }
+    if (this.sessions.has(threadId) || this.pendingStarts.has(threadId)) {
+      throw new Error(`このスレッドのセッションは既に稼働中です`);
+    }
+    if (!existsSync(config.dir)) {
+      throw new Error(
+        `プロジェクトディレクトリが見つかりません: ${config.dir}`,
+      );
+    }
+
+    this.pendingStarts.add(threadId);
+    try {
+      // Resolve the worktree exactly as launchStart does (Issue #154): the
+      // headless child runs in the per-branch worktree, isolated from other
+      // sessions on the same repo. Failures propagate before any spawn.
+      let projectDir = config.dir;
+      let worktree: SessionInfo["worktree"];
+      const trimmedBranch = branch?.trim();
+      if (trimmedBranch) {
+        const result = await this.effects.worktree.ensure(
+          config.dir,
+          trimmedBranch,
+        );
+        projectDir = result.path;
+        worktree = {
+          mainRepoDir: config.dir,
+          path: result.path,
+          branch: trimmedBranch,
+        };
+        console.log(
+          `[SessionManager] ${result.reused ? "Reusing existing worktree" : "Created worktree"} for headless branch '${trimmedBranch}': ${result.path}`,
+        );
+      }
+
+      const sessionId = randomUUID();
+      const claudeSessionId = randomUUID();
+      const args = [
+        ...buildHeadlessClaudeFlags(config, initialCommand),
+        // Pin the session id like launchStart so the DB row captures it
+        // deterministically (Issue #167). randomUUID() is shell-safe, though
+        // there is no shell here.
+        "--session-id",
+        claudeSessionId,
+      ];
+      const now = new Date();
+
+      const result = await this.effects.executor.runHeadless({
+        claudePath: claudePath(),
+        args,
+        cwd: projectDir,
+        env: buildHeadlessEnv(),
+        timeoutMs: headlessTimeoutMs(),
+        onSpawn: (pid) => {
+          // Register the session synchronously the moment the child exists, so
+          // MAX_SESSIONS / count() reflect the in-flight run and the reapers can
+          // observe it. Hand off pendingStarts → sessions (mirrors launchStart).
+          const info: SessionInfo = {
+            id: sessionId,
+            channelName: config.channelName,
+            threadId,
+            projectDir,
+            pid,
+            claudeSessionId,
+            process: null as unknown as any, // the executor owns the child
+            startedAt: now,
+            lastActivityAt: now,
+            status: "running",
+            branch: trimmedBranch || undefined,
+            worktree,
+            executor: "headless",
+          };
+          this.sessions.set(threadId, info);
+          this.pendingStarts.delete(threadId);
+          insertSession({
+            id: sessionId,
+            channel_name: config.channelName,
+            thread_id: threadId,
+            project_dir: projectDir,
+            pid,
+            claude_session_id: claudeSessionId,
+            started_at: now.toISOString(),
+            last_activity_at: now.toISOString(),
+            status: "running",
+            branch: trimmedBranch ?? null,
+          });
+          console.log(
+            `[SessionManager] Started ${config.channelName} headless (PID: ${pid}, thread: ${threadId}, cmd: ${initialCommand})`,
+          );
+        },
+      });
+
+      // Child exited → close the session (frees the slot). Even if onSpawn never
+      // fired (should not happen unless the adapter misbehaves), finishHeadless
+      // is a no-op safe cleanup.
+      await this.finishHeadless(threadId, sessionId, result, worktree);
+
+      return { ...result, sessionId, claudeSessionId };
+    } finally {
+      // Error-path safety net: if the spawn threw before onSpawn, drop the
+      // pending marker so the slot is not leaked (delete is idempotent).
+      this.pendingStarts.delete(threadId);
+    }
+  }
+
+  /**
+   * Close a finished headless session (Epic #285 Phase 2 / #288). Symmetric with
+   * the tmux exit path ({@link watchTmuxSession}'s tmux_exited branch): drop the
+   * live map entry, record the terminal reason, and best-effort remove the
+   * worktree — a headless dispatch has pushed its work to the branch (its result
+   * is a PR), so the completed run's worktree is reclaimed here, matching how a
+   * tmux dispatch's worktree is removed when GoalWatcher/OrphanReaper stop()s it.
+   * The DB reason distinguishes a timeout so operators can audit wedged runs; the
+   * success/failure detail itself is surfaced to the thread by the caller (AC-5).
+   */
+  private async finishHeadless(
+    threadId: string,
+    sessionId: string,
+    result: HeadlessRunResult,
+    worktree: SessionInfo["worktree"],
+  ): Promise<void> {
+    this.sessions.delete(threadId);
+    this.clearWatcher(threadId); // defensive: headless never sets one
+    const reason: StopReason = result.timedOut
+      ? "headless_timeout"
+      : "headless_exited";
+    updateSessionStatus(sessionId, "stopped", reason);
+    // No relay-url file to clean: buildHeadlessEnv() does not set
+    // SUPERVISOR_RELAY_URL and the headless child never writes one (stdout is
+    // captured directly), so there is nothing the progress-relay hook could
+    // have dropped for this cwd.
+    if (worktree && !this.isWorktreePathInUse(worktree.path)) {
+      await this.removeWorktreeBestEffort(worktree);
+    } else if (worktree) {
+      console.log(
+        `[SessionManager] Headless worktree ${worktree.path} still in use by another session; not removing`,
+      );
+    }
+    console.log(
+      `[SessionManager] Headless session for thread ${threadId} closed (reason: ${reason}, exit: ${result.exitCode})`,
+    );
   }
 
   /**

--- a/supervisor/src/session/orphan-dispatch-reaper.ts
+++ b/supervisor/src/session/orphan-dispatch-reaper.ts
@@ -58,6 +58,15 @@ export interface ReapableSession {
   branch?: string;
   status: SessionInfo["status"];
   lastActivityAt: Date;
+  /**
+   * Executor backend (Epic #285 Phase 2). A `"headless"` dispatch session is
+   * NEVER orphan-reaped: it has no external parent to be orphaned by (its
+   * `claude -p` child self-terminates and is bounded by the run timeout), and it
+   * has no relay progress to refresh `lastActivityAt`, so an idle-based reap
+   * would wrongly fire mid-run. Its liveness is the child process, not tmux idle
+   * time. Undefined is treated as `"tmux"` (the pre-#285 behaviour).
+   */
+  executor?: SessionInfo["executor"];
 }
 
 /** One orphaned dispatch session selected for reaping. */
@@ -86,6 +95,10 @@ export function selectReapableDispatch(
   const out: OrphanReapCandidate[] = [];
   for (const [threadId, session] of entries) {
     if (session.status !== "running") continue;
+    // Headless dispatch sessions self-terminate (Epic #285 Phase 2): their child
+    // process is the authoritative liveness bound, and they have no relay to keep
+    // lastActivityAt fresh, so idle-based reaping would kill a working run. Skip.
+    if (session.executor === "headless") continue;
     if (!session.branch || !DISPATCH_BRANCH_RE.test(session.branch)) continue;
     const idleMs = opts.now - session.lastActivityAt.getTime();
     if (Number.isFinite(idleMs) && idleMs >= opts.idleThresholdMs) {

--- a/supervisor/src/session/types.ts
+++ b/supervisor/src/session/types.ts
@@ -34,6 +34,16 @@ export interface SessionInfo {
    * high-context session is warned only when it crosses up into a new band.
    */
   contextBudgetTracker?: ContextBudgetTracker;
+  /**
+   * Which executor backs this session (Epic #285 Phase 2). `"tmux"` (the
+   * default, and the value for every pre-#285 code path) is the interactive Ink
+   * TUI launched via `tmux new-session`; `"headless"` is a `claude -p` child
+   * process whose lifecycle is bounded by {@link SessionManager.runHeadless} —
+   * it has no tmux session and no Ink TUI. Consumers that reason about tmux
+   * liveness (the reapers / goal-watcher) branch on this so they never apply a
+   * tmux-shaped check to a headless session. Undefined is treated as `"tmux"`.
+   */
+  executor?: "tmux" | "headless";
 }
 
 /**
@@ -55,4 +65,4 @@ export interface SessionHealthInfo {
   lastActivityAt: string;
 }
 
-export type StopReason = "manual" | "idle_timeout" | "resource_limit" | "error" | "tmux_exited" | "supervisor_restart" | "self_heal_restart" | "goal_complete" | "orphan_reaped";
+export type StopReason = "manual" | "idle_timeout" | "resource_limit" | "error" | "tmux_exited" | "supervisor_restart" | "self_heal_restart" | "goal_complete" | "orphan_reaped" | "headless_exited" | "headless_timeout";

--- a/supervisor/tests/session/adapters-executor.test.ts
+++ b/supervisor/tests/session/adapters-executor.test.ts
@@ -1,0 +1,126 @@
+import { test, expect, describe, afterAll } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { realExecutorAdapter } from "../../src/session/adapters";
+import { FakeExecutorAdapter } from "../../src/session/adapters-fake";
+
+/**
+ * Epic #285 Phase 2 / #286: the headless executor adapter. The fake is asserted
+ * for argv/cwd/onSpawn (the seam unit tests rely on), and the REAL Bun.spawn
+ * adapter is exercised against tiny stub scripts so stdout capture, non-zero
+ * exit, and the timeout kill are covered end-to-end without a real `claude`.
+ */
+
+const workdir = mkdtempSync(join(tmpdir(), "headless-exec-"));
+afterAll(() => rmSync(workdir, { recursive: true, force: true }));
+
+/** Write an executable stub script and return its absolute path. */
+function stub(name: string, body: string): string {
+  const p = join(workdir, name);
+  writeFileSync(p, `#!/bin/sh\n${body}\n`);
+  chmodSync(p, 0o755);
+  return p;
+}
+
+describe("FakeExecutorAdapter", () => {
+  test("records argv/cwd/env and fires onSpawn with a pid", async () => {
+    const fake = new FakeExecutorAdapter();
+    fake.result = { exitCode: 0, stdout: "hi", stderr: "", timedOut: false };
+    const pids: number[] = [];
+
+    const r = await fake.runHeadless({
+      claudePath: "/x/claude",
+      args: ["-p", "/impl 7", "--session-id", "abc"],
+      cwd: "/work/tree",
+      env: { PATH: "/bin" },
+      timeoutMs: 1000,
+      onSpawn: (pid) => pids.push(pid),
+    });
+
+    expect(r.stdout).toBe("hi");
+    expect(fake.runHeadlessCalls).toHaveLength(1);
+    expect(fake.runHeadlessCalls[0]!.args).toEqual([
+      "-p",
+      "/impl 7",
+      "--session-id",
+      "abc",
+    ]);
+    expect(fake.runHeadlessCalls[0]!.cwd).toBe("/work/tree");
+    expect(pids).toHaveLength(1);
+    expect(pids[0]).toBeGreaterThan(0);
+  });
+
+  test("failOnSpawn throws and never fires onSpawn (no session to register)", async () => {
+    const fake = new FakeExecutorAdapter();
+    fake.failOnSpawn = true;
+    let spawned = false;
+    await expect(
+      fake.runHeadless({
+        claudePath: "/x/claude",
+        args: [],
+        cwd: "/tmp",
+        env: {},
+        timeoutMs: 100,
+        onSpawn: () => {
+          spawned = true;
+        },
+      }),
+    ).rejects.toThrow(/ENOENT/);
+    expect(spawned).toBe(false);
+  });
+});
+
+describe("realExecutorAdapter (Bun.spawn)", () => {
+  test("captures stdout and exit 0, fires onSpawn with the real pid", async () => {
+    const bin = stub("echo0.sh", 'printf "%s" "$1"\nexit 0');
+    let pid = 0;
+    const r = await realExecutorAdapter.runHeadless({
+      claudePath: bin,
+      args: ["hello-stdout"],
+      cwd: workdir,
+      env: { ...process.env },
+      timeoutMs: 5000,
+      onSpawn: (p) => {
+        pid = p;
+      },
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.timedOut).toBe(false);
+    expect(r.stdout).toBe("hello-stdout");
+    expect(pid).toBeGreaterThan(0);
+  });
+
+  test("surfaces a non-zero exit code as data (not a throw)", async () => {
+    const bin = stub("exit3.sh", 'echo out\necho err 1>&2\nexit 3');
+    const r = await realExecutorAdapter.runHeadless({
+      claudePath: bin,
+      args: [],
+      cwd: workdir,
+      env: { ...process.env },
+      timeoutMs: 5000,
+    });
+    expect(r.exitCode).toBe(3);
+    expect(r.timedOut).toBe(false);
+    expect(r.stdout.trim()).toBe("out");
+    expect(r.stderr.trim()).toBe("err");
+  });
+
+  test("kills the child and reports timedOut when it overruns", async () => {
+    const bin = stub("sleep.sh", 'sleep 10\necho done');
+    const started = Date.now();
+    const r = await realExecutorAdapter.runHeadless({
+      claudePath: bin,
+      args: [],
+      cwd: workdir,
+      env: { ...process.env },
+      timeoutMs: 150,
+    });
+    // Must return promptly (killed), long before the 10s sleep would finish.
+    expect(Date.now() - started).toBeLessThan(5000);
+    expect(r.timedOut).toBe(true);
+    // On a timeout kill the numeric exit code is not meaningful → null.
+    expect(r.exitCode).toBeNull();
+    expect(r.stdout).not.toContain("done");
+  });
+});

--- a/supervisor/tests/session/dispatch-headless.test.ts
+++ b/supervisor/tests/session/dispatch-headless.test.ts
@@ -1,0 +1,291 @@
+import { describe, test, expect } from "bun:test";
+import {
+  runDispatch,
+  resolveExecutorMode,
+  type DispatchSessionManager,
+  type DispatchHeadlessOutcome,
+} from "../../src/session/dispatch";
+
+/**
+ * Epic #285 Phase 2 / #287: the headless opt-in branch of runDispatch. Verifies
+ * the env gate (resolveExecutorMode), that stdout is formatted and posted to the
+ * thread (AC-2), that a non-zero exit / timeout / empty output are each surfaced
+ * explicitly (AC-5, no silent success), and that a missing wire fails closed.
+ */
+
+const config = { channelName: "agent-base", dir: "/x/agent-base" };
+
+/** A headless-capable fake manager + captured posts. */
+function harness(
+  outcome: DispatchHeadlessOutcome | (() => Promise<DispatchHeadlessOutcome>),
+) {
+  const runHeadlessCalls: Array<{
+    threadId: string;
+    initialCommand: string;
+    branch?: string;
+  }> = [];
+  const posts: Array<{ threadId: string; content: string }> = [];
+  const manager: DispatchSessionManager = {
+    start: async () => ({}),
+    waitForInputReady: async () => true,
+    sendMessage: async () => ({}),
+    runHeadless: async (_c, threadId, initialCommand, branch) => {
+      runHeadlessCalls.push({ threadId, initialCommand, branch });
+      return typeof outcome === "function" ? outcome() : outcome;
+    },
+  };
+  return { manager, runHeadlessCalls, posts };
+}
+
+describe("resolveExecutorMode", () => {
+  test("defaults to tmux; only the exact 'headless' string opts in", () => {
+    expect(resolveExecutorMode({})).toBe("tmux");
+    expect(resolveExecutorMode({ DISPATCH_EXECUTOR_MODE: "headless" })).toBe(
+      "headless",
+    );
+    expect(resolveExecutorMode({ DISPATCH_EXECUTOR_MODE: "tmux" })).toBe("tmux");
+    expect(resolveExecutorMode({ DISPATCH_EXECUTOR_MODE: "HEADLESS" })).toBe(
+      "tmux",
+    );
+    expect(resolveExecutorMode({ DISPATCH_EXECUTOR_MODE: "" })).toBe("tmux");
+  });
+});
+
+describe("runDispatch headless", () => {
+  test("posts start notice + formatted stdout, returns mode=headless (AC-2)", async () => {
+    const { manager, runHeadlessCalls, posts } = harness({
+      exitCode: 0,
+      stdout: "PR: https://github.com/x/y/pull/1",
+      stderr: "",
+      timedOut: false,
+    });
+    const r = await runDispatch({
+      config,
+      branch: "corp-dispatch-42",
+      issueNumber: 42,
+      command: "impl",
+      sessionManager: manager,
+      executorMode: "headless",
+      createThread: async () => ({ id: "thread-h" }),
+      postToThread: async (threadId, content) => {
+        posts.push({ threadId, content });
+      },
+    });
+
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.mode).toBe("headless");
+      expect(r.threadId).toBe("thread-h");
+      expect(r.injected).toBe("/impl 42");
+      expect(r.exitCode).toBe(0);
+      expect(r.timedOut).toBe(false);
+    }
+    expect(runHeadlessCalls).toEqual([
+      { threadId: "thread-h", initialCommand: "/impl 42", branch: "corp-dispatch-42" },
+    ]);
+    // A start notice, then the stdout, both to the created thread.
+    expect(posts.length).toBeGreaterThanOrEqual(2);
+    expect(posts[0]!.content).toContain("/impl 42");
+    expect(posts.some((p) => p.content.includes("pull/1"))).toBe(true);
+    expect(posts.every((p) => p.threadId === "thread-h")).toBe(true);
+  });
+
+  test("non-zero exit is surfaced as an error with exit code + stderr (AC-5)", async () => {
+    const { manager, posts } = harness({
+      exitCode: 2,
+      stdout: "partial log",
+      stderr: "fatal: boom",
+      timedOut: false,
+    });
+    const r = await runDispatch({
+      config,
+      branch: "corp-dispatch-9",
+      issueNumber: 9,
+      command: "pdca",
+      sessionManager: manager,
+      executorMode: "headless",
+      createThread: async () => ({ id: "t9" }),
+      postToThread: async (threadId, content) => {
+        posts.push({ threadId, content });
+      },
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.exitCode).toBe(2);
+    const joined = posts.map((p) => p.content).join("\n");
+    expect(joined).toContain("非ゼロ終了");
+    expect(joined).toContain("exit 2");
+    expect(joined).toContain("boom");
+  });
+
+  test("timeout is surfaced explicitly", async () => {
+    const { manager, posts } = harness({
+      exitCode: null,
+      stdout: "",
+      stderr: "",
+      timedOut: true,
+    });
+    await runDispatch({
+      config,
+      branch: "corp-dispatch-3",
+      issueNumber: 3,
+      command: "impl",
+      sessionManager: manager,
+      executorMode: "headless",
+      createThread: async () => ({ id: "t3" }),
+      postToThread: async (threadId, content) => {
+        posts.push({ threadId, content });
+      },
+    });
+    expect(posts.map((p) => p.content).join("\n")).toContain("タイムアウト");
+  });
+
+  test("exit 0 with empty stdout is flagged, never presented as silent success", async () => {
+    const { manager, posts } = harness({
+      exitCode: 0,
+      stdout: "   \n",
+      stderr: "",
+      timedOut: false,
+    });
+    await runDispatch({
+      config,
+      branch: "corp-dispatch-5",
+      issueNumber: 5,
+      command: "impl",
+      sessionManager: manager,
+      executorMode: "headless",
+      createThread: async () => ({ id: "t5" }),
+      postToThread: async (threadId, content) => {
+        posts.push({ threadId, content });
+      },
+    });
+    expect(posts.map((p) => p.content).join("\n")).toContain("stdout が空");
+  });
+
+  test("fails closed when the manager cannot run headless (no silent tmux fallback)", async () => {
+    // A tmux-only manager (no runHeadless).
+    const tmuxOnly: DispatchSessionManager = {
+      start: async () => ({}),
+      waitForInputReady: async () => true,
+      sendMessage: async () => ({}),
+    };
+    const r = await runDispatch({
+      config,
+      branch: "b",
+      issueNumber: 1,
+      command: "impl",
+      sessionManager: tmuxOnly,
+      executorMode: "headless",
+      createThread: async () => ({ id: "t" }),
+      postToThread: async () => {},
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.stage).toBe("start");
+      expect(r.error).toContain("not wired");
+    }
+  });
+
+  test("spawn failure surfaces to the thread and the caller (stage=start)", async () => {
+    const posts: string[] = [];
+    const manager: DispatchSessionManager = {
+      start: async () => ({}),
+      waitForInputReady: async () => true,
+      sendMessage: async () => ({}),
+      runHeadless: async () => {
+        throw new Error("spawn claude ENOENT");
+      },
+    };
+    const r = await runDispatch({
+      config,
+      branch: "b",
+      issueNumber: 1,
+      command: "impl",
+      sessionManager: manager,
+      executorMode: "headless",
+      createThread: async () => ({ id: "t" }),
+      postToThread: async (_id, c) => {
+        posts.push(c);
+      },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.stage).toBe("start");
+    expect(posts.join("\n")).toContain("開始できませんでした");
+  });
+
+  test("output posting failure is reported as stage=output", async () => {
+    const { manager } = harness({
+      exitCode: 0,
+      stdout: "some output",
+      stderr: "",
+      timedOut: false,
+    });
+    let calls = 0;
+    const r = await runDispatch({
+      config,
+      branch: "b",
+      issueNumber: 1,
+      command: "impl",
+      sessionManager: manager,
+      executorMode: "headless",
+      createThread: async () => ({ id: "t" }),
+      postToThread: async () => {
+        // Let the start notice through, fail on the output chunk.
+        calls += 1;
+        if (calls >= 2) throw new Error("discord 500");
+      },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.stage).toBe("output");
+  });
+
+  test("thread creation failure short-circuits before running headless", async () => {
+    const { manager, runHeadlessCalls } = harness({
+      exitCode: 0,
+      stdout: "x",
+      stderr: "",
+      timedOut: false,
+    });
+    const r = await runDispatch({
+      config,
+      branch: "b",
+      issueNumber: 1,
+      command: "impl",
+      sessionManager: manager,
+      executorMode: "headless",
+      createThread: async () => {
+        throw new Error("missing perms");
+      },
+      postToThread: async () => {},
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.stage).toBe("thread");
+    expect(runHeadlessCalls).toHaveLength(0);
+  });
+
+  test("default (no executorMode) still uses the tmux path (AC-4)", async () => {
+    const sent: string[] = [];
+    const manager: DispatchSessionManager = {
+      start: async () => ({}),
+      waitForInputReady: async () => true,
+      sendMessage: async (_t, m) => {
+        sent.push(m);
+        return {};
+      },
+      // runHeadless present but must NOT be used when mode is unset/tmux.
+      runHeadless: async () => {
+        throw new Error("headless must not run in tmux mode");
+      },
+    };
+    const r = await runDispatch({
+      config,
+      branch: "corp-dispatch-1",
+      issueNumber: 1,
+      command: "impl",
+      sessionManager: manager,
+      createThread: async () => ({ id: "t" }),
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.mode).toBe("tmux");
+    expect(sent).toEqual(["/impl 1"]);
+  });
+});

--- a/supervisor/tests/session/headless-liveness.test.ts
+++ b/supervisor/tests/session/headless-liveness.test.ts
@@ -1,0 +1,113 @@
+import { describe, test, expect } from "bun:test";
+import {
+  selectReapableDispatch,
+  type ReapableSession,
+} from "../../src/session/orphan-dispatch-reaper";
+import { GoalWatcher } from "../../src/session/goal-watcher";
+import type { SessionInfo, StopReason } from "../../src/session/types";
+import type { SessionManager } from "../../src/session/manager";
+import type { Client } from "discord.js";
+
+/**
+ * Epic #285 Phase 2 / #288: the tmux-shaped liveness machinery must not touch a
+ * headless dispatch session. A headless session self-terminates on its child's
+ * exit (SessionManager.finishHeadless owns teardown) and has no relay to refresh
+ * lastActivityAt, so idle-based orphan reaping and label-driven goal stopping
+ * would both fire wrongly. Both must skip `executor:"headless"`.
+ */
+
+const HOUR = 60 * 60 * 1000;
+
+describe("selectReapableDispatch (orphan reaper) skips headless", () => {
+  const now = 1_000 * HOUR;
+  const idleThresholdMs = 48 * HOUR;
+  const stale = new Date(now - 60 * HOUR); // well past the horizon
+
+  test("a headless dispatch session is never orphan-reaped, even when long-idle", () => {
+    const entries = new Map<string, ReapableSession>([
+      [
+        "tmux-42",
+        { branch: "corp-dispatch-42", status: "running", lastActivityAt: stale },
+      ],
+      [
+        "headless-99",
+        {
+          branch: "corp-dispatch-99",
+          status: "running",
+          lastActivityAt: stale,
+          executor: "headless",
+        },
+      ],
+    ]);
+    const picked = selectReapableDispatch(entries, { idleThresholdMs, now });
+    const ids = picked.map((p) => p.threadId);
+    // The tmux orphan is reaped; the headless one is spared.
+    expect(ids).toContain("tmux-42");
+    expect(ids).not.toContain("headless-99");
+  });
+});
+
+function makeSession(over: Partial<SessionInfo> & { threadId: string }): SessionInfo {
+  const now = new Date();
+  return {
+    id: over.threadId,
+    channelName: "convert-service",
+    projectDir: "/repo/.claude/worktrees/corp-dispatch-1",
+    pid: 1,
+    process: null as unknown as SessionInfo["process"],
+    startedAt: now,
+    lastActivityAt: now,
+    status: "running",
+    ...over,
+  } as SessionInfo;
+}
+
+function makeManager(sessions: Map<string, SessionInfo>): {
+  manager: SessionManager;
+  stopCalls: Array<{ threadId: string; reason: StopReason }>;
+} {
+  const stopCalls: Array<{ threadId: string; reason: StopReason }> = [];
+  const manager = {
+    entries: () => sessions.entries(),
+    stop: async (threadId: string, reason: StopReason) => {
+      stopCalls.push({ threadId, reason });
+      sessions.delete(threadId);
+    },
+  } as unknown as SessionManager;
+  return { manager, stopCalls };
+}
+
+describe("GoalWatcher skips headless dispatch sessions", () => {
+  test("a done-labelled tmux session stops, a done-labelled headless one does not", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["tmux-1", makeSession({ threadId: "tmux-1", branch: "corp-dispatch-1" })],
+      [
+        "headless-1",
+        makeSession({
+          threadId: "headless-1",
+          branch: "corp-dispatch-2",
+          executor: "headless",
+        }),
+      ],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const client = {
+      channels: { cache: { get: () => undefined }, fetch: async () => undefined },
+    } as unknown as Client;
+
+    const watcher = new GoalWatcher(manager, client, {
+      // Both issues carry `done`; grace 0 so a non-skipped session stops on the
+      // second tick (first opens the window, second elapses it).
+      fetchIssueLabels: async () => ["done"],
+      graceMs: 0,
+      now: () => Date.now(),
+    });
+
+    await watcher.check();
+    await watcher.check();
+
+    const stopped = stopCalls.map((c) => c.threadId);
+    expect(stopped).toContain("tmux-1");
+    expect(stopped).not.toContain("headless-1");
+  });
+});

--- a/supervisor/tests/session/manager-headless.test.ts
+++ b/supervisor/tests/session/manager-headless.test.ts
@@ -1,0 +1,164 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { resolve } from "path";
+import { SessionManager } from "../../src/session/manager";
+import {
+  createFakeEffects,
+  FakeExecutorAdapter,
+  type FakeSessionEffects,
+} from "../../src/session/adapters-fake";
+import type {
+  ExecutorAdapter,
+  HeadlessRunOptions,
+  HeadlessRunResult,
+} from "../../src/session/adapters";
+import { resolveWorktreePath } from "../../src/session/worktree";
+import { getSessionByClaudeSessionId } from "../../src/infra/db";
+import type { ChannelConfig } from "../../src/config/channels";
+
+/**
+ * Epic #285 Phase 2 / #286 + #288: SessionManager.runHeadless. Uses the DI fakes
+ * so no real `claude` is spawned. Asserts:
+ *   - the headless argv/cwd handed to the executor (AC-1),
+ *   - the session is registered while the child runs and freed on exit (AC-3),
+ *   - the DB terminal reason distinguishes a timeout,
+ *   - the start guards (dup) and spawn-failure surfacing hold.
+ */
+
+function makeChannelConfig(overrides: Partial<ChannelConfig> = {}): ChannelConfig {
+  const dir = resolve(tmpdir(), `headless-mgr-${process.pid}`);
+  mkdirSync(dir, { recursive: true });
+  return {
+    channelName: "test-channel",
+    dir,
+    displayName: "Test Channel",
+    ...overrides,
+  };
+}
+
+describe("SessionManager.runHeadless", () => {
+  let manager: SessionManager;
+  let effects: FakeSessionEffects;
+  let config: ChannelConfig;
+
+  beforeEach(() => {
+    effects = createFakeEffects();
+    manager = new SessionManager({ effects, gracefulKillTimeoutMs: 0 });
+    config = makeChannelConfig({ channelName: "chan-hl" });
+  });
+
+  afterEach(async () => {
+    await manager.shutdownAll();
+  });
+
+  test("spawns claude -p with the headless flags in the worktree cwd (AC-1)", async () => {
+    const res = await manager.runHeadless(
+      config,
+      "thread-hl-1",
+      "/impl 42",
+      "corp-dispatch-42",
+    );
+
+    expect(effects.executor.runHeadlessCalls).toHaveLength(1);
+    const call = effects.executor.runHeadlessCalls[0]!;
+    // -p <command> first, session id pinned, TUI-only --name excluded.
+    expect(call.args.slice(0, 2)).toEqual(["-p", "/impl 42"]);
+    expect(call.args).toContain("--dangerously-skip-permissions");
+    expect(call.args).toContain("--strict-mcp-config");
+    expect(call.args).toContain('{"mcpServers":{}}');
+    expect(call.args).toContain("--output-format");
+    expect(call.args).not.toContain("--name");
+    // --session-id is pinned to the returned claudeSessionId.
+    const idIdx = call.args.indexOf("--session-id");
+    expect(idIdx).toBeGreaterThanOrEqual(0);
+    expect(call.args[idIdx + 1]).toBe(res.claudeSessionId);
+    // cwd is the per-branch worktree, not the channel dir.
+    expect(call.cwd).toBe(resolveWorktreePath(config.dir, "corp-dispatch-42"));
+    // env carries no ANTHROPIC_API_KEY (Claude Max) and a PATH.
+    expect(call.env.ANTHROPIC_API_KEY).toBeUndefined();
+    expect(call.env.PATH).toBeTruthy();
+  });
+
+  test("registers the session while the child runs and frees the slot on exit (AC-3)", async () => {
+    // A deferred executor lets us observe the in-flight registration.
+    class DeferredExecutor implements ExecutorAdapter {
+      calls: HeadlessRunOptions[] = [];
+      private resolveResult!: (r: HeadlessRunResult) => void;
+      private markSpawned!: () => void;
+      whenSpawned = new Promise<void>((res) => {
+        this.markSpawned = res;
+      });
+      async runHeadless(opts: HeadlessRunOptions): Promise<HeadlessRunResult> {
+        this.calls.push(opts);
+        opts.onSpawn?.(4242);
+        this.markSpawned();
+        return new Promise<HeadlessRunResult>((res) => {
+          this.resolveResult = res;
+        });
+      }
+      finish(r: HeadlessRunResult): void {
+        this.resolveResult(r);
+      }
+    }
+    const exec = new DeferredExecutor();
+    const mgr = new SessionManager({
+      effects: { ...createFakeEffects(), executor: exec },
+      gracefulKillTimeoutMs: 0,
+    });
+
+    const p = mgr.runHeadless(config, "thread-run", "/impl 1", "corp-dispatch-1");
+    await exec.whenSpawned;
+    // Registered during the run: slot is occupied, marked headless.
+    expect(mgr.count()).toBe(1);
+    expect(mgr.has("thread-run")).toBe(true);
+    expect(mgr.get("thread-run")?.executor).toBe("headless");
+
+    exec.finish({ exitCode: 0, stdout: "PR ready", stderr: "", timedOut: false });
+    const res = await p;
+
+    // Freed on exit; DB row closed with the non-timeout reason.
+    expect(mgr.count()).toBe(0);
+    expect(mgr.has("thread-run")).toBe(false);
+    const row = getSessionByClaudeSessionId(res.claudeSessionId);
+    expect(row?.status).toBe("stopped");
+    expect(row?.stopped_reason).toBe("headless_exited");
+    await mgr.shutdownAll();
+  });
+
+  test("records headless_timeout when the run times out", async () => {
+    effects.executor.result = {
+      exitCode: null,
+      stdout: "partial",
+      stderr: "",
+      timedOut: true,
+    };
+    const res = await manager.runHeadless(config, "thread-to", "/pdca 9", "corp-dispatch-9");
+    expect(res.timedOut).toBe(true);
+    const row = getSessionByClaudeSessionId(res.claudeSessionId);
+    expect(row?.stopped_reason).toBe("headless_timeout");
+    expect(manager.has("thread-to")).toBe(false);
+  });
+
+  test("rejects a duplicate thread (single-flight guard)", async () => {
+    await manager.start(config, "dup-thread");
+    await expect(
+      manager.runHeadless(config, "dup-thread", "/impl 1", "b"),
+    ).rejects.toThrow(/既に稼働中/);
+  });
+
+  test("surfaces a spawn failure and registers no session (no silent fallback)", async () => {
+    const failing = new FakeExecutorAdapter();
+    failing.failOnSpawn = true;
+    const mgr = new SessionManager({
+      effects: { ...createFakeEffects(), executor: failing },
+      gracefulKillTimeoutMs: 0,
+    });
+    await expect(
+      mgr.runHeadless(config, "thread-fail", "/impl 1", "corp-dispatch-1"),
+    ).rejects.toThrow(/ENOENT/);
+    expect(mgr.count()).toBe(0);
+    expect(mgr.has("thread-fail")).toBe(false);
+    await mgr.shutdownAll();
+  });
+});


### PR DESCRIPTION
## 概要

Epic #285 Phase 2（headless executor モード）を実装。`DISPATCH_EXECUTOR_MODE=headless` のとき、`/dispatch` 由来の部署セッションを tmux 対話 TUI ではなく `claude -p "<初期コマンド>"` の子プロセスで実行し、stdout を整形して部署スレッドへ返却する。既定（env 未設定）は現行 tmux 経路のまま。

dispatch は「Issue 番号とコマンドを与えて完走させる」バッチ的ワークロードであり対話 TUI である必要がない。headless 化で `waitForInputReady` の TUI 文字列マッチ（RW-025 / RW-047）や copy-mode send-keys drop（RW-019）といった TUI 依存の故障モードが構造的に消える。

Closes #286
Closes #287
Closes #288

## 主な変更点

### #286 headless 実行アダプタ + 起動経路
- `adapters.ts`: `ExecutorAdapter` interface + `realExecutorAdapter`（`Bun.spawn`）。worktree cwd で `claude -p` を spawn し stdout/stderr/exitCode を捕捉。onSpawn で pid を即時通知。timeout で SIGTERM。
- `adapters-fake.ts`: `FakeExecutorAdapter`（argv/cwd/env を assert 可能）。
- `manager.ts`: `SessionManager.runHeadless` + `buildHeadlessClaudeFlags` + `finishHeadless`。子プロセス spawn 時に session 登録（枠確保）、exit で close（DB stopped 化・枠解放・worktree best-effort 削除）。
- 起動フラグは `claude --help`（v2.1.201）で確認。TUI 表示名 `--name` は除外。`buildClaudeFlags` は shell 埋め込み用に pre-quote しているため再利用せず、shell を通さない argv 配列として別に組む。

### #287 dispatch 分岐 + Discord 返却
- `dispatch.ts`: `resolveExecutorMode`（env gate, fail-safe）+ `runDispatch` の headless 分岐。`DispatchSessionManager` に `runHeadless?` を追加（seam 維持）。
- stdout を既存 `formatForDiscord` で chunk 分割してスレッド投稿。
- **非ゼロ exit / タイムアウト / exit 0 だが空出力** はいずれもスレッドに明示投稿（サイレント成功禁止、agent-output-quality #1）。
- `bot.ts`: `DISPATCH_EXECUTOR_MODE` から mode を導出し `postToThread` を配線。tmux welcome は tmux mode のみ。

### #288 liveness / 終端 + docs
- `StopReason` に `headless_exited` / `headless_timeout` を追加（最小限）。
- `OrphanDispatchReaper` / `GoalWatcher` は `executor:"headless"` を skip。headless は自己終了（子プロセスが権威的 liveness）で relay 進捗を出さないため、idle 誤回収・done ラベル起因の stop() レースを回避。wedge した子は `DISPATCH_HEADLESS_TIMEOUT_MS`（既定 2h）で回収。
- `docs/bot-operations.md` に `DISPATCH_EXECUTOR_MODE` の opt-in・逃げ道・観測ログ・段階導入を追記。

## テスト結果

新規 4 ファイル（`tests/session/` に配置し ci.yml に登録済み、gating-coverage lint ✓）+ 既存回帰。

```
# 新規 + 既存 mock-safe 回帰（SUPERVISOR_DB_PATH=:memory:）
bun test tests/session/{dispatch,dispatch-run,dispatch-integration,dispatch-headless,adapters-executor,manager-headless,headless-liveness,manager,manager-resume,manager-liveness,manager-input-ready,output-formatter,worktree,self-heal-restart}.test.ts src/session/{goal-watcher,orphan-dispatch-reaper}.test.ts
→ 203 pass / 0 fail

# mock.module 隔離ファイル（CI と同様に単独実行）
bun test tests/session/adapters.test.ts        → 17 pass / 0 fail
bun test tests/session/tmux.test.ts            → 8 pass / 0 fail
bun test tests/session/adapters-hassession.test.ts → 4 pass / 0 fail

bunx tsc --noEmit                              → PASS
bun scripts/lint-blocking-in-timers.ts         → PASS
bun scripts/lint-no-sync-exec.ts               → PASS
bun scripts/lint-gating-coverage.ts            → PASS (68 files, 0 ungated)
bun scripts/check-access-policy.ts --ci        → PASS (in sync)
```

## AC 検証結果（Epic #285）

| AC | 検証内容 | 検証手段 | 判定 |
|---|---|---|---|
| AC-1 | headless で tmux を作らず子プロセス claude -p が起動する | `manager-headless.test.ts`（argv `-p /impl 42` + cwd=worktree を assert）/ `adapters-executor.test.ts`（実 spawn） | PASS |
| AC-2 | headless 実行の stdout が整形されてスレッド投稿される | `dispatch-headless.test.ts`（formatForDiscord 経由の投稿を assert） | PASS |
| AC-3 | 子プロセス exit でセッション close・枠解放 | `manager-headless.test.ts`（run 中 count=1 → exit 後 count=0、DB stopped/headless_exited） | PASS |
| AC-4 | env 未設定（既定）では現行 tmux 経路が変わらない | 既存 dispatch/manager 全 green + `dispatch-headless.test.ts` の tmux 既定 case | PASS |
| AC-5 | 非ゼロ exit はエラーとしてスレッドに明示（サイレント成功にしない） | `dispatch-headless.test.ts`（exit 2 / timeout / 空出力を明示投稿） | PASS |

## 補足

- 対話セッション（`/session start`・primary channel）は headless 化していない（スコープ外）。
- CHANNEL_MAP に claude-hub は追加していない / tmux socket は `-L claude-hub` を維持（絶対ルール遵守）。
- レビュー・マージは親セッションで実施予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `/dispatch` にヘッドレス実行モードが追加され、対話UIを使わずに実行結果をスレッドへ返せるようになりました。
  * 実行の成功・失敗・タイムアウト・出力なしのケースが、より分かりやすく通知されます。

* **Bug Fixes**
  * ヘッドレス実行のセッションが、不要な自動停止や orphan 回収の対象にならないようになりました。
  * 実行時のタイムアウトや終了理由が、より正確に記録・表示されます。

* **Documentation**
  * ヘッドレス運用手順と注意事項を追記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->