### PR TITLE
feat: dispatch セッションの自動ヘルス回収（沈黙2h＋busy子プロセス無し → auto-reap）(#279)

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -17,6 +17,7 @@ import {
 import { Reaper } from "./session/reaper";
 import { GoalWatcher } from "./session/goal-watcher";
 import { OrphanDispatchReaper } from "./session/orphan-dispatch-reaper";
+import { DispatchHealthReaper } from "./session/dispatch-health-reaper";
 import { ActivityWatchdog } from "./session/session-activity-watchdog";
 import { ResourceMonitor } from "./session/resource-monitor";
 import { createSessionCommand, createSessionHandler } from "./commands/session";
@@ -255,6 +256,13 @@ export async function startBot(token: string): Promise<void> {
   // messages), so this idle-based safety net reaps dispatch sessions idle past
   // DISPATCH_ORPHAN_IDLE_MS while sparing any that are still actively working.
   const orphanDispatchReaper = new OrphanDispatchReaper(sessionManager, client);
+  // Issue #279: the health-aware front line for the same executor-saturation
+  // problem. Escalates ActivityWatchdog's nudge to auto-reap for dispatch
+  // sessions silent past DISPATCH_HEALTH_SILENCE_MS (2h) that also have NO live
+  // CI/build/test/push child process (the mis-fire guard — a session waiting on
+  // a long CI run looks silent but must not be killed mid-work). The 48h
+  // orphanDispatchReaper above stays as the coarse backstop for anything spared.
+  const dispatchHealthReaper = new DispatchHealthReaper(sessionManager, client);
   // Issue #209: nudge the owner when a live session has been running for hours
   // (long_lived, AC3) or has gone silent (quiet, AC1) — the gap between the
   // per-turn stall heartbeat and the idle reaper. De-dup is internal so each
@@ -355,6 +363,7 @@ export async function startBot(token: string): Promise<void> {
     reaper.start();
     goalWatcher.start();
     orphanDispatchReaper.start();
+    dispatchHealthReaper.start();
     activityWatchdog.start();
     resourceMonitor.start();
 
@@ -1005,6 +1014,7 @@ export async function startBot(token: string): Promise<void> {
     reaper.stop();
     goalWatcher.stop();
     orphanDispatchReaper.stop();
+    dispatchHealthReaper.stop();
     activityWatchdog.stop();
     resourceMonitor.stop();
     // Drain pending progress buffers before tearing down the Discord client

--- a/supervisor/src/config/channels.ts
+++ b/supervisor/src/config/channels.ts
@@ -170,6 +170,20 @@ export const GOAL_GRACE_MS = 3 * 60 * 1000; // 3 minutes
 export const DISPATCH_ORPHAN_IDLE_MS = 48 * 60 * 60 * 1000; // 48 hours
 export const DISPATCH_ORPHAN_CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
 
+// DispatchHealthReaper (Issue #279): the health-aware, short-horizon front line
+// for the same executor-saturation problem the OrphanDispatchReaper backstops.
+// The chairman reported dispatch sessions going silent for 2-3h and could not
+// tell from Discord which were stuck vs. genuinely working, so ActivityWatchdog
+// (#209) only *nudged*. This escalates nudge → auto-reap for dispatch sessions
+// that have been silent past DISPATCH_HEALTH_SILENCE_MS AND have no live
+// CI/build/test/push child process (the mis-fire guard — a session waiting on a
+// long CI run looks silent but must NOT be killed mid-work, since stop() removes
+// its worktree). The 48h OrphanDispatchReaper above stays as the coarse backstop
+// for anything this front line spares (probe unknown / stuck busy child). Both
+// thresholds are env-overridable for ops tuning (mirrors the orphan reaper).
+export const DISPATCH_HEALTH_SILENCE_MS = 2 * 60 * 60 * 1000; // 2 hours
+export const DISPATCH_HEALTH_CHECK_INTERVAL_MS = 30 * 60 * 1000; // 30 minutes
+
 // Phase 5b (#293 / Epic #292): the interactive idle reaper threshold is now
 // env-configurable (`SESSION_IDLE_TIMEOUT_MS`) with a much shorter default —
 // idle interactive sessions squat CPU/RAM and worsen the multi-session

--- a/supervisor/src/session/dispatch-child-probe.test.ts
+++ b/supervisor/src/session/dispatch-child-probe.test.ts
@@ -1,0 +1,200 @@
+import { test, expect, describe } from "bun:test";
+import {
+  BUSY_COMMAND_RE,
+  parsePsOutput,
+  collectDescendants,
+  hasBusyDescendant,
+  classifyProbe,
+  realBusyChildProbe,
+  type ProcRow,
+} from "./dispatch-child-probe";
+
+// Issue #279. The child-process probe is the mis-fire guard that separates
+// "silent because genuinely idle" (safe to auto-reap) from "silent because a
+// long CI/build/test is running" (must be spared — stop() removes the worktree
+// and would discard in-flight work). All shell access is injected so these unit
+// tests never spawn `ps` or `tmux`. Danger is asymmetric: a false "idle" reaps a
+// working session, a false "busy" only delays reaping (48h orphan backstop still
+// catches it), so the matcher is deliberately generous toward "busy".
+
+describe("BUSY_COMMAND_RE", () => {
+  test("matches active build/CI/test/push commands", () => {
+    for (const cmd of [
+      "cargo build --release",
+      "/opt/homebrew/bin/cargo test",
+      "node /repo/node_modules/.bin/vitest run",
+      "jest --watch",
+      "playwright test",
+      "python -m pytest tests/",
+      "tsc -w -p tsconfig.json",
+      "gh pr checks 123 --watch",
+      "gh run watch",
+      "git push origin feat/x",
+      "git fetch origin main",
+      "pnpm run build",
+      "npm ci",
+      "yarn test",
+      "bun test src/",
+      "bun run build",
+      "make -j8",
+      "vite build",
+      "esbuild src/index.ts",
+      "eslint .",
+      "docker build -t x .",
+    ]) {
+      expect(BUSY_COMMAND_RE.test(cmd)).toBe(true);
+    }
+  });
+
+  test("does NOT match the agent runtime / shells (false-positive floor)", () => {
+    // These are ALWAYS present under a live pane; matching them would make every
+    // session look busy forever and defeat auto-reap entirely.
+    for (const cmd of [
+      "claude",
+      "/Users/x/.bun/bin/claude --resume abc",
+      "node /usr/local/lib/claude/cli.js",
+      "bun /supervisor/index.ts",
+      "-zsh",
+      "/bin/bash -l",
+      "login -pf user",
+      "tmux -L claude-hub attach",
+      "less /var/log/x",
+    ]) {
+      expect(BUSY_COMMAND_RE.test(cmd)).toBe(false);
+    }
+  });
+});
+
+describe("parsePsOutput", () => {
+  test("parses pid/ppid/command triples and ignores junk lines", () => {
+    const out = [
+      "  501  1 /sbin/launchd",
+      " 1234 501 -zsh",
+      " 5678 1234 cargo build",
+      "garbage line without numbers",
+      "",
+    ].join("\n");
+    const rows = parsePsOutput(out);
+    expect(rows).toEqual([
+      { pid: 501, ppid: 1, command: "/sbin/launchd" },
+      { pid: 1234, ppid: 501, command: "-zsh" },
+      { pid: 5678, ppid: 1234, command: "cargo build" },
+    ]);
+  });
+});
+
+describe("collectDescendants", () => {
+  const rows: ProcRow[] = [
+    { pid: 100, ppid: 1, command: "-zsh" }, // pane root
+    { pid: 200, ppid: 100, command: "claude" }, // agent
+    { pid: 300, ppid: 200, command: "bash -c cargo build" }, // tool shell
+    { pid: 400, ppid: 300, command: "cargo build" }, // deep descendant
+    { pid: 999, ppid: 1, command: "unrelated" }, // sibling tree
+  ];
+
+  test("walks the whole subtree (transitive), excluding the root itself", () => {
+    const got = collectDescendants(100, rows)
+      .map((r) => r.pid)
+      .sort((a, b) => a - b);
+    expect(got).toEqual([200, 300, 400]);
+  });
+
+  test("a leaf pane with no children yields nothing", () => {
+    expect(collectDescendants(999, rows)).toEqual([]);
+  });
+
+  test("is cycle-safe (a malformed ppid loop does not hang)", () => {
+    const loop: ProcRow[] = [
+      { pid: 1, ppid: 2, command: "a" },
+      { pid: 2, ppid: 1, command: "b" },
+    ];
+    // Must terminate; from root 1 the only reachable descendant is 2.
+    expect(collectDescendants(1, loop).map((r) => r.pid)).toEqual([2]);
+  });
+});
+
+describe("hasBusyDescendant", () => {
+  test("true when any descendant is a busy command", () => {
+    const rows: ProcRow[] = [
+      { pid: 100, ppid: 1, command: "-zsh" },
+      { pid: 200, ppid: 100, command: "claude" },
+      { pid: 300, ppid: 200, command: "cargo test" },
+    ];
+    expect(hasBusyDescendant(100, rows)).toBe(true);
+  });
+
+  test("false when the subtree is only the agent + shells (genuinely idle)", () => {
+    const rows: ProcRow[] = [
+      { pid: 100, ppid: 1, command: "-zsh" },
+      { pid: 200, ppid: 100, command: "claude --resume abc" },
+      { pid: 300, ppid: 200, command: "/bin/bash" },
+    ];
+    expect(hasBusyDescendant(100, rows)).toBe(false);
+  });
+});
+
+describe("classifyProbe", () => {
+  const busyRows: ProcRow[] = [
+    { pid: 100, ppid: 1, command: "-zsh" },
+    { pid: 200, ppid: 100, command: "cargo build" },
+  ];
+  const idleRows: ProcRow[] = [
+    { pid: 100, ppid: 1, command: "-zsh" },
+    { pid: 200, ppid: 100, command: "claude" },
+  ];
+
+  test("null pane pid → unknown (fail-safe)", () => {
+    expect(classifyProbe(null, idleRows)).toBe("unknown");
+  });
+  test("null process table → unknown (fail-safe)", () => {
+    expect(classifyProbe(100, null)).toBe("unknown");
+  });
+  test("busy descendant → busy", () => {
+    expect(classifyProbe(100, busyRows)).toBe("busy");
+  });
+  test("no busy descendant → idle", () => {
+    expect(classifyProbe(100, idleRows)).toBe("idle");
+  });
+});
+
+describe("realBusyChildProbe (deps injected — no shell)", () => {
+  const idleRows: ProcRow[] = [
+    { pid: 100, ppid: 1, command: "-zsh" },
+    { pid: 200, ppid: 100, command: "claude" },
+  ];
+
+  test("unknown when the tmux pane pid cannot be resolved (fail-safe)", async () => {
+    const got = await realBusyChildProbe("thread-abc", {
+      getPanePid: async () => null,
+      listProcesses: async () => idleRows,
+    });
+    expect(got).toBe("unknown");
+  });
+
+  test("idle when the resolved subtree has no busy descendant", async () => {
+    const got = await realBusyChildProbe("thread-abc", {
+      getPanePid: async () => 100,
+      listProcesses: async () => idleRows,
+    });
+    expect(got).toBe("idle");
+  });
+
+  test("busy when the resolved subtree has a busy descendant", async () => {
+    const got = await realBusyChildProbe("thread-abc", {
+      getPanePid: async () => 100,
+      listProcesses: async () => [
+        ...idleRows,
+        { pid: 300, ppid: 200, command: "gh pr checks --watch" },
+      ],
+    });
+    expect(got).toBe("busy");
+  });
+
+  test("unknown when the process listing fails (fail-safe)", async () => {
+    const got = await realBusyChildProbe("thread-abc", {
+      getPanePid: async () => 100,
+      listProcesses: async () => null,
+    });
+    expect(got).toBe("unknown");
+  });
+});

--- a/supervisor/src/session/dispatch-child-probe.ts
+++ b/supervisor/src/session/dispatch-child-probe.ts
@@ -1,0 +1,173 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { TMUX_PATH, TMUX_ARGS } from "./tmux";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Child-process probe for the dispatch health reaper (Issue #279).
+ *
+ * A dispatch session that has gone silent (no relay activity for the health
+ * horizon) is only safe to auto-reap if it is *genuinely* idle. A session
+ * blocked on a long CI/build/test/push run produces no relay traffic either —
+ * it looks identical to a dead one from `lastActivityAt` alone — but reaping it
+ * kills work mid-flight: {@link import("./manager").SessionManager.stop} removes
+ * the per-branch worktree, discarding any uncommitted output.
+ *
+ * This module walks the process subtree rooted at the session's tmux pane and
+ * asks a single question: is there a live build/CI/test/push descendant? The
+ * answer gates the reaper:
+ *   - `busy`    → a recognised tool is running → SPARE (keep nudging via #209),
+ *   - `idle`    → only the agent + shells remain → safe to reap,
+ *   - `unknown` → the pane pid or process table could not be read → SPARE
+ *     (fail-safe: "迷ったら止めない"; the 48h orphan reaper is the backstop).
+ *
+ * The danger is asymmetric — a false `idle` reaps a working session, a false
+ * `busy` only delays reaping — so {@link BUSY_COMMAND_RE} is deliberately
+ * generous toward `busy`, and the agent runtime / shells (`claude`, plain
+ * `node`/`bun`, `-zsh`) are intentionally NOT matched (they are always present
+ * and would pin every session to `busy` forever, defeating auto-reap).
+ *
+ * All shell access ({@link RealProbeDeps}) is injectable so the pure matching /
+ * tree-walking logic is unit-tested without spawning `ps` or `tmux`.
+ */
+
+export type BusyProbeResult = "busy" | "idle" | "unknown";
+
+/** One row of the process table the probe reads (pid, parent pid, command). */
+export interface ProcRow {
+  pid: number;
+  ppid: number;
+  command: string;
+}
+
+/**
+ * Commands whose presence in a session's subtree means "actively working".
+ * Subcommand-qualified where a bare binary would be ambiguous (`bun`/`npm` name
+ * the runtime the agent itself runs on, so only `bun test` / `npm run` etc. —
+ * an actual invocation — count). Extend generously: a missed pattern risks
+ * reaping a working session, the far worse failure (see module doc).
+ */
+export const BUSY_COMMAND_RE =
+  /(\bcargo\b|\b(vitest|jest|mocha|playwright|cypress|pytest)\b|\btsc\b|\btsx\b|\beslint\b|\bbiome\b|\bgh\s+(run|pr|workflow)\b|\bgit\s+(push|fetch|pull|clone)\b|\b(npm|pnpm|yarn)\s+(run|test|ci|install|build|exec)\b|\bbun\s+(test|run|x|install|build)\b|\bmake\b|\b(vite|webpack|esbuild|rollup|turbo)\b|\bdocker\b)/;
+
+/**
+ * Parse `ps -o pid=,ppid=,command=` output. Each line is `<pid> <ppid> <cmd…>`;
+ * lines that do not start with two integers (blank / header / wrapped) are
+ * skipped. The command captures the remainder verbatim (may contain spaces).
+ */
+export function parsePsOutput(stdout: string): ProcRow[] {
+  const rows: ProcRow[] = [];
+  for (const line of stdout.split("\n")) {
+    const m = line.match(/^\s*(\d+)\s+(\d+)\s+(.*\S)\s*$/);
+    if (!m) continue;
+    rows.push({ pid: Number(m[1]), ppid: Number(m[2]), command: m[3]! });
+  }
+  return rows;
+}
+
+/**
+ * All transitive descendants of `rootPid` (excluding the root itself). Iterative
+ * DFS with a visited set so a malformed ppid cycle in the table cannot hang the
+ * walk.
+ */
+export function collectDescendants(rootPid: number, rows: ProcRow[]): ProcRow[] {
+  const byParent = new Map<number, ProcRow[]>();
+  for (const r of rows) {
+    const list = byParent.get(r.ppid);
+    if (list) list.push(r);
+    else byParent.set(r.ppid, [r]);
+  }
+  const out: ProcRow[] = [];
+  const seen = new Set<number>([rootPid]);
+  const stack: number[] = [rootPid];
+  while (stack.length) {
+    const pid = stack.pop()!;
+    for (const child of byParent.get(pid) ?? []) {
+      if (seen.has(child.pid)) continue;
+      seen.add(child.pid);
+      out.push(child);
+      stack.push(child.pid);
+    }
+  }
+  return out;
+}
+
+/** True iff any descendant of `rootPid` matches {@link BUSY_COMMAND_RE}. */
+export function hasBusyDescendant(rootPid: number, rows: ProcRow[]): boolean {
+  return collectDescendants(rootPid, rows).some((r) =>
+    BUSY_COMMAND_RE.test(r.command)
+  );
+}
+
+/**
+ * Pure classification. A null pane pid (tmux gone / unreadable) or a null
+ * process table (ps failed) is `unknown` — the fail-safe that spares the
+ * session. Otherwise `busy` when a build/CI/test descendant is live, else
+ * `idle`.
+ */
+export function classifyProbe(
+  panePid: number | null,
+  rows: ProcRow[] | null
+): BusyProbeResult {
+  if (panePid == null || rows == null) return "unknown";
+  return hasBusyDescendant(panePid, rows) ? "busy" : "idle";
+}
+
+export interface RealProbeDeps {
+  /** Resolve the tmux pane's root pid for a session name. Null when unreadable. */
+  getPanePid?: (tmuxSessionName: string) => Promise<number | null>;
+  /** Snapshot the process table. Null when the listing fails. */
+  listProcesses?: () => Promise<ProcRow[] | null>;
+}
+
+const PROBE_TIMEOUT_MS = 3000;
+
+async function defaultGetPanePid(tmuxSessionName: string): Promise<number | null> {
+  // Same shape as adapters.ts getPid(): first pane's #{pane_pid}. Any failure
+  // (no server, timeout, no such session) collapses to null → unknown → spare.
+  try {
+    const { stdout } = await execFileAsync(
+      TMUX_PATH,
+      [...TMUX_ARGS, "list-panes", "-t", tmuxSessionName, "-F", "#{pane_pid}"],
+      { encoding: "utf8", timeout: PROBE_TIMEOUT_MS }
+    );
+    const pid = parseInt(stdout.trim().split("\n")[0] ?? "", 10);
+    return Number.isNaN(pid) ? null : pid;
+  } catch {
+    return null;
+  }
+}
+
+async function defaultListProcesses(): Promise<ProcRow[] | null> {
+  // BSD ps (macOS): -A all processes, -ww no column-width truncation so long
+  // command lines (the CI invocations we match) are not cut off. `=` headers
+  // give a header-less table parsePsOutput can consume directly.
+  try {
+    const { stdout } = await execFileAsync(
+      "ps",
+      ["-A", "-ww", "-o", "pid=,ppid=,command="],
+      { encoding: "utf8", timeout: PROBE_TIMEOUT_MS, maxBuffer: 16 * 1024 * 1024 }
+    );
+    return parsePsOutput(stdout);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Production probe: resolve the pane pid for `<claude-…>` (derived by the
+ * caller), snapshot the process table, and classify. Deps are injectable so the
+ * reaper's tests never shell out.
+ */
+export async function realBusyChildProbe(
+  tmuxSessionName: string,
+  deps: RealProbeDeps = {}
+): Promise<BusyProbeResult> {
+  const getPanePid = deps.getPanePid ?? defaultGetPanePid;
+  const listProcesses = deps.listProcesses ?? defaultListProcesses;
+  const panePid = await getPanePid(tmuxSessionName);
+  if (panePid == null) return "unknown";
+  const rows = await listProcesses();
+  return classifyProbe(panePid, rows);
+}

--- a/supervisor/src/session/dispatch-health-reaper.test.ts
+++ b/supervisor/src/session/dispatch-health-reaper.test.ts
@@ -1,0 +1,398 @@
+import { test, expect, describe } from "bun:test";
+import {
+  DispatchHealthReaper,
+  HEALTH_REAP_REASON,
+} from "./dispatch-health-reaper";
+import type { BusyProbeResult } from "./dispatch-child-probe";
+import type { SessionInfo, StopReason } from "./types";
+import type { SessionManager } from "./manager";
+import type { Client } from "discord.js";
+
+// Issue #279. DispatchHealthReaper escalates ActivityWatchdog's *nudge* to
+// *auto-reap* for dispatch sessions (branch `corp-dispatch-<N>`) that have been
+// silent past the health horizon AND have no live CI/build/test/push child
+// process. It reuses selectReapableDispatch (the orphan reaper's pure selector)
+// for candidate selection, then layers the child-process probe as the mis-fire
+// guard the orphan reaper lacks. All deps (clock, probe, Discord) are injected —
+// the tests never shell out. Covers the journey ACs: AC1 (silent + idle → reap +
+// report), AC2 (silent + busy child → spared), AC3 (silence clock survives a
+// restart because selection is lastActivityAt-based, not startedAt-based).
+
+const HOUR = 60 * 60 * 1000;
+const SILENCE = 2 * HOUR;
+
+function makeSession(
+  over: Partial<SessionInfo> & { threadId: string }
+): SessionInfo {
+  const now = new Date();
+  return {
+    id: over.threadId,
+    channelName: "convert-service",
+    projectDir: "/repo/.claude/worktrees/corp-dispatch-1",
+    pid: 1,
+    process: null as unknown as SessionInfo["process"],
+    startedAt: now,
+    lastActivityAt: now,
+    status: "running",
+    ...over,
+  } as SessionInfo;
+}
+
+interface StopCall {
+  threadId: string;
+  reason: StopReason;
+}
+
+function makeManager(sessions: Map<string, SessionInfo>): {
+  manager: SessionManager;
+  stopCalls: StopCall[];
+} {
+  const stopCalls: StopCall[] = [];
+  const manager = {
+    entries: () => sessions.entries(),
+    stop: async (threadId: string, reason: StopReason) => {
+      stopCalls.push({ threadId, reason });
+      sessions.delete(threadId);
+    },
+  } as unknown as SessionManager;
+  return { manager, stopCalls };
+}
+
+interface ThreadStub {
+  name: string;
+  sent: string[];
+  archived: boolean;
+  renamedTo: string | null;
+}
+
+function makeClient(thread?: ThreadStub): Client {
+  const channel = thread
+    ? {
+        isThread: () => true,
+        get name() {
+          return thread.name;
+        },
+        send: async (msg: string) => {
+          thread.sent.push(msg);
+        },
+        setName: async (n: string) => {
+          thread.renamedTo = n;
+          thread.name = n;
+        },
+        setArchived: async (v: boolean) => {
+          thread.archived = v;
+        },
+      }
+    : undefined;
+  return {
+    channels: {
+      cache: { get: () => channel },
+      fetch: async () => channel,
+    },
+  } as unknown as Client;
+}
+
+function silentSession(
+  threadId: string,
+  branch: string | undefined,
+  hoursSilent: number,
+  now: number,
+  extra: Partial<SessionInfo> = {}
+): SessionInfo {
+  return makeSession({
+    threadId,
+    branch,
+    lastActivityAt: new Date(now - hoursSilent * HOUR),
+    ...extra,
+  });
+}
+
+/** A probe that returns a fixed verdict and records which threads it saw. */
+function fixedProbe(
+  result: BusyProbeResult | ((threadId: string) => BusyProbeResult)
+): { probe: (threadId: string) => Promise<BusyProbeResult>; calls: string[] } {
+  const calls: string[] = [];
+  const probe = async (threadId: string) => {
+    calls.push(threadId);
+    return typeof result === "function" ? result(threadId) : result;
+  };
+  return { probe, calls };
+}
+
+describe("DispatchHealthReaper.check — the silence × child-process quadrants", () => {
+  const now = 3_000_000_000_000;
+
+  test("AC1: silent past horizon + probe idle → stop(health_reaped) + report + rename + archive", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t7", silentSession("t7", "corp-dispatch-7", 3, now)],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const thread: ThreadStub = {
+      name: "🟢 corp-dispatch-7",
+      sent: [],
+      archived: false,
+      renamedTo: null,
+    };
+    const { probe, calls } = fixedProbe("idle");
+    const reaper = new DispatchHealthReaper(manager, makeClient(thread), {
+      now: () => now,
+      silenceThresholdMs: SILENCE,
+      probe,
+    });
+
+    await reaper.check();
+
+    expect(stopCalls).toEqual([{ threadId: "t7", reason: "health_reaped" }]);
+    expect(HEALTH_REAP_REASON).toBe("health_reaped");
+    expect(calls).toEqual(["t7"]);
+    expect(thread.archived).toBe(true);
+    expect(thread.renamedTo).not.toBeNull();
+    expect(thread.sent.length).toBe(1);
+    expect(thread.sent[0]).toContain("#279");
+  });
+
+  test("AC2: silent past horizon but probe busy (CI running) → spared, stays running", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t7", silentSession("t7", "corp-dispatch-7", 5, now)],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const { probe, calls } = fixedProbe("busy");
+    const reaper = new DispatchHealthReaper(manager, makeClient(), {
+      now: () => now,
+      silenceThresholdMs: SILENCE,
+      probe,
+    });
+
+    await reaper.check();
+
+    expect(stopCalls).toEqual([]);
+    expect(sessions.has("t7")).toBe(true);
+    expect(calls).toEqual(["t7"]); // probe WAS consulted for a candidate
+  });
+
+  test("fail-safe: probe unknown (pane/table unreadable) → NOT reaped", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t7", silentSession("t7", "corp-dispatch-7", 5, now)],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const { probe } = fixedProbe("unknown");
+    const reaper = new DispatchHealthReaper(manager, makeClient(), {
+      now: () => now,
+      silenceThresholdMs: SILENCE,
+      probe,
+    });
+
+    await reaper.check();
+    expect(stopCalls).toEqual([]);
+    expect(sessions.has("t7")).toBe(true);
+  });
+
+  test("fail-safe: a probe that throws → NOT reaped (spared), other sessions unaffected", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["boom", silentSession("boom", "corp-dispatch-1", 5, now)],
+      ["ok", silentSession("ok", "corp-dispatch-2", 5, now)],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const probe = async (threadId: string): Promise<BusyProbeResult> => {
+      if (threadId === "boom") throw new Error("probe blew up");
+      return "idle";
+    };
+    const reaper = new DispatchHealthReaper(manager, makeClient(), {
+      now: () => now,
+      silenceThresholdMs: SILENCE,
+      probe,
+    });
+
+    await reaper.check();
+    // "boom" spared (probe threw → fail-safe); "ok" still reaped.
+    expect(stopCalls).toEqual([{ threadId: "ok", reason: "health_reaped" }]);
+    expect(sessions.has("boom")).toBe(true);
+  });
+
+  test("active dispatch session (silent < horizon) is never a candidate — probe not even called", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t7", silentSession("t7", "corp-dispatch-7", 1, now)],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const { probe, calls } = fixedProbe("idle");
+    const reaper = new DispatchHealthReaper(manager, makeClient(), {
+      now: () => now,
+      silenceThresholdMs: SILENCE,
+      probe,
+    });
+
+    await reaper.check();
+    expect(stopCalls).toEqual([]);
+    expect(calls).toEqual([]); // no wasteful probe on a healthy session
+  });
+
+  test("non-dispatch idle session (human / conductor / main) is left alone — probe not called", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["human", silentSession("human", "feature-x", 100, now)],
+      ["main", silentSession("main", "main", 100, now)],
+      ["cond", silentSession("cond", "52-m1-board", 100, now)],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const { probe, calls } = fixedProbe("idle");
+    const reaper = new DispatchHealthReaper(manager, makeClient(), {
+      now: () => now,
+      silenceThresholdMs: SILENCE,
+      probe,
+    });
+
+    await reaper.check();
+    expect(stopCalls).toEqual([]);
+    expect(calls).toEqual([]);
+  });
+
+  test("AC3: silence clock survives a supervisor restart (selection is lastActivityAt-based, not startedAt)", async () => {
+    // Simulate a restart: the process just came up (startedAt = now) but the
+    // session's lastActivityAt was restored from SQLite to 3h ago. A startedAt-
+    // based timer would reset to 0 and never reap; lastActivityAt-based selection
+    // correctly sees 3h of silence and reaps.
+    const sessions = new Map<string, SessionInfo>([
+      [
+        "t7",
+        silentSession("t7", "corp-dispatch-7", 3, now, {
+          startedAt: new Date(now), // freshly restarted
+        }),
+      ],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const { probe } = fixedProbe("idle");
+    const reaper = new DispatchHealthReaper(manager, makeClient(), {
+      now: () => now,
+      silenceThresholdMs: SILENCE,
+      probe,
+    });
+
+    await reaper.check();
+    expect(stopCalls).toEqual([{ threadId: "t7", reason: "health_reaped" }]);
+  });
+
+  test("boundary: silence exactly at the horizon is reaped (>=)", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t7", silentSession("t7", "corp-dispatch-7", 2, now)],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const { probe } = fixedProbe("idle");
+    const reaper = new DispatchHealthReaper(manager, makeClient(), {
+      now: () => now,
+      silenceThresholdMs: SILENCE,
+      probe,
+    });
+    await reaper.check();
+    expect(stopCalls).toEqual([{ threadId: "t7", reason: "health_reaped" }]);
+  });
+
+  test("mixed fleet: only silent+idle dispatch orphans are reaped", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["reap", silentSession("reap", "corp-dispatch-100", 4, now)], // idle → reap
+      ["busy", silentSession("busy", "corp-dispatch-101", 4, now)], // busy → spare
+      ["active", silentSession("active", "corp-dispatch-102", 1, now)], // fresh → spare
+      ["human", silentSession("human", "feature-x", 99, now)], // non-dispatch
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const probe = async (t: string): Promise<BusyProbeResult> =>
+      t === "busy" ? "busy" : "idle";
+    const reaper = new DispatchHealthReaper(manager, makeClient(), {
+      now: () => now,
+      silenceThresholdMs: SILENCE,
+      probe,
+    });
+
+    await reaper.check();
+    expect(stopCalls).toEqual([{ threadId: "reap", reason: "health_reaped" }]);
+    expect(sessions.has("busy")).toBe(true);
+    expect(sessions.has("active")).toBe(true);
+    expect(sessions.has("human")).toBe(true);
+  });
+
+  test("per-session isolation: one failing stop does not abort the others", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["bad", silentSession("bad", "corp-dispatch-1", 4, now)],
+      ["good", silentSession("good", "corp-dispatch-2", 4, now)],
+    ]);
+    const stopCalls: StopCall[] = [];
+    const manager = {
+      entries: () => sessions.entries(),
+      stop: async (threadId: string, reason: StopReason) => {
+        if (threadId === "bad") throw new Error("stop boom");
+        stopCalls.push({ threadId, reason });
+        sessions.delete(threadId);
+      },
+    } as unknown as SessionManager;
+    const { probe } = fixedProbe("idle");
+    const reaper = new DispatchHealthReaper(manager, makeClient(), {
+      now: () => now,
+      silenceThresholdMs: SILENCE,
+      probe,
+    });
+
+    await reaper.check();
+    expect(stopCalls).toEqual([{ threadId: "good", reason: "health_reaped" }]);
+  });
+
+  test("idempotent: a second tick after reaping is a no-op", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t7", silentSession("t7", "corp-dispatch-7", 4, now)],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const { probe } = fixedProbe("idle");
+    const reaper = new DispatchHealthReaper(manager, makeClient(), {
+      now: () => now,
+      silenceThresholdMs: SILENCE,
+      probe,
+    });
+
+    await reaper.check();
+    await reaper.check();
+    expect(stopCalls.length).toBe(1);
+  });
+
+  test("cache miss: an evicted thread is fetched from the API and still reported", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t7", silentSession("t7", "corp-dispatch-7", 4, now)],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const thread: ThreadStub = {
+      name: "🟢 corp-dispatch-7",
+      sent: [],
+      archived: false,
+      renamedTo: null,
+    };
+    // client whose cache misses but fetch resolves the thread.
+    const client = {
+      channels: {
+        cache: { get: () => undefined },
+        fetch: async () => ({
+          isThread: () => true,
+          get name() {
+            return thread.name;
+          },
+          send: async (m: string) => {
+            thread.sent.push(m);
+          },
+          setName: async (n: string) => {
+            thread.renamedTo = n;
+            thread.name = n;
+          },
+          setArchived: async (v: boolean) => {
+            thread.archived = v;
+          },
+        }),
+      },
+    } as unknown as Client;
+    const { probe } = fixedProbe("idle");
+    const reaper = new DispatchHealthReaper(manager, client, {
+      now: () => now,
+      silenceThresholdMs: SILENCE,
+      probe,
+    });
+
+    await reaper.check();
+    expect(stopCalls).toEqual([{ threadId: "t7", reason: "health_reaped" }]);
+    expect(thread.archived).toBe(true);
+    expect(thread.sent.length).toBe(1);
+  });
+});

--- a/supervisor/src/session/dispatch-health-reaper.ts
+++ b/supervisor/src/session/dispatch-health-reaper.ts
@@ -1,0 +1,245 @@
+import { SessionManager } from "./manager";
+import type { StopReason } from "./types";
+import type { ThreadChannel, Client } from "discord.js";
+import { selectReapableDispatch } from "./orphan-dispatch-reaper";
+import { realBusyChildProbe, type BusyProbeResult } from "./dispatch-child-probe";
+import {
+  DISPATCH_HEALTH_SILENCE_MS,
+  DISPATCH_HEALTH_CHECK_INTERVAL_MS,
+} from "../config/channels";
+import { markTitleStopped } from "./thread-title";
+
+/**
+ * Dispatch health reaper (Issue #279) — the health-aware front line for the
+ * dispatch-session lifecycle gap.
+ *
+ * The chairman reported dispatch sessions (branch `corp-dispatch-<N>`) going
+ * silent for 2–3h with no way to tell from Discord which were stuck vs. still
+ * working, so {@link import("./session-activity-watchdog").ActivityWatchdog}
+ * (#209) only *nudged*. This escalates nudge → **auto-reap**, but only when it is
+ * safe: a session is reaped just when it has been silent past the health horizon
+ * ({@link DISPATCH_HEALTH_SILENCE_MS}, default 2h) AND its process subtree has no
+ * live CI/build/test/push child (the mis-fire guard — see
+ * {@link import("./dispatch-child-probe")}). Judgement is fully supervisor-local:
+ * corp only posts `/dispatch` messages and cannot observe session internals, so
+ * the mechanism lives here (fire-and-forget boundary preserved, no new
+ * corp→claude-hub coupling).
+ *
+ * Layering with the existing safety nets:
+ *   - This reaper (2h, health-aware) is the main path — the "重い/応答不能を自分で
+ *     片付ける" behaviour the chairman asked for.
+ *   - {@link import("./orphan-dispatch-reaper").OrphanDispatchReaper} (48h,
+ *     unconditional) is the coarse backstop for anything this spares: a probe
+ *     that stays `unknown`, or a session pinned to `busy` by a wedged child.
+ *   - The 30-day {@link import("./reaper").Reaper} still owns non-dispatch
+ *     (human / interactive) sessions.
+ *
+ * Candidate selection reuses {@link selectReapableDispatch} verbatim (one source
+ * of truth for "which dispatch sessions crossed an idle horizon"); the ONLY
+ * addition over the orphan reaper is the per-candidate child-process probe. That
+ * probe is essential and its failure mode is fail-safe: a `busy` result (working)
+ * or an `unknown` result (pane/table unreadable, or the probe threw) both SPARE
+ * the session — {@link import("./manager").SessionManager.stop} removes the
+ * per-branch worktree, so reaping on doubt could discard in-flight work.
+ *
+ * Selection is `lastActivityAt`-based (via {@link selectReapableDispatch}), and
+ * `lastActivityAt` is persisted in SQLite (`infra/db.ts`) and restored on start,
+ * so the silence clock survives a supervisor restart instead of resetting to the
+ * process start time (#279 AC3).
+ */
+
+/** Stop reason recorded when a session is reaped by the health reaper. */
+export const HEALTH_REAP_REASON: StopReason = "health_reaped";
+
+export interface DispatchHealthReaperDeps {
+  /** Clock injection for deterministic tests. Defaults to `Date.now`. */
+  now?: () => number;
+  /** Poll interval. Defaults to {@link DISPATCH_HEALTH_CHECK_INTERVAL_MS}. */
+  checkIntervalMs?: number;
+  /**
+   * Silence horizon after which a dispatch session becomes a reap *candidate*
+   * (still gated by the child-process probe). Defaults to the
+   * `DISPATCH_HEALTH_REAP_SILENCE_MS` env override, else
+   * {@link DISPATCH_HEALTH_SILENCE_MS}. Env-overridable so ops can tune the
+   * leash without a redeploy (mirrors the orphan reaper / ActivityWatchdog).
+   */
+  silenceThresholdMs?: number;
+  /**
+   * Child-process probe — the mis-fire guard. Returns `"busy"` (a CI/build/test
+   * descendant is live → spare), `"idle"` (safe to reap), or `"unknown"`
+   * (unreadable → fail-safe spare). Injectable so tests never spawn `ps`/`tmux`;
+   * defaults to {@link realBusyChildProbe} over the session's tmux pane.
+   */
+  probe?: (threadId: string) => Promise<BusyProbeResult>;
+}
+
+function envInt(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const n = Number(raw);
+  return Number.isFinite(n) && n > 0 ? Math.floor(n) : fallback;
+}
+
+/**
+ * Periodic driver (mirrors {@link import("./orphan-dispatch-reaper").OrphanDispatchReaper}).
+ * A thin timer + probe + notify shell around the pure
+ * {@link selectReapableDispatch}; the interesting logic stays testable without
+ * tmux, `ps`, or a Discord gateway.
+ */
+export class DispatchHealthReaper {
+  private timer: ReturnType<typeof setInterval> | null = null;
+  /**
+   * Re-entry guard: a `check()` awaits a probe + stop per candidate, which can
+   * outlast the poll interval under load; without this two ticks could overlap
+   * and both try to stop the same thread.
+   */
+  private isChecking = false;
+
+  private readonly now: () => number;
+  private readonly checkIntervalMs: number;
+  private readonly silenceThresholdMs: number;
+  private readonly probe: (threadId: string) => Promise<BusyProbeResult>;
+
+  constructor(
+    private sessionManager: SessionManager,
+    private client: Client,
+    deps: DispatchHealthReaperDeps = {}
+  ) {
+    this.now = deps.now ?? Date.now;
+    this.checkIntervalMs =
+      deps.checkIntervalMs ??
+      envInt("DISPATCH_HEALTH_CHECK_INTERVAL_MS", DISPATCH_HEALTH_CHECK_INTERVAL_MS);
+    this.silenceThresholdMs =
+      deps.silenceThresholdMs ??
+      envInt("DISPATCH_HEALTH_REAP_SILENCE_MS", DISPATCH_HEALTH_SILENCE_MS);
+    this.probe =
+      deps.probe ??
+      ((threadId) =>
+        realBusyChildProbe(SessionManager.tmuxSessionNameFor(threadId)));
+  }
+
+  start(): void {
+    if (this.timer) return;
+    this.timer = setInterval(() => {
+      void this.check();
+    }, this.checkIntervalMs);
+    if (typeof this.timer === "object" && this.timer && "unref" in this.timer) {
+      (this.timer as { unref: () => void }).unref();
+    }
+    console.log(
+      `[DispatchHealthReaper] Started (check every ${this.checkIntervalMs / 1000 / 60}min, silence ${(this.silenceThresholdMs / 1000 / 60 / 60).toFixed(1)}h + no busy child → auto-reap)`
+    );
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+
+  /**
+   * One scan tick. Public so tests can drive it deterministically. Each
+   * candidate is evaluated independently and any per-session error is swallowed
+   * so one bad session never aborts the tick.
+   */
+  async check(): Promise<void> {
+    if (this.isChecking) return;
+    this.isChecking = true;
+    try {
+      const candidates = selectReapableDispatch(this.sessionManager.entries(), {
+        idleThresholdMs: this.silenceThresholdMs,
+        now: this.now(),
+      });
+      for (const { threadId, idleMs } of candidates) {
+        try {
+          await this.evaluate(threadId, idleMs);
+        } catch (err) {
+          console.error(
+            `[DispatchHealthReaper] Error evaluating thread ${threadId}:`,
+            err
+          );
+        }
+      }
+    } finally {
+      this.isChecking = false;
+    }
+  }
+
+  /**
+   * Gate a silent candidate on the child-process probe. `idle` → reap; `busy`
+   * (working) and `unknown` (unreadable) both spare — and a probe that *throws*
+   * is treated as `unknown` (fail-safe): on any doubt we keep the session and
+   * let ActivityWatchdog keep nudging / the 48h orphan reaper backstop it.
+   */
+  private async evaluate(threadId: string, idleMs: number): Promise<void> {
+    let probe: BusyProbeResult;
+    try {
+      probe = await this.probe(threadId);
+    } catch (err) {
+      console.warn(
+        `[DispatchHealthReaper] probe(${threadId}) threw; sparing (fail-safe):`,
+        err
+      );
+      return;
+    }
+    if (probe !== "idle") {
+      console.log(
+        `[DispatchHealthReaper] Thread ${threadId} silent ${(idleMs / 1000 / 60 / 60).toFixed(1)}h but probe=${probe}; sparing`
+      );
+      return;
+    }
+    await this.reap(threadId, idleMs);
+  }
+
+  private async reap(threadId: string, idleMs: number): Promise<void> {
+    const idleHours = (idleMs / 1000 / 60 / 60).toFixed(1);
+    console.log(
+      `[DispatchHealthReaper] Thread ${threadId} silent ${idleHours}h with no busy child; health-reaping (health_reaped)`
+    );
+    try {
+      await this.sessionManager.stop(threadId, HEALTH_REAP_REASON);
+    } catch (err) {
+      // Leave the thread untouched if the stop itself failed; the next tick (or
+      // the 48h orphan reaper) retries.
+      console.error(`[DispatchHealthReaper] Failed to stop ${threadId}:`, err);
+      return;
+    }
+    await this.notifyThread(threadId, idleMs);
+  }
+
+  /**
+   * Post a teardown notice, mark the title stopped, and archive the thread — the
+   * same UX as the orphan reaper / GoalWatcher. Cache-first, then API fetch: the
+   * thread may have been evicted from the cache on a long-running supervisor, and
+   * without the fetch fallback the notice / rename / archive would be silently
+   * skipped.
+   */
+  private async notifyThread(threadId: string, idleMs: number): Promise<void> {
+    try {
+      let thread = this.client.channels.cache.get(threadId) as
+        | ThreadChannel
+        | undefined;
+      if (!thread) {
+        thread = (await this.client.channels
+          .fetch(threadId)
+          .catch(() => undefined)) as ThreadChannel | undefined;
+      }
+
+      if (thread?.isThread()) {
+        const idleHours = Math.round(idleMs / 1000 / 60 / 60);
+        await thread.send(
+          `🧹 dispatch セッションが約 ${idleHours} 時間無応答（作業中プロセスなし）のため自動回収しました（health_reaped / #279）。CI/build 実行中のセッションは残しています。`
+        );
+        const stoppedName = markTitleStopped(thread.name);
+        await thread.setName(stoppedName);
+        await thread.setArchived(true);
+      }
+    } catch (err) {
+      console.error(
+        `[DispatchHealthReaper] Failed to notify thread ${threadId}:`,
+        err
+      );
+    }
+  }
+}

--- a/supervisor/src/session/types.ts
+++ b/supervisor/src/session/types.ts
@@ -65,4 +65,4 @@ export interface SessionHealthInfo {
   lastActivityAt: string;
 }
 
-export type StopReason = "manual" | "idle_timeout" | "resource_limit" | "error" | "tmux_exited" | "supervisor_restart" | "self_heal_restart" | "goal_complete" | "orphan_reaped" | "headless_exited" | "headless_timeout";
+export type StopReason = "manual" | "idle_timeout" | "resource_limit" | "error" | "tmux_exited" | "supervisor_restart" | "self_heal_restart" | "goal_complete" | "orphan_reaped" | "health_reaped" | "headless_exited" | "headless_timeout";


### PR DESCRIPTION
Closes #279

## 目的

dispatch セッション（`corp-dispatch-<N>`）が沈黙したまま MAX_SESSIONS 枠を占有する executor 飽和問題への即応対策。ActivityWatchdog (#209) の「nudge のみ」を、**沈黙 2h ＋ busy 子プロセス無し**の条件付きで auto-reap に格上げする（会長判断不要）。

## 主な変更点

| ファイル | 内容 |
|---|---|
| `session/dispatch-child-probe.ts` (新規) | tmux `pane_pid` → `ps` 全プロセス → 子孫走査 → CI/build/test/push 系コマンド一致で busy 判定する純ロジック。`busy` / `idle` / `unknown` の三値（pane や ps が読めなければ `unknown`） |
| `session/dispatch-health-reaper.ts` (新規) | 30 分周期のドライバ。OrphanDispatchReaper の `selectReapableDispatch` を再利用し、probe が `idle` の候補だけ `stop(reason="health_reaped")` ＋ Discord スレッド報告。`busy` / `unknown` / probe 例外は温存（fail-safe） |
| `config/channels.ts` | `DISPATCH_HEALTH_SILENCE_MS`（2h）/ `DISPATCH_HEALTH_CHECK_INTERVAL_MS`（30min）。env（`DISPATCH_HEALTH_REAP_SILENCE_MS` / `DISPATCH_HEALTH_CHECK_INTERVAL_MS`）で上書き可 |
| `session/types.ts` | `StopReason` に `"health_reaped"` 追加 |
| `bot.ts` | reaper の構築・start/stop 配線 |

## 設計判断

- **誤爆の非対称性に寄せた fail-safe**: 誤 idle 判定 = 作業中セッションの worktree 削除（不可逆）、誤 busy 判定 = 回収が 48h backstop まで遅れるだけ。よって probe は `unknown` / 例外 / busy をすべて温存側に倒す
- **選定ロジックは再利用**: #275 の `selectReapableDispatch` をそのまま使い、新規性は「子プロセス probe ゲート」のみ（DRY）
- **AC3（再起動耐性）**: 選定基準は SQLite 永続の `lastActivityAt`。supervisor 再起動で沈黙時計がリセットされない
- **48h OrphanDispatchReaper は残置**: 本 reaper が温存したもの（probe unknown 等）の粗い backstop

## AC 検証結果

| AC | 検証内容 | 検証手段 | 判定 |
|---|---|---|---|
| AC1 | 沈黙 2h ＋ busy 子無し → reap ＋ Discord 報告 | `dispatch-health-reaper.test.ts`（stop 呼び出し・reason・報告文言を assert） | PASS |
| AC2 | 沈黙 2h でも busy 子あり → 温存 | 同上（probe=busy で stop 不発火） | PASS |
| AC3 | supervisor 再起動後も沈黙時計が継続 | 同上（startedAt=now / lastActivityAt=3h 前 → reap） | PASS |
| fail-safe | probe unknown / 例外 → 温存 | 同上 | PASS |
| 回帰 | 既存テスト無回帰 | `bun test` 全体: 変更前後で fail 数同一（26 件、いずれも main 由来の環境依存 fail）。追加 28 テスト全 PASS。`bunx tsc --noEmit` クリーン | PASS |

## テスト方法

```bash
cd supervisor
bunx tsc --noEmit -p tsconfig.json
bun test src/session/   # 67 pass / 0 fail
```

## 備考

- ローカル隔離 worktree（origin/main ベース）で実装。corp→claude-hub の dispatch 結線は作っていない（メタ依存ガード維持）
- 反映には supervisor 再起動が必要

🤖 Generated with [Claude Code](https://claude.com/claude-code)
