### PR TITLE
feat: headless 実行完了時に Issue へ Dispatch 実行レポートを投稿（corp #75 Phase 4）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,7 @@ jobs:
                    tests/session/dispatch-run.test.ts \
                    tests/session/dispatch-integration.test.ts \
                    tests/session/dispatch-headless.test.ts \
+                   tests/session/dispatch-report.test.ts \
                    tests/session/adapters-executor.test.ts \
                    tests/session/manager-headless.test.ts \
                    tests/session/headless-liveness.test.ts \

--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -121,6 +121,23 @@ headless の argv は `buildHeadlessClaudeFlags()`（`supervisor/src/session/man
 - bot 側: `[Bot] Headless dispatch completed in channel <ch> (thread=..., exit=..., timedOut=...)`
 - 非ゼロ exit / タイムアウト / exit 0 だが stdout 空 は、いずれも**スレッドに明示投稿**する（サイレント成功にしない）。
 
+### 実行レポートコメント（Issue #289 / corp #75 Phase 4）
+
+headless 実行の完了時、対象 Issue へ実行レポートを `gh issue comment` で投稿する（部署 worktree cwd から実行）。これは **corp reconcile が parse する契約**（corp #76 が対向実装）で、見出しと `- key: value` 行の形を機械的に維持する:
+
+```
+## Dispatch 実行レポート
+
+- tokens: <合計 output tokens／取得不能なら行ごと省略>
+- duration_ms: <実行時間（wall-clock, ms）>
+- exit_code: <claude -p の exit code／kill/timeout 時は null>
+```
+
+- tokens は `claude -p --output-format json` の `usage.output_tokens` から取得（実行検証済み・v2.1.201）。取得できない（JSON parse 失敗等）場合は **tokens 行を省略**し捏造しない。`0` は実値として出力する。
+- 投稿失敗は **fail-soft**: `[SessionManager] Failed to post dispatch report ...` を warn ログに残し、セッション終端・実行結果は巻き込まない。
+- headless モード時のみ。tmux 経路には投稿しない。
+- 契約の単一 source: `supervisor/src/session/dispatch-report.ts`（`formatDispatchReport`）。
+
 ### 段階導入（WARN-first dogfood の写像）
 
 1. `DISPATCH_EXECUTOR_MODE=headless` を opt-in で有効化し、agent-base 向け dispatch（no-template / pdca）で数日 dogfood。

--- a/supervisor/src/session/adapters-fake.ts
+++ b/supervisor/src/session/adapters-fake.ts
@@ -2,6 +2,7 @@ import type {
   ExecutorAdapter,
   HeadlessRunOptions,
   HeadlessRunResult,
+  IssueReporterAdapter,
   ItermAdapter,
   ProcessAdapter,
   RelayServerAdapter,
@@ -202,6 +203,7 @@ export class FakeExecutorAdapter implements ExecutorAdapter {
     stdout: "",
     stderr: "",
     timedOut: false,
+    durationMs: 0,
   };
   /** pid handed to onSpawn (incremented per call so concurrent runs differ). */
   spawnPid = 20_000;
@@ -220,6 +222,24 @@ export class FakeExecutorAdapter implements ExecutorAdapter {
   }
 }
 
+export class FakeIssueReporterAdapter implements IssueReporterAdapter {
+  /** Every postComment() call, so tests assert the report body / cwd / issue. */
+  postCommentCalls: { cwd: string; issueNumber: number; body: string }[] = [];
+  /** When set, postComment throws to simulate a `gh` failure (fail-soft path). */
+  failOnPost = false;
+
+  async postComment(opts: {
+    cwd: string;
+    issueNumber: number;
+    body: string;
+  }): Promise<void> {
+    this.postCommentCalls.push(opts);
+    if (this.failOnPost) {
+      throw new Error("gh issue comment failed");
+    }
+  }
+}
+
 export interface FakeSessionEffects extends SessionEffects {
   tmux: FakeTmuxAdapter;
   iterm2: FakeItermAdapter;
@@ -227,6 +247,7 @@ export interface FakeSessionEffects extends SessionEffects {
   process: FakeProcessAdapter;
   worktree: FakeWorktreeAdapter;
   executor: FakeExecutorAdapter;
+  issueReporter: FakeIssueReporterAdapter;
 }
 
 export function createFakeEffects(): FakeSessionEffects {
@@ -237,5 +258,6 @@ export function createFakeEffects(): FakeSessionEffects {
     process: new FakeProcessAdapter(),
     worktree: new FakeWorktreeAdapter(),
     executor: new FakeExecutorAdapter(),
+    issueReporter: new FakeIssueReporterAdapter(),
   };
 }

--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -1,5 +1,8 @@
 import { execFile, spawn } from "child_process";
 import { promisify } from "util";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import {
   openTab as realOpenTab,
   markTabStopped as realMarkTabStopped,
@@ -116,6 +119,13 @@ export interface HeadlessRunResult {
   stderr: string;
   /** True when the run was killed because it exceeded {@link HeadlessRunOptions.timeoutMs}. */
   timedOut: boolean;
+  /**
+   * Wall-clock duration from spawn to exit, in ms (Epic #75 Phase 4 / #289).
+   * Measured here so it is ALWAYS available — even on a timeout or a crash where
+   * the `claude -p --output-format json` `duration_ms` field never gets emitted —
+   * because the dispatch report always carries a duration.
+   */
+  durationMs: number;
 }
 
 export interface HeadlessRunOptions {
@@ -152,6 +162,21 @@ export interface ExecutorAdapter {
   runHeadless(opts: HeadlessRunOptions): Promise<HeadlessRunResult>;
 }
 
+/**
+ * Posts a comment to a GitHub Issue (Epic #75 Phase 4 / #289). Used by the
+ * headless dispatch path to append the machine-parsable "Dispatch 実行レポート"
+ * (a contract corp reconcile parses, corp #76). Injected so unit tests assert
+ * the call without shelling out to `gh`. The real impl runs `gh` in the branch
+ * worktree cwd so the Issue's repo resolves from that dir's git remote.
+ */
+export interface IssueReporterAdapter {
+  postComment(opts: {
+    cwd: string;
+    issueNumber: number;
+    body: string;
+  }): Promise<void>;
+}
+
 export interface SessionEffects {
   tmux: TmuxAdapter;
   iterm2: ItermAdapter;
@@ -159,6 +184,7 @@ export interface SessionEffects {
   process: ProcessAdapter;
   worktree: WorktreeAdapter;
   executor: ExecutorAdapter;
+  issueReporter: IssueReporterAdapter;
 }
 
 // Issue #222: bound every synchronous tmux call so a wedged tmux server (whose
@@ -384,6 +410,7 @@ export const realExecutorAdapter: ExecutorAdapter = {
         return;
       }
       onSpawn?.(pid);
+      const startedAt = Date.now();
 
       let stdout = "";
       let stderr = "";
@@ -429,9 +456,37 @@ export const realExecutorAdapter: ExecutorAdapter = {
         // On a timeout kill the numeric code reflects the signal, not a
         // meaningful "job failed with code N" — report null so the caller
         // renders it as a timeout rather than a numeric non-zero exit.
-        resolve({ exitCode: timedOut ? null : code, stdout, stderr, timedOut });
+        resolve({
+          exitCode: timedOut ? null : code,
+          stdout,
+          stderr,
+          timedOut,
+          durationMs: Date.now() - startedAt,
+        });
       });
     });
+  },
+};
+
+/** Timeout for the `gh issue comment` call — bound a wedged gh so a failed report never hangs teardown. */
+const GH_COMMENT_TIMEOUT_MS = 15_000;
+
+export const realIssueReporterAdapter: IssueReporterAdapter = {
+  async postComment({ cwd, issueNumber, body }) {
+    // --body-file (not --body): the report contains markdown headings and
+    // newlines; a temp file avoids any shell/`gh` re-parsing of the body.
+    const dir = mkdtempSync(join(tmpdir(), "dispatch-report-"));
+    const bodyFile = join(dir, "report.md");
+    try {
+      writeFileSync(bodyFile, body);
+      await execFileAsync(
+        "gh",
+        ["issue", "comment", String(issueNumber), "--body-file", bodyFile],
+        { cwd, encoding: "utf8", timeout: GH_COMMENT_TIMEOUT_MS },
+      );
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   },
 };
 
@@ -442,4 +497,5 @@ export const realSessionEffects: SessionEffects = {
   process: realProcessAdapter,
   worktree: realWorktreeAdapter,
   executor: realExecutorAdapter,
+  issueReporter: realIssueReporterAdapter,
 };

--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -1,6 +1,6 @@
 import { execFile, spawn } from "child_process";
 import { promisify } from "util";
-import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { mkdtemp, rm, writeFile } from "fs/promises";
 import { tmpdir } from "os";
 import { join } from "path";
 import {
@@ -475,17 +475,21 @@ export const realIssueReporterAdapter: IssueReporterAdapter = {
   async postComment({ cwd, issueNumber, body }) {
     // --body-file (not --body): the report contains markdown headings and
     // newlines; a temp file avoids any shell/`gh` re-parsing of the body.
-    const dir = mkdtempSync(join(tmpdir(), "dispatch-report-"));
+    // Async fs (fs/promises) so the temp-file I/O never blocks the Bun event
+    // loop — the same non-blocking discipline as the async execFile tmux path
+    // (Issue #222/#227): a blocking op here would stall relay delivery under
+    // concurrent sessions (gemini PR #291 HIGH).
+    const dir = await mkdtemp(join(tmpdir(), "dispatch-report-"));
     const bodyFile = join(dir, "report.md");
     try {
-      writeFileSync(bodyFile, body);
+      await writeFile(bodyFile, body);
       await execFileAsync(
         "gh",
         ["issue", "comment", String(issueNumber), "--body-file", bodyFile],
         { cwd, encoding: "utf8", timeout: GH_COMMENT_TIMEOUT_MS },
       );
     } finally {
-      rmSync(dir, { recursive: true, force: true });
+      await rm(dir, { recursive: true, force: true });
     }
   },
 };

--- a/supervisor/src/session/dispatch-report.ts
+++ b/supervisor/src/session/dispatch-report.ts
@@ -1,0 +1,50 @@
+/**
+ * Dispatch execution report (Epic corp #75 Phase 4 / #289).
+ *
+ * A headless dispatch run appends this comment to its target Issue when it
+ * finishes. The format is a MACHINE-PARSABLE CONTRACT: corp reconcile (corp #76,
+ * the opposing implementation) reads the `## Dispatch 実行レポート` heading and
+ * the `- key: value` lines to attach token/duration/exit evidence to the
+ * dispatch ledger. Keep the heading text and the `- <key>: <value>` shape stable;
+ * changing them is a breaking change to that contract.
+ *
+ *   ## Dispatch 実行レポート
+ *
+ *   - tokens: <合計 output tokens／取得できなければ行ごと省略>
+ *   - duration_ms: <実行時間>
+ *   - exit_code: <claude -p の exit code>
+ */
+
+export const DISPATCH_REPORT_HEADING = "## Dispatch 実行レポート";
+
+export interface DispatchReportFields {
+  /**
+   * Total output tokens (`usage.output_tokens` from `claude -p --output-format
+   * json`). `null` when it could not be obtained (JSON unparsable / field
+   * absent) — the tokens line is then OMITTED entirely rather than guessed
+   * (#289: 取得できなければ行ごと省略・捏造しない). `0` is a real value and IS
+   * emitted.
+   */
+  tokens: number | null;
+  /** Wall-clock run duration in ms (always present). */
+  durationMs: number;
+  /** `claude -p` exit code, or `null` when the run was killed (e.g. timeout). */
+  exitCode: number | null;
+}
+
+/**
+ * Render the report body. Deterministic and side-effect-free so a unit test can
+ * assert the exact contract (Epic #75 AC-1). The `tokens` line is omitted when
+ * {@link DispatchReportFields.tokens} is null; `duration_ms` and `exit_code`
+ * are always present (`exit_code` renders `null` verbatim when the run had no
+ * numeric exit, so the reader can distinguish a kill/timeout from exit 0).
+ */
+export function formatDispatchReport(fields: DispatchReportFields): string {
+  const lines: string[] = [DISPATCH_REPORT_HEADING, ""];
+  if (fields.tokens !== null) {
+    lines.push(`- tokens: ${fields.tokens}`);
+  }
+  lines.push(`- duration_ms: ${fields.durationMs}`);
+  lines.push(`- exit_code: ${fields.exitCode === null ? "null" : fields.exitCode}`);
+  return lines.join("\n") + "\n";
+}

--- a/supervisor/src/session/dispatch.ts
+++ b/supervisor/src/session/dispatch.ts
@@ -228,12 +228,17 @@ export interface DispatchSessionManager {
    * the captured output. Optional so a tmux-only fake still satisfies the
    * interface; {@link runDispatch} verifies it is present before taking the
    * headless branch (no silent fallback).
+   *
+   * `issueNumber` (Epic #75 Phase 4 / #289) is the target Issue the run posts
+   * its "Dispatch 実行レポート" comment to on completion; it is threaded through
+   * so the manager can post from the worktree cwd before teardown.
    */
   runHeadless?(
     config: unknown,
     threadId: string,
     initialCommand: string,
     branch?: string,
+    issueNumber?: number,
   ): Promise<DispatchHeadlessOutcome>;
 }
 
@@ -423,6 +428,7 @@ async function runDispatchHeadless(
       threadId,
       initialCommand,
       branch,
+      issueNumber,
     );
   } catch (err) {
     // Spawn / worktree failure — surface to the thread AND the caller.

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -40,6 +40,7 @@ import {
   type SelfHealer,
 } from "./self-heal";
 import { compactClaudeHubExit } from "./primary-compact";
+import { formatDispatchReport } from "./dispatch-report";
 
 const DEFAULT_CLAUDE_PATH = resolve(homedir(), ".local", "bin", "claude");
 const TMUX_SESSION_PREFIX = "claude-";
@@ -237,10 +238,13 @@ export function buildHeadlessClaudeFlags(
   const args = [
     "-p",
     initialCommand,
-    // text is the default -p format, but pin it explicitly so a future default
-    // change cannot silently turn stdout into JSON the formatter would post raw.
+    // JSON so the run's usage is machine-readable (Epic #75 Phase 4 / #289):
+    // the final envelope carries `usage.output_tokens` for the dispatch report
+    // and `result` (the final text) for the thread. Verified against a real
+    // `claude -p --output-format json` run (v2.1.201): top-level `result`,
+    // `duration_ms`, and `usage.{input,output}_tokens`.
     "--output-format",
-    "text",
+    "json",
     "--dangerously-skip-permissions",
   ];
 
@@ -283,11 +287,57 @@ function buildHeadlessEnv(): Record<string, string | undefined> {
 }
 
 /** Outcome of {@link SessionManager.runHeadless}. */
-export interface HeadlessSessionResult extends HeadlessRunResult {
+export interface HeadlessSessionResult {
+  /** `claude -p` exit code, or null when killed (e.g. timeout). */
+  exitCode: number | null;
+  /**
+   * Presentable text: the parsed `result` field of the JSON envelope, or the raw
+   * stdout when the envelope could not be parsed (crash / timeout before it was
+   * emitted). This is what the dispatch thread shows — never the raw JSON.
+   */
+  stdout: string;
+  stderr: string;
+  timedOut: boolean;
+  /** Wall-clock run duration in ms (always present). */
+  durationMs: number;
+  /**
+   * Total output tokens (`usage.output_tokens`), or null when unobtainable
+   * (JSON unparsable / field absent). The dispatch report omits the tokens line
+   * when null rather than guessing (#289).
+   */
+  tokens: number | null;
   /** Supervisor session-row id (for correlating with sessions.db). */
   sessionId: string;
   /** The pinned `--session-id` value handed to the child. */
   claudeSessionId: string;
+}
+
+/**
+ * Parse the `claude -p --output-format json` envelope (Epic #75 Phase 4 / #289).
+ * Fail-soft: on any parse failure (empty / partial / non-JSON — e.g. a crash or
+ * timeout before the envelope was written) it returns the raw output as the
+ * presentable text and null tokens, never throwing and never fabricating a token
+ * count. Field names verified against a real run (v2.1.201): top-level `result`,
+ * `usage.output_tokens`.
+ */
+export function parseHeadlessOutput(raw: string): {
+  text: string;
+  tokens: number | null;
+} {
+  const trimmed = raw.trim();
+  if (!trimmed) return { text: "", tokens: null };
+  try {
+    const obj = JSON.parse(trimmed) as {
+      result?: unknown;
+      usage?: { output_tokens?: unknown };
+    };
+    const text = typeof obj.result === "string" ? obj.result : raw;
+    const ot = obj.usage?.output_tokens;
+    const tokens = typeof ot === "number" && Number.isFinite(ot) ? ot : null;
+    return { text, tokens };
+  } catch {
+    return { text: raw, tokens: null };
+  }
 }
 
 /**
@@ -411,6 +461,8 @@ export class SessionManager {
       process: options.effects?.process ?? realSessionEffects.process,
       worktree: options.effects?.worktree ?? realSessionEffects.worktree,
       executor: options.effects?.executor ?? realSessionEffects.executor,
+      issueReporter:
+        options.effects?.issueReporter ?? realSessionEffects.issueReporter,
     };
     this.gracefulKillTimeoutMs =
       options.gracefulKillTimeoutMs ?? GRACEFUL_KILL_TIMEOUT_MS;
@@ -777,6 +829,7 @@ export class SessionManager {
     threadId: string,
     initialCommand: string,
     branch?: string,
+    issueNumber?: number,
   ): Promise<HeadlessSessionResult> {
     // Same single-flight guards as start(): runHeadless is another async entry
     // that registers a session, so it must respect the identical MAX_SESSIONS /
@@ -874,12 +927,34 @@ export class SessionManager {
         },
       });
 
+      // Parse the JSON envelope into presentable text + token usage (#289).
+      // Fail-soft: a crash / timeout that left no valid JSON yields the raw
+      // output and null tokens rather than throwing.
+      const parsed = parseHeadlessOutput(result.stdout);
+      const outcome: HeadlessSessionResult = {
+        exitCode: result.exitCode,
+        stdout: parsed.text,
+        stderr: result.stderr,
+        timedOut: result.timedOut,
+        durationMs: result.durationMs,
+        tokens: parsed.tokens,
+        sessionId,
+        claudeSessionId,
+      };
+
+      // Post the Dispatch 実行レポート to the target Issue BEFORE finishHeadless
+      // removes the worktree — gh runs in that worktree cwd (#289). Fail-soft:
+      // a report failure must never block session teardown or lose the run.
+      if (issueNumber != null) {
+        await this.postDispatchReport(issueNumber, projectDir, outcome);
+      }
+
       // Child exited → close the session (frees the slot). Even if onSpawn never
       // fired (should not happen unless the adapter misbehaves), finishHeadless
       // is a no-op safe cleanup.
       await this.finishHeadless(threadId, sessionId, result, worktree);
 
-      return { ...result, sessionId, claudeSessionId };
+      return outcome;
     } finally {
       // Error-path safety net: if the spawn threw before onSpawn, drop the
       // pending marker so the slot is not leaked (delete is idempotent).
@@ -923,6 +998,38 @@ export class SessionManager {
     console.log(
       `[SessionManager] Headless session for thread ${threadId} closed (reason: ${reason}, exit: ${result.exitCode})`,
     );
+  }
+
+  /**
+   * Append the Dispatch 実行レポート to the target Issue (Epic #75 Phase 4 /
+   * #289). Runs `gh issue comment` in the branch worktree `cwd` (via the injected
+   * {@link IssueReporterAdapter}) so the Issue's repo resolves from that dir's git
+   * remote. FAIL-SOFT: any failure is logged and swallowed — a report is
+   * observability, so it must never abort the run or block session teardown
+   * (agent-output-quality: the failure is surfaced in the log, not silently
+   * dropped).
+   */
+  private async postDispatchReport(
+    issueNumber: number,
+    cwd: string,
+    outcome: HeadlessSessionResult,
+  ): Promise<void> {
+    const body = formatDispatchReport({
+      tokens: outcome.tokens,
+      durationMs: outcome.durationMs,
+      exitCode: outcome.exitCode,
+    });
+    try {
+      await this.effects.issueReporter.postComment({ cwd, issueNumber, body });
+      console.log(
+        `[SessionManager] Posted dispatch report to issue #${issueNumber} (tokens: ${outcome.tokens ?? "n/a"}, duration_ms: ${outcome.durationMs}, exit: ${outcome.exitCode})`,
+      );
+    } catch (err) {
+      console.warn(
+        `[SessionManager] Failed to post dispatch report to issue #${issueNumber} (fail-soft, run unaffected):`,
+        err,
+      );
+    }
   }
 
   /**

--- a/supervisor/tests/session/adapters-executor.test.ts
+++ b/supervisor/tests/session/adapters-executor.test.ts
@@ -26,7 +26,13 @@ function stub(name: string, body: string): string {
 describe("FakeExecutorAdapter", () => {
   test("records argv/cwd/env and fires onSpawn with a pid", async () => {
     const fake = new FakeExecutorAdapter();
-    fake.result = { exitCode: 0, stdout: "hi", stderr: "", timedOut: false };
+    fake.result = {
+      exitCode: 0,
+      stdout: "hi",
+      stderr: "",
+      timedOut: false,
+      durationMs: 5,
+    };
     const pids: number[] = [];
 
     const r = await fake.runHeadless({
@@ -89,6 +95,8 @@ describe("realExecutorAdapter (Bun.spawn)", () => {
     expect(r.timedOut).toBe(false);
     expect(r.stdout).toBe("hello-stdout");
     expect(pid).toBeGreaterThan(0);
+    // Wall-clock duration is measured and non-negative (#289).
+    expect(r.durationMs).toBeGreaterThanOrEqual(0);
   });
 
   test("surfaces a non-zero exit code as data (not a throw)", async () => {

--- a/supervisor/tests/session/dispatch-headless.test.ts
+++ b/supervisor/tests/session/dispatch-headless.test.ts
@@ -23,14 +23,15 @@ function harness(
     threadId: string;
     initialCommand: string;
     branch?: string;
+    issueNumber?: number;
   }> = [];
   const posts: Array<{ threadId: string; content: string }> = [];
   const manager: DispatchSessionManager = {
     start: async () => ({}),
     waitForInputReady: async () => true,
     sendMessage: async () => ({}),
-    runHeadless: async (_c, threadId, initialCommand, branch) => {
-      runHeadlessCalls.push({ threadId, initialCommand, branch });
+    runHeadless: async (_c, threadId, initialCommand, branch, issueNumber) => {
+      runHeadlessCalls.push({ threadId, initialCommand, branch, issueNumber });
       return typeof outcome === "function" ? outcome() : outcome;
     },
   };
@@ -81,7 +82,13 @@ describe("runDispatch headless", () => {
       expect(r.timedOut).toBe(false);
     }
     expect(runHeadlessCalls).toEqual([
-      { threadId: "thread-h", initialCommand: "/impl 42", branch: "corp-dispatch-42" },
+      {
+        threadId: "thread-h",
+        initialCommand: "/impl 42",
+        branch: "corp-dispatch-42",
+        // issueNumber threaded through so the manager posts the report (#289).
+        issueNumber: 42,
+      },
     ]);
     // A start notice, then the stdout, both to the created thread.
     expect(posts.length).toBeGreaterThanOrEqual(2);

--- a/supervisor/tests/session/dispatch-report.test.ts
+++ b/supervisor/tests/session/dispatch-report.test.ts
@@ -1,0 +1,74 @@
+import { describe, test, expect } from "bun:test";
+import {
+  formatDispatchReport,
+  DISPATCH_REPORT_HEADING,
+} from "../../src/session/dispatch-report";
+
+/**
+ * Epic corp #75 Phase 4 / #289, AC-1: the Dispatch 実行レポート format is a
+ * machine-parsable contract that corp reconcile (corp #76) reads. These assert
+ * the exact heading + `- key: value` shape so a drift is caught here, not by a
+ * silently-broken reconcile.
+ */
+describe("formatDispatchReport", () => {
+  test("renders heading + tokens/duration/exit lines when tokens are known", () => {
+    const body = formatDispatchReport({
+      tokens: 345,
+      durationMs: 4200,
+      exitCode: 0,
+    });
+    expect(body).toBe(
+      [
+        "## Dispatch 実行レポート",
+        "",
+        "- tokens: 345",
+        "- duration_ms: 4200",
+        "- exit_code: 0",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  test("heading constant matches the rendered heading (single source of truth)", () => {
+    const body = formatDispatchReport({ tokens: 1, durationMs: 2, exitCode: 0 });
+    expect(body.startsWith(DISPATCH_REPORT_HEADING + "\n")).toBe(true);
+  });
+
+  test("omits the tokens line entirely when tokens is null (no fabrication)", () => {
+    const body = formatDispatchReport({
+      tokens: null,
+      durationMs: 1500,
+      exitCode: 1,
+    });
+    expect(body).not.toContain("tokens:");
+    expect(body).toContain("- duration_ms: 1500");
+    expect(body).toContain("- exit_code: 1");
+    // The heading and the two always-present lines survive.
+    expect(body.split("\n").filter((l) => l.startsWith("- "))).toEqual([
+      "- duration_ms: 1500",
+      "- exit_code: 1",
+    ]);
+  });
+
+  test("emits tokens: 0 (a real value, distinct from unavailable)", () => {
+    const body = formatDispatchReport({ tokens: 0, durationMs: 10, exitCode: 0 });
+    expect(body).toContain("- tokens: 0");
+  });
+
+  test("renders exit_code: null verbatim for a killed/timed-out run", () => {
+    const body = formatDispatchReport({
+      tokens: null,
+      durationMs: 7200000,
+      exitCode: null,
+    });
+    expect(body).toContain("- exit_code: null");
+  });
+
+  test("keys use snake_case exactly (duration_ms, exit_code) for the parse contract", () => {
+    const body = formatDispatchReport({ tokens: 7, durationMs: 3, exitCode: 9 });
+    // Each contract line is a top-level `- key: value` bullet.
+    for (const line of ["- tokens: 7", "- duration_ms: 3", "- exit_code: 9"]) {
+      expect(body.split("\n")).toContain(line);
+    }
+  });
+});

--- a/supervisor/tests/session/manager-headless.test.ts
+++ b/supervisor/tests/session/manager-headless.test.ts
@@ -67,7 +67,9 @@ describe("SessionManager.runHeadless", () => {
     expect(call.args).toContain("--dangerously-skip-permissions");
     expect(call.args).toContain("--strict-mcp-config");
     expect(call.args).toContain('{"mcpServers":{}}');
+    // JSON output so usage.output_tokens is machine-readable for the report (#289).
     expect(call.args).toContain("--output-format");
+    expect(call.args).toContain("json");
     expect(call.args).not.toContain("--name");
     // --session-id is pinned to the returned claudeSessionId.
     const idIdx = call.args.indexOf("--session-id");
@@ -114,7 +116,13 @@ describe("SessionManager.runHeadless", () => {
     expect(mgr.has("thread-run")).toBe(true);
     expect(mgr.get("thread-run")?.executor).toBe("headless");
 
-    exec.finish({ exitCode: 0, stdout: "PR ready", stderr: "", timedOut: false });
+    exec.finish({
+      exitCode: 0,
+      stdout: "PR ready",
+      stderr: "",
+      timedOut: false,
+      durationMs: 12,
+    });
     const res = await p;
 
     // Freed on exit; DB row closed with the non-timeout reason.
@@ -132,12 +140,101 @@ describe("SessionManager.runHeadless", () => {
       stdout: "partial",
       stderr: "",
       timedOut: true,
+      durationMs: 999,
     };
     const res = await manager.runHeadless(config, "thread-to", "/pdca 9", "corp-dispatch-9");
     expect(res.timedOut).toBe(true);
     const row = getSessionByClaudeSessionId(res.claudeSessionId);
     expect(row?.stopped_reason).toBe("headless_timeout");
     expect(manager.has("thread-to")).toBe(false);
+  });
+
+  test("parses usage.output_tokens + result text from the JSON envelope (#289)", async () => {
+    // A realistic `claude -p --output-format json` envelope.
+    effects.executor.result = {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        type: "result",
+        result: "PR opened: https://github.com/x/y/pull/9",
+        duration_ms: 4200,
+        usage: { input_tokens: 1200, output_tokens: 345 },
+      }),
+      stderr: "",
+      timedOut: false,
+      durationMs: 4500,
+    };
+    const res = await manager.runHeadless(
+      config,
+      "thread-json",
+      "/impl 9",
+      "corp-dispatch-9",
+      9,
+    );
+    // Presentable text is the parsed `result`, not the raw JSON.
+    expect(res.stdout).toBe("PR opened: https://github.com/x/y/pull/9");
+    expect(res.tokens).toBe(345);
+    expect(res.durationMs).toBe(4500);
+  });
+
+  test("posts the dispatch report to the target Issue from the worktree cwd (#289)", async () => {
+    effects.executor.result = {
+      exitCode: 0,
+      stdout: JSON.stringify({
+        result: "done",
+        usage: { output_tokens: 500 },
+      }),
+      stderr: "",
+      timedOut: false,
+      durationMs: 3000,
+    };
+    await manager.runHeadless(config, "thread-rep", "/impl 42", "corp-dispatch-42", 42);
+
+    expect(effects.issueReporter.postCommentCalls).toHaveLength(1);
+    const call = effects.issueReporter.postCommentCalls[0]!;
+    expect(call.issueNumber).toBe(42);
+    expect(call.cwd).toBe(resolveWorktreePath(config.dir, "corp-dispatch-42"));
+    expect(call.body).toContain("## Dispatch 実行レポート");
+    expect(call.body).toContain("- tokens: 500");
+    expect(call.body).toContain("- duration_ms: 3000");
+    expect(call.body).toContain("- exit_code: 0");
+  });
+
+  test("omits the tokens line when usage is unavailable (no fabrication, #289)", async () => {
+    effects.executor.result = {
+      exitCode: 2,
+      // Non-JSON output (e.g. a crash before the envelope) → tokens unknown.
+      stdout: "boom, not json",
+      stderr: "fatal",
+      timedOut: false,
+      durationMs: 800,
+    };
+    await manager.runHeadless(config, "thread-notok", "/impl 3", "corp-dispatch-3", 3);
+    const call = effects.issueReporter.postCommentCalls[0]!;
+    expect(call.body).not.toContain("tokens:");
+    expect(call.body).toContain("- duration_ms: 800");
+    expect(call.body).toContain("- exit_code: 2");
+  });
+
+  test("does not post a report when no issueNumber is given", async () => {
+    await manager.runHeadless(config, "thread-noissue", "/impl 1", "corp-dispatch-1");
+    expect(effects.issueReporter.postCommentCalls).toHaveLength(0);
+  });
+
+  test("report posting failure is fail-soft: the run still completes and the session closes (#289)", async () => {
+    effects.issueReporter.failOnPost = true;
+    effects.executor.result = {
+      exitCode: 0,
+      stdout: JSON.stringify({ result: "ok", usage: { output_tokens: 10 } }),
+      stderr: "",
+      timedOut: false,
+      durationMs: 100,
+    };
+    const res = await manager.runHeadless(config, "thread-soft", "/impl 5", "corp-dispatch-5", 5);
+    // The report threw, but the run resolved and the session was closed anyway.
+    expect(res.exitCode).toBe(0);
+    expect(manager.has("thread-soft")).toBe(false);
+    const row = getSessionByClaudeSessionId(res.claudeSessionId);
+    expect(row?.status).toBe("stopped");
   });
 
   test("rejects a duplicate thread (single-flight guard)", async () => {


### PR DESCRIPTION
## 概要

corp Epic #75 Phase 4（観測性）の sub。headless executor（Epic #285、merge 済み #290）の実行完了時に、対象 Issue へ **Dispatch 実行レポート**コメントを投稿する。フォーマットは corp reconcile が parse する契約（corp #76 が対向実装）で、見出しと `- key: value` 行を機械的に維持する。

```
## Dispatch 実行レポート

- tokens: <合計 output tokens／取得不能なら行ごと省略>
- duration_ms: <実行時間（wall-clock, ms）>
- exit_code: <claude -p の exit code／kill/timeout 時は null>
```

Closes #289

## 主な変更点

- **`dispatch-report.ts`（新規）**: `formatDispatchReport` を契約の単一 source として実装。tokens が null なら行ごと省略（捏造しない）、`0` は実値として出力。`duration_ms` / `exit_code` は常時出力（exit は kill/timeout 時 `null` を明示）。
- **token 取得**: headless の出力を `--output-format text` → `--output-format json` に変更し、`usage.output_tokens` を抽出。**フィールド名は実際に `claude -p --output-format json` を実行して実在確認**（v2.1.201: top-level `result` / `duration_ms`、`usage.output_tokens`）。`result` を presentable text として抽出しスレッド返却、JSON parse 失敗時は raw stdout に fail-soft fallback。
- **duration_ms**: executor（`child_process.spawn`）で wall-clock 実測。JSON が無い timeout/crash でも常に取得可能。
- **`IssueReporterAdapter`（新規 effect）**: `gh issue comment <N> --body-file` を**部署 worktree cwd** で実行（worktree 削除前に投稿）。投稿失敗は **fail-soft**（`[SessionManager] Failed to post dispatch report ...` warn ログのみ、セッション終端・実行結果を巻き込まない）。
- headless モード時のみ。tmux 経路には投稿しない。bot.ts 変更なし（manager が default effect で投稿）。

## テスト結果

新規 2 ファイル（`dispatch-report.test.ts` / 既存 `manager-headless.test.ts` 拡張）+ 回帰。ci.yml 登録済（gating-coverage ✓）。

```
# 新規 + 既存 mock-safe 回帰（SUPERVISOR_DB_PATH=:memory:）
bun test tests/session/{dispatch,dispatch-run,dispatch-integration,dispatch-headless,dispatch-report,adapters-executor,manager-headless,headless-liveness,manager,manager-resume,manager-liveness,manager-input-ready,output-formatter,worktree,self-heal-restart}.test.ts src/session/{goal-watcher,orphan-dispatch-reaper}.test.ts
→ 214 pass / 0 fail

# mock.module 隔離ファイル（CI と同様に単独実行）
bun test tests/session/adapters.test.ts        → 17 pass / 0 fail
bun test tests/session/tmux.test.ts            → 8 pass / 0 fail
bun test tests/session/adapters-hassession.test.ts → 4 pass / 0 fail

bunx tsc --noEmit                              → PASS
bun scripts/lint-blocking-in-timers.ts         → PASS
bun scripts/lint-no-sync-exec.ts               → PASS
bun scripts/lint-gating-coverage.ts            → PASS (69 files, 0 ungated)
```

## AC 検証結果（Epic corp #75 AC-1）

| AC | 検証内容 | 検証手段 | 判定 |
|---|---|---|---|
| AC-1 | 実行レポートのフォーマットを bun test で assert | `dispatch-report.test.ts`（見出し + `- key: value` の完全一致、tokens 省略/0/null exit の各分岐） | PASS |
| 付随 | tokens を JSON usage から実在フィールドで取得 | `manager-headless.test.ts`（`usage.output_tokens` parse → `- tokens: N`）+ 実 CLI 実行でフィールド名確認 | PASS |
| 付随 | 取得不能時は tokens 行を省略（捏造しない） | `manager-headless.test.ts`（非 JSON 出力 → tokens 行なし・duration/exit のみ） | PASS |
| 付随 | worktree cwd から Issue へ投稿 | `manager-headless.test.ts`（`postComment` の cwd = worktree path・issueNumber・body assert） | PASS |
| 付随 | 投稿失敗は fail-soft（終端を巻き込まない） | `manager-headless.test.ts`（`failOnPost` → run 完了・session close 継続） | PASS |

## 補足

- token 取得フィールドは推測せず、実機で `claude -p --output-format json` を実行して `usage.output_tokens` を確認（fact-checking 準拠）。
- 絶対ルール遵守: CHANNEL_MAP に claude-hub 追加なし / tmux socket `-L claude-hub` 維持。
- レビュー・マージは親セッションで実施予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
