### PR TITLE
feat: DISPATCH_CLAUDE_MODEL で headless の --model を明示指定（corp #81 Phase 6）

### DIFF
--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -100,8 +100,10 @@ dispatch は「Issue 番号とコマンドを与えて完走させる」バッ�
 | `DISPATCH_EXECUTOR_MODE` | 未設定（既定） / `tmux` | 現行の tmux 対話 TUI 経路（変更なし） |
 | `DISPATCH_EXECUTOR_MODE` | `headless` | dispatch を `claude -p` の子プロセスで実行し stdout をスレッド返却 |
 | `DISPATCH_HEADLESS_TIMEOUT_MS` | 正の整数（既定 `7200000` = 2h） | headless 子プロセスの wall-clock 上限。超過で SIGTERM → スレッドにタイムアウト明示 |
+| `DISPATCH_CLAUDE_MODEL` | 未設定（既定） | 設定時のみ headless argv に `--model <値>` を追加（例 `claude-opus-4-8`）。未設定・空白のみ = 環境既定モデル（現行不変）。corp #81 Phase 6 / #298 |
 
 - 完全に **opt-in**: `headless` 以外の値（未設定・空・大文字 `HEADLESS` 等）はすべて `tmux` にフォールバックする（`resolveExecutorMode`、fail-safe）。
+- `DISPATCH_CLAUDE_MODEL`: 不正なモデル ID はサイレント fallback せず、`claude -p` のローンチ失敗（非ゼロ exit）として既存経路でスレッドに明示される。`--model` は `claude --help`（v2.1.201）で実在確認済み。
 - 対話セッション（`/session start`、primary channel）は headless 化しない。人間との対話は TUI のまま。
 - Supervisor の plist `EnvironmentVariables` に `DISPATCH_EXECUTOR_MODE=headless` を追加 → `launchctl bootout`+`bootstrap` で反映（他の env 同様、`kickstart -k` では env 再読込されない点に注意）。
 

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -231,9 +231,25 @@ function headlessTimeoutMs(): number {
  * `initialCommand` is the first prompt (e.g. `/impl 42`) — a fixed literal built
  * from the validated selector + issue number, never free user text.
  */
+/**
+ * Resolve the dispatch model override (corp #81 Phase 6 / #298). Returns the
+ * trimmed `DISPATCH_CLAUDE_MODEL` value, or undefined when unset / blank /
+ * whitespace-only (all treated as "no override" → the environment's default
+ * model, current behaviour). No validation of the id here: an invalid model is
+ * surfaced by the run's non-zero exit (posted to the thread), NOT silently fixed
+ * up (#298 — no silent fallback).
+ */
+export function resolveDispatchModel(
+  env: Record<string, string | undefined> = process.env,
+): string | undefined {
+  const trimmed = env.DISPATCH_CLAUDE_MODEL?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
 export function buildHeadlessClaudeFlags(
   config: ChannelConfig,
   initialCommand: string,
+  model?: string,
 ): string[] {
   const args = [
     "-p",
@@ -256,6 +272,15 @@ export function buildHeadlessClaudeFlags(
   if (profile === "none") {
     // Raw JSON (no surrounding quotes): argv is passed literally, no shell.
     args.push("--strict-mcp-config", "--mcp-config", '{"mcpServers":{}}');
+  }
+
+  // corp #81 Phase 6 (#298): pin the model only when explicitly requested. Absent
+  // → no `--model`, so the environment default is used (behaviour unchanged).
+  // `--model <model>` verified against `claude --help` (v2.1.201). Trim guards a
+  // whitespace-only value passed directly.
+  const trimmedModel = model?.trim();
+  if (trimmedModel) {
+    args.push("--model", trimmedModel);
   }
 
   return args;
@@ -902,7 +927,11 @@ export class SessionManager {
       const sessionId = randomUUID();
       const claudeSessionId = randomUUID();
       const args = [
-        ...buildHeadlessClaudeFlags(config, initialCommand),
+        ...buildHeadlessClaudeFlags(
+          config,
+          initialCommand,
+          resolveDispatchModel(),
+        ),
         // Pin the session id like launchStart so the DB row captures it
         // deterministically (Issue #167). randomUUID() is shell-safe, though
         // there is no shell here.

--- a/supervisor/tests/session/manager-headless.test.ts
+++ b/supervisor/tests/session/manager-headless.test.ts
@@ -2,7 +2,11 @@ import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 import { mkdirSync } from "fs";
 import { tmpdir } from "os";
 import { resolve } from "path";
-import { SessionManager } from "../../src/session/manager";
+import {
+  SessionManager,
+  buildHeadlessClaudeFlags,
+  resolveDispatchModel,
+} from "../../src/session/manager";
 import {
   createFakeEffects,
   FakeExecutorAdapter,
@@ -257,5 +261,58 @@ describe("SessionManager.runHeadless", () => {
     expect(mgr.count()).toBe(0);
     expect(mgr.has("thread-fail")).toBe(false);
     await mgr.shutdownAll();
+  });
+
+  // corp #81 Phase 6 / #298: DISPATCH_CLAUDE_MODEL → headless --model.
+  describe("DISPATCH_CLAUDE_MODEL model override (#298)", () => {
+    test("resolveDispatchModel trims and treats blank/whitespace as unset", () => {
+      expect(resolveDispatchModel({})).toBeUndefined();
+      expect(resolveDispatchModel({ DISPATCH_CLAUDE_MODEL: "" })).toBeUndefined();
+      expect(resolveDispatchModel({ DISPATCH_CLAUDE_MODEL: "   " })).toBeUndefined();
+      expect(
+        resolveDispatchModel({ DISPATCH_CLAUDE_MODEL: "claude-opus-4-8" }),
+      ).toBe("claude-opus-4-8");
+      expect(
+        resolveDispatchModel({ DISPATCH_CLAUDE_MODEL: "  claude-opus-4-8  " }),
+      ).toBe("claude-opus-4-8");
+    });
+
+    test("buildHeadlessClaudeFlags adds --model <value> only when a model is given", () => {
+      const withModel = buildHeadlessClaudeFlags(config, "/impl 1", "claude-opus-4-8");
+      const i = withModel.indexOf("--model");
+      expect(i).toBeGreaterThanOrEqual(0);
+      expect(withModel[i + 1]).toBe("claude-opus-4-8");
+
+      // Unset / empty / whitespace-only → no --model (default model, unchanged).
+      expect(buildHeadlessClaudeFlags(config, "/impl 1")).not.toContain("--model");
+      expect(buildHeadlessClaudeFlags(config, "/impl 1", "")).not.toContain("--model");
+      expect(buildHeadlessClaudeFlags(config, "/impl 1", "   ")).not.toContain("--model");
+    });
+
+    test("runHeadless passes --model through when DISPATCH_CLAUDE_MODEL is set (fake adapter argv)", async () => {
+      const prev = process.env.DISPATCH_CLAUDE_MODEL;
+      process.env.DISPATCH_CLAUDE_MODEL = "claude-opus-4-8";
+      try {
+        await manager.runHeadless(config, "thread-model", "/impl 1", "corp-dispatch-1");
+        const call = effects.executor.runHeadlessCalls[0]!;
+        const i = call.args.indexOf("--model");
+        expect(i).toBeGreaterThanOrEqual(0);
+        expect(call.args[i + 1]).toBe("claude-opus-4-8");
+      } finally {
+        if (prev === undefined) delete process.env.DISPATCH_CLAUDE_MODEL;
+        else process.env.DISPATCH_CLAUDE_MODEL = prev;
+      }
+    });
+
+    test("runHeadless omits --model when DISPATCH_CLAUDE_MODEL is unset (default unchanged)", async () => {
+      const prev = process.env.DISPATCH_CLAUDE_MODEL;
+      delete process.env.DISPATCH_CLAUDE_MODEL;
+      try {
+        await manager.runHeadless(config, "thread-nomodel", "/impl 1", "corp-dispatch-1");
+        expect(effects.executor.runHeadlessCalls[0]!.args).not.toContain("--model");
+      } finally {
+        if (prev !== undefined) process.env.DISPATCH_CLAUDE_MODEL = prev;
+      }
+    });
   });
 });


### PR DESCRIPTION
## 概要

corp Epic #81 Phase 6（モデル可搬性）の sub。dispatch（headless）セッションのモデルを env `DISPATCH_CLAUDE_MODEL` で明示指定できるようにする。**未設定 = 現行どおり（`--model` なし・環境既定モデル）で既定挙動不変**。

Closes #298

## 主な変更点

- `resolveDispatchModel(env)`: `DISPATCH_CLAUDE_MODEL` を trim。空文字・空白のみは**未設定扱い**（undefined）。
- `buildHeadlessClaudeFlags(config, initialCommand, model?)`: `model` 指定時のみ argv 末尾に `--model <値>` を追加。未設定/空白は付与しない。
- `runHeadless` が `resolveDispatchModel()` の結果を渡して配線。
- **不正モデル ID はサイレント fallback しない**: `claude -p` のローンチ失敗（非ゼロ exit）として、既存の「スレッドにエラー明示」経路（#287 / AC-5）に委ねる。
- `--model` フラグの実在は `claude --help`（v2.1.201: `--model <model>  Model for the current session`）で確認済み（fact-checking）。
- `docs/bot-operations.md` の headless 節に `DISPATCH_CLAUDE_MODEL` を追記。

## テスト結果

`manager-headless.test.ts` に #298 の describe を追加（新規テストファイルなし = ci.yml 変更不要、gating lint ✓）。

```
# 該当 + 回帰（SUPERVISOR_DB_PATH=:memory:）
bun test tests/session/{manager,manager-headless,dispatch-headless,dispatch-report,adapters-executor,headless-liveness}.test.ts
→ manager+manager-headless 65 pass / 0 fail、headless 群 37 pass / 0 fail

bun test tests/session/adapters.test.ts (isolated) → 17 pass / 0 fail
bunx tsc --noEmit                                  → PASS
lint-gating-coverage / lint-no-sync-exec / lint-blocking-in-timers → PASS
```

## AC 検証結果（Epic corp #81 AC-1 / AC-2）

| AC | 検証内容 | 検証手段 | 判定 |
|---|---|---|---|
| AC-1 | 設定時に headless argv へ `--model <値>` が入る | `manager-headless.test.ts`（`DISPATCH_CLAUDE_MODEL=claude-opus-4-8` → fake adapter argv に `--model claude-opus-4-8`）+ `buildHeadlessClaudeFlags` 単体 | PASS |
| AC-2 | 未設定・空文字・空白のみは `--model` なし（既定不変） | `manager-headless.test.ts`（未設定 argv に `--model` なし / `resolveDispatchModel` が空・空白を undefined） | PASS |

## 補足

- `--model` 挿入位置は argv 末尾（`--session-id` の前）。既存の arg 順アサーション（`slice(0,2)` 等）に影響なし。
- 破壊的変更なし・CHANNEL_MAP 不変・tmux socket `-L claude-hub` 維持。
- レビュー・マージは親セッションで実施予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
