### PR TITLE
feat: 多セッション性能 — idle reaper 短縮 + dispatch FIFO キュー + WARN-first admission（Epic #292 Phase 5）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,6 +155,9 @@ jobs:
                    tests/session/adapters-executor.test.ts \
                    tests/session/manager-headless.test.ts \
                    tests/session/headless-liveness.test.ts \
+                   tests/session/reaper.test.ts \
+                   tests/session/dispatch-queue.test.ts \
+                   tests/session/admission.test.ts \
                    tests/session/latency-logger.test.ts \
                    tests/session/manager-input-ready.test.ts \
                    tests/session/progress-buffer.test.ts \

--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -143,6 +143,45 @@ headless 実行の完了時、対象 Issue へ実行レポートを `gh issue co
 1. `DISPATCH_EXECUTOR_MODE=headless` を opt-in で有効化し、agent-base 向け dispatch（no-template / pdca）で数日 dogfood。
 2. 故障モードを観測ログで確認。問題なければ既定を headless に昇格し、tmux は明示指定の逃げ道として残す。
 
+## 多セッション性能（Phase 5, Epic #292）
+
+10+ セッション同時起動の重さ・timeout は **CPU 実行キュー飽和**が主犯（実測: 10 core に load 13-21、swap 0）。MAX_SESSIONS=10 は 11 本目を拒否するだけで 10 本同時 active の飽和を防げないため、以下の 3 施策を追加した。既定値はすべて安全側（現行挙動を壊さない）。
+
+### 5b: 対話セッション idle reaper の短縮（#293）
+
+| env | 既定 | 意味 |
+|---|---|---|
+| `SESSION_IDLE_TIMEOUT_MS` | `21600000`（6h） | 対話セッションの idle 自動終了しきい値。idle セッションは CPU/RAM を squat するため 30 日→6h に短縮 |
+
+- 30 日は **hard backstop に降格**: 実効しきい値 = `min(SESSION_IDLE_TIMEOUT_MS, 30日)`。巨大値を設定しても 30 日で必ず回収する。
+- `SESSION_IDLE_TIMEOUT_MS=2592000000`（30日）で**旧挙動を完全復元**できる。
+- 停止時にスレッドへ **resume 導線**（`/session resume <id>` または `/session start <branch>`）を残す。
+- dispatch 専用の `DISPATCH_ORPHAN_IDLE_MS`（48h, #275）とは別軸。二重実装せず、本 5b は汎用 Reaper のしきい値のみを可変化。
+
+### 5c: dispatch 同時実行制限 + FIFO キュー（#294）
+
+| env | 既定 | 意味 |
+|---|---|---|
+| `DISPATCH_MAX_CONCURRENT` | `3` | 同時に実行する dispatch セッションの上限。超過分は**拒否せずキュー**に積み、先行完了で FIFO 起動 |
+
+- 対話 `/session start` は**このキューを通らない**（`MAX_SESSIONS` のみで制限）。人間の体験は不変。
+- キュー投入時・キューから起動時にスレッドへ状態を明示（サイレントに待たせない）。
+- **再起動時のキュー扱い（選択理由）**: キューは **in-memory** で、supervisor 再起動で消える。永続化（DB + 再起動時 dedup）は不採用。理由: corp reconcile が未完了 Issue を再検出して re-dispatch するため、落ちたキュー項目は上流で self-heal する（既存の「再起動で in-flight relay 状態が消える」姿勢と同じ）。
+
+### 5d: ResourceMonitor 連動の動的 admission（WARN-first, #295）
+
+| env | 既定 | 意味 |
+|---|---|---|
+| `DISPATCH_ADMISSION_ENFORCE` | 未設定（= observe） | `1` で enforce（高負荷時に新規起動を遅延）。既定は**観測のみ**（WARN ログ、遅延なし） |
+
+- **WARN-first**: 既定は observe モード = 高負荷（load > core 数）で WARN を出すが遅延しない。ResourceMonitor が定期サンプリングして高負荷エピソードをログ化する。
+- enforce は **数日 observe して false positive ゼロを確認してから**有効化する（thin-scaffolding dogfood）。決して起動を拒否せず、遅延のみ（dispatch は落とさない）。
+- **撤退基準（YAGNI）**: 5c の FIFO キューだけで timeout が解消するなら、本 5d の enforce は**有効化しない**。observe のログで「遅延が必要な高負荷が実際に発生しているか」を確認し、発生していなければ enforce へ昇格させず observe のまま（または撤去）とする。
+
+### 5a: headless の有効化（運用のみ）
+
+`DISPATCH_EXECUTOR_MODE=headless`（上記「Headless executor モード」節）を Supervisor 環境に設定して dogfood 開始。完了で自己終了するため常駐 TUI の squat が構造的に消え、5c/5d の効果と相乗する。
+
 ## Access Policy (claudeHubExit)
 
 claudeHubExit Bot は `~/.claude/channels/discord/access.json` で access 制御される。Issue #47 以降、以下の方針で運用する。

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -53,6 +53,8 @@ import {
   runDispatch,
   resolveExecutorMode,
 } from "./session/dispatch";
+import { DispatchQueue } from "./session/dispatch-queue";
+import { AdmissionController } from "./session/admission";
 import { buildThreadTitle } from "./session/thread-title";
 
 /** Shared context for delivering a self-heal outcome to a thread (Issue #206/#244). */
@@ -288,6 +290,15 @@ export async function startBot(token: string): Promise<void> {
     },
   });
   const resourceMonitor = new ResourceMonitor(sessionManager);
+  // Phase 5c (#294): dispatch concurrency limiter + FIFO queue. Only
+  // handleDispatchMessage submits here; interactive /session start bypasses it
+  // (AC-3). The SessionManager frees a slot when a dispatch session ends.
+  const dispatchQueue = new DispatchQueue();
+  sessionManager.onSessionEnd((threadId) => dispatchQueue.notifyEnded(threadId));
+  // Phase 5d (#295): dynamic admission (WARN-first). Default observe-only — logs a
+  // WARN under high load but does not delay; enforcement is opt-in via
+  // DISPATCH_ADMISSION_ENFORCE=1.
+  const admissionController = new AdmissionController();
   const sessionHandler = createSessionHandler(sessionManager);
 
   // Per-thread progress buffer (Issue #119): coalesce PostToolUse events
@@ -528,70 +539,106 @@ export async function startBot(token: string): Promise<void> {
     // Epic #285 Phase 2: headless is opt-in via DISPATCH_EXECUTOR_MODE=headless.
     // Default (unset) keeps the current tmux path unchanged.
     const executorMode = resolveExecutorMode();
-    const result = await runDispatch({
-      config,
-      branch,
-      issueNumber,
-      command,
-      sessionManager,
-      executorMode,
-      // Headless streams its formatted output back through this poster (the tmux
-      // path never calls it — it posts its own welcome below).
-      postToThread: async (tId: string, content: string) => {
-        const thread = await client.channels.fetch(tId);
-        if (thread?.isThread()) {
-          await thread.send(content);
-        }
-      },
-      createThread: async (b: string) => {
-        // Sequence suffix only when another session is already live on the same
-        // branch (mirrors handleStart / RW-046 same-branch multi-session).
-        const sameBranchCount = sessionManager
-          .listRunningByChannel(channelName)
-          .filter((s) => s.branch === b).length;
-        const threadName = buildThreadTitle(
-          "running",
-          b,
-          config.displayName,
-          sameBranchCount + 1
-        );
-        const thread = await textChannel.threads.create({
-          name: threadName,
-          autoArchiveDuration: 10080, // 7 days
-        });
-        return { id: thread.id };
-      },
-    });
 
-    if (result.ok && result.mode === "tmux") {
-      try {
-        const thread = await client.channels.fetch(result.threadId);
-        if (thread?.isThread()) {
-          await thread.send(
+    const postToThread = async (tId: string, content: string): Promise<void> => {
+      const thread = await client.channels.fetch(tId);
+      if (thread?.isThread()) {
+        await thread.send(content);
+      }
+    };
+
+    // Phase 5c (#294): the thread is created EAGERLY (before the concurrency
+    // decision) so a queued dispatch can be told it is waiting, in its own thread.
+    // Sequence suffix mirrors handleStart / RW-046 same-branch multi-session.
+    let dispatchThread: { id: string };
+    try {
+      const sameBranchCount = sessionManager
+        .listRunningByChannel(channelName)
+        .filter((s) => s.branch === branch).length;
+      const threadName = buildThreadTitle(
+        "running",
+        branch,
+        config.displayName,
+        sameBranchCount + 1
+      );
+      const created = await textChannel.threads.create({
+        name: threadName,
+        autoArchiveDuration: 10080, // 7 days
+      });
+      dispatchThread = { id: created.id };
+    } catch (err) {
+      console.error(
+        `[Bot] Dispatch thread creation failed in channel ${channelName}:`,
+        err
+      );
+      return true;
+    }
+
+    // Runs the actual dispatch once a concurrency slot is granted. Returns whether
+    // a session actually started (the queue holds the slot until the session ends
+    // when true; frees it immediately when false).
+    const runOnce = async (): Promise<boolean> => {
+      // Phase 5d (#295): WARN-first admission. Observe mode (default) only logs a
+      // WARN under high load; enforce mode delays the start.
+      await admissionController.gate();
+      const result = await runDispatch({
+        config,
+        branch,
+        issueNumber,
+        command,
+        sessionManager,
+        executorMode,
+        postToThread,
+        createThread: async () => dispatchThread, // reuse the eagerly-created thread
+      });
+
+      if (result.ok && result.mode === "tmux") {
+        try {
+          await postToThread(
+            result.threadId,
             `🛰️ **${config.displayName}** をディスパッチで起動しました\n\n` +
               `🌿 ブランチ: \`${branch}\`\n` +
               `▶️ 初期コマンド: \`${result.injected}\`\n` +
               `📊 稼働中セッション: ${sessionManager.count()}/${MAX_SESSIONS}`
           );
+        } catch (err) {
+          console.error(
+            `[Bot] Dispatch welcome message failed for thread ${result.threadId}:`,
+            err
+          );
         }
-      } catch (err) {
+      } else if (result.ok) {
+        console.log(
+          `[Bot] Headless dispatch completed in channel ${channelName} (thread=${result.threadId}, exit=${result.exitCode}, timedOut=${result.timedOut})`
+        );
+      } else {
         console.error(
-          `[Bot] Dispatch welcome message failed for thread ${result.threadId}:`,
-          err
+          `[Bot] Dispatch failed (stage=${result.stage}) in channel ${channelName}: ${result.error}`
         );
       }
-    } else if (result.ok) {
-      // Headless: runDispatch already posted the start notice + formatted output
-      // to the thread. Log the job outcome so a non-zero exit / timeout is
-      // visible in the supervisor log too (the thread carries the detail).
-      console.log(
-        `[Bot] Headless dispatch completed in channel ${channelName} (thread=${result.threadId}, exit=${result.exitCode}, timedOut=${result.timedOut})`
-      );
-    } else {
-      console.error(
-        `[Bot] Dispatch failed (stage=${result.stage}) in channel ${channelName}: ${result.error}`
-      );
-    }
+      return result.ok;
+    };
+
+    // Phase 5c (#294): submit to the concurrency-limited FIFO queue. Under the
+    // limit it starts now; over the limit it is queued (not rejected) and the
+    // thread is told its position.
+    await dispatchQueue.submit({
+      key: dispatchThread.id,
+      run: runOnce,
+      onQueued: async (position) => {
+        await postToThread(
+          dispatchThread.id,
+          `⏳ 同時実行の上限（${dispatchQueue.limit()}）に達しているため待機中です（キュー ${position} 番目）。` +
+            `先行 dispatch の完了後、FIFO で自動起動します。`
+        );
+      },
+      onDequeued: async () => {
+        await postToThread(
+          dispatchThread.id,
+          `▶️ 空きが出たため、キューから起動します。`
+        );
+      },
+    });
     return true;
   }
 

--- a/supervisor/src/config/channels.ts
+++ b/supervisor/src/config/channels.ts
@@ -169,3 +169,34 @@ export const GOAL_GRACE_MS = 3 * 60 * 1000; // 3 minutes
 // idle threshold is env-overridable (`DISPATCH_ORPHAN_IDLE_MS`) for ops tuning.
 export const DISPATCH_ORPHAN_IDLE_MS = 48 * 60 * 60 * 1000; // 48 hours
 export const DISPATCH_ORPHAN_CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+
+// Phase 5b (#293 / Epic #292): the interactive idle reaper threshold is now
+// env-configurable (`SESSION_IDLE_TIMEOUT_MS`) with a much shorter default —
+// idle interactive sessions squat CPU/RAM and worsen the multi-session
+// saturation the Epic targets. The old 30-day value (IDLE_TIMEOUT_MS above) is
+// demoted to a HARD BACKSTOP: the effective timeout is
+// min(SESSION_IDLE_TIMEOUT_MS, SESSION_IDLE_BACKSTOP_MS), so a misconfigured huge
+// env value can never disable reaping past 30 days. Setting
+// SESSION_IDLE_TIMEOUT_MS=2592000000 restores the exact old 30-day behaviour
+// (AC-1). On teardown the reaper leaves a resume導線 in the thread.
+export const SESSION_IDLE_DEFAULT_MS = 6 * 60 * 60 * 1000; // 6 hours
+export const SESSION_IDLE_BACKSTOP_MS = IDLE_TIMEOUT_MS; // 30 days, hard cap
+
+// Phase 5c (#294 / Epic #292): dispatch concurrency limit + FIFO queue. When the
+// number of running dispatch sessions reaches this, a new /dispatch is QUEUED
+// (not rejected) and started FIFO as slots free. Interactive /session start does
+// NOT go through this queue (it is capped only by MAX_SESSIONS), so the human
+// experience is unchanged. Kept well under MAX_SESSIONS so interactive keeps
+// headroom. Env-overridable via `DISPATCH_MAX_CONCURRENT`.
+export const DISPATCH_MAX_CONCURRENT = 3;
+
+// Phase 5d (#295 / Epic #292): dynamic admission is WARN-first — it defaults to
+// OBSERVE ONLY (log a WARN when load is high, but do NOT delay). Enforcement
+// (actually delaying a start under high load) is opt-in via
+// `DISPATCH_ADMISSION_ENFORCE=1`, to be flipped on only after a few days of
+// zero-false-positive observation (thin-scaffolding dogfood). The load ceiling
+// is `core_count * ADMISSION_LOAD_FACTOR`; over it, enforcement waits
+// ADMISSION_DELAY_MS before admitting (never rejects — dispatch is queued/delayed,
+// not dropped).
+export const ADMISSION_LOAD_FACTOR = 1.0;
+export const ADMISSION_DELAY_MS = 5000; // 5s

--- a/supervisor/src/session/admission.ts
+++ b/supervisor/src/session/admission.ts
@@ -1,0 +1,137 @@
+import { cpus, loadavg, freemem, totalmem } from "os";
+import {
+  ADMISSION_LOAD_FACTOR,
+  ADMISSION_DELAY_MS,
+} from "../config/channels";
+
+/**
+ * Dynamic admission control (Phase 5d / #295, Epic #292). Samples system load and
+ * decides whether a NEW session start should be delayed under high load.
+ *
+ * WARN-FIRST (thin-scaffolding dogfood): the default mode is OBSERVE — it logs a
+ * WARN when load is high but never delays (delayMs = 0). Enforcement (an actual
+ * delay) is opt-in via `DISPATCH_ADMISSION_ENFORCE=1`, to be flipped on only
+ * after a few days of zero-false-positive observation. It NEVER rejects a start —
+ * the worst it does is delay, so a dispatch is never dropped by admission.
+ *
+ * Retreat criteria (documented in docs/bot-operations.md): if the Phase 5c FIFO
+ * queue alone resolves the timeout問題, admission enforcement is never enabled and
+ * this stays observe-only (YAGNI).
+ */
+
+/** A point-in-time system load/memory sample. Injectable so tests never read real os metrics. */
+export interface SystemSample {
+  /** 1-minute load average. */
+  load1: number;
+  /** Number of logical CPUs. */
+  cores: number;
+  /** Free memory ratio in [0,1] (freemem/totalmem); lower = more pressure. */
+  freeMemRatio: number;
+}
+
+export interface LoadSampler {
+  sample(): SystemSample;
+}
+
+/** Real sampler over `os` (cross-platform: loadavg is 0 on unsupported platforms). */
+export const realLoadSampler: LoadSampler = {
+  sample(): SystemSample {
+    const total = totalmem();
+    return {
+      load1: loadavg()[0] ?? 0,
+      cores: Math.max(1, cpus().length),
+      freeMemRatio: total > 0 ? freemem() / total : 1,
+    };
+  },
+};
+
+export type AdmissionMode = "observe" | "enforce";
+
+/**
+ * Resolve the admission mode from the environment (#295). WARN-first: anything
+ * other than the exact opt-in `DISPATCH_ADMISSION_ENFORCE=1` resolves to
+ * "observe" (log-only, no delay), so the default is safe.
+ */
+export function resolveAdmissionMode(
+  env: Record<string, string | undefined> = process.env,
+): AdmissionMode {
+  return env.DISPATCH_ADMISSION_ENFORCE === "1" ? "enforce" : "observe";
+}
+
+/** Decision from {@link AdmissionController.evaluate}. Pure data — the caller logs/sleeps. */
+export interface AdmissionDecision {
+  /** ms the caller should wait before starting. Always 0 in observe mode. */
+  delayMs: number;
+  /** A WARN message to log when load is high, else null. */
+  warn: string | null;
+  /** The sample the decision was based on (for structured logging). */
+  sample: SystemSample;
+}
+
+export interface AdmissionControllerDeps {
+  sampler?: LoadSampler;
+  mode?: AdmissionMode;
+  /** Load ceiling factor: high when load1 > cores * factor. Defaults to {@link ADMISSION_LOAD_FACTOR}. */
+  loadFactor?: number;
+  /** Delay applied in enforce mode when over the ceiling. Defaults to {@link ADMISSION_DELAY_MS}. */
+  delayMs?: number;
+}
+
+export class AdmissionController {
+  private readonly sampler: LoadSampler;
+  private readonly mode: AdmissionMode;
+  private readonly loadFactor: number;
+  private readonly delayMs: number;
+
+  constructor(deps: AdmissionControllerDeps = {}) {
+    this.sampler = deps.sampler ?? realLoadSampler;
+    this.mode = deps.mode ?? resolveAdmissionMode();
+    this.loadFactor = deps.loadFactor ?? ADMISSION_LOAD_FACTOR;
+    this.delayMs = deps.delayMs ?? ADMISSION_DELAY_MS;
+  }
+
+  /**
+   * Evaluate whether a new start should be delayed. Side-effect-free (samples
+   * only), so tests assert the decision deterministically:
+   *   - load ≤ ceiling                 → { delayMs: 0, warn: null }
+   *   - load > ceiling, observe (default) → { delayMs: 0, warn: "…" }  (WARN-first, AC-5)
+   *   - load > ceiling, enforce        → { delayMs: N, warn: "…" }     (AC-4)
+   */
+  evaluate(): AdmissionDecision {
+    const sample = this.sampler.sample();
+    const ceiling = sample.cores * this.loadFactor;
+    if (sample.load1 <= ceiling) {
+      return { delayMs: 0, warn: null, sample };
+    }
+    const warn =
+      `[Admission] high load: load1=${sample.load1.toFixed(2)} > ceiling ${ceiling.toFixed(2)} ` +
+      `(cores=${sample.cores}, freeMem=${(sample.freeMemRatio * 100).toFixed(0)}%), mode=${this.mode}` +
+      (this.mode === "observe"
+        ? " — observe only (no delay)"
+        : ` — delaying start by ${this.delayMs}ms`);
+    return {
+      delayMs: this.mode === "enforce" ? this.delayMs : 0,
+      warn,
+      sample,
+    };
+  }
+
+  /**
+   * Convenience gate used before a real start: evaluate, log the WARN if any, and
+   * (enforce mode only) wait `delayMs`. Returns the decision so callers can also
+   * record it. `sleep` is injectable so tests never wait real time.
+   */
+  async gate(
+    log: Pick<Console, "warn"> = console,
+    sleep: (ms: number) => Promise<void> = defaultSleep,
+  ): Promise<AdmissionDecision> {
+    const decision = this.evaluate();
+    if (decision.warn) log.warn(decision.warn);
+    if (decision.delayMs > 0) await sleep(decision.delayMs);
+    return decision;
+  }
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/supervisor/src/session/dispatch-queue.ts
+++ b/supervisor/src/session/dispatch-queue.ts
@@ -1,0 +1,149 @@
+import { DISPATCH_MAX_CONCURRENT } from "../config/channels";
+
+/**
+ * Dispatch concurrency limiter + FIFO queue (Phase 5c / #294, Epic #292).
+ *
+ * The multi-session timeout問題 is CPU run-queue saturation: MAX_SESSIONS=10 only
+ * rejects the 11th, it does not stop 10 dispatches from starting at once and
+ * driving load ≫ cores. This gates *dispatch* starts to at most
+ * `DISPATCH_MAX_CONCURRENT` concurrent; a dispatch over the limit is QUEUED (not
+ * rejected) and started FIFO as running dispatches end.
+ *
+ * Interactive `/session start` does NOT go through this queue — it starts
+ * immediately (capped only by MAX_SESSIONS), so the human experience is unchanged
+ * (AC-3). Only `handleDispatchMessage` submits here.
+ *
+ * A slot is held for the whole session lifetime: {@link submit}/{@link pump}
+ * mark the threadId active when a start begins, and the owner frees it via
+ * {@link notifyEnded} when the session actually ends (the SessionManager calls it
+ * from stop / tmux-exit / headless-finish). This is why `run()` returns whether a
+ * session actually started: if it did (tmux: session outlives run(); headless:
+ * notifyEnded already fired), the slot stays until the end event; if it did not
+ * (thread/start/spawn failure), the queue frees the slot immediately so it is
+ * never leaked.
+ *
+ * Restart handling (chosen + justified): the queue is IN-MEMORY and lost on a
+ * supervisor restart. Persisting it (DB + dedup-on-restart) was rejected as
+ * unjustified complexity: corp's reconcile loop re-detects an incomplete Issue
+ * and re-dispatches it, so a dropped queued dispatch self-heals upstream. This
+ * mirrors the existing "supervisor restart drops in-flight relay state" posture.
+ */
+
+/** One unit of dispatch work managed by the queue. `key` is the (unique) threadId. */
+export interface QueuedDispatch {
+  key: string;
+  /**
+   * Perform the dispatch. Resolves `true` when a session actually started (the
+   * slot must stay held until {@link DispatchQueue.notifyEnded}), `false` when no
+   * session started (queue frees the slot now). Must not throw for a normal
+   * dispatch failure — return false; a throw is treated as false with a log.
+   */
+  run: () => Promise<boolean>;
+  /** Posted when the item is placed on the queue (over the concurrency limit). `position` is 1-based. */
+  onQueued: (position: number) => Promise<void>;
+  /** Posted when the item leaves the queue to start (a slot freed). */
+  onDequeued: () => Promise<void>;
+}
+
+export interface DispatchQueueDeps {
+  maxConcurrent?: number;
+  log?: Pick<Console, "error" | "warn" | "log">;
+}
+
+function resolveMaxConcurrent(): number {
+  const raw = process.env.DISPATCH_MAX_CONCURRENT;
+  const n = raw != null ? Number(raw) : NaN;
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : DISPATCH_MAX_CONCURRENT;
+}
+
+export class DispatchQueue {
+  /** threadIds of dispatches currently occupying a concurrency slot. */
+  private readonly active = new Set<string>();
+  /** FIFO pending queue (over the concurrency limit). */
+  private readonly pending: QueuedDispatch[] = [];
+  private readonly maxConcurrent: number;
+  private readonly log: Pick<Console, "error" | "warn" | "log">;
+
+  constructor(deps: DispatchQueueDeps = {}) {
+    this.maxConcurrent = deps.maxConcurrent ?? resolveMaxConcurrent();
+    this.log = deps.log ?? console;
+  }
+
+  /** The concurrency limit (for status messages). */
+  limit(): number {
+    return this.maxConcurrent;
+  }
+
+  activeCount(): number {
+    return this.active.size;
+  }
+
+  pendingCount(): number {
+    return this.pending.length;
+  }
+
+  /**
+   * Submit a dispatch. Starts it immediately when under the concurrency limit,
+   * otherwise enqueues it FIFO and calls `onQueued` with its 1-based position.
+   * Returns which happened so the caller can log/report.
+   */
+  async submit(item: QueuedDispatch): Promise<"started" | "queued"> {
+    if (this.active.size < this.maxConcurrent && !this.active.has(item.key)) {
+      this.active.add(item.key);
+      void this.runItem(item);
+      return "started";
+    }
+    this.pending.push(item);
+    try {
+      await item.onQueued(this.pending.length);
+    } catch (err) {
+      this.log.error(`[DispatchQueue] onQueued failed for ${item.key}:`, err);
+    }
+    return "queued";
+  }
+
+  /**
+   * Free the slot held by `threadId` (called by the SessionManager when a
+   * dispatch session ends) and pump the queue. A no-op when the threadId does not
+   * hold a slot (e.g. an interactive session ended), so interactive teardown
+   * never disturbs the dispatch queue.
+   */
+  notifyEnded(threadId: string | undefined): void {
+    if (!threadId || !this.active.has(threadId)) return;
+    this.active.delete(threadId);
+    this.pump();
+  }
+
+  /** Start as many queued items as free slots allow, FIFO. */
+  private pump(): void {
+    while (this.active.size < this.maxConcurrent && this.pending.length > 0) {
+      const item = this.pending.shift()!;
+      this.active.add(item.key);
+      void this.dequeueAndRun(item);
+    }
+  }
+
+  private async dequeueAndRun(item: QueuedDispatch): Promise<void> {
+    try {
+      await item.onDequeued();
+    } catch (err) {
+      this.log.error(`[DispatchQueue] onDequeued failed for ${item.key}:`, err);
+    }
+    await this.runItem(item);
+  }
+
+  private async runItem(item: QueuedDispatch): Promise<void> {
+    let started = false;
+    try {
+      started = await item.run();
+    } catch (err) {
+      this.log.error(`[DispatchQueue] run() threw for ${item.key}:`, err);
+      started = false;
+    }
+    // No session started (failure) → the SessionManager will never emit an end
+    // event for this slot, so free it here to avoid a permanent leak. When a
+    // session DID start, the slot stays until notifyEnded (which, for headless,
+    // has already fired by the time run() resolves).
+    if (!started) this.notifyEnded(item.key);
+  }
+}

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -444,6 +444,14 @@ export class SessionManager {
    * would double-write the transcript jsonl — RW-046-type corruption).
    */
   private readonly resumingClaudeSessions = new Set<string>();
+  /**
+   * Optional listener fired whenever a session ends (stop / tmux-exit /
+   * headless-finish), with its threadId (Phase 5c / #294). The DispatchQueue
+   * registers it to free a concurrency slot and pump the FIFO queue. Kept generic
+   * (the manager does not know "dispatch"): the queue ignores threadIds that do
+   * not hold a slot, so an interactive session ending is a harmless no-op.
+   */
+  private dispatchEndListener?: (threadId: string) => void;
   private readonly effects: SessionEffects;
   private readonly gracefulKillTimeoutMs: number;
   private readonly resumePromptPollAttempts: number;
@@ -497,6 +505,27 @@ export class SessionManager {
    * stopped, which races nothing the first relay depends on).
    */
   readonly recovery: Promise<void>;
+
+  /**
+   * Register the session-end listener (Phase 5c / #294). Called once at startup
+   * by bot.ts to connect the DispatchQueue. Fired after a session leaves the live
+   * map on any terminal path.
+   */
+  onSessionEnd(listener: (threadId: string) => void): void {
+    this.dispatchEndListener = listener;
+  }
+
+  /** Notify the end listener, swallowing listener errors (must never break teardown). */
+  private emitSessionEnd(threadId: string): void {
+    try {
+      this.dispatchEndListener?.(threadId);
+    } catch (err) {
+      console.error(
+        `[SessionManager] dispatchEndListener threw for ${threadId}:`,
+        err,
+      );
+    }
+  }
 
   count(): number {
     return this.sessions.size;
@@ -979,6 +1008,7 @@ export class SessionManager {
     worktree: SessionInfo["worktree"],
   ): Promise<void> {
     this.sessions.delete(threadId);
+    this.emitSessionEnd(threadId); // Phase 5c: free a dispatch queue slot (#294)
     this.clearWatcher(threadId); // defensive: headless never sets one
     const reason: StopReason = result.timedOut
       ? "headless_timeout"
@@ -1658,6 +1688,7 @@ export class SessionManager {
 
     this.clearWatcher(threadId);
     this.sessions.delete(threadId);
+    this.emitSessionEnd(threadId); // Phase 5c: free a dispatch queue slot (#294)
     // Issue #244: drop the per-conversation self-heal planner on a TERMINAL stop
     // so its cap does not leak. A `self_heal_restart` stop is NOT terminal — the
     // conversation is about to be `claude --resume`d into a fresh thread, so the
@@ -1808,6 +1839,7 @@ export class SessionManager {
             `[SessionManager] tmux session ${tmuxName} exited`
           );
           this.sessions.delete(threadId);
+          this.emitSessionEnd(threadId); // Phase 5c: free a dispatch queue slot (#294)
           if (session) {
             this.effects.iterm2.markTabStopped(session.channelName, tmuxName);
             this.cleanupRelayUrlFile(session.projectDir);

--- a/supervisor/src/session/reaper.ts
+++ b/supervisor/src/session/reaper.ts
@@ -1,23 +1,69 @@
 import type { SessionManager } from "./manager";
 import type { ThreadChannel, Client } from "discord.js";
 import {
-  IDLE_TIMEOUT_MS,
   IDLE_CHECK_INTERVAL_MS,
+  SESSION_IDLE_DEFAULT_MS,
+  SESSION_IDLE_BACKSTOP_MS,
 } from "../config/channels";
 import { markTitleStopped } from "./thread-title";
 
+/**
+ * Resolve the effective idle-reap threshold (Phase 5b / #293). The primary
+ * threshold comes from `SESSION_IDLE_TIMEOUT_MS` (default {@link
+ * SESSION_IDLE_DEFAULT_MS} = 6h), but it is CAPPED at {@link
+ * SESSION_IDLE_BACKSTOP_MS} (30 days) — the old 30-day value demoted to a hard
+ * backstop so a misconfigured huge env value can never disable reaping. Setting
+ * the env to 2592000000 (30d) restores the exact pre-#293 behaviour (AC-1).
+ */
+export function resolveIdleTimeoutMs(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env.SESSION_IDLE_TIMEOUT_MS;
+  const parsed = raw != null ? Number(raw) : NaN;
+  const configured =
+    Number.isFinite(parsed) && parsed > 0
+      ? Math.floor(parsed)
+      : SESSION_IDLE_DEFAULT_MS;
+  return Math.min(configured, SESSION_IDLE_BACKSTOP_MS);
+}
+
+export interface ReaperDeps {
+  /** Effective idle timeout. Defaults to {@link resolveIdleTimeoutMs}. */
+  idleTimeoutMs?: number;
+  /** Poll interval. Defaults to {@link IDLE_CHECK_INTERVAL_MS}. */
+  checkIntervalMs?: number;
+  /** Clock injection for deterministic tests. Defaults to `Date.now`. */
+  now?: () => number;
+}
+
+/** Minimal snapshot captured before stop() removes the session, for the resume導線. */
+interface ReapedSessionInfo {
+  claudeSessionId?: string;
+  branch?: string;
+}
+
 export class Reaper {
   private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly idleTimeoutMs: number;
+  private readonly checkIntervalMs: number;
+  private readonly now: () => number;
 
   constructor(
     private sessionManager: SessionManager,
-    private client: Client
-  ) {}
+    private client: Client,
+    deps: ReaperDeps = {},
+  ) {
+    this.idleTimeoutMs = deps.idleTimeoutMs ?? resolveIdleTimeoutMs();
+    this.checkIntervalMs = deps.checkIntervalMs ?? IDLE_CHECK_INTERVAL_MS;
+    this.now = deps.now ?? Date.now;
+  }
 
   start(): void {
-    this.timer = setInterval(() => this.check(), IDLE_CHECK_INTERVAL_MS);
+    this.timer = setInterval(() => {
+      void this.check();
+    }, this.checkIntervalMs);
     console.log(
-      `[Reaper] Started (check every ${IDLE_CHECK_INTERVAL_MS / 1000 / 60}min, timeout ${IDLE_TIMEOUT_MS / 1000 / 60 / 60 / 24}days)`
+      `[Reaper] Started (check every ${this.checkIntervalMs / 1000 / 60}min, idle timeout ${(this.idleTimeoutMs / 1000 / 60 / 60).toFixed(1)}h, backstop ${(SESSION_IDLE_BACKSTOP_MS / 1000 / 60 / 60 / 24).toFixed(0)}d)`,
     );
   }
 
@@ -28,34 +74,71 @@ export class Reaper {
     }
   }
 
-  private async check(): Promise<void> {
-    const now = Date.now();
+  /**
+   * One scan tick. Public so tests can drive it deterministically. Snapshots the
+   * session's resume identifiers BEFORE stop() removes it from the live map, so
+   * the teardown notice can offer a `/session resume` path (#293).
+   */
+  async check(): Promise<void> {
+    const now = this.now();
     for (const [threadId, session] of this.sessionManager.entries()) {
       const idleMs = now - session.lastActivityAt.getTime();
-      if (idleMs > IDLE_TIMEOUT_MS) {
+      if (idleMs > this.idleTimeoutMs) {
+        const snapshot: ReapedSessionInfo = {
+          claudeSessionId: session.claudeSessionId,
+          branch: session.branch,
+        };
         console.log(
-          `[Reaper] Thread ${threadId} (${session.channelName}) idle for ${(idleMs / 1000 / 60 / 60 / 24).toFixed(1)} days, terminating`
+          `[Reaper] Thread ${threadId} (${session.channelName}) idle for ${(idleMs / 1000 / 60 / 60).toFixed(1)}h (> ${(this.idleTimeoutMs / 1000 / 60 / 60).toFixed(1)}h), terminating`,
         );
         await this.sessionManager.stop(threadId, "idle_timeout");
-        await this.notifyThread(threadId);
+        await this.notifyThread(threadId, idleMs, snapshot);
       }
     }
   }
 
-  private async notifyThread(threadId: string): Promise<void> {
+  /**
+   * Build the idle-teardown notice, including a resume導線 (#293). When the
+   * session had a captured claude session id, offer `/session resume <id>` so the
+   * user can pick the conversation back up; otherwise fall back to guiding a fresh
+   * `/session start`. Static + deterministic so a unit test can assert the resume
+   * line is present.
+   */
+  static buildIdleNotice(idleMs: number, info: ReapedSessionInfo): string {
+    const idleHours = (idleMs / 1000 / 60 / 60).toFixed(1);
+    const head = `⏰ ${idleHours} 時間無操作のためセッションを自動終了しました（省リソースのための idle reaper, #292）。`;
+    if (info.claudeSessionId) {
+      return (
+        `${head}\n` +
+        `↩️ 会話を続けるには \`/session resume ${info.claudeSessionId}\` を実行してください。`
+      );
+    }
+    const startHint = info.branch
+      ? `\`/session start ${info.branch}\``
+      : "`/session start <branch>`";
+    return `${head}\n↩️ 新しく始めるには ${startHint} を実行してください。`;
+  }
+
+  private async notifyThread(
+    threadId: string,
+    idleMs: number,
+    info: ReapedSessionInfo,
+  ): Promise<void> {
     try {
-      const thread = this.client.channels.cache.get(threadId) as
+      let thread = this.client.channels.cache.get(threadId) as
         | ThreadChannel
         | undefined;
+      // The idle horizon is now hours, but on a long-running / restarted
+      // supervisor the thread may still be cache-evicted — fetch as a fallback so
+      // the notice / rename / archive are not silently skipped.
+      if (!thread) {
+        thread = (await this.client.channels
+          .fetch(threadId)
+          .catch(() => undefined)) as ThreadChannel | undefined;
+      }
 
       if (thread?.isThread()) {
-        // Derive the day count from IDLE_TIMEOUT_MS so the message never drifts
-        // out of sync with the constant (it used to hardcode "7日").
-        const idleDays = Math.round(IDLE_TIMEOUT_MS / 1000 / 60 / 60 / 24);
-        await thread.send(
-          `⏰ ${idleDays}日間無操作のためセッションを自動終了しました。`
-        );
-
+        await thread.send(Reaper.buildIdleNotice(idleMs, info));
         // Rename and archive. markTitleStopped also handles ♻️ resume threads,
         // which the old `.replace("🟢", ...)` skipped (Issue #175).
         const stoppedName = markTitleStopped(thread.name);

--- a/supervisor/src/session/reaper.ts
+++ b/supervisor/src/session/reaper.ts
@@ -81,7 +81,10 @@ export class Reaper {
    */
   async check(): Promise<void> {
     const now = this.now();
-    for (const [threadId, session] of this.sessionManager.entries()) {
+    // Snapshot first: stop() awaits and mutates the live map mid-loop, so
+    // iterating the raw entries() iterator while deleting is a race (gemini PR
+    // #297 HIGH). Mirrors GoalWatcher / OrphanDispatchReaper, which already do this.
+    for (const [threadId, session] of Array.from(this.sessionManager.entries())) {
       const idleMs = now - session.lastActivityAt.getTime();
       if (idleMs > this.idleTimeoutMs) {
         const snapshot: ReapedSessionInfo = {

--- a/supervisor/src/session/resource-monitor.ts
+++ b/supervisor/src/session/resource-monitor.ts
@@ -63,7 +63,10 @@ export class ResourceMonitor {
 
   async check(): Promise<void> {
     this.sampleLoad();
-    for (const [threadId, session] of this.sessionManager.entries()) {
+    // Snapshot first: stop() (resource_limit teardown below) awaits and mutates
+    // the live map mid-loop, so iterating the raw entries() iterator while
+    // deleting is a race (gemini PR #297 HIGH). Mirrors the reapers.
+    for (const [threadId, session] of Array.from(this.sessionManager.entries())) {
       if (!session.pid) continue;
       try {
         const { stdout } = await execAsync(`ps -o rss= -p ${session.pid}`);

--- a/supervisor/src/session/resource-monitor.ts
+++ b/supervisor/src/session/resource-monitor.ts
@@ -5,13 +5,31 @@ import {
   RESOURCE_CHECK_INTERVAL_MS,
   MAX_MEMORY_PER_SESSION_MB,
 } from "../config/channels";
+import { AdmissionController } from "./admission";
 
 const execAsync = promisify(exec);
 
+export interface ResourceMonitorDeps {
+  /**
+   * Admission controller used purely for its load/memory sampling here (Phase 5d
+   * / #295): each check() samples system load and logs a WARN when it is high, so
+   * saturation episodes are observable in the supervisor log even in the default
+   * observe-only mode. The start-time admission GATE lives in bot.ts; this is the
+   * periodic observation half. Defaults to a fresh observe-mode controller.
+   */
+  admission?: AdmissionController;
+}
+
 export class ResourceMonitor {
   private timer: ReturnType<typeof setInterval> | null = null;
+  private readonly admission: AdmissionController;
 
-  constructor(private sessionManager: SessionManager) {}
+  constructor(
+    private sessionManager: SessionManager,
+    deps: ResourceMonitorDeps = {},
+  ) {
+    this.admission = deps.admission ?? new AdmissionController();
+  }
 
   start(): void {
     this.timer = setInterval(
@@ -30,7 +48,21 @@ export class ResourceMonitor {
     }
   }
 
-  private async check(): Promise<void> {
+  /**
+   * Sample system load and log a WARN when it is over the ceiling (Phase 5d /
+   * #295). Public so a test can drive it deterministically with an injected
+   * sampler. Observation only — it never stops or delays anything here (the
+   * start-time gate is in bot.ts); this makes high-load episodes visible.
+   */
+  sampleLoad(): void {
+    const decision = this.admission.evaluate();
+    if (decision.warn) {
+      console.warn(`[ResourceMonitor] ${decision.warn}`);
+    }
+  }
+
+  async check(): Promise<void> {
+    this.sampleLoad();
     for (const [threadId, session] of this.sessionManager.entries()) {
       if (!session.pid) continue;
       try {

--- a/supervisor/tests/session/admission.test.ts
+++ b/supervisor/tests/session/admission.test.ts
@@ -1,0 +1,145 @@
+import { describe, test, expect, spyOn } from "bun:test";
+import {
+  AdmissionController,
+  resolveAdmissionMode,
+  type LoadSampler,
+  type SystemSample,
+} from "../../src/session/admission";
+import { ResourceMonitor } from "../../src/session/resource-monitor";
+import type { SessionManager } from "../../src/session/manager";
+
+/**
+ * Phase 5d / #295 (Epic #292 AC-4 / AC-5): WARN-first dynamic admission. Default
+ * observe mode logs a WARN under high load but never delays; enforce mode delays.
+ * A fake sampler injects the load so no real system metrics are read.
+ */
+
+function sampler(load1: number, cores = 10): LoadSampler {
+  const s: SystemSample = { load1, cores, freeMemRatio: 0.5 };
+  return { sample: () => s };
+}
+
+describe("resolveAdmissionMode", () => {
+  test("defaults to observe; only DISPATCH_ADMISSION_ENFORCE=1 enables enforce", () => {
+    expect(resolveAdmissionMode({})).toBe("observe");
+    expect(resolveAdmissionMode({ DISPATCH_ADMISSION_ENFORCE: "1" })).toBe(
+      "enforce",
+    );
+    expect(resolveAdmissionMode({ DISPATCH_ADMISSION_ENFORCE: "0" })).toBe(
+      "observe",
+    );
+    expect(resolveAdmissionMode({ DISPATCH_ADMISSION_ENFORCE: "true" })).toBe(
+      "observe",
+    );
+  });
+});
+
+describe("AdmissionController.evaluate", () => {
+  test("low load (≤ cores) → no warn, no delay", () => {
+    const c = new AdmissionController({ sampler: sampler(4, 10), mode: "observe" });
+    const d = c.evaluate();
+    expect(d.warn).toBeNull();
+    expect(d.delayMs).toBe(0);
+  });
+
+  test("high load, observe (default) → WARN but NO delay (WARN-first, AC-5)", () => {
+    const c = new AdmissionController({ sampler: sampler(15, 10), mode: "observe" });
+    const d = c.evaluate();
+    expect(d.warn).toContain("high load");
+    expect(d.warn).toContain("observe only");
+    expect(d.delayMs).toBe(0);
+  });
+
+  test("high load, enforce → WARN and a positive delay (AC-4)", () => {
+    const c = new AdmissionController({
+      sampler: sampler(21, 10),
+      mode: "enforce",
+      delayMs: 5000,
+    });
+    const d = c.evaluate();
+    expect(d.warn).toContain("high load");
+    expect(d.delayMs).toBe(5000);
+  });
+
+  test("loadFactor scales the ceiling", () => {
+    // ceiling = cores(10) * 0.5 = 5 → load 6 is over.
+    const c = new AdmissionController({
+      sampler: sampler(6, 10),
+      mode: "observe",
+      loadFactor: 0.5,
+    });
+    expect(c.evaluate().warn).toContain("high load");
+  });
+});
+
+describe("AdmissionController.gate", () => {
+  test("observe mode logs the WARN and does not sleep (AC-5)", async () => {
+    const warns: string[] = [];
+    const sleeps: number[] = [];
+    const c = new AdmissionController({ sampler: sampler(15, 10), mode: "observe" });
+    await c.gate({ warn: (m: string) => warns.push(m) }, async (ms) => {
+      sleeps.push(ms);
+    });
+    expect(warns).toHaveLength(1);
+    expect(sleeps).toHaveLength(0); // no delay in observe mode
+  });
+
+  test("enforce mode logs the WARN and sleeps the delay (AC-4)", async () => {
+    const warns: string[] = [];
+    const sleeps: number[] = [];
+    const c = new AdmissionController({
+      sampler: sampler(15, 10),
+      mode: "enforce",
+      delayMs: 5000,
+    });
+    await c.gate({ warn: (m: string) => warns.push(m) }, async (ms) => {
+      sleeps.push(ms);
+    });
+    expect(warns).toHaveLength(1);
+    expect(sleeps).toEqual([5000]);
+  });
+
+  test("low load: no warn, no sleep", async () => {
+    const warns: string[] = [];
+    const sleeps: number[] = [];
+    const c = new AdmissionController({ sampler: sampler(3, 10), mode: "enforce" });
+    await c.gate({ warn: (m: string) => warns.push(m) }, async (ms) => {
+      sleeps.push(ms);
+    });
+    expect(warns).toHaveLength(0);
+    expect(sleeps).toHaveLength(0);
+  });
+});
+
+describe("ResourceMonitor.sampleLoad (#295 periodic observation)", () => {
+  const emptyManager = {
+    entries: () => new Map().entries(),
+  } as unknown as SessionManager;
+
+  test("logs a WARN when load is high (observe-only, no stop)", () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const rm = new ResourceMonitor(emptyManager, {
+        admission: new AdmissionController({ sampler: sampler(18, 10), mode: "observe" }),
+      });
+      rm.sampleLoad();
+      expect(warnSpy).toHaveBeenCalledTimes(1);
+      expect(String(warnSpy.mock.calls[0]![0])).toContain("high load");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("stays silent when load is within the ceiling", () => {
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      const rm = new ResourceMonitor(emptyManager, {
+        admission: new AdmissionController({ sampler: sampler(4, 10), mode: "observe" }),
+      });
+      rm.sampleLoad();
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+});

--- a/supervisor/tests/session/dispatch-queue.test.ts
+++ b/supervisor/tests/session/dispatch-queue.test.ts
@@ -1,0 +1,160 @@
+import { describe, test, expect } from "bun:test";
+import {
+  DispatchQueue,
+  type QueuedDispatch,
+} from "../../src/session/dispatch-queue";
+
+/**
+ * Phase 5c / #294 (Epic #292 AC-2 / AC-3): dispatch concurrency limit + FIFO
+ * queue, with interactive /session start bypassing it. A silent quiet log keeps
+ * the deterministic test output clean.
+ */
+
+const quietLog = { error: () => {}, warn: () => {}, log: () => {} };
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("DispatchQueue (AC-2: concurrency limit + FIFO)", () => {
+  test("starts up to the limit, queues the rest, then dequeues FIFO as slots free", async () => {
+    const started: string[] = [];
+    const dequeued: string[] = [];
+    const queued: Array<{ key: string; pos: number }> = [];
+    const item = (key: string): QueuedDispatch => ({
+      key,
+      run: async () => {
+        started.push(key);
+        return true; // a session started → slot held until notifyEnded
+      },
+      onQueued: async (pos) => {
+        queued.push({ key, pos });
+      },
+      onDequeued: async () => {
+        dequeued.push(key);
+      },
+    });
+
+    const q = new DispatchQueue({ maxConcurrent: 3, log: quietLog });
+    const outcomes: string[] = [];
+    for (const k of ["t1", "t2", "t3", "t4", "t5", "t6"]) {
+      outcomes.push(await q.submit(item(k)));
+    }
+    await flush();
+
+    // 3 started immediately, 3 queued (not rejected).
+    expect(outcomes).toEqual([
+      "started",
+      "started",
+      "started",
+      "queued",
+      "queued",
+      "queued",
+    ]);
+    expect(started).toEqual(["t1", "t2", "t3"]);
+    expect(queued).toEqual([
+      { key: "t4", pos: 1 },
+      { key: "t5", pos: 2 },
+      { key: "t6", pos: 3 },
+    ]);
+    expect(q.activeCount()).toBe(3);
+    expect(q.pendingCount()).toBe(3);
+
+    // A running dispatch ends → the next queued one starts (FIFO).
+    q.notifyEnded("t1");
+    await flush();
+    expect(dequeued).toEqual(["t4"]);
+    expect(started).toEqual(["t1", "t2", "t3", "t4"]);
+    expect(q.activeCount()).toBe(3);
+    expect(q.pendingCount()).toBe(2);
+
+    q.notifyEnded("t2");
+    await flush();
+    q.notifyEnded("t3");
+    await flush();
+    // All six ran, strict FIFO order, queue drained.
+    expect(started).toEqual(["t1", "t2", "t3", "t4", "t5", "t6"]);
+    expect(dequeued).toEqual(["t4", "t5", "t6"]);
+    expect(q.pendingCount()).toBe(0);
+  });
+
+  test("run() returning false frees the slot immediately (no leak) and pumps", async () => {
+    const started: string[] = [];
+    const q = new DispatchQueue({ maxConcurrent: 1, log: quietLog });
+
+    // First item fails to start a session (run → false).
+    await q.submit({
+      key: "fail",
+      run: async () => {
+        started.push("fail");
+        return false;
+      },
+      onQueued: async () => {},
+      onDequeued: async () => {},
+    });
+    // Second item queues behind it, then should run once the slot frees.
+    await q.submit({
+      key: "ok",
+      run: async () => {
+        started.push("ok");
+        return true;
+      },
+      onQueued: async () => {},
+      onDequeued: async () => {},
+    });
+    await flush();
+
+    expect(started).toEqual(["fail", "ok"]);
+    expect(q.activeCount()).toBe(1); // only "ok" holds a slot
+    expect(q.pendingCount()).toBe(0);
+  });
+
+  test("run() throwing is treated as not-started (slot freed)", async () => {
+    const q = new DispatchQueue({ maxConcurrent: 1, log: quietLog });
+    await q.submit({
+      key: "boom",
+      run: async () => {
+        throw new Error("start blew up");
+      },
+      onQueued: async () => {},
+      onDequeued: async () => {},
+    });
+    await flush();
+    // The throw must not leak the slot.
+    expect(q.activeCount()).toBe(0);
+  });
+});
+
+describe("DispatchQueue (AC-3: interactive bypass)", () => {
+  test("a full dispatch queue does not gate a non-submitted (interactive) start", async () => {
+    const q = new DispatchQueue({ maxConcurrent: 1, log: quietLog });
+    await q.submit({
+      key: "d1",
+      run: async () => true,
+      onQueued: async () => {},
+      onDequeued: async () => {},
+    });
+    await q.submit({
+      key: "d2",
+      run: async () => true,
+      onQueued: async () => {},
+      onDequeued: async () => {},
+    });
+    await flush();
+    // Dispatch queue is full (1 active, 1 pending).
+    expect(q.activeCount()).toBe(1);
+    expect(q.pendingCount()).toBe(1);
+
+    // Interactive /session start never calls queue.submit — model it as a direct
+    // start that runs immediately regardless of the full dispatch queue.
+    let interactiveStarted = false;
+    const interactiveStart = async () => {
+      interactiveStarted = true;
+    };
+    await interactiveStart();
+    expect(interactiveStarted).toBe(true);
+
+    // And an interactive session ending (threadId not in the queue) is a no-op:
+    // it must not spuriously dequeue a pending dispatch.
+    q.notifyEnded("interactive-thread-not-in-queue");
+    expect(q.activeCount()).toBe(1);
+    expect(q.pendingCount()).toBe(1);
+  });
+});

--- a/supervisor/tests/session/reaper.test.ts
+++ b/supervisor/tests/session/reaper.test.ts
@@ -1,0 +1,151 @@
+import { describe, test, expect } from "bun:test";
+import { Reaper, resolveIdleTimeoutMs } from "../../src/session/reaper";
+import {
+  SESSION_IDLE_DEFAULT_MS,
+  SESSION_IDLE_BACKSTOP_MS,
+} from "../../src/config/channels";
+import type { SessionInfo, StopReason } from "../../src/session/types";
+import type { SessionManager } from "../../src/session/manager";
+import type { Client } from "discord.js";
+
+/**
+ * Phase 5b / #293 (Epic #292 AC-1): the interactive idle reaper threshold is
+ * env-configurable with a shortened default, the old 30-day value is a hard
+ * backstop, and teardown leaves a resume導線.
+ */
+
+const HOUR = 60 * 60 * 1000;
+const DAY = 24 * HOUR;
+
+describe("resolveIdleTimeoutMs", () => {
+  test("defaults to the shortened 6h default", () => {
+    expect(resolveIdleTimeoutMs({})).toBe(SESSION_IDLE_DEFAULT_MS);
+    expect(SESSION_IDLE_DEFAULT_MS).toBe(6 * HOUR);
+  });
+
+  test("honours a valid env override", () => {
+    expect(resolveIdleTimeoutMs({ SESSION_IDLE_TIMEOUT_MS: String(3 * HOUR) })).toBe(
+      3 * HOUR,
+    );
+  });
+
+  test("restores the old 30-day behaviour when env is set to 30d (AC-1)", () => {
+    expect(resolveIdleTimeoutMs({ SESSION_IDLE_TIMEOUT_MS: String(30 * DAY) })).toBe(
+      30 * DAY,
+    );
+  });
+
+  test("caps at the 30-day hard backstop even for a huge env value", () => {
+    expect(
+      resolveIdleTimeoutMs({ SESSION_IDLE_TIMEOUT_MS: String(9999 * DAY) }),
+    ).toBe(SESSION_IDLE_BACKSTOP_MS);
+    expect(SESSION_IDLE_BACKSTOP_MS).toBe(30 * DAY);
+  });
+
+  test("falls back to the default for invalid / non-positive env", () => {
+    expect(resolveIdleTimeoutMs({ SESSION_IDLE_TIMEOUT_MS: "abc" })).toBe(
+      SESSION_IDLE_DEFAULT_MS,
+    );
+    expect(resolveIdleTimeoutMs({ SESSION_IDLE_TIMEOUT_MS: "0" })).toBe(
+      SESSION_IDLE_DEFAULT_MS,
+    );
+    expect(resolveIdleTimeoutMs({ SESSION_IDLE_TIMEOUT_MS: "-5" })).toBe(
+      SESSION_IDLE_DEFAULT_MS,
+    );
+  });
+});
+
+describe("Reaper.buildIdleNotice", () => {
+  test("includes a /session resume line when a claude session id is present", () => {
+    const notice = Reaper.buildIdleNotice(7 * HOUR, {
+      claudeSessionId: "abc-123",
+      branch: "feat/x",
+    });
+    expect(notice).toContain("自動終了");
+    expect(notice).toContain("/session resume abc-123");
+  });
+
+  test("falls back to /session start guidance when no claude session id", () => {
+    const notice = Reaper.buildIdleNotice(7 * HOUR, { branch: "corp-dispatch-9" });
+    expect(notice).toContain("/session start corp-dispatch-9");
+    expect(notice).not.toContain("/session resume");
+  });
+});
+
+function makeSession(over: Partial<SessionInfo> & { threadId: string }): SessionInfo {
+  const now = new Date();
+  return {
+    id: over.threadId,
+    channelName: "chan",
+    projectDir: "/repo",
+    pid: 1,
+    process: null as unknown as SessionInfo["process"],
+    startedAt: now,
+    lastActivityAt: now,
+    status: "running",
+    ...over,
+  } as SessionInfo;
+}
+
+function makeManager(sessions: Map<string, SessionInfo>): {
+  manager: SessionManager;
+  stopCalls: Array<{ threadId: string; reason: StopReason }>;
+} {
+  const stopCalls: Array<{ threadId: string; reason: StopReason }> = [];
+  const manager = {
+    entries: () => sessions.entries(),
+    stop: async (threadId: string, reason: StopReason) => {
+      stopCalls.push({ threadId, reason });
+      sessions.delete(threadId);
+    },
+  } as unknown as SessionManager;
+  return { manager, stopCalls };
+}
+
+describe("Reaper.check", () => {
+  test("reaps a session idle beyond the configured threshold and posts resume導線", async () => {
+    const NOW = 1000 * HOUR;
+    const sessions = new Map<string, SessionInfo>([
+      [
+        "idle",
+        makeSession({
+          threadId: "idle",
+          claudeSessionId: "sess-idle",
+          lastActivityAt: new Date(NOW - 7 * HOUR), // idle 7h > 6h default
+        }),
+      ],
+      [
+        "fresh",
+        makeSession({
+          threadId: "fresh",
+          lastActivityAt: new Date(NOW - 1 * HOUR), // idle 1h < 6h
+        }),
+      ],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const sent: string[] = [];
+    const thread = {
+      isThread: () => true,
+      name: "🟢 x",
+      send: async (m: string) => {
+        sent.push(m);
+      },
+      setName: async () => {},
+      setArchived: async () => {},
+    };
+    const client = {
+      channels: { cache: { get: () => thread }, fetch: async () => thread },
+    } as unknown as Client;
+
+    const reaper = new Reaper(manager, client, {
+      idleTimeoutMs: 6 * HOUR,
+      now: () => NOW,
+    });
+    await reaper.check();
+
+    // Only the idle-past-threshold session is reaped.
+    expect(stopCalls).toEqual([{ threadId: "idle", reason: "idle_timeout" }]);
+    // The teardown notice carried the resume導線 with the captured session id.
+    expect(sent.join("\n")).toContain("/session resume sess-idle");
+  });
+});

--- a/supervisor/tests/session/reaper.test.ts
+++ b/supervisor/tests/session/reaper.test.ts
@@ -148,4 +148,37 @@ describe("Reaper.check", () => {
     // The teardown notice carried the resume導線 with the captured session id.
     expect(sent.join("\n")).toContain("/session resume sess-idle");
   });
+
+  test("reaps EVERY idle session even though stop() deletes from the live map mid-iteration (PR #297 HIGH)", async () => {
+    const NOW = 1000 * HOUR;
+    // All three are idle past the threshold. makeManager.stop deletes each from
+    // the map, so without the Array.from snapshot the live-iterator could skip
+    // entries; the snapshot guarantees all three are processed.
+    const sessions = new Map<string, SessionInfo>(
+      ["a", "b", "c"].map((id) => [
+        id,
+        makeSession({ threadId: id, lastActivityAt: new Date(NOW - 8 * HOUR) }),
+      ]),
+    );
+    const { manager, stopCalls } = makeManager(sessions);
+    const thread = {
+      isThread: () => true,
+      name: "🟢 x",
+      send: async () => {},
+      setName: async () => {},
+      setArchived: async () => {},
+    };
+    const client = {
+      channels: { cache: { get: () => thread }, fetch: async () => thread },
+    } as unknown as Client;
+
+    const reaper = new Reaper(manager, client, {
+      idleTimeoutMs: 6 * HOUR,
+      now: () => NOW,
+    });
+    await reaper.check();
+
+    expect(stopCalls.map((c) => c.threadId).sort()).toEqual(["a", "b", "c"]);
+    expect(sessions.size).toBe(0); // all removed
+  });
 });


### PR DESCRIPTION
## 概要

Epic #292 Phase 5（多セッション性能）の sub #293/#294/#295 を実装。10+ セッション同時起動の重さ・timeout（実測で主犯 = CPU 実行キュー飽和、10 core に load 13-21、swap 0）を構造的に緩和する。**既定値はすべて安全側で現行挙動を壊さない**。

Closes #293
Closes #294
Closes #295

## 主な変更点

### #293 (5b) 対話 idle reaper の短縮 + resume 導線
- `reaper.ts`: 閾値を `SESSION_IDLE_TIMEOUT_MS`（既定 6h）で env 可変化。旧 30 日は **hard backstop に降格**（実効値 = `min(env, 30日)`）。`SESSION_IDLE_TIMEOUT_MS=2592000000` で旧 30 日挙動を完全復元。
- 停止時にスレッドへ **resume 導線**（claude session id があれば `/session resume <id>`、無ければ `/session start <branch>`）。停止前に session を snapshot して導線に使う。
- dispatch 専用の `DISPATCH_ORPHAN_IDLE_MS`（48h, #275）とは別軸。二重実装せず汎用 Reaper のしきい値のみ可変化。

### #294 (5c) dispatch 同時実行制限 + FIFO キュー（対話優先）
- `dispatch-queue.ts`（新規）: `DispatchQueue`。同時上限 `DISPATCH_MAX_CONCURRENT`（既定 3）超は拒否せずキュー、先行終了で FIFO 起動。slot は threadId で管理。
- 対話 `/session start` は**キューを通らない**（`manager.start` 直接、`MAX_SESSIONS` のみで制限）＝現行体験不変。
- bot.ts: dispatch のスレッドを**先に作成**し、キュー投入時（位置表示）・キューから起動時にスレッドへ明示。
- `manager.ts`: `onSessionEnd` リスナを追加し `stop` / tmux-exit / `finishHeadless` で発火 → 空き slot を pump。
- **再起動時のキュー扱い（選択理由）**: in-memory（再起動で消失を許容）。永続化は不採用 — corp reconcile が未完了 Issue を re-dispatch して上流で self-heal するため（既存の in-flight relay 状態が再起動で消える姿勢と同じ）。PR 本文・docs に明記。

### #295 (5d) ResourceMonitor 連動の動的 admission（WARN-first）
- `admission.ts`（新規）: `AdmissionController` + 注入可能 `LoadSampler`。`evaluate()` は load > `core数 × factor` で判定。
- **WARN-first**: 既定 observe（`DISPATCH_ADMISSION_ENFORCE` 未設定）= 高負荷で WARN のみ・遅延なし。`=1` で enforce（遅延）。決して拒否せず遅延のみ。
- `resource-monitor.ts`: 定期 check で load をサンプリングし高負荷時に WARN（観測）。start-time gate は bot.ts の `runOnce` で `admission.gate()`。
- **撤退基準**（docs 明記）: 5c のキューだけで timeout 解消なら enforce は有効化しない（YAGNI）。

## テスト結果

新規 3 ファイル（ci.yml 登録済・gating lint ✓）。

```
# 新規 Phase 5 + 回帰（SUPERVISOR_DB_PATH=:memory:）
bun test tests/session/{reaper,admission,dispatch-queue,manager,manager-headless,manager-resume,manager-liveness,manager-input-ready,dispatch,dispatch-run,dispatch-integration,dispatch-headless,dispatch-report,adapters-executor,headless-liveness,self-heal-restart,worktree,output-formatter}.test.ts src/session/{goal-watcher,orphan-dispatch-reaper}.test.ts
→ 236 pass / 0 fail

# mock.module 隔離ファイル（CI と同様に単独実行）
adapters / tmux / adapters-hassession → 17 / 8 / 4 pass, 0 fail

bunx tsc --noEmit                       → PASS
lint-blocking-in-timers / lint-no-sync-exec / lint-gating-coverage / check-access-policy --ci → PASS
```

## AC 検証結果（Epic #292）

| AC | 検証内容 | 検証手段 | 判定 |
|---|---|---|---|
| AC-1 | idle 閾値が env 可変・既定短縮・30 日を env で復元可能 | `reaper.test.ts`（`resolveIdleTimeoutMs`: 既定 6h / env override / 30日復元 / backstop cap / 不正値 fallback） | PASS |
| AC-2 | 上限超の dispatch が拒否されずキュー、空きで FIFO 起動 | `dispatch-queue.test.ts`（max3 に 6 投入 → 3 起動 3 キュー、notifyEnded で FIFO 起動） | PASS |
| AC-3 | 対話 /session start はキュー非経由で優先 | `dispatch-queue.test.ts`（満杯キューでも非 submit の起動は即実行、未知 threadId の notifyEnded は no-op）+ bot.ts で handleStart は queue 非経由 | PASS |
| AC-4 | 高負荷時に起動遅延 + WARN 観測（fake サンプラ） | `admission.test.ts`（enforce + 高 load → delayMs>0 + WARN、gate が sleep 呼出） | PASS |
| AC-5 | 既定 OFF/WARN-first（初期は遅延せず観測のみ） | `admission.test.ts`（observe 既定 → delayMs 0 + WARN のみ）+ `resolveAdmissionMode` 既定 observe + ResourceMonitor.sampleLoad の WARN | PASS |

## 補足

- 破壊的変更なし・CHANNEL_MAP 不変・tmux socket `-L claude-hub` 維持。
- 5a（`DISPATCH_EXECUTOR_MODE=headless` の運用有効化）は env 設定のみのため本 PR 対象外（docs に手順記載）。
- レビュー・マージは親セッションで実施予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * セッションのアイドル終了ルールが見直され、長時間放置されたセッションをより早く整理できるようになりました。
  * `/dispatch` は同時実行数を制御し、上限超過時は順番待ちで開始されるようになりました。
  * 負荷が高い場合の開始制御が追加され、状況に応じて警告や待機が行われます。

* **改善**
  * セッション終了時の案内に、再開や再開開始への導線が表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->