### PR TITLE
feat(#318): Supervisor に /orchestrate メッセージコマンドを追加（オーケストレーター起動、純追加）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,6 +152,7 @@ jobs:
                    tests/session/dispatch-integration.test.ts \
                    tests/session/dispatch-headless.test.ts \
                    tests/session/dispatch-report.test.ts \
+                   tests/session/orchestrate.test.ts \
                    tests/session/adapters-executor.test.ts \
                    tests/session/manager-headless.test.ts \
                    tests/session/headless-liveness.test.ts \

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -62,6 +62,7 @@ import {
   runOrchestrate,
   findRunningOrchestrator,
   orchestrateBranchName,
+  OrchestrateLaunchLock,
 } from "./session/orchestrate";
 import { AdmissionController } from "./session/admission";
 import { buildThreadTitle } from "./session/thread-title";
@@ -329,6 +330,10 @@ export async function startBot(token: string): Promise<void> {
   // WARN under high load but does not delay; enforcement is opt-in via
   // DISPATCH_ADMISSION_ENFORCE=1.
   const admissionController = new AdmissionController();
+  // Epic #316 Phase 1 (#318, PR #324 review): per-channel in-flight lock so two
+  // rapid /orchestrate messages cannot both pass the duplicate-launch guard
+  // before the first session registers (TOCTOU).
+  const orchestrateLaunchLock = new OrchestrateLaunchLock();
   const sessionHandler = createSessionHandler(sessionManager);
 
   // Per-thread progress buffer (Issue #119): coalesce PostToolUse events
@@ -755,109 +760,132 @@ export async function startBot(token: string): Promise<void> {
       return true;
     }
 
-    // Duplicate-launch guard (#318): one orchestrator per channel. When one is
-    // already running (branch prefix `orchestrate-`), answer with its thread
-    // link instead of starting a second — unless the user explicitly passed
-    // `--new`.
-    const running = findRunningOrchestrator(
-      sessionManager.listRunningByChannel(channelName)
-    );
-    if (running && !parsed.forceNew) {
+    // In-flight lock (PR #324 review): acquired SYNCHRONOUSLY (no await between
+    // the running-session guard below and the lock) so two rapid /orchestrate
+    // messages cannot both pass the guard while the first launch is still
+    // creating its thread / starting its session (TOCTOU). Released in finally
+    // once the launch settles (success or failure) — from then on the
+    // running-session guard takes over because the session is registered.
+    if (!orchestrateLaunchLock.tryAcquire(channelName)) {
       try {
         await textChannel.send(
-          `ℹ️ このチャンネルでは既にオーケストレーターが稼働中です: <#${running.threadId}>\n` +
-            `稼働中のスレッドに追加指示を送るか、別のオーケストレーターが必要な場合は ` +
-            `\`/orchestrate --new <タスク...>\` で明示起動してください。`
+          `⏳ このチャンネルでオーケストレーターの起動処理が進行中です。完了後に再試行してください。`
         );
       } catch (err) {
         console.error(
-          `[Bot] Orchestrate duplicate-guard notice failed in channel ${channelName}:`,
+          `[Bot] Orchestrate in-flight notice failed in channel ${channelName}:`,
           err
         );
       }
       return true;
     }
-
-    const branch = orchestrateBranchName();
-    console.log(
-      `[Bot] Orchestrate accepted in channel ${channelName} (branch=${branch}, args len=${parsed.rawArgs.length}, forceNew=${parsed.forceNew})`
-    );
-
-    // Thread creation mirrors handleDispatchMessage (sequence suffix per
-    // RW-046 same-branch multi-session).
-    let orchestrateThread: { id: string };
     try {
-      const sameBranchCount = sessionManager
-        .listRunningByChannel(channelName)
-        .filter((s) => s.branch === branch).length;
-      const threadName = buildThreadTitle(
-        "running",
-        branch,
-        config.displayName,
-        sameBranchCount + 1
+      // Duplicate-launch guard (#318): one orchestrator per channel. When one
+      // is already running (branch prefix `orchestrate-`), answer with its
+      // thread link instead of starting a second — unless the user explicitly
+      // passed `--new`.
+      const running = findRunningOrchestrator(
+        sessionManager.listRunningByChannel(channelName)
       );
-      const created = await textChannel.threads.create({
-        name: threadName,
-        autoArchiveDuration: 10080, // 7 days
-      });
-      orchestrateThread = { id: created.id };
-    } catch (err) {
-      console.error(
-        `[Bot] Orchestrate thread creation failed in channel ${channelName}:`,
-        err
-      );
-      return true;
-    }
-
-    const result = await runOrchestrate({
-      config,
-      branch,
-      rawArgs: parsed.rawArgs,
-      sessionManager,
-      createThread: async () => orchestrateThread, // reuse the created thread
-    });
-
-    if (result.ok) {
-      try {
-        const thread = await client.channels.fetch(result.threadId);
-        if (thread?.isThread()) {
-          // Echo the injected command (arguments included) so the thread's
-          // first message confirms what the orchestrator received (統合
-          // ジャーニーAC 1). Truncated to stay well under Discord's 2000-char
-          // message limit alongside the surrounding text.
-          const echo =
-            result.injected.length > 1500
-              ? `${result.injected.slice(0, 1500)}…`
-              : result.injected;
-          await thread.send(
-            `🎼 **${config.displayName}** のオーケストレーターを起動しました\n\n` +
-              `🌿 ブランチ: \`${branch}\`\n` +
-              `▶️ 初期コマンド: \`${echo}\`\n` +
-              `📊 稼働中セッション: ${sessionManager.count()}/${MAX_SESSIONS}`
+      if (running && !parsed.forceNew) {
+        try {
+          await textChannel.send(
+            `ℹ️ このチャンネルでは既にオーケストレーターが稼働中です: <#${running.threadId}>\n` +
+              `稼働中のスレッドに追加指示を送るか、別のオーケストレーターが必要な場合は ` +
+              `\`/orchestrate --new <タスク...>\` で明示起動してください。`
+          );
+        } catch (err) {
+          console.error(
+            `[Bot] Orchestrate duplicate-guard notice failed in channel ${channelName}:`,
+            err
           );
         }
+        return true;
+      }
+
+      const branch = orchestrateBranchName();
+      console.log(
+        `[Bot] Orchestrate accepted in channel ${channelName} (branch=${branch}, args len=${parsed.rawArgs.length}, forceNew=${parsed.forceNew})`
+      );
+
+      // Thread creation mirrors handleDispatchMessage (sequence suffix per
+      // RW-046 same-branch multi-session).
+      let orchestrateThread: { id: string };
+      try {
+        const sameBranchCount = sessionManager
+          .listRunningByChannel(channelName)
+          .filter((s) => s.branch === branch).length;
+        const threadName = buildThreadTitle(
+          "running",
+          branch,
+          config.displayName,
+          sameBranchCount + 1
+        );
+        const created = await textChannel.threads.create({
+          name: threadName,
+          autoArchiveDuration: 10080, // 7 days
+        });
+        orchestrateThread = { id: created.id };
       } catch (err) {
         console.error(
-          `[Bot] Orchestrate welcome message failed for thread ${result.threadId}:`,
+          `[Bot] Orchestrate thread creation failed in channel ${channelName}:`,
           err
         );
+        return true;
       }
-    } else {
-      console.error(
-        `[Bot] Orchestrate failed (stage=${result.stage}) in channel ${channelName}: ${result.error}`
-      );
-      try {
-        await textChannel.send(
-          `❌ オーケストレーターの起動に失敗しました（stage=${result.stage}）。Supervisor ログを確認してください。`
-        );
-      } catch (postErr) {
+
+      const result = await runOrchestrate({
+        config,
+        branch,
+        rawArgs: parsed.rawArgs,
+        sessionManager,
+        createThread: async () => orchestrateThread, // reuse the created thread
+      });
+
+      if (result.ok) {
+        try {
+          const thread = await client.channels.fetch(result.threadId);
+          if (thread?.isThread()) {
+            // Echo the injected command (arguments included) so the thread's
+            // first message confirms what the orchestrator received (統合
+            // ジャーニーAC 1). Truncated to stay well under Discord's 2000-char
+            // message limit alongside the surrounding text.
+            const echo =
+              result.injected.length > 1500
+                ? `${result.injected.slice(0, 1500)}…`
+                : result.injected;
+            await thread.send(
+              `🎼 **${config.displayName}** のオーケストレーターを起動しました\n\n` +
+                `🌿 ブランチ: \`${branch}\`\n` +
+                `▶️ 初期コマンド: \`${echo}\`\n` +
+                `📊 稼働中セッション: ${sessionManager.count()}/${MAX_SESSIONS}`
+            );
+          }
+        } catch (err) {
+          console.error(
+            `[Bot] Orchestrate welcome message failed for thread ${result.threadId}:`,
+            err
+          );
+        }
+      } else {
         console.error(
-          `[Bot] Orchestrate failure notice failed in channel ${channelName}:`,
-          postErr
+          `[Bot] Orchestrate failed (stage=${result.stage}) in channel ${channelName}: ${result.error}`
         );
+        try {
+          await textChannel.send(
+            `❌ オーケストレーターの起動に失敗しました（stage=${result.stage}）。Supervisor ログを確認してください。`
+          );
+        } catch (postErr) {
+          console.error(
+            `[Bot] Orchestrate failure notice failed in channel ${channelName}:`,
+            postErr
+          );
+        }
       }
+      return true;
+    } finally {
+      orchestrateLaunchLock.release(channelName);
     }
-    return true;
   }
 
   // Message relay: thread messages → Claude Code → thread reply

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -56,6 +56,13 @@ import {
   resolveExecutorMode,
 } from "./session/dispatch";
 import { DispatchQueue } from "./session/dispatch-queue";
+import {
+  ORCHESTRATE_PREFIX,
+  parseOrchestrateCommand,
+  runOrchestrate,
+  findRunningOrchestrator,
+  orchestrateBranchName,
+} from "./session/orchestrate";
 import { AdmissionController } from "./session/admission";
 import { buildThreadTitle } from "./session/thread-title";
 
@@ -666,6 +673,193 @@ export async function startBot(token: string): Promise<void> {
     return true;
   }
 
+  // Epic #316 Phase 1 (#318): handle an `/orchestrate <生引数...>` message in a
+  // known department channel — start ONE orchestrator session (tmux + thread)
+  // and inject `/orchestrate-runner <生引数>` as its first prompt. Placed
+  // alongside handleDispatchMessage (same intercept shape) but authorized via
+  // the normal-message gate (`evaluateAccess` / access.json `allowFrom`,
+  // fail-closed), NOT the dispatch-source policy. Returns true when the message
+  // was an orchestrate attempt and was fully handled (caller must stop), false
+  // when it is not an orchestrate and normal processing should continue.
+  //
+  // Per ADR-002 D2 the Supervisor's responsibility ends here: argument
+  // interpretation, worker dispatching, monitoring and merge decisions all
+  // live in the orchestrator skill (Phase 2 #319). The raw arguments are never
+  // parsed — they travel through the relay's argv-no-shell injection path
+  // (sendMessage → tmux send-keys -l) untouched.
+  async function handleOrchestrateMessage(message: Message): Promise<boolean> {
+    // Orchestrate only applies to a non-thread message in a known department
+    // channel whose text starts with the orchestrate token.
+    if (message.channel.isThread()) return false;
+    const content = message.content ?? "";
+    const trimmed = content.trim();
+    if (
+      trimmed !== ORCHESTRATE_PREFIX &&
+      !trimmed.startsWith(ORCHESTRATE_PREFIX + " ") &&
+      !trimmed.startsWith(ORCHESTRATE_PREFIX + "\n")
+    ) {
+      return false;
+    }
+
+    const channelName =
+      "name" in message.channel ? (message.channel.name as string) : "";
+    const config = CHANNEL_MAP.get(channelName);
+    if (!config) {
+      // Unknown channel: not a valid orchestrate target — fall through to
+      // normal processing (non-thread messages are ignored there anyway).
+      return false;
+    }
+    const textChannel = message.channel as TextChannel;
+
+    // Authorize the sender with the SAME gate as normal relay messages
+    // (access.json `allowFrom` keyed on the channel id). Fail-closed: a
+    // missing / broken policy or an unlisted sender denies. Independent of
+    // the dispatch-only `dispatchFrom` list (#318).
+    {
+      const botUserId = client.user?.id;
+      const isMention = botUserId
+        ? message.mentions.users.has(botUserId)
+        : false;
+      const decision = evaluateAccess({
+        channelKey: textChannel.id,
+        userId: message.author.id,
+        isMention,
+      });
+      if (!decision.allowed) {
+        // Identifier-free denial log; never log the sender snowflake or body.
+        console.warn(
+          `[Bot] Orchestrate denied (reason=${decision.reason}) in channel ${channelName}; not started`
+        );
+        // Consume the message: by here it is an `/orchestrate` in a known
+        // department channel, which the normal relay path never acts on.
+        return true;
+      }
+    }
+
+    const parsed = parseOrchestrateCommand(content);
+    if (parsed.kind === "not_orchestrate") {
+      return false;
+    }
+    if (parsed.kind === "error") {
+      console.warn(
+        `[Bot] Orchestrate rejected in channel ${channelName}: ${parsed.reason}`
+      );
+      try {
+        await textChannel.send(`⚠️ ${parsed.reason}`);
+      } catch (err) {
+        console.error(
+          `[Bot] Orchestrate rejection notice failed in channel ${channelName}:`,
+          err
+        );
+      }
+      return true;
+    }
+
+    // Duplicate-launch guard (#318): one orchestrator per channel. When one is
+    // already running (branch prefix `orchestrate-`), answer with its thread
+    // link instead of starting a second — unless the user explicitly passed
+    // `--new`.
+    const running = findRunningOrchestrator(
+      sessionManager.listRunningByChannel(channelName)
+    );
+    if (running && !parsed.forceNew) {
+      try {
+        await textChannel.send(
+          `ℹ️ このチャンネルでは既にオーケストレーターが稼働中です: <#${running.threadId}>\n` +
+            `稼働中のスレッドに追加指示を送るか、別のオーケストレーターが必要な場合は ` +
+            `\`/orchestrate --new <タスク...>\` で明示起動してください。`
+        );
+      } catch (err) {
+        console.error(
+          `[Bot] Orchestrate duplicate-guard notice failed in channel ${channelName}:`,
+          err
+        );
+      }
+      return true;
+    }
+
+    const branch = orchestrateBranchName();
+    console.log(
+      `[Bot] Orchestrate accepted in channel ${channelName} (branch=${branch}, args len=${parsed.rawArgs.length}, forceNew=${parsed.forceNew})`
+    );
+
+    // Thread creation mirrors handleDispatchMessage (sequence suffix per
+    // RW-046 same-branch multi-session).
+    let orchestrateThread: { id: string };
+    try {
+      const sameBranchCount = sessionManager
+        .listRunningByChannel(channelName)
+        .filter((s) => s.branch === branch).length;
+      const threadName = buildThreadTitle(
+        "running",
+        branch,
+        config.displayName,
+        sameBranchCount + 1
+      );
+      const created = await textChannel.threads.create({
+        name: threadName,
+        autoArchiveDuration: 10080, // 7 days
+      });
+      orchestrateThread = { id: created.id };
+    } catch (err) {
+      console.error(
+        `[Bot] Orchestrate thread creation failed in channel ${channelName}:`,
+        err
+      );
+      return true;
+    }
+
+    const result = await runOrchestrate({
+      config,
+      branch,
+      rawArgs: parsed.rawArgs,
+      sessionManager,
+      createThread: async () => orchestrateThread, // reuse the created thread
+    });
+
+    if (result.ok) {
+      try {
+        const thread = await client.channels.fetch(result.threadId);
+        if (thread?.isThread()) {
+          // Echo the injected command (arguments included) so the thread's
+          // first message confirms what the orchestrator received (統合
+          // ジャーニーAC 1). Truncated to stay well under Discord's 2000-char
+          // message limit alongside the surrounding text.
+          const echo =
+            result.injected.length > 1500
+              ? `${result.injected.slice(0, 1500)}…`
+              : result.injected;
+          await thread.send(
+            `🎼 **${config.displayName}** のオーケストレーターを起動しました\n\n` +
+              `🌿 ブランチ: \`${branch}\`\n` +
+              `▶️ 初期コマンド: \`${echo}\`\n` +
+              `📊 稼働中セッション: ${sessionManager.count()}/${MAX_SESSIONS}`
+          );
+        }
+      } catch (err) {
+        console.error(
+          `[Bot] Orchestrate welcome message failed for thread ${result.threadId}:`,
+          err
+        );
+      }
+    } else {
+      console.error(
+        `[Bot] Orchestrate failed (stage=${result.stage}) in channel ${channelName}: ${result.error}`
+      );
+      try {
+        await textChannel.send(
+          `❌ オーケストレーターの起動に失敗しました（stage=${result.stage}）。Supervisor ログを確認してください。`
+        );
+      } catch (postErr) {
+        console.error(
+          `[Bot] Orchestrate failure notice failed in channel ${channelName}:`,
+          postErr
+        );
+      }
+    }
+    return true;
+  }
+
   // Message relay: thread messages → Claude Code → thread reply
   client.on(Events.MessageCreate, async (message: Message) => {
     // Issue #32 / S7 (dispatch transport): intercept `/dispatch` from an allowed
@@ -676,6 +870,17 @@ export async function startBot(token: string): Promise<void> {
       if (await handleDispatchMessage(message)) return;
     } catch (err) {
       console.error("[Bot] Dispatch handler error:", err);
+      return;
+    }
+
+    // Epic #316 Phase 1 (#318): intercept `/orchestrate` in a known department
+    // channel BEFORE the blanket bot/webhook drop below (same shape as the
+    // dispatch intercept). Fail-closed inside handleOrchestrateMessage via
+    // evaluateAccess (access.json `allowFrom`).
+    try {
+      if (await handleOrchestrateMessage(message)) return;
+    } catch (err) {
+      console.error("[Bot] Orchestrate handler error:", err);
       return;
     }
 

--- a/supervisor/src/session/orchestrate.ts
+++ b/supervisor/src/session/orchestrate.ts
@@ -1,0 +1,238 @@
+/**
+ * Message-driven orchestrator startup (Epic #316 Phase 1 / Issue #318).
+ *
+ * `/orchestrate <生引数...>` は corp チャンネルから複数タスク（handoff `.tmp`
+ * パス / `repo#issue` / 自然言語の混在可）を一括で受け付け、オーケストレーター
+ * 専用の Claude Code セッション（tmux + corp スレッド）を 1 本起動して、引数を
+ * そのまま初期プロンプトとして注入する。
+ *
+ * ADR-002 (docs/adr/2026-07-05-corp-orchestration.md) D2 の責務境界に従い、
+ * Supervisor 側の実装は「受付・認可・多重起動ガード・セッション起動・引数注入」
+ * のみに留める（thin-scaffolding）。監視ループ・依存管理・merge 判断はすべて
+ * オーケストレータースキル（Phase 2 #319 の `/orchestrate-runner`）の責務。
+ *
+ * dispatch.ts と同型の構成: パース（純関数）とオーケストレーション（注入可能な
+ * seam）を分離し、Discord gateway / 実 SessionManager なしでユニットテスト可能
+ * に保つ。認可は dispatch の `dispatchFrom` とは独立で、通常メッセージと同じ
+ * `evaluateAccess`（access.json の `allowFrom`、fail-closed）を bot.ts 側で通す。
+ *
+ * 引数の安全性: Supervisor は引数を一切解釈しない（解釈はスキル側の責務）。
+ * 注入は既存 relay の argv-no-shell 経路（`SessionManager.sendMessage` →
+ * tmux `send-keys -l`、シェル展開なし）のみを通るため、shell メタ文字を含む
+ * 生引数でもコマンドインジェクション面は生じない。
+ */
+
+/** Literal trigger token. `/orchestrated` 等の前方一致誤爆は parser 側で防ぐ。 */
+export const ORCHESTRATE_PREFIX = "/orchestrate";
+
+/**
+ * オーケストレーターセッションの branch prefix。多重起動ガード
+ * ({@link findRunningOrchestrator}) は running セッションの branch がこの
+ * prefix で始まるかで「オーケストレーターかどうか」を判定する。
+ */
+export const ORCHESTRATE_BRANCH_PREFIX = "orchestrate-";
+
+/**
+ * 起動直後に注入するスキルコマンド名（Phase 2 #319 のスキル名との
+ * インターフェース契約 — 変更するときは Epic #316 の全 Phase と同期すること）。
+ * 常に固定リテラルで、生引数は後ろに付くのみ。
+ */
+export const ORCHESTRATE_RUNNER_COMMAND = "/orchestrate-runner";
+
+/**
+ * 多重起動ガードを明示的に迂回するフラグ。先頭トークンとしてのみ解釈する
+ * （`/orchestrate --new <引数...>`）。それ以外の位置の `--new` は生引数の一部
+ * としてそのままオーケストレーターへ渡る（Supervisor は引数を解釈しない原則）。
+ */
+export const ORCHESTRATE_NEW_FLAG = "--new";
+
+export type ParsedOrchestrate =
+  | { kind: "ok"; rawArgs: string; forceNew: boolean }
+  | { kind: "not_orchestrate" }
+  | { kind: "error"; reason: string };
+
+/**
+ * Parse a `/orchestrate <生引数...>` message. Returns:
+ *   - `not_orchestrate` when the content is not an `/orchestrate` command
+ *     (caller falls through to the normal relay / dispatch path),
+ *   - `error` when the command has no arguments (there is nothing to run),
+ *   - `ok` with the raw argument string preserved verbatim (inner whitespace
+ *     included) and the `--new` leading-flag extracted.
+ *
+ * dispatch と違い引数の形状検証は行わない — `.tmp` パス / `repo#issue` /
+ * 自然言語の解釈はオーケストレータースキルの責務（ADR-002 D2）。
+ */
+export function parseOrchestrateCommand(content: string): ParsedOrchestrate {
+  const trimmed = content.trim();
+
+  // Match the exact `/orchestrate` token (not `/orchestrated`, not
+  // `/orchestrate-runner`). The command must be the whole leading token
+  // followed by whitespace or EOL.
+  if (
+    trimmed !== ORCHESTRATE_PREFIX &&
+    !trimmed.startsWith(ORCHESTRATE_PREFIX + " ") &&
+    !trimmed.startsWith(ORCHESTRATE_PREFIX + "\n")
+  ) {
+    return { kind: "not_orchestrate" };
+  }
+
+  let rest = trimmed.slice(ORCHESTRATE_PREFIX.length).trim();
+
+  // `--new` は先頭トークンのみフラグとして解釈し、残りを生引数とする。
+  let forceNew = false;
+  if (rest === ORCHESTRATE_NEW_FLAG) {
+    forceNew = true;
+    rest = "";
+  } else if (rest.startsWith(ORCHESTRATE_NEW_FLAG + " ")) {
+    forceNew = true;
+    rest = rest.slice(ORCHESTRATE_NEW_FLAG.length).trim();
+  }
+
+  if (rest.length === 0) {
+    return {
+      kind: "error",
+      reason:
+        "引数が空です。/orchestrate <タスク...>（.tmp パス / repo#issue / 自然言語、複数可）で指定してください。",
+    };
+  }
+
+  return { kind: "ok", rawArgs: rest, forceNew };
+}
+
+/**
+ * Minimal running-session surface the duplicate-launch guard needs (structural
+ * subset of SessionInfo so tests can pass plain objects).
+ */
+export interface OrchestratorSessionLike {
+  threadId: string;
+  branch?: string;
+}
+
+/**
+ * Duplicate-launch guard: return the first running orchestrator session
+ * (branch prefixed {@link ORCHESTRATE_BRANCH_PREFIX}) in the given channel's
+ * running-session list, or undefined when none. The caller (bot.ts) answers
+ * with a thread link instead of starting a second orchestrator, unless the
+ * user explicitly passed `--new`.
+ */
+export function findRunningOrchestrator(
+  sessions: readonly OrchestratorSessionLike[],
+): OrchestratorSessionLike | undefined {
+  return sessions.find((s) =>
+    (s.branch ?? "").startsWith(ORCHESTRATE_BRANCH_PREFIX),
+  );
+}
+
+/**
+ * Generate the orchestrator worktree branch name: `orchestrate-<yyyymmdd-hhmm>`
+ * (Issue #318 の作業項目で指定された形式、ローカル時刻)。数字とハイフンのみで
+ * 構成されるため RW-045 の worktree guard（メタ文字 / traversal 拒否）を常に
+ * 通過する。同一分内の再起動は多重起動ガード（または `--new` 時の worktree
+ * 追加失敗）で表面化する — silent fallback はしない。
+ */
+export function orchestrateBranchName(now: Date = new Date()): string {
+  const pad = (n: number): string => String(n).padStart(2, "0");
+  const y = now.getFullYear();
+  const m = pad(now.getMonth() + 1);
+  const d = pad(now.getDate());
+  const hh = pad(now.getHours());
+  const mm = pad(now.getMinutes());
+  return `${ORCHESTRATE_BRANCH_PREFIX}${y}${m}${d}-${hh}${mm}`;
+}
+
+/**
+ * Minimal SessionManager surface the orchestrate flow needs. Keeping it
+ * structural lets tests inject a fake without the real tmux/claude stack
+ * (dispatch.ts の DispatchSessionManager と同パターン)。
+ */
+export interface OrchestrateSessionManager {
+  start(config: unknown, threadId: string, branch?: string): Promise<unknown>;
+  /**
+   * Wait until the freshly started session's Ink TUI is ready to accept
+   * input. {@link runOrchestrate} injects `/orchestrate-runner <生引数>` only
+   * after this so the slash-picker doesn't swallow the leading `/` while the
+   * TUI is still booting (RW-025 / RW-047 timing class).
+   */
+  waitForInputReady(threadId: string): Promise<boolean>;
+  sendMessage(threadId: string, message: string): Promise<unknown>;
+}
+
+/** Creates the Discord thread the orchestrator runs in and returns its id. */
+export type OrchestrateThreadFactory = (
+  branch: string,
+) => Promise<{ id: string }>;
+
+export interface RunOrchestrateArgs {
+  config: unknown;
+  branch: string;
+  /** 生引数（パースしない）。`/orchestrate-runner ` の後ろにそのまま付く。 */
+  rawArgs: string;
+  sessionManager: OrchestrateSessionManager;
+  createThread: OrchestrateThreadFactory;
+}
+
+export type RunOrchestrateResult =
+  | { ok: true; threadId: string; injected: string }
+  | { ok: false; stage: "thread" | "start" | "inject"; error: string };
+
+/**
+ * Orchestrate a validated `/orchestrate`: create the thread, start the session
+ * in the channel's repo on the `orchestrate-<yyyymmdd-hhmm>` branch, then
+ * inject `/orchestrate-runner <生引数>` as the first prompt. `start()` does not
+ * accept an initial command (it only launches the pane), so the command is
+ * injected via `sendMessage` after the session is registered — the same
+ * argv-no-shell path a user's first thread message would take.
+ *
+ * Errors are surfaced (no silent fallback): a failure is tagged with the stage
+ * so the caller can log it without leaking the raw payload.
+ */
+export async function runOrchestrate(
+  args: RunOrchestrateArgs,
+): Promise<RunOrchestrateResult> {
+  const { config, branch, rawArgs, sessionManager, createThread } = args;
+
+  let threadId: string;
+  try {
+    const thread = await createThread(branch);
+    threadId = thread.id;
+  } catch (err) {
+    return { ok: false, stage: "thread", error: errMsg(err) };
+  }
+
+  try {
+    await sessionManager.start(config, threadId, branch);
+  } catch (err) {
+    return { ok: false, stage: "start", error: errMsg(err) };
+  }
+
+  // The TUI is still booting when start() returns — start() only waits for the
+  // PID, not an input-ready prompt (dispatch.ts と同じ RW-025 / RW-047 対策)。
+  // Best-effort: on timeout / probe error we still inject (the marker may have
+  // scrolled off and the TUI is ready by then) so a transient miss never drops
+  // the orchestrate silently.
+  try {
+    const ready = await sessionManager.waitForInputReady(threadId);
+    if (!ready) {
+      console.warn(
+        `[Orchestrate] input-ready marker not seen for thread ${threadId}; injecting anyway`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `[Orchestrate] waitForInputReady failed for thread ${threadId}: ${errMsg(err)}`,
+    );
+  }
+
+  const initialCommand = `${ORCHESTRATE_RUNNER_COMMAND} ${rawArgs}`;
+  try {
+    await sessionManager.sendMessage(threadId, initialCommand);
+  } catch (err) {
+    return { ok: false, stage: "inject", error: errMsg(err) };
+  }
+
+  return { ok: true, threadId, injected: initialCommand };
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/supervisor/src/session/orchestrate.ts
+++ b/supervisor/src/session/orchestrate.ts
@@ -124,6 +124,35 @@ export function findRunningOrchestrator(
 }
 
 /**
+ * Per-channel in-flight launch lock (PR #324 review): closes the TOCTOU window
+ * between the duplicate-launch guard ({@link findRunningOrchestrator} over
+ * `listRunningByChannel`) and the session actually registering in the
+ * SessionManager. Thread creation + session start span several awaits, so two
+ * `/orchestrate` messages in rapid succession could BOTH pass the
+ * running-session guard before either session exists. `tryAcquire` mutates the
+ * set synchronously (no await between check and add), which on Node's
+ * single-threaded event loop makes the acquisition race-free. Applies to
+ * `--new` launches too — only one orchestrator launch may be in flight per
+ * channel at a time (an explicit second one can be sent again seconds later;
+ * same-minute branch names would collide anyway).
+ */
+export class OrchestrateLaunchLock {
+  private readonly channels = new Set<string>();
+
+  /** Acquire the per-channel lock; false when a launch is already in flight. */
+  tryAcquire(channelName: string): boolean {
+    if (this.channels.has(channelName)) return false;
+    this.channels.add(channelName);
+    return true;
+  }
+
+  /** Release after the launch settles (success OR failure — call in finally). */
+  release(channelName: string): void {
+    this.channels.delete(channelName);
+  }
+}
+
+/**
  * Generate the orchestrator worktree branch name: `orchestrate-<yyyymmdd-hhmm>`
  * (Issue #318 の作業項目で指定された形式、ローカル時刻)。数字とハイフンのみで
  * 構成されるため RW-045 の worktree guard（メタ文字 / traversal 拒否）を常に

--- a/supervisor/tests/session/orchestrate.test.ts
+++ b/supervisor/tests/session/orchestrate.test.ts
@@ -1,0 +1,516 @@
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  ORCHESTRATE_PREFIX,
+  ORCHESTRATE_RUNNER_COMMAND,
+  ORCHESTRATE_BRANCH_PREFIX,
+  parseOrchestrateCommand,
+  findRunningOrchestrator,
+  orchestrateBranchName,
+  runOrchestrate,
+} from "../../src/session/orchestrate";
+import type { OrchestrateSessionManager } from "../../src/session/orchestrate";
+import {
+  isSenderAllowed,
+  loadAccessPolicy,
+} from "../../src/config/access-policy";
+
+/**
+ * Epic #316 Phase 1 (Issue #318): the `/orchestrate <生引数...>` message command.
+ *
+ * `parseOrchestrateCommand` is the pure validator: it detects the exact
+ * `/orchestrate` token, rejects an empty argument list, extracts a leading
+ * `--new` flag, and otherwise preserves the raw argument string verbatim
+ * (Supervisor never interprets the arguments — ADR-002 D2).
+ *
+ * `runOrchestrate` mirrors runDispatch's tmux path: create thread → start
+ * session on the `orchestrate-<yyyymmdd-hhmm>` branch → waitForInputReady
+ * (best-effort, RW-025/047) → inject `/orchestrate-runner <生引数>`.
+ */
+
+// ---------------------------------------------------------------------------
+// AC-1: parser (command detection / empty-args error / raw-args fidelity)
+// ---------------------------------------------------------------------------
+
+describe("parseOrchestrateCommand", () => {
+  test("parses a valid /orchestrate with mixed raw args", () => {
+    const r = parseOrchestrateCommand(
+      "/orchestrate ~/.claude/sessions/a.tmp agent-base#42 corp の記事を1本書く",
+    );
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") {
+      expect(r.rawArgs).toBe(
+        "~/.claude/sessions/a.tmp agent-base#42 corp の記事を1本書く",
+      );
+      expect(r.forceNew).toBe(false);
+    }
+  });
+
+  test("preserves inner whitespace of the raw args verbatim", () => {
+    const r = parseOrchestrateCommand("/orchestrate a.tmp    b.tmp  タスク");
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.rawArgs).toBe("a.tmp    b.tmp  タスク");
+  });
+
+  test("raw args are NOT interpreted: shell metacharacters pass through", () => {
+    // 安全性は relay の argv-no-shell 注入経路が担保する。Supervisor は
+    // 引数を解釈も変形もしない（ADR-002 D2）。
+    const r = parseOrchestrateCommand("/orchestrate `echo x` $(id) ; rm -rf /");
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.rawArgs).toBe("`echo x` $(id) ; rm -rf /");
+  });
+
+  test("bare /orchestrate (no args) → error (nothing to run)", () => {
+    const r = parseOrchestrateCommand("/orchestrate");
+    expect(r.kind).toBe("error");
+  });
+
+  test("whitespace-only args → error", () => {
+    expect(parseOrchestrateCommand("/orchestrate    ").kind).toBe("error");
+  });
+
+  test("leading --new is extracted as forceNew and stripped from raw args", () => {
+    const r = parseOrchestrateCommand("/orchestrate --new a.tmp b.tmp");
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") {
+      expect(r.forceNew).toBe(true);
+      expect(r.rawArgs).toBe("a.tmp b.tmp");
+    }
+  });
+
+  test("--new alone (no tasks) → error", () => {
+    expect(parseOrchestrateCommand("/orchestrate --new").kind).toBe("error");
+    expect(parseOrchestrateCommand("/orchestrate --new   ").kind).toBe("error");
+  });
+
+  test("non-leading --new is left inside the raw args (not a flag)", () => {
+    const r = parseOrchestrateCommand("/orchestrate a.tmp --new b.tmp");
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") {
+      expect(r.forceNew).toBe(false);
+      expect(r.rawArgs).toBe("a.tmp --new b.tmp");
+    }
+  });
+
+  test("tolerates surrounding whitespace", () => {
+    const r = parseOrchestrateCommand("   /orchestrate   タスクA   ");
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.rawArgs).toBe("タスクA");
+  });
+
+  test("multiline message after the command is kept as raw args", () => {
+    const r = parseOrchestrateCommand("/orchestrate\nタスクA\nタスクB");
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.rawArgs).toBe("タスクA\nタスクB");
+  });
+
+  test("non-orchestrate content → not_orchestrate (falls through)", () => {
+    expect(parseOrchestrateCommand("hello").kind).toBe("not_orchestrate");
+    expect(parseOrchestrateCommand("/dispatch b 42").kind).toBe(
+      "not_orchestrate",
+    );
+    expect(parseOrchestrateCommand("").kind).toBe("not_orchestrate");
+  });
+
+  test("prefix must be the whole token: /orchestrated etc. fall through", () => {
+    expect(parseOrchestrateCommand("/orchestrated x").kind).toBe(
+      "not_orchestrate",
+    );
+    expect(parseOrchestrateCommand("/orchestrate-runner x").kind).toBe(
+      "not_orchestrate",
+    );
+    // Phase 2 スキルコマンドを Supervisor が横取りしないこと（契約の分離）。
+    expect(ORCHESTRATE_RUNNER_COMMAND.startsWith(ORCHESTRATE_PREFIX)).toBe(
+      true,
+    );
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-4: duplicate-launch guard
+// ---------------------------------------------------------------------------
+
+describe("findRunningOrchestrator", () => {
+  test("finds a running session whose branch has the orchestrate- prefix", () => {
+    const hit = findRunningOrchestrator([
+      { threadId: "t1", branch: "corp-dispatch-42" },
+      { threadId: "t2", branch: "orchestrate-20260705-1200" },
+    ]);
+    expect(hit?.threadId).toBe("t2");
+  });
+
+  test("ignores dispatch/worktree sessions and branchless sessions", () => {
+    expect(
+      findRunningOrchestrator([
+        { threadId: "t1", branch: "corp-dispatch-42" },
+        { threadId: "t2", branch: "feat/orchestrate-docs" },
+        { threadId: "t3" },
+      ]),
+    ).toBeUndefined();
+  });
+
+  test("empty list → undefined", () => {
+    expect(findRunningOrchestrator([])).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// branch name: orchestrate-<yyyymmdd-hhmm>
+// ---------------------------------------------------------------------------
+
+describe("orchestrateBranchName", () => {
+  test("formats a given date as orchestrate-<yyyymmdd-hhmm> (local time)", () => {
+    const d = new Date(2026, 6, 5, 9, 7); // 2026-07-05 09:07 local
+    expect(orchestrateBranchName(d)).toBe("orchestrate-20260705-0907");
+  });
+
+  test("matches the guard prefix and the documented shape", () => {
+    const name = orchestrateBranchName();
+    expect(name.startsWith(ORCHESTRATE_BRANCH_PREFIX)).toBe(true);
+    expect(name).toMatch(/^orchestrate-\d{8}-\d{4}$/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runOrchestrate (thread → start → waitForInputReady → inject)
+// ---------------------------------------------------------------------------
+
+function fakeManager(
+  overrides: Partial<{
+    start: (
+      config: unknown,
+      threadId: string,
+      branch?: string,
+    ) => Promise<unknown>;
+    waitForInputReady: (threadId: string) => Promise<boolean>;
+    sendMessage: (threadId: string, message: string) => Promise<unknown>;
+  }> = {},
+): {
+  manager: OrchestrateSessionManager;
+  startCalls: Array<{ threadId: string; branch?: string }>;
+  sendCalls: Array<{ threadId: string; message: string }>;
+} {
+  const startCalls: Array<{ threadId: string; branch?: string }> = [];
+  const sendCalls: Array<{ threadId: string; message: string }> = [];
+  const manager: OrchestrateSessionManager = {
+    start:
+      overrides.start ??
+      (async (_config, threadId, branch) => {
+        startCalls.push({ threadId, branch });
+        return { id: "session-1" };
+      }),
+    waitForInputReady: overrides.waitForInputReady ?? (async () => true),
+    sendMessage:
+      overrides.sendMessage ??
+      (async (threadId, message) => {
+        sendCalls.push({ threadId, message });
+        return {};
+      }),
+  };
+  return { manager, startCalls, sendCalls };
+}
+
+const config = { channelName: "corp", dir: "/x/corp" };
+
+describe("runOrchestrate", () => {
+  test("happy path: thread created, session started on the branch, runner injected with raw args", async () => {
+    const { manager, startCalls, sendCalls } = fakeManager();
+    let threadBranch: string | undefined;
+
+    const r = await runOrchestrate({
+      config,
+      branch: "orchestrate-20260705-1200",
+      rawArgs: "~/.claude/sessions/a.tmp agent-base#42 記事を書く",
+      sessionManager: manager,
+      createThread: async (branch) => {
+        threadBranch = branch;
+        return { id: "thread-orc" };
+      },
+    });
+
+    expect(r.ok).toBe(true);
+    if (r.ok) {
+      expect(r.threadId).toBe("thread-orc");
+      expect(r.injected).toBe(
+        "/orchestrate-runner ~/.claude/sessions/a.tmp agent-base#42 記事を書く",
+      );
+    }
+    expect(threadBranch).toBe("orchestrate-20260705-1200");
+    expect(startCalls).toEqual([
+      { threadId: "thread-orc", branch: "orchestrate-20260705-1200" },
+    ]);
+    expect(sendCalls).toEqual([
+      {
+        threadId: "thread-orc",
+        message:
+          "/orchestrate-runner ~/.claude/sessions/a.tmp agent-base#42 記事を書く",
+      },
+    ]);
+  });
+
+  test("start runs BEFORE the injected runner command (ordering)", async () => {
+    const order: string[] = [];
+    const { manager } = fakeManager({
+      start: async () => {
+        order.push("start");
+        return { id: "s" };
+      },
+      sendMessage: async () => {
+        order.push("inject");
+        return {};
+      },
+    });
+    await runOrchestrate({
+      config,
+      branch: "orchestrate-20260705-1200",
+      rawArgs: "x",
+      sessionManager: manager,
+      createThread: async () => ({ id: "t" }),
+    });
+    expect(order).toEqual(["start", "inject"]);
+  });
+
+  test("waitForInputReady=false still injects (best-effort, never a silent drop)", async () => {
+    const { manager, sendCalls } = fakeManager({
+      waitForInputReady: async () => false,
+    });
+    const r = await runOrchestrate({
+      config,
+      branch: "orchestrate-20260705-1200",
+      rawArgs: "x",
+      sessionManager: manager,
+      createThread: async () => ({ id: "t" }),
+    });
+    expect(r.ok).toBe(true);
+    expect(sendCalls).toHaveLength(1);
+  });
+
+  test("thread creation failure → ok:false stage=thread, no start/inject", async () => {
+    const { manager, startCalls, sendCalls } = fakeManager();
+    const r = await runOrchestrate({
+      config,
+      branch: "orchestrate-20260705-1200",
+      rawArgs: "x",
+      sessionManager: manager,
+      createThread: async () => {
+        throw new Error("missing perms");
+      },
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.stage).toBe("thread");
+    expect(startCalls).toHaveLength(0);
+    expect(sendCalls).toHaveLength(0);
+  });
+
+  test("session start failure → ok:false stage=start, no inject (no silent fallback)", async () => {
+    const { manager, sendCalls } = fakeManager({
+      start: async () => {
+        throw new Error("最大セッション数に達しています");
+      },
+    });
+    const r = await runOrchestrate({
+      config,
+      branch: "orchestrate-20260705-1200",
+      rawArgs: "x",
+      sessionManager: manager,
+      createThread: async () => ({ id: "t" }),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.stage).toBe("start");
+    expect(sendCalls).toHaveLength(0);
+  });
+
+  test("inject failure → ok:false stage=inject", async () => {
+    const { manager } = fakeManager({
+      sendMessage: async () => {
+        throw new Error("tmux gone");
+      },
+    });
+    const r = await runOrchestrate({
+      config,
+      branch: "orchestrate-20260705-1200",
+      rawArgs: "x",
+      sessionManager: manager,
+      createThread: async () => ({ id: "t" }),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.stage).toBe("inject");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-2: authorization fail-closed (evaluateAccess / access.json allowFrom),
+// integrated the same way bot.ts's handleOrchestrateMessage wires it:
+//   1. isSenderAllowed(loadAccessPolicy(), channelId, userId, isMention)
+//   2. parseOrchestrateCommand(content)
+//   3. duplicate-launch guard (findRunningOrchestrator)
+//   4. runOrchestrate(...)
+// ---------------------------------------------------------------------------
+
+const CHANNEL_ID = "846209781206941736";
+const OWNER = "111111111111111111";
+const OUTSIDER = "999999999999999999";
+
+interface SimResult {
+  outcome: "started" | "denied" | "rejected" | "guarded" | "ignored";
+  startCalls: Array<{ threadId: string; branch?: string }>;
+  sendCalls: Array<{ threadId: string; message: string }>;
+}
+
+/** Simulate bot.ts's orchestrate decision sequence for a single message. */
+async function simulateOrchestrate(opts: {
+  accessPath: string;
+  channelId: string;
+  userId: string;
+  content: string;
+  running?: Array<{ threadId: string; branch?: string }>;
+}): Promise<SimResult> {
+  const { manager, startCalls, sendCalls } = fakeManager();
+  const base = { startCalls, sendCalls };
+
+  // Step 1: authorize the sender (fail-closed) — same gate as normal relay
+  // messages (allowFrom), independent of the dispatch-only dispatchFrom.
+  const decision = isSenderAllowed(
+    loadAccessPolicy(opts.accessPath),
+    opts.channelId,
+    opts.userId,
+    /* isMention */ false,
+  );
+  if (!decision.allowed) return { outcome: "denied", ...base };
+
+  // Step 2: parse.
+  const parsed = parseOrchestrateCommand(opts.content);
+  if (parsed.kind === "not_orchestrate") return { outcome: "ignored", ...base };
+  if (parsed.kind === "error") return { outcome: "rejected", ...base };
+
+  // Step 3: duplicate-launch guard.
+  const running = findRunningOrchestrator(opts.running ?? []);
+  if (running && !parsed.forceNew) return { outcome: "guarded", ...base };
+
+  // Step 4: run.
+  await runOrchestrate({
+    config,
+    branch: "orchestrate-20260705-1200",
+    rawArgs: parsed.rawArgs,
+    sessionManager: manager,
+    createThread: async () => ({ id: "thread-orc" }),
+  });
+  return { outcome: "started", ...base };
+}
+
+describe("orchestrate integration (auth -> parse -> guard -> run)", () => {
+  let dir: string;
+  let accessPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "orchestrate-int-"));
+    accessPath = join(dir, "access.json");
+  });
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writePolicy(allowFrom: string[]): void {
+    writeFileSync(
+      accessPath,
+      JSON.stringify({
+        groups: {
+          [CHANNEL_ID]: { requireMention: false, allowFrom },
+        },
+      }),
+    );
+  }
+
+  test("allowFrom sender starts the orchestrator and injects the runner", async () => {
+    writePolicy([OWNER]);
+    const r = await simulateOrchestrate({
+      accessPath,
+      channelId: CHANNEL_ID,
+      userId: OWNER,
+      content: "/orchestrate a.tmp b.tmp",
+    });
+    expect(r.outcome).toBe("started");
+    expect(r.sendCalls).toEqual([
+      { threadId: "thread-orc", message: "/orchestrate-runner a.tmp b.tmp" },
+    ]);
+  });
+
+  test("sender outside allowFrom is denied: no session, no injection (AC-2)", async () => {
+    writePolicy([OWNER]);
+    const r = await simulateOrchestrate({
+      accessPath,
+      channelId: CHANNEL_ID,
+      userId: OUTSIDER,
+      content: "/orchestrate a.tmp",
+    });
+    expect(r.outcome).toBe("denied");
+    expect(r.startCalls).toHaveLength(0);
+    expect(r.sendCalls).toHaveLength(0);
+  });
+
+  test("missing policy file denies (fail-closed)", async () => {
+    const r = await simulateOrchestrate({
+      accessPath: join(dir, "does-not-exist.json"),
+      channelId: CHANNEL_ID,
+      userId: OWNER,
+      content: "/orchestrate a.tmp",
+    });
+    expect(r.outcome).toBe("denied");
+    expect(r.startCalls).toHaveLength(0);
+  });
+
+  test("channel not configured in the policy denies (fail-closed)", async () => {
+    writePolicy([OWNER]);
+    const r = await simulateOrchestrate({
+      accessPath,
+      channelId: "123456789012345678",
+      userId: OWNER,
+      content: "/orchestrate a.tmp",
+    });
+    expect(r.outcome).toBe("denied");
+    expect(r.startCalls).toHaveLength(0);
+  });
+
+  test("running orchestrator blocks a second launch (AC-4)", async () => {
+    writePolicy([OWNER]);
+    const r = await simulateOrchestrate({
+      accessPath,
+      channelId: CHANNEL_ID,
+      userId: OWNER,
+      content: "/orchestrate c.tmp",
+      running: [{ threadId: "t-live", branch: "orchestrate-20260705-1100" }],
+    });
+    expect(r.outcome).toBe("guarded");
+    expect(r.startCalls).toHaveLength(0);
+    expect(r.sendCalls).toHaveLength(0);
+  });
+
+  test("--new bypasses the duplicate-launch guard explicitly (AC-4)", async () => {
+    writePolicy([OWNER]);
+    const r = await simulateOrchestrate({
+      accessPath,
+      channelId: CHANNEL_ID,
+      userId: OWNER,
+      content: "/orchestrate --new c.tmp",
+      running: [{ threadId: "t-live", branch: "orchestrate-20260705-1100" }],
+    });
+    expect(r.outcome).toBe("started");
+    expect(r.sendCalls).toEqual([
+      { threadId: "thread-orc", message: "/orchestrate-runner c.tmp" },
+    ]);
+  });
+
+  test("empty args are rejected before any session work (AC-1)", async () => {
+    writePolicy([OWNER]);
+    const r = await simulateOrchestrate({
+      accessPath,
+      channelId: CHANNEL_ID,
+      userId: OWNER,
+      content: "/orchestrate",
+    });
+    expect(r.outcome).toBe("rejected");
+    expect(r.startCalls).toHaveLength(0);
+  });
+});

--- a/supervisor/tests/session/orchestrate.test.ts
+++ b/supervisor/tests/session/orchestrate.test.ts
@@ -10,6 +10,7 @@ import {
   findRunningOrchestrator,
   orchestrateBranchName,
   runOrchestrate,
+  OrchestrateLaunchLock,
 } from "../../src/session/orchestrate";
 import type { OrchestrateSessionManager } from "../../src/session/orchestrate";
 import {
@@ -153,6 +154,62 @@ describe("findRunningOrchestrator", () => {
 
   test("empty list → undefined", () => {
     expect(findRunningOrchestrator([])).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// AC-4 (PR #324 review): in-flight launch lock closes the TOCTOU window
+// between the running-session guard and session registration
+// ---------------------------------------------------------------------------
+
+describe("OrchestrateLaunchLock", () => {
+  test("second acquire on the same channel is rejected until release", () => {
+    const lock = new OrchestrateLaunchLock();
+    expect(lock.tryAcquire("corp")).toBe(true);
+    expect(lock.tryAcquire("corp")).toBe(false);
+    lock.release("corp");
+    expect(lock.tryAcquire("corp")).toBe(true);
+  });
+
+  test("channels are independent", () => {
+    const lock = new OrchestrateLaunchLock();
+    expect(lock.tryAcquire("corp")).toBe(true);
+    expect(lock.tryAcquire("agent-base")).toBe(true);
+  });
+
+  test("release is idempotent (releasing an unheld channel is a no-op)", () => {
+    const lock = new OrchestrateLaunchLock();
+    lock.release("corp");
+    expect(lock.tryAcquire("corp")).toBe(true);
+  });
+
+  test("rapid double /orchestrate: only the first launch proceeds (TOCTOU)", async () => {
+    // Simulate bot.ts: both messages pass the running-session guard (no
+    // session registered yet), but the lock is acquired synchronously before
+    // any await, so the second attempt is rejected while the first is still
+    // launching.
+    const lock = new OrchestrateLaunchLock();
+    const { manager, startCalls } = fakeManager();
+
+    const attempt = async (): Promise<"launched" | "in_flight"> => {
+      if (!lock.tryAcquire("corp")) return "in_flight";
+      try {
+        await runOrchestrate({
+          config,
+          branch: "orchestrate-20260705-1200",
+          rawArgs: "x",
+          sessionManager: manager,
+          createThread: async () => ({ id: "t" }),
+        });
+        return "launched";
+      } finally {
+        lock.release("corp");
+      }
+    };
+
+    const [a, b] = await Promise.all([attempt(), attempt()]);
+    expect([a, b].sort()).toEqual(["in_flight", "launched"]);
+    expect(startCalls).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
Closes #318（親 Epic #316 Phase 1）

## 目的

corp チャンネルから `/orchestrate <生引数...>`（.tmp パス / repo#issue / 自然言語の混在、複数可）を受け付け、オーケストレーター専用セッション（tmux + スレッド）を 1 本起動して `/orchestrate-runner <生引数>` を初期プロンプトとして注入する。Supervisor 側の追加は ADR-002 D2（受付 + 起動のみ）に留める。

## 主な変更点

| ファイル | 内容 |
|---|---|
| `supervisor/src/session/orchestrate.ts`（新規） | パーサー（空引数エラー / 先頭 `--new` フラグ / 生引数は解釈せず保持）、多重起動ガード（branch prefix `orchestrate-`）、branch 名生成（`orchestrate-<yyyymmdd-hhmm>`）、`runOrchestrate`（thread → `SessionManager.start` → `waitForInputReady` → `sendMessage`、RW-025/047 の TUI タイミング対策踏襲） |
| `supervisor/src/bot.ts` | `handleOrchestrateMessage` を dispatch 横取りと並置で追加（MessageCreate への追加は 1 箇所のみ）。認可は既存 `evaluateAccess`（access.json `allowFrom`、fail-closed）で、dispatch 用 `dispatchFrom` とは独立 |
| `supervisor/tests/session/orchestrate.test.ts`（新規） | ユニットテスト 30 件（パーサー正常/異常・認可 fail-closed・多重起動ガード・runOrchestrate 各段の失敗表面化・auth→parse→guard→run 統合） |

## 設計準拠（ADR-002）

- **D2 責務境界**: Supervisor は受付・認可・多重起動ガード・起動・注入のみ。引数の解釈（.tmp 読取 / Issue 化 / DAG）・監視・merge 判断は Phase 2 スキル（`/orchestrate-runner`）の責務
- **引数の安全性**: 生引数は一切パースせず、既存 relay の argv-no-shell 経路（`sendMessage` → tmux `send-keys -l`）でのみ注入。shell 展開面なし
- **インターフェース契約**: 注入コマンド名は `/orchestrate-runner`（Phase 2 #319 と同期）。生引数をそのまま後ろに付ける
- **既存機能の非破壊**: `/session *`・`/dispatch`・relay の既存コード経路は変更なし。**既存テストの変更 0 件**

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | /orchestrate パーサーが正常系/異常系を判定 | `bun test tests/session/orchestrate.test.ts` | green | 30 pass / 0 fail | PASS |
| AC-2 | 認可 fail-closed（allowFrom 外は拒否） | 同上（`sender outside allowFrom is denied` ほか policy 欠如/未設定チャンネル） | green | pass（start/send 0 件を確認） | PASS |
| AC-3 | 既存テストが全て green（非破壊、既存テスト変更 0 件） | `bun test`（全体）を本変更あり/なしで実行し fail 集合を diff | fail 集合が origin/main と同一 | `IDENTICAL FAIL SETS`（27 fail は origin/main 由来の既知 tmux adapter 環境起因。CI を正とする） | PASS |
| AC-4 | 多重起動ガード（`--new` 明示時のみ許可） | `bun test tests/session/orchestrate.test.ts`（guarded / --new bypass） | green | pass | PASS |

全体: 4/4 PASS（ローカル。最終判定は CI green）

## thin-scaffolding self-check

- [x] **6 か月先の model でも gain が残るか**: Y（Discord→セッション起動の配線は model 能力と独立なインフラ）
- [x] **model への指示で代替できないか**: N/A（Supervisor プロセスの受付経路はコードでしか実現できない。意味判断は全てスキル側へ委譲済み）
- [x] **責務は 1 つに絞れているか**: Y（観点 = /orchestrate の受付と起動のみ。監視・依存管理・merge は持たない）
- [x] **失敗観測性はあるか**: Y（各 stage の console.error + チャンネルへの ❌ 通知。silent fallback なし）
- [x] **対象外の経路を明記したか**: Y（thread 内 / 未登録チャンネル / `/orchestrated` 等の前方一致はフォールスルー）
- [x] **撤退基準**: Epic #316 が撤収される場合、bot.ts の横取り 1 箇所 + orchestrate.ts + テストの削除で完全に戻せる（既存経路への浸食ゼロ）
- [x] **BLOCKING なら WARN-first**: 非 BLOCKING（既存フローを止めない純追加コマンド）のため対象外

## テスト方法

```
cd supervisor
bun test tests/session/orchestrate.test.ts   # 30 pass
bunx tsc --noEmit                            # exit 0
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
