### PR TITLE
feat(#305): Pushover ワンタップアクション受信 endpoint と実行アダプタ

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -168,7 +168,10 @@ jobs:
                    tests/session/keep-attachment.test.ts \
                    tests/commands/session-keep.test.ts \
                    tests/session/self-heal.test.ts \
-                   tests/session/self-heal-restart.test.ts
+                   tests/session/self-heal-restart.test.ts \
+                   tests/action/token.test.ts \
+                   tests/action/execute.test.ts \
+                   tests/action/receiver.test.ts
 
       # #238 regression: realTmuxAdapter.hasSession must treat a tmux
       # control-channel ETIMEDOUT as "alive" (assume the session survives),

--- a/supervisor/.env.example
+++ b/supervisor/.env.example
@@ -1,2 +1,13 @@
 # Supervisor Bot Token (sole Discord bot under stdin/stdout relay arch — see Issue #3)
 SUPERVISOR_BOT_TOKEN=your-supervisor-bot-token-here
+
+# --- Pushover one-tap action receiver (Issue #305, 層3+4) ---
+# Shared HMAC secret for one-tap action tokens. MUST match the value on the
+# sending side (agent-base). Resolved env-first, then macOS Keychain (service
+# PUSHOVER_ACTION_HMAC_KEY or pushover-action-hmac-key). Unset → receiver disabled.
+# PUSHOVER_ACTION_HMAC_KEY=your-shared-hmac-secret
+# Bind IP override. Default: the node's Tailscale IPv4 (`tailscale ip -4`).
+# Wildcard binds (0.0.0.0 / ::) are rejected — the endpoint must stay tailnet-only.
+# ACTION_RECEIVER_BIND=100.x.y.z
+# Port for GET /act (default 8317).
+# ACTION_RECEIVER_PORT=8317

--- a/supervisor/src/action/execute.ts
+++ b/supervisor/src/action/execute.ts
@@ -1,0 +1,190 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { realpathSync } from "fs";
+import { resolve } from "path";
+import { TMUX_PATH, TMUX_ARGS } from "../session/tmux";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Layer 4 — execution adapter for Pushover one-tap actions (Issue #305, spec §6).
+ *
+ * `executeAction(action, target)` is the single entry point. Adding an action is
+ * two edits: a member in {@link ALLOWED_ACTIONS} and a `case` in the switch
+ * below. The receiver (layer 3) has already verified the token's signature, TTL,
+ * allowlist membership, and nonce before calling here — but the switch's
+ * `default` still rejects any non-allowlisted action, so an arbitrary command is
+ * structurally unexecutable even if the pipeline is bypassed (spec §8 defence 3).
+ *
+ * All external effects (session lookup, key send) are injected via
+ * {@link ExecuteDeps} / {@link SessionResolveDeps} so this module stays pure and
+ * unit-testable without a real DB or tmux. Production wiring lives in ./receiver.
+ */
+
+/**
+ * Actions the receiver may execute. Completeness with the {@link executeAction}
+ * switch is the contract: a member here without a `case` would resolve the
+ * session then fall through to `disallowed_action` (fail-closed, not silent).
+ */
+export const ALLOWED_ACTIONS: ReadonlySet<string> = new Set(["compact"]);
+
+export function isActionAllowed(action: string): boolean {
+  return ALLOWED_ACTIONS.has(action);
+}
+
+/**
+ * Intent appended to the one-tap `/compact`. A bare `/compact` produces a poor
+ * summary because the model cannot predict the next work direction (RW-032), so
+ * every compact — interactive (commands/session.ts `DEFAULT_COMPACT_INTENT`) or
+ * one-tap — carries an explicit intent. Kept as a local constant to keep this
+ * layer decoupled from the Discord command layer.
+ */
+export const ONE_TAP_COMPACT_INTENT = "直近の作業状態と次アクションを保持して圧縮";
+
+/** A running session or live tmux pane, reduced to what target-matching needs. */
+export interface ResolvableSession {
+  /** tmux session name to send keys to (e.g. `claude-<threadId12>`). */
+  tmuxSession: string;
+  /** The session's cwd (worktree path) to match against the token target. */
+  projectDir: string;
+}
+
+export interface SessionResolveDeps {
+  /** Running sessions from the DB, pre-mapped to tmux name + cwd. */
+  runningSessions: () => ResolvableSession[];
+  /** Live tmux panes (name + cwd) on the supervisor socket — the fallback walk. */
+  listTmuxPanes: () => Promise<{ sessionName: string; cwd: string }[]>;
+  /** Path normaliser (symlink-resolved absolute) for robust cwd comparison. */
+  realpath: (p: string) => string;
+}
+
+/**
+ * Resolve a target worktree path to a tmux session name (spec §6 order):
+ *   1. the supervisor DB's running sessions (project_dir === target), then
+ *   2. a live tmux pane whose cwd === target (covers sessions not in the DB,
+ *      e.g. claudeHubExit or a manually-started pane).
+ * Paths are compared symlink-resolved so a trailing slash / symlinked worktree
+ * still matches. Returns null when nothing matches — the caller surfaces an
+ * explicit "target not found" (never a silent success).
+ */
+export async function resolveTmuxSessionForTarget(
+  target: string,
+  deps: SessionResolveDeps
+): Promise<string | null> {
+  const targetReal = deps.realpath(target);
+
+  for (const s of deps.runningSessions()) {
+    if (deps.realpath(s.projectDir) === targetReal) {
+      return s.tmuxSession;
+    }
+  }
+
+  let panes: { sessionName: string; cwd: string }[];
+  try {
+    panes = await deps.listTmuxPanes();
+  } catch (err) {
+    // A tmux failure (no server / timeout) leaves only the DB path, which
+    // already missed — treat as unresolved and let the caller report it.
+    console.warn(
+      "[action-execute] tmux pane walk failed during target resolution:",
+      err instanceof Error ? err.message : String(err)
+    );
+    return null;
+  }
+  for (const p of panes) {
+    if (deps.realpath(p.cwd) === targetReal) {
+      return p.sessionName;
+    }
+  }
+  return null;
+}
+
+export type ExecuteResult =
+  | { ok: true; tmuxSession: string; sentText: string }
+  | {
+      ok: false;
+      reason: "disallowed_action" | "target_not_found" | "send_failed";
+      detail?: string;
+    };
+
+export interface ExecuteDeps {
+  /** Resolve a target to a tmux session name, or null when none matches. */
+  resolveSession: (target: string) => Promise<string | null>;
+  /** Send the keystrokes to the pane (production: relay.ts `sendToPane`). */
+  send: (tmuxSession: string, text: string) => Promise<void>;
+}
+
+/**
+ * Execute an allow-listed action against its target. `compact` resolves the
+ * target worktree to a tmux session and sends `/compact <intent>` via the shared
+ * send sequence. Any non-allowlisted action returns `disallowed_action` rather
+ * than executing (defence-in-depth). A send failure is returned as
+ * `send_failed` with the cause — never swallowed.
+ */
+export async function executeAction(
+  action: string,
+  target: string,
+  deps: ExecuteDeps
+): Promise<ExecuteResult> {
+  switch (action) {
+    case "compact": {
+      const tmuxSession = await deps.resolveSession(target);
+      if (!tmuxSession) {
+        return { ok: false, reason: "target_not_found" };
+      }
+      const text = `/compact ${ONE_TAP_COMPACT_INTENT}`;
+      try {
+        await deps.send(tmuxSession, text);
+      } catch (err) {
+        return {
+          ok: false,
+          reason: "send_failed",
+          detail: err instanceof Error ? err.message : String(err),
+        };
+      }
+      return { ok: true, tmuxSession, sentText: text };
+    }
+    default:
+      // Unreachable when the receiver enforces the allowlist first, but kept as
+      // the structural guarantee that only known actions ever run (spec §8).
+      return { ok: false, reason: "disallowed_action" };
+  }
+}
+
+/**
+ * Production tmux pane walk: enumerate every pane on the supervisor's dedicated
+ * `-L claude-hub` socket with its cwd, tab-separated so paths containing spaces
+ * survive. Uses the async execFile (no shell) so a wedged tmux server cannot
+ * block the event loop and a path cannot inject metacharacters.
+ */
+export async function realTmuxPaneList(): Promise<
+  { sessionName: string; cwd: string }[]
+> {
+  const { stdout } = await execFileAsync(
+    TMUX_PATH,
+    [...TMUX_ARGS, "list-panes", "-a", "-F", "#{session_name}\t#{pane_current_path}"],
+    { timeout: 3000 }
+  );
+  const out: { sessionName: string; cwd: string }[] = [];
+  for (const rawLine of stdout.toString().split("\n")) {
+    const line = rawLine.trim();
+    if (!line) continue;
+    const tab = line.indexOf("\t");
+    if (tab < 0) continue;
+    out.push({ sessionName: line.slice(0, tab), cwd: line.slice(tab + 1) });
+  }
+  return out;
+}
+
+/**
+ * Normalise a path for cwd comparison: symlink-resolved absolute, falling back
+ * to a plain resolve when the path cannot be realpath'd (e.g. it no longer
+ * exists). Mirrors worktree.ts's comparison normalisation.
+ */
+export function realpathOrResolve(p: string): string {
+  try {
+    return realpathSync(resolve(p));
+  } catch {
+    return resolve(p);
+  }
+}

--- a/supervisor/src/action/key.ts
+++ b/supervisor/src/action/key.ts
@@ -1,0 +1,63 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Resolve the shared HMAC secret for one-tap action tokens (Issue #305).
+ *
+ * Resolution order (spec §5 / task): the `PUSHOVER_ACTION_HMAC_KEY` env first,
+ * then the macOS Keychain. Two Keychain service names are tried so a key stored
+ * per EITHER side's documentation is found: `PUSHOVER_ACTION_HMAC_KEY` (this
+ * receiver's setup instruction) and `pushover-action-hmac-key` (agent-base's
+ * `action-token.sh` header — `security add-generic-password -s
+ * pushover-action-hmac-key`). The VALUE must be identical on both machines; the
+ * service NAME only affects where each side reads it.
+ *
+ * Returns null when no source has the key — the caller disables the receiver
+ * with a WARN rather than starting with a broken verifier (not a silent skip).
+ */
+export const HMAC_KEY_ENV = "PUSHOVER_ACTION_HMAC_KEY";
+export const HMAC_KEY_KEYCHAIN_SERVICES = [
+  "PUSHOVER_ACTION_HMAC_KEY",
+  "pushover-action-hmac-key",
+] as const;
+
+export interface KeyResolveDeps {
+  env?: NodeJS.ProcessEnv;
+  /** Keychain lookup by service name; returns the secret or null. Injectable for tests. */
+  keychainLookup?: (service: string) => Promise<string | null>;
+}
+
+export async function resolveHmacKey(deps: KeyResolveDeps = {}): Promise<string | null> {
+  const env = deps.env ?? process.env;
+  const fromEnv = env[HMAC_KEY_ENV]?.trim();
+  if (fromEnv) return fromEnv;
+
+  const lookup = deps.keychainLookup ?? securityKeychainLookup;
+  for (const service of HMAC_KEY_KEYCHAIN_SERVICES) {
+    const val = await lookup(service);
+    if (val && val.trim()) return val.trim();
+  }
+  return null;
+}
+
+/**
+ * macOS Keychain lookup via `security find-generic-password -s <service> -w`.
+ * Returns null on any failure (not on macOS, service absent, `security`
+ * missing) so resolution falls through to the next source. argv (no shell) so
+ * the service name cannot inject metacharacters.
+ */
+async function securityKeychainLookup(service: string): Promise<string | null> {
+  try {
+    const { stdout } = await execFileAsync(
+      "security",
+      ["find-generic-password", "-s", service, "-w"],
+      { timeout: 3000 }
+    );
+    const val = stdout.toString().replace(/\n$/, "");
+    return val || null;
+  } catch {
+    return null;
+  }
+}

--- a/supervisor/src/action/receiver.ts
+++ b/supervisor/src/action/receiver.ts
@@ -367,11 +367,18 @@ export async function startActionReceiver(
       return new Response("ok", { status: 200 });
     }
     if (url.pathname === "/act" && req.method === "GET") {
-      return handleActRequest(url, {
-        ...base,
-        key: boundKey,
-        nowSeconds: Math.floor(Date.now() / 1000),
-      });
+      try {
+        return await handleActRequest(url, {
+          ...base,
+          key: boundKey,
+          nowSeconds: Math.floor(Date.now() / 1000),
+        });
+      } catch (err) {
+        // DB ロックや一時的な I/O エラー等の未捕捉例外でサーバを落とさず、
+        // スマホ側にも 500 の結果画面を返す（CodeRabbit medium 指摘対応）
+        console.error("[action-receiver] Unhandled error in handleActRequest:", err);
+        return htmlResponse(500, renderResultHtml({ status: 500, outcome: "send_failed" }));
+      }
     }
     return new Response("Not found", { status: 404 });
   };

--- a/supervisor/src/action/receiver.ts
+++ b/supervisor/src/action/receiver.ts
@@ -1,0 +1,445 @@
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { parseToken, verifySignature, isExpired } from "./token";
+import {
+  executeAction,
+  resolveTmuxSessionForTarget,
+  realTmuxPaneList,
+  realpathOrResolve,
+  isActionAllowed,
+} from "./execute";
+import type { ExecuteResult } from "./execute";
+import { resolveHmacKey } from "./key";
+import { getRunningSessions, consumeActionNonce } from "../infra/db";
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Layer 3 — HTTP receiver for Pushover one-tap actions (Issue #305, spec §5).
+ *
+ * `GET /act?t=<token>` runs the fixed verification pipeline, executes the
+ * layer-4 adapter on success, and returns a phone-friendly HTML page either way.
+ * The server binds ONLY to the Tailscale interface IP (never 0.0.0.0), so it is
+ * unreachable outside the tailnet — the first of the spec's three defences
+ * (network / token / allowlist). It co-habits the supervisor process; a startup
+ * failure disables the endpoint with a WARN and never takes the bot down.
+ *
+ * The pipeline ({@link evaluateAction}) and HTML rendering are pure and injected
+ * with their effects, so the whole request path is unit-testable without binding
+ * a port, a real DB, or tmux. Production wiring is dynamic-imported inside
+ * {@link startActionReceiver} to keep this module's static imports light.
+ */
+
+const DEFAULT_ACTION_RECEIVER_PORT = 8317;
+
+/** Non-secret verification effects, minus the per-request `key`/`nowSeconds`. */
+export interface EvaluateBase {
+  isActionAllowed: (action: string) => boolean;
+  /** Atomically record a nonce; false = already used (replay). */
+  consumeNonce: (nonce: string, action: string) => boolean;
+  execute: (action: string, target: string) => Promise<ExecuteResult>;
+}
+
+export interface EvaluateDeps extends EvaluateBase {
+  key: string;
+  /** Current time, epoch seconds (injected so tests control expiry). */
+  nowSeconds: number;
+}
+
+export type ReceiverOutcome =
+  | "sent"
+  | "malformed"
+  | "bad_signature"
+  | "expired"
+  | "disallowed_action"
+  | "nonce_reused"
+  | "target_not_found"
+  | "send_failed";
+
+export interface EvaluateResult {
+  status: number;
+  outcome: ReceiverOutcome;
+  action?: string;
+  target?: string;
+  /** Short, identifier-free diagnostic for logs (never the token/key). */
+  detail?: string;
+}
+
+/**
+ * The verification + execution pipeline. Order is fixed by the contract and by
+ * cost (spec §5): signature → TTL → allowlist → nonce → execute. A token that
+ * fails signature, TTL, or the allowlist is rejected BEFORE the nonce is
+ * consumed, so only a fully-valid tap burns its one-time nonce. The nonce is
+ * consumed atomically immediately before execute; a subsequent execute failure
+ * therefore does not reopen the URL to replay (fail-closed) — the user retries
+ * from a fresh notification.
+ */
+export async function evaluateAction(
+  rawToken: string,
+  deps: EvaluateDeps
+): Promise<EvaluateResult> {
+  const parsed = parseToken(rawToken);
+  if (!parsed.ok) {
+    return { status: 400, outcome: "malformed", detail: parsed.reason };
+  }
+  const { token, payload, sig } = parsed;
+
+  if (!verifySignature(payload, sig, deps.key)) {
+    return { status: 401, outcome: "bad_signature", action: token.action };
+  }
+  if (isExpired(token, deps.nowSeconds)) {
+    return { status: 410, outcome: "expired", action: token.action };
+  }
+  if (!deps.isActionAllowed(token.action)) {
+    return { status: 403, outcome: "disallowed_action", action: token.action };
+  }
+  if (!deps.consumeNonce(token.nonce, token.action)) {
+    return { status: 409, outcome: "nonce_reused", action: token.action };
+  }
+
+  const result = await deps.execute(token.action, token.target);
+  if (result.ok) {
+    return { status: 200, outcome: "sent", action: token.action, target: token.target };
+  }
+  switch (result.reason) {
+    case "target_not_found":
+      return {
+        status: 404,
+        outcome: "target_not_found",
+        action: token.action,
+        target: token.target,
+      };
+    case "disallowed_action":
+      return { status: 403, outcome: "disallowed_action", action: token.action };
+    case "send_failed":
+      return {
+        status: 502,
+        outcome: "send_failed",
+        action: token.action,
+        detail: result.detail,
+      };
+    default:
+      return { status: 500, outcome: "send_failed", action: token.action };
+  }
+}
+
+/** Fixed, non-reflective user message per outcome (no token/target echoed → no XSS). */
+function messageFor(outcome: ReceiverOutcome): { title: string; body: string } {
+  switch (outcome) {
+    case "sent":
+      return { title: "送信しました", body: "✅ /compact を送信しました" };
+    case "malformed":
+      return { title: "無効なリンク", body: "❌ リンクが不正です" };
+    case "bad_signature":
+      return { title: "署名エラー", body: "❌ 署名を確認できませんでした" };
+    case "expired":
+      return { title: "期限切れ", body: "⌛ リンクの有効期限が切れています" };
+    case "disallowed_action":
+      return { title: "未許可アクション", body: "🚫 このアクションは許可されていません" };
+    case "nonce_reused":
+      return { title: "使用済み", body: "♻️ このリンクは使用済みです" };
+    case "target_not_found":
+      return { title: "対象が見つかりません", body: "🔍 対象セッションが見つかりませんでした" };
+    case "send_failed":
+      return { title: "送信失敗", body: "⚠️ 送信に失敗しました" };
+  }
+}
+
+/**
+ * Render the phone-facing result page. Self-contained, no external assets, with
+ * a viewport meta so it reads well on a locked-down mobile browser. Only fixed
+ * strings from {@link messageFor} are interpolated — the token, target, and any
+ * request input are never reflected, so there is no injection surface.
+ */
+export function renderResultHtml(result: EvaluateResult): string {
+  const { title, body } = messageFor(result.outcome);
+  return `<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title}</title>
+<style>
+  body { font-family: -apple-system, system-ui, sans-serif; margin: 0; min-height: 100vh;
+         display: flex; align-items: center; justify-content: center; background: #0d1117; color: #e6edf3; }
+  .card { text-align: center; padding: 2rem 1.5rem; }
+  .body { font-size: 1.5rem; line-height: 1.5; }
+</style>
+</head>
+<body>
+<div class="card"><div class="body">${body}</div></div>
+</body>
+</html>`;
+}
+
+function htmlResponse(status: number, html: string): Response {
+  return new Response(html, {
+    status,
+    headers: {
+      "Content-Type": "text/html; charset=utf-8",
+      "Cache-Control": "no-store",
+    },
+  });
+}
+
+/**
+ * HTTP-shaped handler for `GET /act`: extract `t`, run {@link evaluateAction},
+ * log the outcome (spec §12 observability — every request, with reason, never
+ * the token), and render the result page with the mapped status. Exported so a
+ * test can exercise the full request path via a URL without binding a port.
+ */
+export async function handleActRequest(
+  url: URL,
+  deps: EvaluateDeps
+): Promise<Response> {
+  const token = url.searchParams.get("t");
+  if (!token) {
+    console.warn("[action-receiver] request rejected: missing token");
+    return htmlResponse(400, renderResultHtml({ status: 400, outcome: "malformed" }));
+  }
+  const result = await evaluateAction(token, deps);
+  const targetNote = result.target ? ` target=${result.target}` : "";
+  const detailNote = result.detail ? ` detail=${result.detail}` : "";
+  const line =
+    `[action-receiver] outcome=${result.outcome} status=${result.status}` +
+    ` action=${result.action ?? "-"}${targetNote}${detailNote}`;
+  if (result.outcome === "sent") console.log(line);
+  else console.warn(line);
+  return htmlResponse(result.status, renderResultHtml(result));
+}
+
+export interface BindResolveDeps {
+  env?: NodeJS.ProcessEnv;
+  /** Returns `tailscale ip -4` stdout, or null when unavailable. Injectable for tests. */
+  runTailscale?: () => Promise<string | null>;
+}
+
+/** Reject wildcard/any-address binds — the spec forbids exposing beyond the tailnet. */
+function isWildcardBind(host: string): boolean {
+  return host === "" || host === "0.0.0.0" || host === "::" || host === "*";
+}
+
+function isPlausibleIpv4(host: string): boolean {
+  const m = host.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
+  if (!m) return false;
+  return m.slice(1).every((o) => {
+    const n = Number(o);
+    return n >= 0 && n <= 255;
+  });
+}
+
+/**
+ * Resolve the interface IP to bind to. `ACTION_RECEIVER_BIND` overrides (still
+ * rejecting wildcard addresses); otherwise the node's Tailscale IPv4 from
+ * `tailscale ip -4` (PATH binary, then the macOS app bundle). Returns null when
+ * no tailnet IP can be found, so the caller disables the endpoint with a WARN
+ * instead of falling back to a broader bind.
+ */
+export async function resolveBindHost(deps: BindResolveDeps = {}): Promise<string | null> {
+  const env = deps.env ?? process.env;
+  const override = env.ACTION_RECEIVER_BIND?.trim();
+  if (override) {
+    if (isWildcardBind(override)) {
+      console.warn(
+        `[action-receiver] ACTION_RECEIVER_BIND='${override}' is a wildcard bind (forbidden) — endpoint disabled`
+      );
+      return null;
+    }
+    return override;
+  }
+
+  const run = deps.runTailscale ?? defaultRunTailscale;
+  const ip = (await run())?.trim();
+  if (!ip) return null;
+  if (isWildcardBind(ip) || !isPlausibleIpv4(ip)) {
+    console.warn(`[action-receiver] tailscale returned an unusable bind address '${ip}' — endpoint disabled`);
+    return null;
+  }
+  return ip;
+}
+
+async function defaultRunTailscale(): Promise<string | null> {
+  const candidates = [
+    "tailscale",
+    "/Applications/Tailscale.app/Contents/MacOS/Tailscale",
+  ];
+  for (const bin of candidates) {
+    try {
+      const { stdout } = await execFileAsync(bin, ["ip", "-4"], { timeout: 3000 });
+      const first = stdout
+        .toString()
+        .split("\n")
+        .map((s) => s.trim())
+        .find(Boolean);
+      if (first) return first;
+    } catch {
+      // Try the next candidate binary.
+    }
+  }
+  return null;
+}
+
+function readPort(env: NodeJS.ProcessEnv = process.env): number {
+  const raw = env.ACTION_RECEIVER_PORT;
+  const n = raw !== undefined ? Number(raw) : NaN;
+  return Number.isInteger(n) && n > 0 && n < 65536 ? n : DEFAULT_ACTION_RECEIVER_PORT;
+}
+
+/** Minimal server handle — the subset of Bun.serve's return we use. */
+interface ServerHandle {
+  stop: (closeActiveConnections?: boolean) => void;
+  port?: number;
+  hostname?: string;
+}
+
+let server: ServerHandle | null = null;
+
+export interface StartActionReceiverOptions {
+  resolveKey?: () => Promise<string | null>;
+  resolveBind?: () => Promise<string | null>;
+  port?: number;
+  /** Injectable server factory (defaults to Bun.serve). */
+  serve?: (options: {
+    hostname: string;
+    port: number;
+    fetch: (req: Request) => Promise<Response>;
+  }) => ServerHandle;
+  /** Injectable production effects builder (defaults to the real DB/tmux wiring). */
+  buildEvaluateBase?: (key: string) => EvaluateBase | Promise<EvaluateBase>;
+}
+
+export type StartResult =
+  | { started: true; hostname: string; port: number }
+  | { started: false; reason: string };
+
+/**
+ * Start the receiver, resolving the key and bind IP first. Never throws: any
+ * failure (missing key, no tailnet IP, bind error) returns `{ started: false }`
+ * with a reason and a WARN, leaving the supervisor/bot fully operational.
+ */
+export async function startActionReceiver(
+  opts: StartActionReceiverOptions = {}
+): Promise<StartResult> {
+  if (server) return { started: false, reason: "already_started" };
+
+  let key: string | null;
+  try {
+    key = await (opts.resolveKey ?? resolveHmacKey)();
+  } catch (err) {
+    console.warn("[action-receiver] key resolution failed — endpoint disabled:", err);
+    return { started: false, reason: "key_error" };
+  }
+  if (!key) {
+    console.warn(
+      "[action-receiver] disabled: PUSHOVER_ACTION_HMAC_KEY not set (env / Keychain). One-tap actions are off."
+    );
+    return { started: false, reason: "no_key" };
+  }
+
+  let host: string | null;
+  try {
+    host = await (opts.resolveBind ?? resolveBindHost)();
+  } catch (err) {
+    console.warn("[action-receiver] bind resolution failed — endpoint disabled:", err);
+    return { started: false, reason: "bind_error" };
+  }
+  if (!host) {
+    console.warn(
+      "[action-receiver] disabled: could not resolve a Tailscale bind IP (set ACTION_RECEIVER_BIND to override)."
+    );
+    return { started: false, reason: "no_bind" };
+  }
+
+  const port = opts.port ?? readPort();
+  const base = await (opts.buildEvaluateBase
+    ? opts.buildEvaluateBase(key)
+    : buildProductionEvaluateBase());
+
+  const boundKey = key;
+  const fetchHandler = async (req: Request): Promise<Response> => {
+    let url: URL;
+    try {
+      url = new URL(req.url);
+    } catch {
+      return htmlResponse(400, renderResultHtml({ status: 400, outcome: "malformed" }));
+    }
+    if (url.pathname === "/health" && req.method === "GET") {
+      return new Response("ok", { status: 200 });
+    }
+    if (url.pathname === "/act" && req.method === "GET") {
+      return handleActRequest(url, {
+        ...base,
+        key: boundKey,
+        nowSeconds: Math.floor(Date.now() / 1000),
+      });
+    }
+    return new Response("Not found", { status: 404 });
+  };
+
+  const serveImpl = opts.serve ?? ((o) => Bun.serve(o) as unknown as ServerHandle);
+  try {
+    const s = serveImpl({ hostname: host, port, fetch: fetchHandler });
+    server = s;
+    const boundPort = s.port ?? port;
+    console.log(
+      `[action-receiver] listening on http://${host}:${boundPort}/act (Tailscale-only bind)`
+    );
+    return { started: true, hostname: host, port: boundPort };
+  } catch (err) {
+    console.warn(
+      `[action-receiver] failed to bind ${host}:${port}: ${
+        err instanceof Error ? err.message : String(err)
+      } — endpoint disabled (bot unaffected)`
+    );
+    server = null;
+    return { started: false, reason: "bind_failed" };
+  }
+}
+
+/**
+ * Build the production verification effects. The heavy session modules
+ * (manager, relay) are dynamic-imported here so importing this file for the
+ * pure pipeline (tests) does not pull the whole session tree.
+ */
+async function buildProductionEvaluateBase(): Promise<EvaluateBase> {
+  const { SessionManager } = await import("../session/manager");
+  const { sendToPane } = await import("../session/relay");
+
+  const resolveSession = (target: string) =>
+    resolveTmuxSessionForTarget(target, {
+      runningSessions: () =>
+        getRunningSessions()
+          .filter((r): r is typeof r & { thread_id: string } =>
+            typeof r.thread_id === "string" && r.thread_id.length > 0
+          )
+          .map((r) => ({
+            tmuxSession: SessionManager.tmuxSessionNameFor(r.thread_id),
+            projectDir: r.project_dir,
+          })),
+      listTmuxPanes: realTmuxPaneList,
+      realpath: realpathOrResolve,
+    });
+
+  return {
+    isActionAllowed,
+    consumeNonce: consumeActionNonce,
+    execute: (action, target) =>
+      executeAction(action, target, { resolveSession, send: sendToPane }),
+  };
+}
+
+/** Stop the receiver (shutdown path). Safe to call when never started. */
+export function stopActionReceiver(): void {
+  if (!server) return;
+  try {
+    server.stop(true);
+  } catch (err) {
+    console.warn("[action-receiver] error stopping server:", err);
+  }
+  server = null;
+}
+
+/** Test-only: whether the receiver is currently running. */
+export function isActionReceiverRunning(): boolean {
+  return server !== null;
+}

--- a/supervisor/src/action/token.ts
+++ b/supervisor/src/action/token.ts
@@ -1,0 +1,175 @@
+import { createHmac, timingSafeEqual } from "crypto";
+
+/**
+ * Pushover one-tap action token — decode + verify (Issue #305, 層2/層3 boundary).
+ *
+ * This is the claude-hub (receiving) half of the token contract shared with
+ * agent-base's `scripts/lib/action-token.sh` (the generating half, Issue #447).
+ * The contract (正 = agent-base Issue #447 本文 / corp spec
+ * `docs/superpowers/specs/2026-07-05-pushover-one-tap-action-design.md` §3):
+ *
+ *   payload = base64url(JSON{ v:1, action, target, iat, ttl, nonce })
+ *   token   = payload + "." + base64url(HMAC-SHA256(payload, key))
+ *
+ * The HMAC is computed over the base64url-encoded payload STRING (the exact
+ * bytes before the "."), keyed by the shared secret. Round-trip verified
+ * against the real action-token.sh output (matching openssl HMAC bytes).
+ *
+ * This module is pure (no I/O): key resolution lives in ./key, nonce one-time
+ * enforcement in ../infra/db, and the HTTP/execution pipeline in ./receiver.
+ */
+
+/** Decoded, shape-validated token payload. `v` is pinned to 1 by the contract. */
+export interface ActionToken {
+  v: 1;
+  /** Action identifier — checked against the receiver allowlist before execution. */
+  action: string;
+  /** Action target; for `compact` this is the session worktree absolute path. */
+  target: string;
+  /** Issued-at, epoch seconds. */
+  iat: number;
+  /** Time-to-live, seconds (> 0). Token is expired once `now > iat + ttl`. */
+  ttl: number;
+  /** One-time nonce (hex); the receiver records used nonces to block replay. */
+  nonce: string;
+}
+
+/**
+ * Result of {@link parseToken}. On success the raw `payload`/`sig` substrings are
+ * returned alongside the decoded token so the caller can verify the signature
+ * against the exact bytes the HMAC was computed over (never a re-encoding).
+ */
+export type ParseResult =
+  | { ok: true; token: ActionToken; payload: string; sig: string }
+  | { ok: false; reason: string };
+
+/**
+ * Upper bound on the accepted token length. The sender caps the Pushover `url`
+ * parameter at 512 chars (spec §3); 4096 is a generous ceiling that still
+ * rejects absurd input before any base64/JSON work.
+ */
+const MAX_TOKEN_LENGTH = 4096;
+
+/**
+ * Decode a base64url string to bytes. Mirrors action-token.sh's `_action_token_b64url`
+ * inverse: restore the standard alphabet (`-_` → `+/`) and re-pad to a multiple
+ * of 4 before a standard base64 decode. Implemented explicitly (rather than
+ * Buffer's "base64url") so the transform is identical to the bash contract and
+ * independent of runtime base64url support.
+ */
+export function base64urlToBuffer(s: string): Buffer {
+  const b64 = s.replace(/-/g, "+").replace(/_/g, "/");
+  const remainder = b64.length % 4;
+  const pad = remainder === 0 ? "" : "=".repeat(4 - remainder);
+  return Buffer.from(b64 + pad, "base64");
+}
+
+/** Encode bytes as base64url (padding stripped). Used only for diagnostics/tests. */
+export function bufferToBase64url(buf: Buffer): string {
+  return buf.toString("base64").replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/**
+ * Split a token, base64url-decode the payload, and validate its shape. Does NOT
+ * verify the signature or expiry — that is {@link verifySignature} /
+ * {@link isExpired}, kept separate so the receiver pipeline runs them in the
+ * contract's order (signature → TTL). Every rejection carries a short,
+ * identifier-free `reason` for logging.
+ */
+export function parseToken(raw: string): ParseResult {
+  if (typeof raw !== "string" || raw.length === 0) {
+    return { ok: false, reason: "empty" };
+  }
+  if (raw.length > MAX_TOKEN_LENGTH) {
+    return { ok: false, reason: "too_long" };
+  }
+  // Exactly one "." separating payload and signature. A leading/trailing dot or
+  // a second dot means the token is not in `<payload>.<sig>` form.
+  const dot = raw.indexOf(".");
+  if (dot <= 0 || dot === raw.length - 1) {
+    return { ok: false, reason: "format" };
+  }
+  const payload = raw.slice(0, dot);
+  const sig = raw.slice(dot + 1);
+  if (sig.includes(".")) {
+    return { ok: false, reason: "format" };
+  }
+
+  let json: string;
+  try {
+    json = base64urlToBuffer(payload).toString("utf8");
+  } catch {
+    return { ok: false, reason: "base64" };
+  }
+
+  let obj: unknown;
+  try {
+    obj = JSON.parse(json);
+  } catch {
+    return { ok: false, reason: "json" };
+  }
+  if (typeof obj !== "object" || obj === null) {
+    return { ok: false, reason: "not_object" };
+  }
+
+  const rec = obj as Record<string, unknown>;
+  if (rec.v !== 1) return { ok: false, reason: "version" };
+  if (typeof rec.action !== "string" || rec.action.length === 0) {
+    return { ok: false, reason: "action" };
+  }
+  if (typeof rec.target !== "string" || rec.target.length === 0) {
+    return { ok: false, reason: "target" };
+  }
+  if (typeof rec.iat !== "number" || !Number.isInteger(rec.iat)) {
+    return { ok: false, reason: "iat" };
+  }
+  if (typeof rec.ttl !== "number" || !Number.isInteger(rec.ttl) || rec.ttl <= 0) {
+    return { ok: false, reason: "ttl" };
+  }
+  if (typeof rec.nonce !== "string" || rec.nonce.length === 0) {
+    return { ok: false, reason: "nonce" };
+  }
+
+  return {
+    ok: true,
+    payload,
+    sig,
+    token: {
+      v: 1,
+      action: rec.action,
+      target: rec.target,
+      iat: rec.iat,
+      ttl: rec.ttl,
+      nonce: rec.nonce,
+    },
+  };
+}
+
+/**
+ * Constant-time verify that `sig` (base64url) is HMAC-SHA256(payload, key).
+ * Returns false on any length mismatch or malformed signature rather than
+ * throwing, so a crafted token can never surface as a 500. The comparison is
+ * `timingSafeEqual` over the raw digest bytes to avoid leaking via early-exit.
+ */
+export function verifySignature(payload: string, sig: string, key: string): boolean {
+  if (!key) return false;
+  const expected = createHmac("sha256", key).update(payload).digest();
+  let actual: Buffer;
+  try {
+    actual = base64urlToBuffer(sig);
+  } catch {
+    return false;
+  }
+  if (actual.length !== expected.length) return false;
+  return timingSafeEqual(actual, expected);
+}
+
+/**
+ * True once the token's lifetime has elapsed. `nowSeconds` is injected (epoch
+ * seconds) so the receiver and tests share one clock. A token whose `iat` is in
+ * the future is not treated as expired here (only lifetime elapse matters);
+ * such tokens require the shared key to forge, which is the trust boundary.
+ */
+export function isExpired(token: ActionToken, nowSeconds: number): boolean {
+  return nowSeconds > token.iat + token.ttl;
+}

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -25,6 +25,7 @@ import { CHANNEL_MAP, MAX_SESSIONS } from "./config/channels";
 import type { AttachmentInfo } from "./session/relay";
 import { buildDialogStuckHandler } from "./session/dialog-stuck-handler";
 import { notifyPushover, warnIfPushoverUnconfigured } from "./session/notify-pushover";
+import { startActionReceiver, stopActionReceiver } from "./action/receiver";
 import { updateSessionClaudeId } from "./infra/db";
 import {
   buildSalvageReply,
@@ -206,6 +207,20 @@ export async function startBot(token: string): Promise<void> {
   // stall heartbeat / dialog watchdog pages silently drop, so warn the operator
   // up front instead of leaving it to be noticed only when a stall fails to page.
   warnIfPushoverUnconfigured();
+
+  // Issue #305 (層3): Pushover one-tap action receiver. Fire-and-forget so a
+  // slow Tailscale IP probe never delays Discord login, and fully self-contained
+  // (never throws) so a missing key / no tailnet IP disables the endpoint with a
+  // WARN without taking the bot down.
+  startActionReceiver()
+    .then((r) => {
+      if (!r.started) {
+        console.warn(`[Bot] action receiver not started (${r.reason})`);
+      }
+    })
+    .catch((err) => {
+      console.warn("[Bot] action receiver start error (endpoint off, bot unaffected):", err);
+    });
 
   const client = new Client({
     intents: [
@@ -1011,6 +1026,7 @@ export async function startBot(token: string): Promise<void> {
   // Graceful shutdown
   const shutdown = async () => {
     console.log("[Bot] Shutdown signal received");
+    stopActionReceiver();
     reaper.stop();
     goalWatcher.stop();
     orphanDispatchReaper.stop();

--- a/supervisor/src/infra/db.ts
+++ b/supervisor/src/infra/db.ts
@@ -30,6 +30,17 @@ export function getDb(): Database {
     // (started before this column) stay valid; resume of such a row falls back
     // to the display-name-only thread title.
     addColumnIfMissing(db, "branch", "TEXT");
+    // Issue #305 (層3): one-time nonce ledger for Pushover one-tap action tokens.
+    // A tapped `/act?t=<token>` URL is replay-protected by recording its nonce
+    // here; a second tap of the same URL finds the row and is rejected. PRIMARY
+    // KEY on nonce makes the consume atomic (INSERT ... ON CONFLICT DO NOTHING).
+    db.exec(`
+      CREATE TABLE IF NOT EXISTS action_nonces (
+        nonce TEXT PRIMARY KEY,
+        action TEXT NOT NULL,
+        used_at TEXT NOT NULL
+      )
+    `);
   }
   return db;
 }
@@ -202,4 +213,23 @@ export function getRunningSessionsByChannel(
       `SELECT * FROM sessions WHERE channel_name = ? AND status = 'running' ORDER BY started_at`
     )
     .all(channelName) as SessionRow[];
+}
+
+/**
+ * Atomically consume a one-time action nonce (Issue #305, 層3). Returns `true`
+ * when the nonce was newly recorded (first use → the caller may proceed), and
+ * `false` when it was already present (replay → the caller must reject with a
+ * "used" error). Atomicity comes from the PRIMARY KEY on `nonce`: the
+ * `ON CONFLICT DO NOTHING` makes a duplicate insert a no-op, so `changes === 1`
+ * uniquely identifies the first caller even under concurrent taps.
+ */
+export function consumeActionNonce(nonce: string, action: string): boolean {
+  const db = getDb();
+  const result = db
+    .prepare(
+      `INSERT INTO action_nonces (nonce, action, used_at) VALUES (?, ?, ?)
+       ON CONFLICT(nonce) DO NOTHING`
+    )
+    .run(nonce, action, new Date().toISOString());
+  return result.changes === 1;
 }

--- a/supervisor/tests/action/execute.test.ts
+++ b/supervisor/tests/action/execute.test.ts
@@ -1,0 +1,156 @@
+import { test, expect, describe } from "bun:test";
+import {
+  executeAction,
+  resolveTmuxSessionForTarget,
+  isActionAllowed,
+  ALLOWED_ACTIONS,
+  ONE_TAP_COMPACT_INTENT,
+  realpathOrResolve,
+  type ExecuteDeps,
+  type SessionResolveDeps,
+} from "../../src/action/execute";
+
+describe("action/execute allowlist", () => {
+  test("only compact is allowed", () => {
+    expect(isActionAllowed("compact")).toBe(true);
+    expect(isActionAllowed("rm-rf")).toBe(false);
+    expect(isActionAllowed("COMPACT")).toBe(false);
+    expect(isActionAllowed("")).toBe(false);
+    expect([...ALLOWED_ACTIONS]).toEqual(["compact"]);
+  });
+});
+
+describe("action/execute executeAction", () => {
+  function deps(overrides: Partial<ExecuteDeps> = {}): ExecuteDeps & {
+    sent: { session: string; text: string }[];
+  } {
+    const sent: { session: string; text: string }[] = [];
+    return {
+      resolveSession: async () => "claude-abcdef012345",
+      send: async (session, text) => {
+        sent.push({ session, text });
+      },
+      sent,
+      ...overrides,
+    };
+  }
+
+  test("compact resolves the session and sends /compact <intent>", async () => {
+    const d = deps();
+    const result = await executeAction("compact", "/Users/x/wt/issue-441", d);
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("unreachable");
+    expect(result.tmuxSession).toBe("claude-abcdef012345");
+    expect(result.sentText).toBe(`/compact ${ONE_TAP_COMPACT_INTENT}`);
+    expect(d.sent).toHaveLength(1);
+    expect(d.sent[0]!.session).toBe("claude-abcdef012345");
+    expect(d.sent[0]!.text).toBe(`/compact ${ONE_TAP_COMPACT_INTENT}`);
+  });
+
+  test("unresolved target returns target_not_found and does not send", async () => {
+    const d = deps({ resolveSession: async () => null });
+    const result = await executeAction("compact", "/Users/x/gone", d);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.reason).toBe("target_not_found");
+    expect(d.sent).toHaveLength(0);
+  });
+
+  test("send failure is surfaced (send_failed) with the cause, never swallowed", async () => {
+    const d = deps({
+      send: async () => {
+        throw new Error("tmux send-keys failed");
+      },
+    });
+    const result = await executeAction("compact", "/Users/x/wt/issue-441", d);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.reason).toBe("send_failed");
+    expect(result.detail).toContain("tmux send-keys failed");
+  });
+
+  test("non-allowlisted action is structurally refused and never sends", async () => {
+    const d = deps();
+    const result = await executeAction("rm-rf", "/Users/x/wt/issue-441", d);
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error("unreachable");
+    expect(result.reason).toBe("disallowed_action");
+    expect(d.sent).toHaveLength(0);
+  });
+});
+
+describe("action/execute resolveTmuxSessionForTarget", () => {
+  // Identity realpath by default; a normalising variant is used to prove the
+  // comparison is realpath-based rather than raw-string.
+  const identity = (p: string) => p;
+
+  function resolveDeps(overrides: Partial<SessionResolveDeps> = {}): SessionResolveDeps {
+    return {
+      runningSessions: () => [],
+      listTmuxPanes: async () => [],
+      realpath: identity,
+      ...overrides,
+    };
+  }
+
+  test("prefers the DB session and does not walk tmux when it matches", async () => {
+    let walked = false;
+    const session = await resolveTmuxSessionForTarget("/wt/a", resolveDeps({
+      runningSessions: () => [
+        { tmuxSession: "claude-db111111", projectDir: "/wt/a" },
+        { tmuxSession: "claude-db222222", projectDir: "/wt/b" },
+      ],
+      listTmuxPanes: async () => {
+        walked = true;
+        return [];
+      },
+    }));
+    expect(session).toBe("claude-db111111");
+    expect(walked).toBe(false);
+  });
+
+  test("falls back to the tmux pane cwd walk when the DB misses", async () => {
+    const session = await resolveTmuxSessionForTarget("/wt/c", resolveDeps({
+      runningSessions: () => [{ tmuxSession: "claude-db111111", projectDir: "/wt/a" }],
+      listTmuxPanes: async () => [
+        { sessionName: "claude-pane00000", cwd: "/wt/b" },
+        { sessionName: "manual-shell", cwd: "/wt/c" },
+      ],
+    }));
+    expect(session).toBe("manual-shell");
+  });
+
+  test("returns null when neither source matches", async () => {
+    const session = await resolveTmuxSessionForTarget("/wt/none", resolveDeps({
+      runningSessions: () => [{ tmuxSession: "claude-db111111", projectDir: "/wt/a" }],
+      listTmuxPanes: async () => [{ sessionName: "s", cwd: "/wt/b" }],
+    }));
+    expect(session).toBeNull();
+  });
+
+  test("a tmux walk failure resolves to null (not an exception)", async () => {
+    const session = await resolveTmuxSessionForTarget("/wt/x", resolveDeps({
+      runningSessions: () => [],
+      listTmuxPanes: async () => {
+        throw new Error("no server running");
+      },
+    }));
+    expect(session).toBeNull();
+  });
+
+  test("comparison is realpath-normalised (trailing slash still matches)", async () => {
+    const stripTrailingSlash = (p: string) => p.replace(/\/+$/, "");
+    const session = await resolveTmuxSessionForTarget("/wt/a/", resolveDeps({
+      runningSessions: () => [{ tmuxSession: "claude-norm00000", projectDir: "/wt/a" }],
+      realpath: stripTrailingSlash,
+    }));
+    expect(session).toBe("claude-norm00000");
+  });
+});
+
+describe("action/execute realpathOrResolve", () => {
+  test("falls back to resolve for a non-existent path (no throw)", () => {
+    const p = "/definitely/not/here/xyz-12345";
+    expect(realpathOrResolve(p)).toBe(p);
+  });
+});

--- a/supervisor/tests/action/receiver.test.ts
+++ b/supervisor/tests/action/receiver.test.ts
@@ -1,0 +1,354 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { createHmac } from "crypto";
+import { bufferToBase64url } from "../../src/action/token";
+import type { EvaluateDeps, EvaluateResult } from "../../src/action/receiver";
+
+// In-memory DB for the nonce-store tests (must be set before db.ts loads).
+process.env.SUPERVISOR_DB_PATH = ":memory:";
+
+const {
+  evaluateAction,
+  handleActRequest,
+  renderResultHtml,
+  resolveBindHost,
+  startActionReceiver,
+  stopActionReceiver,
+  isActionReceiverRunning,
+} = await import("../../src/action/receiver");
+const { consumeActionNonce, getDb } = await import("../../src/infra/db");
+
+const KEY = "receiver-test-key";
+const NOW = 1_000_000; // fixed clock (epoch seconds) for deterministic expiry
+
+function buildToken(obj: Record<string, unknown>, key = KEY): string {
+  const payload = bufferToBase64url(Buffer.from(JSON.stringify(obj), "utf8"));
+  const sig = bufferToBase64url(createHmac("sha256", key).update(payload).digest());
+  return `${payload}.${sig}`;
+}
+
+let nonceCounter = 0;
+function tokenFields(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    v: 1,
+    action: "compact",
+    target: "/wt/a",
+    iat: NOW,
+    ttl: 1800,
+    nonce: `n-${nonceCounter++}`,
+    ...overrides,
+  };
+}
+
+type SpyDeps = EvaluateDeps & {
+  executed: { action: string; target: string }[];
+  nonceCalls: string[];
+};
+
+function makeDeps(overrides: Partial<EvaluateDeps> = {}): SpyDeps {
+  const executed: { action: string; target: string }[] = [];
+  const nonceCalls: string[] = [];
+  return {
+    key: KEY,
+    nowSeconds: NOW,
+    isActionAllowed: (a) => a === "compact",
+    consumeNonce: (nonce) => {
+      nonceCalls.push(nonce);
+      return true;
+    },
+    execute: async (action, target) => {
+      executed.push({ action, target });
+      return { ok: true, tmuxSession: "claude-x", sentText: "/compact intent" };
+    },
+    executed,
+    nonceCalls,
+    ...overrides,
+  };
+}
+
+describe("action/receiver evaluateAction pipeline", () => {
+  test("valid token executes and returns 200 sent", async () => {
+    const deps = makeDeps();
+    const result = await evaluateAction(buildToken(tokenFields()), deps);
+    expect(result.status).toBe(200);
+    expect(result.outcome).toBe("sent");
+    expect(deps.executed).toEqual([{ action: "compact", target: "/wt/a" }]);
+  });
+
+  test("signature mismatch → 401 and neither nonce nor execute is touched", async () => {
+    const deps = makeDeps();
+    const token = buildToken(tokenFields(), "attacker-key");
+    const result = await evaluateAction(token, deps);
+    expect(result.status).toBe(401);
+    expect(result.outcome).toBe("bad_signature");
+    expect(deps.nonceCalls).toHaveLength(0);
+    expect(deps.executed).toHaveLength(0);
+  });
+
+  test("expired token → 410 before the nonce is consumed (order: sig→ttl→nonce)", async () => {
+    const deps = makeDeps();
+    // iat + ttl < NOW → expired.
+    const token = buildToken(tokenFields({ iat: NOW - 10_000, ttl: 1800 }));
+    const result = await evaluateAction(token, deps);
+    expect(result.status).toBe(410);
+    expect(result.outcome).toBe("expired");
+    expect(deps.nonceCalls).toHaveLength(0);
+    expect(deps.executed).toHaveLength(0);
+  });
+
+  test("allowlist-external action (valid signature) → 403, nonce not consumed", async () => {
+    const deps = makeDeps();
+    const token = buildToken(tokenFields({ action: "rm-rf" }));
+    const result = await evaluateAction(token, deps);
+    expect(result.status).toBe(403);
+    expect(result.outcome).toBe("disallowed_action");
+    expect(deps.nonceCalls).toHaveLength(0);
+    expect(deps.executed).toHaveLength(0);
+  });
+
+  test("nonce reuse → first 200, second 409, execute runs only once", async () => {
+    const used = new Set<string>();
+    const executed: { action: string; target: string }[] = [];
+    const deps = makeDeps({
+      consumeNonce: (nonce) => {
+        if (used.has(nonce)) return false;
+        used.add(nonce);
+        return true;
+      },
+      execute: async (action, target) => {
+        executed.push({ action, target });
+        return { ok: true, tmuxSession: "claude-x", sentText: "/compact intent" };
+      },
+    });
+    const token = buildToken(tokenFields());
+    const first = await evaluateAction(token, deps);
+    const second = await evaluateAction(token, deps);
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(409);
+    expect(second.outcome).toBe("nonce_reused");
+    expect(executed).toHaveLength(1);
+  });
+
+  test("malformed token → 400", async () => {
+    const result = await evaluateAction("not-a-real-token", makeDeps());
+    expect(result.status).toBe(400);
+    expect(result.outcome).toBe("malformed");
+  });
+
+  test("execute target_not_found → 404", async () => {
+    const deps = makeDeps({
+      execute: async () => ({ ok: false, reason: "target_not_found" }),
+    });
+    const result = await evaluateAction(buildToken(tokenFields()), deps);
+    expect(result.status).toBe(404);
+    expect(result.outcome).toBe("target_not_found");
+  });
+
+  test("execute send_failed → 502 with the cause", async () => {
+    const deps = makeDeps({
+      execute: async () => ({ ok: false, reason: "send_failed", detail: "boom" }),
+    });
+    const result = await evaluateAction(buildToken(tokenFields()), deps);
+    expect(result.status).toBe(502);
+    expect(result.outcome).toBe("send_failed");
+    expect(result.detail).toBe("boom");
+  });
+});
+
+describe("action/receiver handleActRequest (HTTP shape)", () => {
+  test("valid /act?t= → 200 text/html success page", async () => {
+    const token = buildToken(tokenFields());
+    const url = new URL(`http://100.1.1.1:8317/act?t=${encodeURIComponent(token)}`);
+    const res = await handleActRequest(url, makeDeps());
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toContain("text/html");
+    const body = await res.text();
+    expect(body).toContain("✅ /compact を送信しました");
+  });
+
+  test("missing token → 400 error page", async () => {
+    const url = new URL("http://100.1.1.1:8317/act");
+    const res = await handleActRequest(url, makeDeps());
+    expect(res.status).toBe(400);
+    const body = await res.text();
+    expect(body).toContain("リンクが不正");
+  });
+});
+
+describe("action/receiver renderResultHtml", () => {
+  test("is a self-contained mobile page and reflects no request input", () => {
+    const result: EvaluateResult = {
+      status: 200,
+      outcome: "sent",
+      action: "compact",
+      target: "<script>alert(1)</script>",
+    };
+    const html = renderResultHtml(result);
+    expect(html).toContain("<!doctype html>");
+    expect(html).toContain('name="viewport"');
+    expect(html).toContain("✅ /compact を送信しました");
+    // The target is never reflected → no injection surface.
+    expect(html).not.toContain("<script>alert(1)</script>");
+  });
+
+  test("each outcome renders its own message", () => {
+    expect(renderResultHtml({ status: 409, outcome: "nonce_reused" })).toContain("使用済み");
+    expect(renderResultHtml({ status: 410, outcome: "expired" })).toContain("期限切れ");
+    expect(renderResultHtml({ status: 403, outcome: "disallowed_action" })).toContain("許可されていません");
+    expect(renderResultHtml({ status: 404, outcome: "target_not_found" })).toContain("見つかりません");
+  });
+});
+
+describe("action/receiver resolveBindHost", () => {
+  test("ACTION_RECEIVER_BIND override is used verbatim", async () => {
+    const host = await resolveBindHost({ env: { ACTION_RECEIVER_BIND: "100.9.9.9" } });
+    expect(host).toBe("100.9.9.9");
+  });
+
+  test("wildcard override is rejected (0.0.0.0 forbidden)", async () => {
+    expect(await resolveBindHost({ env: { ACTION_RECEIVER_BIND: "0.0.0.0" } })).toBeNull();
+    expect(await resolveBindHost({ env: { ACTION_RECEIVER_BIND: "::" } })).toBeNull();
+  });
+
+  test("falls back to the Tailscale IPv4", async () => {
+    const host = await resolveBindHost({
+      env: {},
+      runTailscale: async () => "100.64.5.6\n",
+    });
+    expect(host).toBe("100.64.5.6");
+  });
+
+  test("no Tailscale IP → null (endpoint disabled, not a broader bind)", async () => {
+    expect(await resolveBindHost({ env: {}, runTailscale: async () => null })).toBeNull();
+  });
+
+  test("Tailscale returning a wildcard / non-IP → null", async () => {
+    expect(await resolveBindHost({ env: {}, runTailscale: async () => "0.0.0.0" })).toBeNull();
+    expect(await resolveBindHost({ env: {}, runTailscale: async () => "not-an-ip" })).toBeNull();
+    expect(await resolveBindHost({ env: {}, runTailscale: async () => "999.1.1.1" })).toBeNull();
+  });
+});
+
+describe("action/receiver startActionReceiver lifecycle", () => {
+  afterEach(() => stopActionReceiver());
+
+  test("no key → not started, serve never called", async () => {
+    let served = false;
+    const res = await startActionReceiver({
+      resolveKey: async () => null,
+      resolveBind: async () => "100.1.1.1",
+      serve: () => {
+        served = true;
+        return { stop: () => {} };
+      },
+    });
+    expect(res).toEqual({ started: false, reason: "no_key" });
+    expect(served).toBe(false);
+    expect(isActionReceiverRunning()).toBe(false);
+  });
+
+  test("no bind IP → not started", async () => {
+    const res = await startActionReceiver({
+      resolveKey: async () => KEY,
+      resolveBind: async () => null,
+      serve: () => ({ stop: () => {} }),
+    });
+    expect(res).toEqual({ started: false, reason: "no_bind" });
+    expect(isActionReceiverRunning()).toBe(false);
+  });
+
+  test("serve throwing → not started (bot unaffected), reason bind_failed", async () => {
+    const res = await startActionReceiver({
+      resolveKey: async () => KEY,
+      resolveBind: async () => "100.1.1.1",
+      serve: () => {
+        throw new Error("EADDRINUSE");
+      },
+      buildEvaluateBase: () => ({
+        isActionAllowed: (a) => a === "compact",
+        consumeNonce: () => true,
+        execute: async () => ({ ok: true, tmuxSession: "x", sentText: "y" }),
+      }),
+    });
+    expect(res).toEqual({ started: false, reason: "bind_failed" });
+    expect(isActionReceiverRunning()).toBe(false);
+  });
+
+  test("happy path binds, routes /act, /health, unknown, and stops cleanly", async () => {
+    let capturedFetch: ((req: Request) => Promise<Response>) | undefined;
+    let stopCalled = false;
+    const res = await startActionReceiver({
+      resolveKey: async () => KEY,
+      resolveBind: async () => "100.1.1.1",
+      port: 8317,
+      serve: (o) => {
+        capturedFetch = o.fetch;
+        return {
+          stop: () => {
+            stopCalled = true;
+          },
+          port: o.port,
+          hostname: o.hostname,
+        };
+      },
+      buildEvaluateBase: (key) => {
+        expect(key).toBe(KEY);
+        return {
+          isActionAllowed: (a) => a === "compact",
+          consumeNonce: () => true,
+          execute: async () => ({ ok: true, tmuxSession: "claude-x", sentText: "/compact x" }),
+        };
+      },
+    });
+    expect(res).toEqual({ started: true, hostname: "100.1.1.1", port: 8317 });
+    expect(isActionReceiverRunning()).toBe(true);
+    expect(capturedFetch).toBeDefined();
+
+    // A second start is refused while one is live.
+    const again = await startActionReceiver({ resolveKey: async () => KEY });
+    expect(again).toEqual({ started: false, reason: "already_started" });
+
+    // Route /act with a fresh, correctly-signed token (server uses real clock).
+    const token = buildToken(tokenFields({ iat: Math.floor(Date.now() / 1000) }));
+    const actRes = await capturedFetch!(
+      new Request(`http://100.1.1.1:8317/act?t=${encodeURIComponent(token)}`)
+    );
+    expect(actRes.status).toBe(200);
+
+    const health = await capturedFetch!(new Request("http://100.1.1.1:8317/health"));
+    expect(health.status).toBe(200);
+    expect(await health.text()).toBe("ok");
+
+    const unknown = await capturedFetch!(new Request("http://100.1.1.1:8317/nope"));
+    expect(unknown.status).toBe(404);
+
+    stopActionReceiver();
+    expect(stopCalled).toBe(true);
+    expect(isActionReceiverRunning()).toBe(false);
+  });
+});
+
+describe("infra/db consumeActionNonce (in-memory, one-time)", () => {
+  beforeEach(() => {
+    getDb().exec("DELETE FROM action_nonces");
+  });
+
+  test("first consume succeeds, replay of the same nonce fails", () => {
+    expect(consumeActionNonce("nonce-A", "compact")).toBe(true);
+    expect(consumeActionNonce("nonce-A", "compact")).toBe(false);
+  });
+
+  test("distinct nonces are independent", () => {
+    expect(consumeActionNonce("nonce-B", "compact")).toBe(true);
+    expect(consumeActionNonce("nonce-C", "compact")).toBe(true);
+    expect(consumeActionNonce("nonce-B", "compact")).toBe(false);
+  });
+
+  test("end-to-end replay protection through evaluateAction using the real store", async () => {
+    const token = buildToken(tokenFields({ nonce: "e2e-nonce-1" }));
+    const deps = makeDeps({ consumeNonce: consumeActionNonce });
+    const first = await evaluateAction(token, deps);
+    const second = await evaluateAction(token, deps);
+    expect(first.status).toBe(200);
+    expect(second.status).toBe(409);
+  });
+});

--- a/supervisor/tests/action/token.test.ts
+++ b/supervisor/tests/action/token.test.ts
@@ -1,0 +1,214 @@
+import { test, expect, describe } from "bun:test";
+import { execFileSync } from "child_process";
+import { existsSync, mkdtempSync, writeFileSync } from "fs";
+import { tmpdir, homedir } from "os";
+import { join, resolve } from "path";
+import {
+  parseToken,
+  verifySignature,
+  isExpired,
+  base64urlToBuffer,
+  bufferToBase64url,
+} from "../../src/action/token";
+
+/**
+ * Token contract tests (Issue #305). The signing side is agent-base's
+ * scripts/lib/action-token.sh (openssl HMAC). These tests generate tokens with
+ * the SAME openssl pipeline (inline, CI-portable) and verify them in TS to lock
+ * the cross-language contract, plus a best-effort round-trip against the real
+ * action-token.sh source when it is reachable from origin/main.
+ */
+
+const KEY = "test-shared-key-abc123";
+
+// Inline generator byte-for-byte mirroring action-token.sh's algorithm:
+//   payload = base64url(JSON{v,action,target,iat,ttl,nonce})
+//   sig     = base64url(HMAC-SHA256(payload, key))
+// `iat` is a parameter so expiry can be exercised deterministically.
+const GEN_SCRIPT = `
+set -euo pipefail
+action="$1"; target="$2"; ttl="$3"; iat="$4"
+nonce=$(openssl rand -hex 16)
+json=$(printf '{"v":1,"action":"%s","target":"%s","iat":%s,"ttl":%s,"nonce":"%s"}' "$action" "$target" "$iat" "$ttl" "$nonce")
+payload=$(printf '%s' "$json" | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+sig=$(printf '%s' "$payload" | openssl dgst -sha256 -hmac "$PUSHOVER_ACTION_HMAC_KEY" -binary | openssl base64 -A | tr '+/' '-_' | tr -d '=')
+printf '%s.%s' "$payload" "$sig"
+`;
+
+function genToken(
+  action: string,
+  target: string,
+  opts: { ttl?: number; iat?: number; key?: string } = {}
+): string {
+  const ttl = opts.ttl ?? 1800;
+  const iat = opts.iat ?? Math.floor(Date.now() / 1000);
+  return execFileSync(
+    "bash",
+    ["-c", GEN_SCRIPT, "bash", action, target, String(ttl), String(iat)],
+    {
+      env: { ...process.env, PUSHOVER_ACTION_HMAC_KEY: opts.key ?? KEY },
+      encoding: "utf8",
+    }
+  );
+}
+
+/**
+ * Generate a token with the REAL agent-base action-token.sh, extracted from
+ * origin/main into a temp dir alongside its keychain-get.sh dependency. Returns
+ * null when agent-base / git is unreachable (e.g. CI) so the caller can skip.
+ */
+function genTokenViaRealScript(action: string, target: string): string | null {
+  try {
+    const agentBase = resolve(homedir(), "agent-base");
+    if (!existsSync(agentBase)) return null;
+    const lib = mkdtempSync(join(tmpdir(), "action-token-lib-"));
+    for (const f of ["action-token.sh", "keychain-get.sh"]) {
+      const content = execFileSync(
+        "git",
+        ["-C", agentBase, "show", `origin/main:scripts/lib/${f}`],
+        { encoding: "utf8" }
+      );
+      writeFileSync(join(lib, f), content);
+    }
+    return execFileSync(
+      "bash",
+      [join(lib, "action-token.sh"), action, target, "1800"],
+      {
+        env: {
+          ...process.env,
+          PUSHOVER_ACTION_HMAC_KEY: KEY,
+          KEYCHAIN_GET_SKIP_KEYCHAIN: "1",
+          KEYCHAIN_GET_ENV_FILE: "/nonexistent",
+        },
+        encoding: "utf8",
+      }
+    ).trim();
+  } catch {
+    return null;
+  }
+}
+
+describe("action/token base64url", () => {
+  test("encode/decode round-trips arbitrary bytes", () => {
+    const s = "こんにちは/世界+foo?=";
+    const encoded = bufferToBase64url(Buffer.from(s, "utf8"));
+    expect(encoded).not.toContain("+");
+    expect(encoded).not.toContain("/");
+    expect(encoded).not.toContain("=");
+    expect(base64urlToBuffer(encoded).toString("utf8")).toBe(s);
+  });
+});
+
+describe("action/token parseToken", () => {
+  test("valid token decodes to the expected shape", () => {
+    const token = genToken("compact", "/Users/x/wt/issue-441", { ttl: 1800 });
+    const parsed = parseToken(token);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) throw new Error("unreachable");
+    expect(parsed.token.v).toBe(1);
+    expect(parsed.token.action).toBe("compact");
+    expect(parsed.token.target).toBe("/Users/x/wt/issue-441");
+    expect(parsed.token.ttl).toBe(1800);
+    expect(parsed.token.nonce).toMatch(/^[0-9a-f]{32}$/);
+  });
+
+  test("rejects malformed input (empty / no dot / bad base64 / bad json)", () => {
+    expect(parseToken("").ok).toBe(false);
+    expect(parseToken("nodothere").ok).toBe(false);
+    expect(parseToken(".sig").ok).toBe(false);
+    expect(parseToken("payload.").ok).toBe(false);
+    expect(parseToken("a.b.c").ok).toBe(false);
+    // payload is valid base64url but not JSON.
+    const notJson = `${bufferToBase64url(Buffer.from("not json"))}.sig`;
+    expect(parseToken(notJson).ok).toBe(false);
+  });
+
+  test("rejects wrong version and missing/invalid fields", () => {
+    const mk = (obj: unknown) => `${bufferToBase64url(Buffer.from(JSON.stringify(obj)))}.sig`;
+    const base = { v: 1, action: "compact", target: "/x", iat: 1000, ttl: 60, nonce: "n" };
+    expect(parseToken(mk({ ...base, v: 2 })).ok).toBe(false);
+    expect(parseToken(mk({ ...base, action: "" })).ok).toBe(false);
+    expect(parseToken(mk({ ...base, target: "" })).ok).toBe(false);
+    expect(parseToken(mk({ ...base, iat: 1.5 })).ok).toBe(false);
+    expect(parseToken(mk({ ...base, ttl: 0 })).ok).toBe(false);
+    expect(parseToken(mk({ ...base, ttl: -1 })).ok).toBe(false);
+    expect(parseToken(mk({ ...base, nonce: "" })).ok).toBe(false);
+    expect(parseToken(mk({ ...base, nonce: 123 })).ok).toBe(false);
+  });
+});
+
+describe("action/token verifySignature (contract with openssl)", () => {
+  test("valid openssl-generated token verifies with the shared key", () => {
+    const token = genToken("compact", "/Users/x/wt/issue-441");
+    const parsed = parseToken(token);
+    if (!parsed.ok) throw new Error("parse failed");
+    expect(verifySignature(parsed.payload, parsed.sig, KEY)).toBe(true);
+  });
+
+  test("wrong key fails verification", () => {
+    const token = genToken("compact", "/Users/x/wt/issue-441");
+    const parsed = parseToken(token);
+    if (!parsed.ok) throw new Error("parse failed");
+    expect(verifySignature(parsed.payload, parsed.sig, "wrong-key")).toBe(false);
+  });
+
+  test("tampered signature fails verification", () => {
+    const token = genToken("compact", "/Users/x/wt/issue-441");
+    const parsed = parseToken(token);
+    if (!parsed.ok) throw new Error("parse failed");
+    // Flip a character in the signature.
+    const badSig = parsed.sig.slice(0, -1) + (parsed.sig.endsWith("A") ? "B" : "A");
+    expect(verifySignature(parsed.payload, badSig, KEY)).toBe(false);
+  });
+
+  test("tampered payload (target swapped) fails verification", () => {
+    const token = genToken("compact", "/Users/x/wt/issue-441");
+    const parsed = parseToken(token);
+    if (!parsed.ok) throw new Error("parse failed");
+    const forgedPayload = bufferToBase64url(
+      Buffer.from(JSON.stringify({ ...parsed.token, target: "/etc/evil" }))
+    );
+    expect(verifySignature(forgedPayload, parsed.sig, KEY)).toBe(false);
+  });
+
+  test("garbage signature does not throw (returns false)", () => {
+    const token = genToken("compact", "/x");
+    const parsed = parseToken(token);
+    if (!parsed.ok) throw new Error("parse failed");
+    expect(verifySignature(parsed.payload, "!!!not-base64!!!", KEY)).toBe(false);
+    expect(verifySignature(parsed.payload, parsed.sig, "")).toBe(false);
+  });
+
+  test("round-trip against the real agent-base action-token.sh (skips if unavailable)", () => {
+    const token = genTokenViaRealScript("compact", "/Users/x/wt/issue-441");
+    if (!token) {
+      console.log(
+        "[token.test] skip real action-token.sh round-trip (agent-base origin/main unreachable)"
+      );
+      return;
+    }
+    const parsed = parseToken(token);
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) throw new Error("unreachable");
+    expect(parsed.token.action).toBe("compact");
+    expect(verifySignature(parsed.payload, parsed.sig, KEY)).toBe(true);
+    expect(verifySignature(parsed.payload, parsed.sig, "wrong")).toBe(false);
+  });
+});
+
+describe("action/token isExpired", () => {
+  test("live token within ttl is not expired", () => {
+    const iat = 1_000_000;
+    const token = parseToken(genToken("compact", "/x", { ttl: 1800, iat }));
+    if (!token.ok) throw new Error("parse failed");
+    expect(isExpired(token.token, iat + 100)).toBe(false);
+    expect(isExpired(token.token, iat + 1800)).toBe(false); // boundary: still valid
+  });
+
+  test("token past iat+ttl is expired", () => {
+    const iat = 1_000_000;
+    const token = parseToken(genToken("compact", "/x", { ttl: 1800, iat }));
+    if (!token.ok) throw new Error("parse failed");
+    expect(isExpired(token.token, iat + 1801)).toBe(true);
+  });
+});


### PR DESCRIPTION
## 概要

Pushover 通知ワンタップアクションの **受信・実行側（層3+4）** を claude-hub supervisor プロセス内に実装しました。スマホでタップ1回 → Tailscale 経由で対象 Claude Code セッションに `/compact` を投入します。

設計 spec: corp `docs/superpowers/specs/2026-07-05-pushover-one-tap-action-design.md`（§5 受信 / §6 実行 / §8 セキュリティ）。トークン仕様の正は agent-base `scripts/lib/action-token.sh`（層1+2）。

Closes #305

## 実装

新規モジュール `supervisor/src/action/`（層ごとに分離）:

| ファイル | 層 | 役割 |
|---|---|---|
| `token.ts` | 2/3 境界 | base64url + HMAC-SHA256 検証・TTL 判定（純粋、I/O なし） |
| `key.ts` | 3 | 共有鍵解決: env `PUSHOVER_ACTION_HMAC_KEY` → macOS Keychain |
| `execute.ts` | 4 | `execute(action, target)` アダプタ。allowlist（compact のみ）+ セッション解決 |
| `receiver.ts` | 3 | `GET /act?t=` の検証パイプライン + Tailscale bind + HTTP サーバ |

- **検証順（spec §5 / コスト順）**: 署名 → TTL → allowlist → nonce → 実行。無効・期限切れ・未許可のトークンは **nonce を消費する前に** 拒否するため、正当なタップだけがワンタイム nonce を消費します。
- **bind は Tailscale IP のみ**（`tailscale ip -4`、`ACTION_RECEIVER_BIND` で上書き）。wildcard（`0.0.0.0` / `::`）は拒否。IP 取得失敗時は endpoint 無効化 + WARN で、**bot 本体は無傷**（`startBot` に fire-and-forget で統合、never throw）。
- **nonce ワンタイム保証**は `sessions.db` の `action_nonces`（PRIMARY KEY + `ON CONFLICT DO NOTHING` で原子的 consume）。
- **allowlist default 拒否**: 実行アダプタの `switch` default が未許可アクションを構造的に実行不可能に（spec §8 第3防御）。
- **サイレントフォールバック禁止**: 対象セッション不明・送信失敗は明示エラー（4xx/5xx + ログ）で握りつぶさない。
- tmux 投入は既存の `sendToPane`（mode-exit / Escape / `send-keys -l` / C-m、テキストと Enter を分割: RW-025 回避）を再利用。

## AC 検証結果

決定的検証コマンド:

```bash
cd supervisor
bun test tests/action/token.test.ts tests/action/execute.test.ts tests/action/receiver.test.ts
bunx tsc --noEmit
bun scripts/lint-gating-coverage.ts && bun scripts/lint-no-sync-exec.ts && bun scripts/lint-blocking-in-timers.ts
```

### コンポーネントAC（自動・決定的）

| AC | 検証内容 | 期待 | 実測 | 判定 |
|---|---|---|---|---|
| C-1 | 正常トークン | 署名 verify true / パイプライン 200 sent | 47 pass | PASS |
| C-2 | 署名不一致 | verify false / 401（nonce 未消費） | 401, nonceCalls=0 | PASS |
| C-3 | TTL 切れ | 410（nonce 未消費） | 410, nonceCalls=0 | PASS |
| C-4 | nonce 再利用 | 2回目 409 + 実行1回のみ | 200→409, exec×1 | PASS |
| C-5 | allowlist 外（正規署名） | 403（nonce 未消費・未実行） | 403 | PASS |
| C-6 | agent-base round-trip | openssl 生成トークンを TS 検証 true | PASS（実 `action-token.sh` も一致） | PASS |

### 統合ジャーニーAC（Issue #305）

| # | 期待 | 検証手段 | 判定 |
|---|---|---|---|
| 1 | タップ → 「✅ /compact を送信しました」+ 対象に `/compact` 投入 | `handleActRequest` 200+成功HTML（unit）/ `executeAction` が `sendToPane` に `/compact <意図>`（unit）。transcript boundary の live 確認は実機（tmux+iPhone）依存で **未実施（手動確認事項）** | 機械部分 PASS |
| 2 | 同一 URL 再タップ → 「使用済み」+ 再実行なし | `evaluateAction` nonce 再利用 409 + 実 `consumeActionNonce` の end-to-end 置換 | PASS |
| 3 | TTL 超過 → 4xx | `evaluateAction` 期限切れ 410 / `isExpired` 境界 | PASS |
| 4 | tailnet 外 → 到達不能 | 構造保証: Tailscale IP のみ bind・wildcard 拒否（`resolveBindHost` tests）。実 curl は tailnet 依存で **未実施（構造保証）** | 構造 PASS |
| 5 | allowlist 外 self-signed → 未許可 4xx | `evaluateAction` 403 + `executeAction` default 拒否 | PASS |

### 品質ゲート

| 項目 | 実測 | 判定 |
|---|---|---|
| 新規テスト | 47 pass / 0 fail（3 ファイル） | PASS |
| 回帰（curated 30 ファイル） | 443 pass / 0 fail | PASS |
| `tsc --noEmit` | exit 0 | PASS |
| lint（gating-coverage / no-sync-exec / blocking-in-timers） | 全 pass（新規 3 テストを ci.yml に登録） | PASS |

## 未実施事項

- **live E2E（AC 1 の transcript boundary / AC 4 の tailnet 外 curl）**: 実機（Mac の tmux セッション + iPhone + tailnet on/off）依存のため自動テスト外。機械部分（署名検証・HTML・送信・bind 構造）は unit で網羅済み。層1+2（agent-base 送信側）完了後に実機で通し確認が必要。
- **成功時の Pushover 折り返し通知**（spec §5 の任意項目）: 本 PR ではタップ後の HTML 表示を確認手段とし、折り返し通知は未実装（スコープ外）。
- **TLS（`tailscale serve` 併用）**: 本 PR は Tailscale IP への直 bind。TLS フロントは運用設定の課題として spec に委譲。

## 設定（新規 env、`.env.example` に追記済み）

- `PUSHOVER_ACTION_HMAC_KEY`: 送信側と共有する HMAC 鍵（未設定なら receiver 無効）
- `ACTION_RECEIVER_BIND`: bind IP 上書き（既定は `tailscale ip -4`）
- `ACTION_RECEIVER_PORT`: `GET /act` のポート（既定 8317）
