### PR TITLE
feat(#303): /session start に model 引数を追加してモデル選択可能に

### DIFF
--- a/supervisor/src/commands/session.ts
+++ b/supervisor/src/commands/session.ts
@@ -5,7 +5,7 @@ import {
   type ThreadChannel,
   EmbedBuilder,
 } from "discord.js";
-import type { SessionManager } from "../session/manager";
+import { isValidModelId, type SessionManager } from "../session/manager";
 import { CHANNEL_MAP, MAX_SESSIONS } from "../config/channels";
 import { buildThreadTitle, markTitleStopped } from "../session/thread-title";
 import { buildStatusReply } from "../session/status-reply";
@@ -28,6 +28,18 @@ export function createSessionCommand() {
           opt
             .setName("branch")
             .setDescription("作業ブランチ名（例: feature-foo）")
+            .setRequired(false)
+        )
+        // Issue #303: optional model override for this session. Free-text so
+        // both aliases (fable/opus/sonnet/haiku → latest of that family) and
+        // pinned full names (e.g. claude-fable-5) work with zero maintenance.
+        // Omitted → no --model → recommended/environment-default model.
+        .addStringOption((opt) =>
+          opt
+            .setName("model")
+            .setDescription(
+              "モデル（例: fable, opus, sonnet, haiku, claude-fable-5。省略時は推奨モデル）"
+            )
             .setRequired(false)
         )
     )
@@ -341,6 +353,23 @@ async function handleStart(
     return;
   }
 
+  // Issue #303: optional model override. Empty/whitespace → undefined (no
+  // --model, environment default; behaviour unchanged). A character-safety gate
+  // rejects shell metacharacters at this Discord boundary BEFORE the value can
+  // reach the tmux bash command string (buildClaudeFlags embeds it there). A
+  // charset-valid but nonexistent id (e.g. claude-bogus) is intentionally NOT
+  // blocked here — it flows to claude and is surfaced by a non-zero exit
+  // (#298 no-silent-fallback).
+  const model = interaction.options.getString("model")?.trim() || undefined;
+  if (model && !isValidModelId(model)) {
+    await interaction.reply({
+      content:
+        "❌ model の書式が不正です。英数字と `.` `_` `-` のみ使えます（例: `fable`, `opus`, `claude-fable-5`）。",
+      flags: 64,
+    });
+    return;
+  }
+
   if (sessionManager.count() >= MAX_SESSIONS) {
     const sessions = sessionManager.listRunning();
     const oldest = sessions.sort(
@@ -396,15 +425,18 @@ async function handleStart(
 
     // Start the session with the thread ID — runs claude in a per-branch
     // worktree (Issue #154).
-    const session = await sessionManager.start(config, thread.id, branch);
+    const session = await sessionManager.start(config, thread.id, branch, model);
 
     // Post welcome message in the thread
     const locationLine = session.worktree
       ? `📁 Worktree: \`${session.worktree.path}\`\n🌿 ブランチ: \`${session.worktree.branch}\``
       : `📁 ディレクトリ: \`${config.dir}\``;
+    // #303: surface the model override so the user can confirm what was pinned
+    // (omitted → recommended/environment default, so no line is shown).
+    const modelLine = model ? `\n🤖 モデル: \`${model}\`` : "";
     await thread.send(
       `✅ **${config.displayName}** のセッションを開始しました\n\n` +
-        `${locationLine}\n` +
+        `${locationLine}${modelLine}\n` +
         `📊 稼働中セッション: ${sessionManager.count()}/${MAX_SESSIONS}\n\n` +
         `このスレッドにメッセージを送信すると、Claude Code に中継されます。\n` +
         `終了するには \`/session stop\` をこのスレッド内で実行してください。`

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -169,7 +169,36 @@ const INPUT_READY_POLL_ATTEMPTS = 60;
  * not survive that round-trip. Single-quoted JSON for `--mcp-config` is safe
  * because bash treats it as a single literal argument.
  */
-export function buildClaudeFlags(config: ChannelConfig): string[] {
+/**
+ * Character-safety gate for a `/session start` model override (#303).
+ *
+ * This is NOT a model allowlist: it deliberately accepts any id/alias whose
+ * characters are shell-inert, so `claude-bogus` passes here and is later
+ * rejected by `claude` with a non-zero exit (the #298 no-silent-fallback
+ * contract). Its sole job is to reject shell metacharacters at the Discord
+ * boundary so a value like `x; rm -rf ~` can never reach the tmux bash command
+ * string. Every real id/alias matches: `fable`, `opus`, `sonnet`, `haiku`,
+ * `claude-fable-5`, `claude-opus-4-8`, `claude-haiku-4-5-20251001`.
+ */
+export function isValidModelId(model: string): boolean {
+  return /^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(model);
+}
+
+/**
+ * POSIX single-quote a value for safe embedding in the tmux bash *command
+ * string* (buildClaudeFlags tokens are space-joined into a bash line — see the
+ * buildClaudeFlags contract above). Single quotes disable every shell expansion;
+ * an embedded `'` is closed, escaped, and reopened (`'\''`). Defense-in-depth:
+ * even if a caller skips {@link isValidModelId}, the value cannot break out.
+ */
+function shellSingleQuote(value: string): string {
+  return `'${value.replace(/'/g, `'\\''`)}'`;
+}
+
+export function buildClaudeFlags(
+  config: ChannelConfig,
+  model?: string,
+): string[] {
   const args = [
     "--dangerously-skip-permissions",
     "--name",
@@ -187,6 +216,16 @@ export function buildClaudeFlags(config: ChannelConfig): string[] {
       "--mcp-config",
       `'{"mcpServers":{}}'`,
     );
+  }
+
+  // #303: pin the model only when explicitly requested via `/session start`.
+  // Absent → no `--model`, environment default (behaviour unchanged; mirrors
+  // buildHeadlessClaudeFlags / #298). Unlike the headless argv path, these
+  // tokens are embedded in the tmux bash command string, so the value is
+  // single-quoted. `--model <model>` verified against `claude --help` (v2.1.201).
+  const trimmedModel = model?.trim();
+  if (trimmedModel) {
+    args.push("--model", shellSingleQuote(trimmedModel));
   }
 
   return args;
@@ -667,7 +706,8 @@ export class SessionManager {
   async start(
     config: ChannelConfig,
     threadId: string,
-    branch?: string
+    branch?: string,
+    model?: string
   ): Promise<SessionInfo> {
     // Single-flight guard (review #185 gemini HIGH): start() is async (awaits
     // the PID poll below), so these checks must not be bypassed by a second
@@ -691,7 +731,7 @@ export class SessionManager {
 
     this.pendingStarts.add(threadId);
     try {
-      return await this.launchStart(config, threadId, branch);
+      return await this.launchStart(config, threadId, branch, model);
     } finally {
       this.pendingStarts.delete(threadId);
     }
@@ -707,7 +747,8 @@ export class SessionManager {
   private async launchStart(
     config: ChannelConfig,
     threadId: string,
-    branch?: string
+    branch?: string,
+    model?: string
   ): Promise<SessionInfo> {
     // Issue #154: resolve the effective cwd. With a branch, create/reuse a
     // worktree (Q1/Q2/Q4 in worktree.ts); failures propagate so the caller can
@@ -771,7 +812,7 @@ export class SessionManager {
       // it is shell-safe to embed here.
       // Quote claudePath() so SUPERVISOR_CLAUDE_PATH values containing spaces
       // (e.g. a test fixture under "/Users/Test User/...") don't word-split.
-      `exec "${claudePath()}" --session-id ${claudeSessionId} ${buildClaudeFlags(config).join(" ")}`,
+      `exec "${claudePath()}" --session-id ${claudeSessionId} ${buildClaudeFlags(config, model).join(" ")}`,
     ].join(" && ");
 
     // Launch via tmux (provides a real TTY). Uses Supervisor's dedicated

--- a/supervisor/tests/session/manager.test.ts
+++ b/supervisor/tests/session/manager.test.ts
@@ -12,6 +12,7 @@ import { resolve } from "path";
 import {
   SessionManager,
   buildClaudeFlags,
+  isValidModelId,
   AUTO_COMPACT_INTENT,
 } from "../../src/session/manager";
 import {
@@ -522,6 +523,83 @@ describe("buildClaudeFlags()", () => {
       `"test-channel"`,
     ]);
   });
+
+  // Issue #303: optional model override on the interactive `/session start` path.
+  test("no model arg → no --model (environment default, behaviour unchanged)", () => {
+    expect(buildClaudeFlags(baseConfig)).not.toContain("--model");
+    expect(buildClaudeFlags(baseConfig, undefined)).not.toContain("--model");
+  });
+
+  test("blank/whitespace model → no --model (treated as unset)", () => {
+    expect(buildClaudeFlags(baseConfig, "")).not.toContain("--model");
+    expect(buildClaudeFlags(baseConfig, "   ")).not.toContain("--model");
+  });
+
+  test("model alias → --model with a single-quoted value (tmux bash-string safe)", () => {
+    const flags = buildClaudeFlags(baseConfig, "fable");
+    const i = flags.indexOf("--model");
+    expect(i).toBeGreaterThanOrEqual(0);
+    expect(flags[i + 1]).toBe("'fable'");
+  });
+
+  test("full model name is single-quoted and trimmed", () => {
+    const flags = buildClaudeFlags(baseConfig, "  claude-fable-5  ");
+    const i = flags.indexOf("--model");
+    expect(flags[i + 1]).toBe("'claude-fable-5'");
+  });
+
+  test("defense-in-depth: shell metacharacters cannot break out of the quote", () => {
+    // buildClaudeFlags must be safe even if a caller skips isValidModelId.
+    const flags = buildClaudeFlags(baseConfig, "x'; rm -rf ~ #");
+    const i = flags.indexOf("--model");
+    // The embedded single quote is closed/escaped/reopened ('\'') so the whole
+    // value stays one bash literal — no command substitution / word split.
+    expect(flags[i + 1]).toBe("'x'\\''; rm -rf ~ #'");
+  });
+});
+
+describe("isValidModelId() (#303 shell-safety gate)", () => {
+  test("accepts real aliases and full names", () => {
+    for (const ok of [
+      "fable",
+      "opus",
+      "sonnet",
+      "haiku",
+      "claude-fable-5",
+      "claude-opus-4-8",
+      "claude-sonnet-5",
+      "claude-haiku-4-5-20251001",
+      "claude-fable-5-mythos-5",
+    ]) {
+      expect(isValidModelId(ok)).toBe(true);
+    }
+  });
+
+  test("accepts charset-valid but nonexistent ids (rejection is claude's job, #298)", () => {
+    // No allowlist here: a bogus-but-safe id must pass the gate and be surfaced
+    // downstream by claude's non-zero exit, not silently blocked/fixed.
+    expect(isValidModelId("claude-bogus")).toBe(true);
+  });
+
+  test("rejects shell metacharacters and whitespace", () => {
+    for (const bad of [
+      "x; rm -rf ~",
+      "$(whoami)",
+      "`id`",
+      "a b",
+      "a'b",
+      'a"b',
+      "a|b",
+      "a&b",
+      "a>b",
+      "-rf", // leading hyphen rejected → cannot masquerade as a claude flag
+      "",
+      "   ",
+      "/etc/passwd",
+    ]) {
+      expect(isValidModelId(bad)).toBe(false);
+    }
+  });
 });
 
 describe("SessionManager worktree integration (#154)", () => {
@@ -564,6 +642,20 @@ describe("SessionManager worktree integration (#154)", () => {
     expect(session.worktree).toBeUndefined();
     expect(session.projectDir).toBe(config.dir);
     expect(effects.worktree.ensureCalls).toHaveLength(0);
+  });
+
+  test("#303: start with model injects --model into the claude command (single-quoted)", async () => {
+    await manager.start(config, "t-model", "feature-foo", "claude-fable-5");
+    const cmd = effects.tmux.getCommand("claude-t-model");
+    // AC-1 (journey): the launched claude carries the pinned model.
+    expect(cmd).toContain("--model 'claude-fable-5'");
+  });
+
+  test("#303: start without model omits --model (behaviour unchanged)", async () => {
+    await manager.start(config, "t-nomodel", "feature-foo");
+    const cmd = effects.tmux.getCommand("claude-t-nomodel");
+    // AC-2 (journey): omitting model must not add --model (env default).
+    expect(cmd).not.toContain("--model");
   });
 
   test("AC-3 / Q4: a pre-existing worktree is reused", async () => {


### PR DESCRIPTION
## 概要

`/session start {branch}` に **optional な `model` 引数**を追加し、interactive セッション（tmux TUI）でも起動時にモデルを選べるようにする。#298（headless 版の `DISPATCH_CLAUDE_MODEL` → `--model`）の **interactive 版**。

Closes #303

## 変更内容

| ファイル | 変更 |
|---|---|
| `supervisor/src/commands/session.ts` | `start` サブコマンドに optional `model` 引数を追加。handleStart で取得し、Discord 境界で `isValidModelId` により shell メタ文字を Fail-Fast 拒否 → `start(config, threadId, branch, model)` へ伝播。welcome にモデル表示（可観測性） |
| `supervisor/src/session/manager.ts` | `buildClaudeFlags(config, model?)` を拡張し `--model` を付与。`start` / `launchStart` に `model?` を追加。`isValidModelId`（export）+ `shellSingleQuote`（内部）を追加 |
| `supervisor/tests/session/manager.test.ts` | テスト10件追加 |

## 設計判断（KISS / #298 哲学との整合）

**free-text string 引数 + 文字安全ゲート**を採用（choices ドロップダウンではなく）:

- エイリアス（`fable`/`opus`/`sonnet`/`haiku` = 最新版に自動追従）と固定フルネーム（`claude-fable-5` 等）を**保守ゼロで両対応**
- #298 の「allowlist を持たず、不正モデルは claude の非ゼロ exit で表面化（no-silent-fallback）」哲学を踏襲
- モデル ID / エイリアスは `claude --help`（v2.1.201）+ claude バイナリの文字列列挙で実在検証済み（#303 コメント参照）

> choices ドロップダウン（iPhone 入力の UX 改善）は fast-follow 候補。本 PR では最小変更・柔軟性優先で free-text とした。

## セキュリティ（本 PR の要点）

model は Discord ユーザー入力であり、**tmux の bash コマンド文字列に埋め込まれる**（headless の argv 配列と異なり shell を経由する）。二層で防御:

1. **境界ゲート** `isValidModelId`（`^[A-Za-z0-9][A-Za-z0-9._-]*$`）: `x; rm -rf ~` / `$(...)` / backtick / 先頭ハイフン等を Discord 境界で拒否
2. **多層防御** `shellSingleQuote`: buildClaudeFlags 内で single-quote エスケープ。ゲートを迂回する呼び出し元があっても値が quote から脱出できない

charset 適合な非実在 ID（例 `claude-bogus`）は**意図的に通し**、claude の exit で表面化させる（#298 準拠）。

## 統合ジャーニーAC 検証（決定的・テストで担保）

| AC | 内容 | 検証テスト | 結果 |
|---|---|---|---|
| AC-1 | model 指定 → claude が `--model` 付きで起動 | `#303: start with model injects --model ...`（tmux コマンド文字列に `--model 'claude-fable-5'` を含む） | ✅ |
| AC-2 | model 省略 → `--model` 無し（従来挙動不変） | `#303: start without model omits --model` / `no model arg → no --model` | ✅ |
| AC-3 | 非実在だが安全な ID → block せず claude へ | `isValidModelId` が `claude-bogus` を true（gate 通過）| ✅ |
| 追加 | injection 文字列は境界で拒否 | `rejects shell metacharacters and whitespace` / `defense-in-depth: ... cannot break out of the quote` | ✅ |

## テスト結果

- `bunx tsc --noEmit`: **exit 0**（型エラーなし）
- `bun test tests/session/manager.test.ts`: **61 pass / 0 fail**（新規10件含む）
- manager 系（headless/resume/liveness/input-ready 含む）: **104 pass / 0 fail**
- `bun test tests/commands/`（session start コマンド）: **44 pass / 0 fail**

## スコープ外（本 PR と無関係な既存事項）

- 全体 `bun test` で 26 fail が出るが**すべて本 PR と無関係**: 25 件は CI が分離実行する mock 汚染グループ（個別実行で全 green）、1 件は `src/infra/db.ts:45` の既存 shell-exec guard 失敗（clean main でも fail・CI の coverage 実行対象外なので main は green）。本 PR の diff は `session.ts` / `manager.ts` / `manager.test.ts` のみ
- `resume` パスのモデル指定は本 issue のスコープ外（既定モデル維持）

## 関連

- #298（closed・headless 版モデル指定）/ corp #81 Phase 6（Opus 4.8 可搬性）/ #302（TUI 性能）
