### PR TITLE
feat(#320): session-ctl ローカル CLI + claude-hub work セッション経路（ADR-002 D5）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -172,7 +172,10 @@ jobs:
                    tests/session/self-heal-restart.test.ts \
                    tests/action/token.test.ts \
                    tests/action/execute.test.ts \
-                   tests/action/receiver.test.ts
+                   tests/action/receiver.test.ts \
+                   tests/session/hub-work.test.ts \
+                   tests/session/relay-server-hub-work.test.ts \
+                   tests/tools/session-ctl.test.ts
 
       # #238 regression: realTmuxAdapter.hasSession must treat a tmux
       # control-channel ETIMEDOUT as "alive" (assume the session survives),

--- a/supervisor/README.md
+++ b/supervisor/README.md
@@ -13,3 +13,49 @@ bun run index.ts
 ```
 
 This project was created using `bun init` in bun v1.3.11. [Bun](https://bun.com) is a fast all-in-one JavaScript runtime.
+
+## session-ctl — ローカル介入 CLI（Epic #316 Phase 3 / #320）
+
+オーケストレーター CC セッション（ローカル）が Supervisor 管理下のワーカーを
+観測・介入するための薄い CLI。**sessions.db には一切書かない**（読み取り専用、
+書き込みは Supervisor の専権）。
+
+```bash
+# cwd: ~/claude-hub
+bun run supervisor/tools/session-ctl.ts list
+bun run supervisor/tools/session-ctl.ts status <id>
+bun run supervisor/tools/session-ctl.ts send <thread_id|session_id> <text...>
+bun run supervisor/tools/session-ctl.ts stop <id>
+bun run supervisor/tools/session-ctl.ts start-hub-worker <branch> <issueNumber> [selector]
+```
+
+- `<id>` は session row id / thread_id / claude_session_id のいずれでも可
+- `send` は relay.ts の `sendToPane`（copy-mode 解除 → Escape → `send-keys -l` →
+  C-m、argv-no-shell、専用 socket `-L claude-hub` = RW-019）を共有する
+- `stop` は SIGTERM → 猶予 → `tmux kill-session`。sessions.db の status 反映は
+  Supervisor の watcher が行い（~10s で `stopped` / `tmux_exited`）、worktree は
+  保持される（RW-046 の共有 worktree 破壊は構造的に起こらない）。Supervisor
+  停止中は次回起動時の `supervisor_restart` 整合に委ねる
+
+### claude-hub work セッション経路（ADR-002 D5 / #208 案B）
+
+`start-hub-worker` は Supervisor の relay サーバ（loopback-only）の
+`POST /hub-work` を叩き、**CHANNEL_MAP を経由しない** ephemeral config で
+`~/claude-hub` の branch worktree にワーカーセッションを起動する。
+
+- ワーカースレッドは **corp チャンネル**配下に立つ（D5-3）
+- `CHANNEL_MAP` に `claude-hub` は追加しない（`channels.ts` の FATAL guard 維持。
+  ephemeral config の CHANNEL_MAP 登録も禁止）
+- selector（`impl` / `no-template` / `pdca` / `article` / `devcycle`、省略時
+  `impl`）は既存 `/dispatch` と同一の閉集合・同一の注入機構
+- 並列上限・FIFO キューも既存 dispatch と同じ `DISPATCH_MAX_CONCURRENT` に従う
+- ポート発見: relay サーバが起動時に runtime dir（`$XDG_RUNTIME_DIR/claude-hub-supervisor`
+  または `/tmp/claude-hub-supervisor-$USER`）の `relay-port` へ実ポートを書く
+- claudeHubExit（hijoguchi）の access policy / 機械ゲートには非干渉（復旧経路の
+  独立性は不変。詳細は `docs/adr/2026-07-05-corp-orchestration.md` D5）
+
+例（オーケストレーターが Issue #999 を pdca で投入）:
+
+```bash
+bun run supervisor/tools/session-ctl.ts start-hub-worker corp-dispatch-999 999 pdca
+```

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -502,6 +502,11 @@ export async function startBot(token: string): Promise<void> {
             );
             if (ch) {
               parent = ch as TextChannel;
+              // 複数ギルド参加時の追跡性（PR #325 gemini medium）: どのギルドの
+              // #corp を選んだかをログに残す（cache の列挙順は保証されないため）。
+              console.log(
+                `[HubWork] resolved #${HUB_WORK_PARENT_CHANNEL} in guild ${guild.name} (${guild.id})`,
+              );
               break;
             }
           }

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -31,7 +31,13 @@ import {
   buildSalvageReply,
   buildStatusReply,
 } from "./session/status-reply";
-import { onProgress, onLateResponse, onSessionsQuery } from "./session/relay-server";
+import {
+  onProgress,
+  onLateResponse,
+  onSessionsQuery,
+  onHubWork,
+} from "./session/relay-server";
+import { runHubWork, HUB_WORK_PARENT_CHANNEL } from "./session/hub-work";
 import {
   extractFilePaths,
   collectAttachableFiles,
@@ -465,6 +471,59 @@ export async function startBot(token: string): Promise<void> {
         console.error(`[Bot] Late response send error for thread ${event.threadId}:`, err);
       }
     });
+
+    // Epic #316 Phase 3 (#320, ADR-002 D5): claude-hub work セッション経路。
+    // relay サーバの `POST /hub-work`（loopback-only、session-ctl
+    // start-hub-worker が叩く）を runHubWork へ結線する。config は
+    // CHANNEL_MAP.get() を通らない ephemeral なもの（runHubWork 内で組み立て、
+    // CHANNEL_MAP へは登録しない）。ワーカースレッドは corp チャンネル配下
+    // （D5-3）。キュー / admission / executor は既存 /dispatch と同一機構。
+    onHubWork(async (body) =>
+      runHubWork({
+        body,
+        sessionManager,
+        queue: dispatchQueue,
+        admissionGate: async () => {
+          await admissionController.gate();
+        },
+        executorMode: resolveExecutorMode(),
+        createThread: async (threadName) => {
+          // corp チャンネル（work スレッドの親）をギルド横断で名前解決する。
+          // 既存 dispatch は受信 message からチャンネルを得るが、HTTP 起動には
+          // message が無いので cache から引く。
+          let parent: TextChannel | null = null;
+          for (const [, guild] of readyClient.guilds.cache) {
+            const ch = guild.channels.cache.find(
+              (c) =>
+                c.name === HUB_WORK_PARENT_CHANNEL &&
+                c.isTextBased() &&
+                !c.isThread() &&
+                "threads" in c,
+            );
+            if (ch) {
+              parent = ch as TextChannel;
+              break;
+            }
+          }
+          if (!parent) {
+            throw new Error(
+              `work スレッドの親チャンネル (#${HUB_WORK_PARENT_CHANNEL}) が見つかりません`,
+            );
+          }
+          const created = await parent.threads.create({
+            name: threadName,
+            autoArchiveDuration: 10080, // 7 days（既存 dispatch と同じ）
+          });
+          return { id: created.id };
+        },
+        postToThread: async (tId, content) => {
+          const thread = await client.channels.fetch(tId);
+          if (thread?.isThread()) {
+            await thread.send(content);
+          }
+        },
+      }),
+    );
   });
 
   // Safe reply helper: never throws. Used in error paths where the interaction may

--- a/supervisor/src/infra/db.ts
+++ b/supervisor/src/infra/db.ts
@@ -2,7 +2,21 @@ import { Database } from "bun:sqlite";
 import { resolve } from "path";
 import { homedir } from "os";
 
-const DB_PATH = process.env.SUPERVISOR_DB_PATH ?? resolve(homedir(), "claude-hub", "supervisor", "sessions.db");
+/**
+ * sessions.db の実パスを解決する（#320 で外出し）。Supervisor 本体（下の
+ * DB_PATH、モジュールロード時に固定）と読み取り専用 CLI（tools/session-ctl.ts、
+ * 呼び出し時に解決）が同じ規則を共有するための single source of truth。
+ */
+export function resolveDbPath(
+  env: Record<string, string | undefined> = process.env,
+): string {
+  return (
+    env.SUPERVISOR_DB_PATH ??
+    resolve(homedir(), "claude-hub", "supervisor", "sessions.db")
+  );
+}
+
+const DB_PATH = resolveDbPath();
 
 let db: Database;
 

--- a/supervisor/src/session/hub-work.ts
+++ b/supervisor/src/session/hub-work.ts
@@ -1,0 +1,326 @@
+/**
+ * claude-hub work セッション経路 (Epic #316 Phase 3 / #320, ADR-002 D5 = #208 案B).
+ *
+ * claude-hub は Supervisor 自身のリポジトリであり、CHANNEL_MAP へ登録すると
+ * Supervisor クラッシュ時の Discord 復旧経路（claudeHubExit / hijoguchi）が
+ * メタ依存で失われる。そのため `channels.ts:141-147` の FATAL guard が登録を
+ * 起動時 throw で禁止している（絶対ルール、docs/bot-operations.md）。
+ *
+ * 本モジュールはその絶対ルールを保ったまま claude-hub タスクを dispatch 可能に
+ * する「work セッション経路」を実装する（ADR-002 D5）:
+ *
+ *   1. CHANNEL_MAP には一切触れない。config は `CHANNEL_MAP.get()` を通さず
+ *      本モジュールが組み立てる ephemeral な {@link ChannelConfig} を
+ *      SessionManager に明示渡しする。**この config を CHANNEL_MAP へ登録する
+ *      ことは禁止**（ADR-002 D5-2。{@link buildHubWorkConfig} の contract）。
+ *   2. ワーカースレッドは corp チャンネル配下に立てる（D5-3、専用チャンネル案
+ *      は却下済み）。スレッド作成は caller（bot.ts）が corp チャンネルを解決
+ *      して行い、本モジュールは Discord に依存しない。
+ *   3. work セッションは使い捨ての worktree セッションであり claude-hub の
+ *      復旧経路ではない（D5 非干渉条件 2）。hijoguchi の access policy /
+ *      機械ゲートには一切触れない（非干渉条件 3）。
+ *
+ * 起動・selector 注入・welcome・FIFO キューは既存 /dispatch と同一機構
+ * （{@link runDispatch} / DispatchQueue）を再利用する（Epic #316 決定 4:
+ * 新規ワーカー機構は作らない）。トリガーは Discord メッセージではなく
+ * relay サーバの `POST /hub-work`（loopback-only）で、ローカルの
+ * オーケストレーター CC セッションが `session-ctl start-hub-worker` から叩く。
+ */
+
+import { resolve } from "path";
+import { homedir } from "os";
+import { existsSync } from "fs";
+import type { ChannelConfig } from "../config/channels";
+import { MAX_SESSIONS } from "../config/channels";
+import {
+  DISPATCH_PREFIX,
+  parseDispatchCommand,
+  runDispatch,
+  type DispatchCommand,
+  type DispatchExecutorMode,
+  type DispatchSessionManager,
+  type DispatchThreadPoster,
+} from "./dispatch";
+import type { QueuedDispatch } from "./dispatch-queue";
+import { buildThreadTitle } from "./thread-title";
+
+/**
+ * sessions.db の `channel_name` に記録される work セッションのラベル。
+ * Discord チャンネル名ではない（work スレッドの親は corp チャンネル）。
+ * CHANNEL_MAP のどのキーとも一致しないこと、そして `"claude-hub"` そのもの
+ * ではないこと（FATAL guard の検査対象文字列）がテストで固定される。
+ */
+export const HUB_WORK_CHANNEL_NAME = "claude-hub-work";
+
+/** work ワーカースレッドを立てる親チャンネル（ADR-002 D5-3: corp 採用）。 */
+export const HUB_WORK_PARENT_CHANNEL = "corp";
+
+export const HUB_WORK_DISPLAY_NAME = "Claude Hub Work";
+
+/**
+ * work セッション用の ephemeral な ChannelConfig を組み立てる（ADR-002 D5-2）。
+ *
+ * CONTRACT: この config を CHANNEL_MAP に登録してはならない。登録した瞬間に
+ * FATAL guard の意図（復旧経路のメタ依存禁止）が形骸化する。SessionManager /
+ * runDispatch へ**引数として明示渡し**する用途に限る。
+ *
+ * mcpProfile / chromeEnabled は既定（"none" / false）のまま = dispatch
+ * セッションと同じ軽量プロファイルで起動する。
+ */
+export function buildHubWorkConfig(home: string = homedir()): ChannelConfig {
+  return {
+    channelName: HUB_WORK_CHANNEL_NAME,
+    dir: resolve(home, "claude-hub"),
+    displayName: HUB_WORK_DISPLAY_NAME,
+  };
+}
+
+export type ParsedHubWork =
+  | {
+      kind: "ok";
+      branch: string;
+      issueNumber: number;
+      command: DispatchCommand;
+    }
+  | { kind: "error"; reason: string };
+
+/**
+ * `POST /hub-work` の JSON body（`{branch, issueNumber, selector?}`）を検証する。
+ *
+ * 検証本体は既存 `/dispatch` のパーサ（{@link parseDispatchCommand}）へ委譲する
+ * ことで single source of truth を保つ: branch の RW-045 guard（メタ文字 /
+ * path traversal 拒否）と selector の閉集合 fail-closed 検証は dispatch と
+ * バイト単位で同一になる。委譲前に「1 トークンとして安全に文字列合成できる形か」
+ * （空白を含まない等）だけをここで確認する。
+ */
+export function parseHubWorkRequest(body: unknown): ParsedHubWork {
+  if (typeof body !== "object" || body === null || Array.isArray(body)) {
+    return {
+      kind: "error",
+      reason:
+        "リクエスト body は {branch, issueNumber, selector?} の JSON オブジェクトで指定してください。",
+    };
+  }
+  const { branch, issueNumber, selector } = body as Record<string, unknown>;
+
+  if (typeof branch !== "string" || branch.length === 0 || /\s/.test(branch)) {
+    return {
+      kind: "error",
+      reason: "branch は空白を含まない非空文字列で指定してください。",
+    };
+  }
+  if (
+    typeof issueNumber !== "number" ||
+    !Number.isSafeInteger(issueNumber) ||
+    issueNumber <= 0
+  ) {
+    return {
+      kind: "error",
+      reason: "issueNumber は正の整数で指定してください。",
+    };
+  }
+  if (selector !== undefined) {
+    if (typeof selector !== "string" || selector.length === 0 || /\s/.test(selector)) {
+      return {
+        kind: "error",
+        reason:
+          "selector は impl / no-template / pdca / article / devcycle のいずれかを指定してください。",
+      };
+    }
+  }
+
+  // ここまでで各フィールドは 1 トークンであることが保証されているので、
+  // `/dispatch <branch> <N> [selector]` の message 形に合成して既存パーサへ
+  // 委譲できる（トークン境界が崩れない）。
+  const message =
+    `${DISPATCH_PREFIX} ${branch} ${issueNumber}` +
+    (selector !== undefined ? ` ${selector}` : "");
+  const parsed = parseDispatchCommand(message);
+  if (parsed.kind === "ok") {
+    return {
+      kind: "ok",
+      branch: parsed.branch,
+      issueNumber: parsed.issueNumber,
+      command: parsed.command,
+    };
+  }
+  if (parsed.kind === "error") {
+    return { kind: "error", reason: parsed.reason };
+  }
+  // "not_dispatch" は合成 message が DISPATCH_PREFIX で始まる以上起こり得ない
+  // が、fail-closed に倒す（黙って通さない）。
+  return { kind: "error", reason: "リクエスト形式が不正です。" };
+}
+
+/** runHubWork が使うキューの最小面（DispatchQueue が構造的に満たす）。 */
+export interface HubWorkQueue {
+  limit(): number;
+  submit(item: QueuedDispatch): Promise<"started" | "queued">;
+}
+
+/** runHubWork が使う SessionManager の最小面（実 SessionManager が構造的に満たす）。 */
+export interface HubWorkSessionManager extends DispatchSessionManager {
+  listRunningByChannel(channelName: string): Array<{ branch?: string }>;
+  count(): number;
+}
+
+export interface RunHubWorkArgs {
+  /** `POST /hub-work` の JSON body（未検証）。 */
+  body: unknown;
+  sessionManager: HubWorkSessionManager;
+  queue: HubWorkQueue;
+  /**
+   * corp チャンネル配下にワーカースレッドを作る（ADR-002 D5-3）。caller
+   * （bot.ts）が corp チャンネルの解決と Discord API 呼び出しを担う。throw は
+   * 500 として caller へ返る。
+   */
+  createThread: (threadName: string) => Promise<{ id: string }>;
+  /** スレッドへ 1 メッセージ投稿（Discord 2000 字制限は caller/formatter 側で担保）。 */
+  postToThread: DispatchThreadPoster;
+  /** 省略時は {@link buildHubWorkConfig}()。テストで差し替え可能。 */
+  config?: ChannelConfig;
+  /** 省略時 "tmux"（既存 dispatch と同じ既定）。 */
+  executorMode?: DispatchExecutorMode;
+  /** Phase 5d admission ゲート（既存 dispatch と同じ WARN-first）。省略時 no-op。 */
+  admissionGate?: () => Promise<void>;
+  /** テスト差し替え用。省略時 fs.existsSync。 */
+  dirExists?: (dir: string) => boolean;
+}
+
+export type RunHubWorkResult =
+  | { ok: true; threadId: string; queued: boolean; injected: string }
+  | { ok: false; status: number; error: string };
+
+/**
+ * hub work dispatch を 1 件オーケストレーションする:
+ * body 検証（fail-closed）→ corp スレッド作成 → 既存 DispatchQueue へ submit
+ * → スロット獲得後に {@link runDispatch}（ephemeral config 明示渡し）。
+ *
+ * 既存 `/dispatch`（bot.ts handleDispatchMessage）と同じ「スレッド先行作成 →
+ * queue.submit(key=threadId)」順序を踏襲するので、FIFO / 上限 /
+ * notifyEnded によるスロット解放のセマンティクスは既存とまったく同じになる
+ * （ADR-002 D4: 独自の並列制御を持たない）。
+ */
+export async function runHubWork(args: RunHubWorkArgs): Promise<RunHubWorkResult> {
+  const parsed = parseHubWorkRequest(args.body);
+  if (parsed.kind === "error") {
+    return { ok: false, status: 400, error: parsed.reason };
+  }
+  const { branch, issueNumber, command } = parsed;
+
+  const config = args.config ?? buildHubWorkConfig();
+  const dirExists = args.dirExists ?? existsSync;
+  if (!dirExists(config.dir)) {
+    return {
+      ok: false,
+      status: 500,
+      error: `claude-hub リポジトリが見つかりません: ${config.dir}`,
+    };
+  }
+
+  const { sessionManager, queue, postToThread } = args;
+
+  // スレッド名は既存 dispatch と同じ規約（同 branch 並走のシーケンス付き、
+  // RW-046 の同 branch 多重セッション識別）。
+  let thread: { id: string };
+  try {
+    const sameBranchCount = sessionManager
+      .listRunningByChannel(config.channelName)
+      .filter((s) => s.branch === branch).length;
+    const threadName = buildThreadTitle(
+      "running",
+      branch,
+      config.displayName,
+      sameBranchCount + 1,
+    );
+    thread = await args.createThread(threadName);
+  } catch (err) {
+    return {
+      ok: false,
+      status: 500,
+      error: `ワーカースレッドを作成できませんでした: ${errMsg(err)}`,
+    };
+  }
+
+  const injected = `/${command} ${issueNumber}`;
+
+  // スロット獲得後に実行される本体。戻り値はセッションが実際に起動したか
+  // （DispatchQueue のスロット保持契約。失敗時 false で即時解放）。
+  const runOnce = async (): Promise<boolean> => {
+    await args.admissionGate?.();
+    const result = await runDispatch({
+      config,
+      branch,
+      issueNumber,
+      command,
+      sessionManager,
+      executorMode: args.executorMode ?? "tmux",
+      postToThread,
+      createThread: async () => thread, // 先行作成済みスレッドを再利用
+    });
+
+    if (result.ok && result.mode === "tmux") {
+      try {
+        await postToThread(
+          result.threadId,
+          `🛰️ **${config.displayName}** を work セッション経路で起動しました（ADR-002 D5 / #320）\n\n` +
+            `🌿 ブランチ: \`${branch}\`\n` +
+            `▶️ 初期コマンド: \`${result.injected}\`\n` +
+            `📊 稼働中セッション: ${sessionManager.count()}/${MAX_SESSIONS}`,
+        );
+      } catch (err) {
+        console.error(
+          `[HubWork] welcome message failed for thread ${result.threadId}:`,
+          errMsg(err),
+        );
+      }
+    } else if (result.ok) {
+      console.log(
+        `[HubWork] headless hub work completed (thread=${result.threadId}, exit=${result.exitCode}, timedOut=${result.timedOut})`,
+      );
+    } else {
+      console.error(
+        `[HubWork] hub work dispatch failed (stage=${result.stage}): ${result.error}`,
+      );
+      // 起動失敗をスレッドにも明示する（サイレント失敗にしない）。
+      try {
+        await postToThread(
+          thread.id,
+          `❌ work セッションの起動に失敗しました（stage=${result.stage}）: ${result.error}`,
+        );
+      } catch (postErr) {
+        console.error(
+          `[HubWork] failed to post start-error to thread ${thread.id}:`,
+          errMsg(postErr),
+        );
+      }
+    }
+    return result.ok;
+  };
+
+  const submitted = await queue.submit({
+    key: thread.id,
+    run: runOnce,
+    onQueued: async (position) => {
+      await postToThread(
+        thread.id,
+        `⏳ 同時実行の上限（${queue.limit()}）に達しているため待機中です（キュー ${position} 番目）。` +
+          `先行 dispatch の完了後、FIFO で自動起動します。`,
+      );
+    },
+    onDequeued: async () => {
+      await postToThread(thread.id, `▶️ 空きが出たため、キューから起動します。`);
+    },
+  });
+
+  return {
+    ok: true,
+    threadId: thread.id,
+    queued: submitted === "queued",
+    injected,
+  };
+}
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/supervisor/src/session/relay-server.ts
+++ b/supervisor/src/session/relay-server.ts
@@ -1,3 +1,5 @@
+import { mkdirSync, unlinkSync, writeFileSync } from "fs";
+import { dirname } from "path";
 import { formatForDiscord } from "./output-formatter";
 import { MAX_SESSIONS } from "../config/channels";
 import type { SessionHealthInfo } from "./types";
@@ -43,6 +45,20 @@ export interface AskUserEvent {
   question: string;
   options?: string[];
 }
+
+// Epic #316 Phase 3 (#320, ADR-002 D5): claude-hub work セッション経路の起動口。
+// ローカルのオーケストレーター CC セッション（session-ctl start-hub-worker）が
+// `POST /hub-work` に {branch, issueNumber, selector?} を投げると、bot.ts が
+// 登録したハンドラ（src/session/hub-work.ts の runHubWork）へ委譲される。
+// サーバは loopback-only bind（下記 hostname: "127.0.0.1"）なので到達できるのは
+// ローカルプロセスのみ — session-ctl と同じ操作者ローカルの信頼レベル。
+// 検証（fail-closed な branch / issueNumber / selector 検査）はハンドラ側が担う。
+export type HubWorkResponse =
+  | { ok: true; threadId: string; queued: boolean; injected: string }
+  | { ok: false; status: number; error: string };
+export type HubWorkHandler = (
+  body: Record<string, unknown>,
+) => Promise<HubWorkResponse>;
 
 type ProgressCallback = (event: ProgressEvent) => void;
 type LateResponseCallback = (event: LateResponseEvent) => void;
@@ -95,6 +111,50 @@ let progressCallback: ProgressCallback | null = null;
 let lateResponseCallback: LateResponseCallback | null = null;
 let askUserCallback: AskUserCallback | null = null;
 let sessionsProvider: SessionsProvider | null = null;
+let hubWorkHandler: HubWorkHandler | null = null;
+
+/**
+ * Well-known file that carries the relay server's ephemeral port (#320).
+ * `Bun.serve({port: 0})` picks a random port, so an external local CLI
+ * (session-ctl) needs a discovery point to reach `POST /hub-work`. Uses the
+ * same runtime-dir scheme as manager.ts's relayUrlFilePath (XDG_RUNTIME_DIR
+ * when present, else /tmp/claude-hub-supervisor-<USER>) so there is exactly one
+ * runtime dir per user.
+ */
+export function relayPortFilePath(): string {
+  const fromXdg = process.env.XDG_RUNTIME_DIR;
+  const user = process.env.USER || "default";
+  const runtimeDir = fromXdg
+    ? `${fromXdg}/claude-hub-supervisor`
+    : `/tmp/claude-hub-supervisor-${user}`;
+  return `${runtimeDir}/relay-port`;
+}
+
+/**
+ * Best-effort write of the port-discovery file (#320). Fail-soft: a filesystem
+ * error must never take the relay server down — session-ctl start-hub-worker
+ * simply reports "Supervisor 未起動" until the file appears.
+ */
+function writeRelayPortFile(port: number): void {
+  const file = relayPortFilePath();
+  try {
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, String(port));
+  } catch (err) {
+    console.warn(`[relay-server] failed to write port file ${file}:`, err);
+  }
+}
+
+/** Best-effort removal of the port-discovery file (stop path; ENOENT is fine). */
+function removeRelayPortFile(): void {
+  try {
+    unlinkSync(relayPortFilePath());
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== "ENOENT") {
+      console.warn(`[relay-server] failed to remove port file:`, err);
+    }
+  }
+}
 
 export function onProgress(callback: ProgressCallback): void {
   progressCallback = callback;
@@ -116,6 +176,15 @@ export function onLateResponse(callback: LateResponseCallback): void {
 
 export function onAskUser(callback: AskUserCallback): void {
   askUserCallback = callback;
+}
+
+/**
+ * Register the handler that backs `POST /hub-work` (#320, ADR-002 D5). When no
+ * handler is registered the endpoint answers 503 (fail-closed) — a hub work
+ * request can never silently no-op.
+ */
+export function onHubWork(handler: HubWorkHandler): void {
+  hubWorkHandler = handler;
 }
 
 /**
@@ -174,6 +243,45 @@ export function startRelayServer(): void {
           max: MAX_SESSIONS,
           sessions,
         });
+      }
+
+      // Epic #316 Phase 3 (#320): claude-hub work セッション経路の起動口。
+      // loopback-only なのでローカルの session-ctl / オーケストレーター CC
+      // セッションだけが叩ける。ハンドラ未登録は 503（fail-closed）。
+      if (url.pathname === "/hub-work" && req.method === "POST") {
+        const handler = hubWorkHandler;
+        if (!handler) {
+          return Response.json(
+            { error: "hub work handler not registered (Supervisor 起動中?)" },
+            { status: 503 },
+          );
+        }
+        let body: Record<string, unknown>;
+        try {
+          const parsed = (await req.json()) as unknown;
+          if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+            return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+          }
+          body = parsed as Record<string, unknown>;
+        } catch {
+          return Response.json({ error: "Invalid JSON" }, { status: 400 });
+        }
+        try {
+          const result = await handler(body);
+          if (result.ok) {
+            return Response.json(result, { status: 200 });
+          }
+          return Response.json(
+            { error: result.error },
+            { status: result.status },
+          );
+        } catch (err) {
+          console.error("[relay-server] hubWorkHandler error:", err);
+          return Response.json(
+            { error: err instanceof Error ? err.message : String(err) },
+            { status: 500 },
+          );
+        }
       }
 
       // Progress endpoint: PostToolUse hook sends tool progress here
@@ -385,6 +493,9 @@ export function startRelayServer(): void {
   });
 
   relayPort = server.port ?? 0;
+  // #320: publish the ephemeral port so a local CLI (session-ctl) can discover
+  // the /hub-work endpoint. Fail-soft — never blocks server startup.
+  writeRelayPortFile(relayPort);
   console.log(`[relay-server] started on port ${relayPort}`);
 }
 
@@ -411,6 +522,8 @@ export function stopRelayServer(): void {
   lateResponseCallback = null;
   askUserCallback = null;
   sessionsProvider = null;
+  hubWorkHandler = null;
+  removeRelayPortFile();
 }
 
 export function waitForRelay(

--- a/supervisor/tests/session/hub-work.test.ts
+++ b/supervisor/tests/session/hub-work.test.ts
@@ -1,0 +1,314 @@
+import { test, expect, describe } from "bun:test";
+import { CHANNEL_MAP } from "../../src/config/channels";
+import {
+  HUB_WORK_CHANNEL_NAME,
+  HUB_WORK_PARENT_CHANNEL,
+  buildHubWorkConfig,
+  parseHubWorkRequest,
+  runHubWork,
+  type HubWorkQueue,
+  type HubWorkSessionManager,
+  type RunHubWorkArgs,
+} from "../../src/session/hub-work";
+import type { QueuedDispatch } from "../../src/session/dispatch-queue";
+
+/**
+ * Epic #316 Phase 3 (#320, ADR-002 D5) — claude-hub work セッション経路。
+ *
+ * 絶対ルール（CHANNEL_MAP に claude-hub を追加しない）を保ったまま、
+ * ephemeral config の明示渡しで dispatch 相当の起動ができることを検証する。
+ */
+
+describe("FATAL guard 非接触 (ADR-002 D5-1, AC-4)", () => {
+  test("CHANNEL_MAP に claude-hub が存在しない（guard が生きたまま import 成功）", () => {
+    // channels.ts の import が throw しなかった時点で FATAL guard は green。
+    expect(CHANNEL_MAP.has("claude-hub")).toBe(false);
+  });
+
+  test("ephemeral work config は CHANNEL_MAP に登録されない", () => {
+    // buildHubWorkConfig を呼んでも CHANNEL_MAP は不変（登録禁止 contract）。
+    buildHubWorkConfig();
+    expect(CHANNEL_MAP.has(HUB_WORK_CHANNEL_NAME)).toBe(false);
+    expect(CHANNEL_MAP.has("claude-hub")).toBe(false);
+  });
+
+  test("work スレッドの親チャンネルは corp（ADR-002 D5-3）で、corp は既存登録済み", () => {
+    expect(HUB_WORK_PARENT_CHANNEL).toBe("corp");
+    expect(CHANNEL_MAP.has("corp")).toBe(true);
+  });
+});
+
+describe("buildHubWorkConfig", () => {
+  test("cwd は <home>/claude-hub、channel 名は claude-hub-work", () => {
+    const config = buildHubWorkConfig("/Users/testuser");
+    expect(config.channelName).toBe(HUB_WORK_CHANNEL_NAME);
+    expect(config.dir).toBe("/Users/testuser/claude-hub");
+    expect(config.displayName).toBe("Claude Hub Work");
+  });
+
+  test("channel 名は FATAL guard の検査対象文字列そのものではない", () => {
+    // guard は文字列 "claude-hub" の完全一致で検査する（channels.ts:141）。
+    expect(HUB_WORK_CHANNEL_NAME).not.toBe("claude-hub");
+  });
+});
+
+describe("parseHubWorkRequest（fail-closed、/dispatch パーサと同一検証）", () => {
+  test("selector 省略 → impl", () => {
+    const parsed = parseHubWorkRequest({ branch: "feat-320", issueNumber: 320 });
+    expect(parsed).toEqual({
+      kind: "ok",
+      branch: "feat-320",
+      issueNumber: 320,
+      command: "impl",
+    });
+  });
+
+  test("selector pdca → pdca", () => {
+    const parsed = parseHubWorkRequest({
+      branch: "corp-dispatch-320",
+      issueNumber: 320,
+      selector: "pdca",
+    });
+    expect(parsed).toEqual({
+      kind: "ok",
+      branch: "corp-dispatch-320",
+      issueNumber: 320,
+      command: "pdca",
+    });
+  });
+
+  test("selector no-template → impl に collapse", () => {
+    const parsed = parseHubWorkRequest({
+      branch: "b",
+      issueNumber: 1,
+      selector: "no-template",
+    });
+    expect(parsed.kind).toBe("ok");
+    if (parsed.kind === "ok") expect(parsed.command).toBe("impl");
+  });
+
+  test.each([
+    ["null body", null],
+    ["array body", [1, 2]],
+    ["string body", "hi" as unknown],
+  ])("非オブジェクト body は error: %s", (_label, body) => {
+    expect(parseHubWorkRequest(body).kind).toBe("error");
+  });
+
+  test.each([
+    ["空 branch", ""],
+    ["空白入り branch", "feat 320"],
+    ["シェルメタ文字 branch（二重引用符）", 'a"b'],
+    ["シェルメタ文字 branch（backtick）", "a`b"],
+    ["シェルメタ文字 branch（$）", "a$b"],
+    ["path traversal branch", "../etc"],
+  ])("不正 branch は error: %s", (_label, branch) => {
+    expect(parseHubWorkRequest({ branch, issueNumber: 1 }).kind).toBe("error");
+  });
+
+  test.each([
+    ["文字列 issueNumber", "320" as unknown],
+    ["ゼロ", 0],
+    ["負数", -1],
+    ["小数", 1.5],
+  ])("不正 issueNumber は error: %s", (_label, issueNumber) => {
+    expect(parseHubWorkRequest({ branch: "b", issueNumber }).kind).toBe("error");
+  });
+
+  test("selector は閉集合（未知トークンは推測せず拒否）", () => {
+    const parsed = parseHubWorkRequest({
+      branch: "b",
+      issueNumber: 1,
+      selector: "yolo",
+    });
+    expect(parsed.kind).toBe("error");
+  });
+});
+
+/** run() を即時 inline 実行する fake queue（決定的にアサートするため）。 */
+function inlineQueue(): HubWorkQueue & { submitted: QueuedDispatch[] } {
+  const submitted: QueuedDispatch[] = [];
+  return {
+    submitted,
+    limit: () => 3,
+    submit: async (item) => {
+      submitted.push(item);
+      await item.run();
+      return "started";
+    },
+  };
+}
+
+interface FakeManagerCalls {
+  start: Array<{ config: unknown; threadId: string; branch?: string }>;
+  sendMessage: Array<{ threadId: string; message: string }>;
+}
+
+function fakeManager(opts?: { startError?: Error }): HubWorkSessionManager & {
+  calls: FakeManagerCalls;
+} {
+  const calls: FakeManagerCalls = { start: [], sendMessage: [] };
+  return {
+    calls,
+    start: async (config, threadId, branch) => {
+      if (opts?.startError) throw opts.startError;
+      calls.start.push({ config, threadId, branch });
+      return {};
+    },
+    waitForInputReady: async () => true,
+    sendMessage: async (threadId, message) => {
+      calls.sendMessage.push({ threadId, message });
+      return {};
+    },
+    listRunningByChannel: () => [],
+    count: () => 1,
+  };
+}
+
+function baseArgs(overrides: Partial<RunHubWorkArgs> = {}): RunHubWorkArgs & {
+  posts: Array<{ threadId: string; content: string }>;
+  threads: string[];
+} {
+  const posts: Array<{ threadId: string; content: string }> = [];
+  const threads: string[] = [];
+  return {
+    posts,
+    threads,
+    body: { branch: "feat-320", issueNumber: 320, selector: "pdca" },
+    sessionManager: fakeManager(),
+    queue: inlineQueue(),
+    createThread: async (name) => {
+      threads.push(name);
+      return { id: "T1" };
+    },
+    postToThread: async (threadId, content) => {
+      posts.push({ threadId, content });
+    },
+    config: buildHubWorkConfig("/tmp/hub-work-test-home"),
+    dirExists: () => true,
+    ...overrides,
+  };
+}
+
+describe("runHubWork", () => {
+  test("happy path: corp スレッド作成 → ephemeral config 明示渡しで start → selector 注入", async () => {
+    const manager = fakeManager();
+    const args = baseArgs({ sessionManager: manager });
+    const result = await runHubWork(args);
+
+    expect(result).toEqual({
+      ok: true,
+      threadId: "T1",
+      queued: false,
+      injected: "/pdca 320",
+    });
+
+    // スレッド名は既存 dispatch と同じ規約（branch + displayName）。
+    expect(args.threads).toHaveLength(1);
+    expect(args.threads[0]).toContain("feat-320");
+    expect(args.threads[0]).toContain("Claude Hub Work");
+
+    // start は CHANNEL_MAP を経由しない ephemeral config が明示渡しされる。
+    expect(manager.calls.start).toHaveLength(1);
+    const startCall = manager.calls.start[0]!;
+    expect(startCall.threadId).toBe("T1");
+    expect(startCall.branch).toBe("feat-320");
+    const passedConfig = startCall.config as { channelName: string; dir: string };
+    expect(passedConfig.channelName).toBe(HUB_WORK_CHANNEL_NAME);
+    expect(passedConfig.dir).toBe("/tmp/hub-work-test-home/claude-hub");
+
+    // 初期コマンドは既存 dispatch と同一の注入形。
+    expect(manager.calls.sendMessage).toEqual([
+      { threadId: "T1", message: "/pdca 320" },
+    ]);
+
+    // welcome がスレッドへ投稿される。
+    expect(args.posts.some((p) => p.content.includes("work セッション経路で起動"))).toBe(
+      true,
+    );
+  });
+
+  test("body 不正 → 400（スレッドは作られない）", async () => {
+    const args = baseArgs({ body: { branch: 'a"b', issueNumber: 1 } });
+    const result = await runHubWork(args);
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.status).toBe(400);
+    expect(args.threads).toHaveLength(0);
+  });
+
+  test("claude-hub リポ不在 → 500（スレッドは作られない）", async () => {
+    const args = baseArgs({ dirExists: () => false });
+    const result = await runHubWork(args);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(500);
+      expect(result.error).toContain("claude-hub");
+    }
+    expect(args.threads).toHaveLength(0);
+  });
+
+  test("スレッド作成失敗 → 500", async () => {
+    const args = baseArgs({
+      createThread: async () => {
+        throw new Error("no corp channel");
+      },
+    });
+    const result = await runHubWork(args);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(500);
+      expect(result.error).toContain("no corp channel");
+    }
+  });
+
+  test("start 失敗 → run() は false（スロット即時解放契約）+ スレッドへ失敗を明示", async () => {
+    const manager = fakeManager({ startError: new Error("boom") });
+    let runReturned: boolean | undefined;
+    const queue: HubWorkQueue = {
+      limit: () => 3,
+      submit: async (item) => {
+        runReturned = await item.run();
+        return "started";
+      },
+    };
+    const args = baseArgs({ sessionManager: manager, queue });
+    const result = await runHubWork(args);
+    // submit 自体は受理される（既存 dispatch と同じ: 失敗はスレッドで報告）。
+    expect(result.ok).toBe(true);
+    expect(runReturned).toBe(false);
+    expect(args.posts.some((p) => p.content.includes("起動に失敗"))).toBe(true);
+  });
+
+  test("上限超過: queued=true で onQueued の待機通知が届く", async () => {
+    const queue: HubWorkQueue = {
+      limit: () => 3,
+      submit: async (item) => {
+        await item.onQueued(2);
+        return "queued"; // スロットが空くまで run() は走らない
+      },
+    };
+    const args = baseArgs({ queue });
+    const result = await runHubWork(args);
+    expect(result.ok).toBe(true);
+    if (result.ok) expect(result.queued).toBe(true);
+    expect(args.posts.some((p) => p.content.includes("待機中"))).toBe(true);
+  });
+
+  test("admissionGate はスロット獲得後・start 前に await される", async () => {
+    const order: string[] = [];
+    const manager = fakeManager();
+    const origStart = manager.start.bind(manager);
+    manager.start = async (config, threadId, branch) => {
+      order.push("start");
+      return origStart(config, threadId, branch);
+    };
+    const args = baseArgs({
+      sessionManager: manager,
+      admissionGate: async () => {
+        order.push("gate");
+      },
+    });
+    await runHubWork(args);
+    expect(order).toEqual(["gate", "start"]);
+  });
+});

--- a/supervisor/tests/session/relay-server-hub-work.test.ts
+++ b/supervisor/tests/session/relay-server-hub-work.test.ts
@@ -1,0 +1,126 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { existsSync, readFileSync } from "fs";
+import {
+  startRelayServer,
+  stopRelayServer,
+  getRelayPort,
+  onHubWork,
+  relayPortFilePath,
+} from "../../src/session/relay-server";
+
+/**
+ * `POST /hub-work`（Epic #316 Phase 3 / #320, ADR-002 D5）と relay ポート
+ * ファイルの追加分だけを検証する。既存 relay-server.test.ts には触れない
+ * （既存テスト変更 0 件の BLOCKING 制約）。
+ */
+
+function hubWorkUrl(): string {
+  return `http://127.0.0.1:${getRelayPort()}/hub-work`;
+}
+
+describe("POST /hub-work", () => {
+  beforeEach(() => {
+    startRelayServer();
+  });
+
+  afterEach(() => {
+    stopRelayServer();
+  });
+
+  test("ハンドラ未登録は 503（fail-closed、黙って no-op しない）", async () => {
+    const res = await fetch(hubWorkUrl(), {
+      method: "POST",
+      body: JSON.stringify({ branch: "b", issueNumber: 1 }),
+    });
+    expect(res.status).toBe(503);
+  });
+
+  test("不正 JSON は 400", async () => {
+    onHubWork(async () => {
+      throw new Error("should not be called");
+    });
+    const res = await fetch(hubWorkUrl(), { method: "POST", body: "{oops" });
+    expect(res.status).toBe(400);
+  });
+
+  test("非オブジェクト JSON（配列）は 400", async () => {
+    onHubWork(async () => {
+      throw new Error("should not be called");
+    });
+    const res = await fetch(hubWorkUrl(), {
+      method: "POST",
+      body: JSON.stringify([1, 2, 3]),
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("ok ハンドラ結果は 200 + JSON パススルー", async () => {
+    let received: unknown = null;
+    onHubWork(async (body) => {
+      received = body;
+      return { ok: true, threadId: "T1", queued: false, injected: "/pdca 320" };
+    });
+    const res = await fetch(hubWorkUrl(), {
+      method: "POST",
+      body: JSON.stringify({ branch: "feat-320", issueNumber: 320, selector: "pdca" }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.ok).toBe(true);
+    expect(json.threadId).toBe("T1");
+    expect(json.injected).toBe("/pdca 320");
+    expect(received).toEqual({
+      branch: "feat-320",
+      issueNumber: 320,
+      selector: "pdca",
+    });
+  });
+
+  test("ハンドラの ok:false は status/error をそのまま返す", async () => {
+    onHubWork(async () => ({ ok: false, status: 400, error: "branch が不正" }));
+    const res = await fetch(hubWorkUrl(), {
+      method: "POST",
+      body: JSON.stringify({ branch: "a;b", issueNumber: 1 }),
+    });
+    expect(res.status).toBe(400);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.error).toContain("branch");
+  });
+
+  test("ハンドラ throw は 500（unhandled で落ちない）", async () => {
+    onHubWork(async () => {
+      throw new Error("kaboom");
+    });
+    const res = await fetch(hubWorkUrl(), {
+      method: "POST",
+      body: JSON.stringify({ branch: "b", issueNumber: 1 }),
+    });
+    expect(res.status).toBe(500);
+  });
+
+  test("stopRelayServer でハンドラがリセットされる（再 start 後は 503）", async () => {
+    onHubWork(async () => ({ ok: true, threadId: "T1", queued: false, injected: "/impl 1" }));
+    stopRelayServer();
+    startRelayServer();
+    const res = await fetch(hubWorkUrl(), {
+      method: "POST",
+      body: JSON.stringify({ branch: "b", issueNumber: 1 }),
+    });
+    expect(res.status).toBe(503);
+  });
+});
+
+describe("relay ポートファイル（session-ctl のポート発見点、#320）", () => {
+  afterEach(() => {
+    stopRelayServer();
+  });
+
+  test("start で実ポートが書かれ、stop で消える", () => {
+    startRelayServer();
+    const file = relayPortFilePath();
+    expect(existsSync(file)).toBe(true);
+    expect(readFileSync(file, "utf8").trim()).toBe(String(getRelayPort()));
+    stopRelayServer();
+    expect(existsSync(file)).toBe(false);
+  });
+});

--- a/supervisor/tests/tools/session-ctl.test.ts
+++ b/supervisor/tests/tools/session-ctl.test.ts
@@ -238,6 +238,16 @@ describe("stop", () => {
     expect(calls.out.join("\n")).toContain("Supervisor が停止中の可能性");
   });
 
+  test("tmux セッション消滅済み → SIGTERM も kill もスキップ（PID 再利用ガード）", async () => {
+    const { fx, calls } = fakeFx({ rows: [row()], tmuxAlive: false });
+    expect(await runSessionCtl(["stop", "sess-1"], fx, STOP_OPTS)).toBe(0);
+    // DB の pid が OS に再利用されている可能性があるため、tmux の生存を確認
+    // できない限りシグナルを送らない（PR #325 gemini high）。
+    expect(calls.killedPids).toHaveLength(0);
+    expect(calls.killedTmux).toHaveLength(0);
+    expect(calls.out.join("\n")).toContain("スキップ");
+  });
+
   test("running でないセッション → exit 1（何も kill しない）", async () => {
     const { fx, calls } = fakeFx({ rows: [row({ status: "stopped" })] });
     expect(await runSessionCtl(["stop", "sess-1"], fx, STOP_OPTS)).toBe(1);

--- a/supervisor/tests/tools/session-ctl.test.ts
+++ b/supervisor/tests/tools/session-ctl.test.ts
@@ -1,0 +1,358 @@
+import { test, expect, describe } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { Database } from "bun:sqlite";
+import type { SessionRow } from "../../src/infra/db";
+import {
+  runSessionCtl,
+  tmuxNameForThread,
+  createRealEffects,
+  type SessionCtlEffects,
+  type SessionStore,
+} from "../../tools/session-ctl";
+import { SessionManager } from "../../src/session/manager";
+
+/**
+ * session-ctl ローカル CLI（Epic #316 Phase 3 / #320）の fake adapters テスト。
+ *
+ * - sessions.db は読み取り専用（SessionStore に書き込み API が存在しないことが
+ *   構造的担保。実配線は bun:sqlite `{readonly:true}`）
+ * - send は relay.ts の sendToPane を共有（ここでは fake が受け取る tmux 名 /
+ *   テキストの正しさを検証。送信シーケンス自体は relay.test.ts が担保）
+ * - stop は DB に書かず、Supervisor watcher の status 反映を読み取りで確認する
+ */
+
+function row(overrides: Partial<SessionRow> = {}): SessionRow {
+  return {
+    id: "sess-1",
+    channel_name: "claude-hub-work",
+    thread_id: "111122223333444455",
+    project_dir: "/Users/x/claude-hub/.claude/worktrees/feat-320",
+    pid: 4242,
+    claude_session_id: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+    started_at: "2026-07-05T00:00:00.000Z",
+    last_activity_at: "2026-07-05T00:10:00.000Z",
+    status: "running",
+    stopped_reason: null,
+    branch: "feat-320",
+    ...overrides,
+  };
+}
+
+interface FakeCalls {
+  sends: Array<{ tmuxName: string; text: string }>;
+  killedPids: Array<{ pid: number; signal: string }>;
+  killedTmux: string[];
+  posts: Array<{ url: string; body: unknown }>;
+  out: string[];
+  err: string[];
+}
+
+function fakeFx(opts: {
+  rows?: SessionRow[];
+  tmuxAlive?: boolean;
+  pidAlive?: boolean;
+  relayPort?: number | null;
+  httpResponse?: { status: number; body: unknown };
+  /** stop 中、tmux kill 後に store が返す status（Supervisor watcher 反映の模擬）。 */
+  statusAfterKill?: string;
+} = {}): { fx: SessionCtlEffects; calls: FakeCalls } {
+  const calls: FakeCalls = {
+    sends: [],
+    killedPids: [],
+    killedTmux: [],
+    posts: [],
+    out: [],
+    err: [],
+  };
+  const rows = opts.rows ?? [];
+  let killed = false;
+
+  const currentRows = (): SessionRow[] =>
+    killed && opts.statusAfterKill
+      ? rows.map((r) => ({
+          ...r,
+          status: opts.statusAfterKill!,
+          stopped_reason: "tmux_exited",
+        }))
+      : rows;
+
+  const byKey = (key: string, runningOnly: boolean): SessionRow | undefined =>
+    currentRows().find(
+      (r) =>
+        (r.id === key || r.thread_id === key || r.claude_session_id === key) &&
+        (!runningOnly || r.status === "running"),
+    );
+
+  const store: SessionStore = {
+    listRunning: () => currentRows().filter((r) => r.status === "running"),
+    findByKey: (key) => byKey(key, false),
+    findRunningByKey: (key) => byKey(key, true),
+  };
+
+  const fx: SessionCtlEffects = {
+    store,
+    sendText: async (tmuxName, text) => {
+      calls.sends.push({ tmuxName, text });
+    },
+    hasTmuxSession: async () => opts.tmuxAlive ?? true,
+    killTmuxSession: async (name) => {
+      calls.killedTmux.push(name);
+      killed = true;
+    },
+    killPid: (pid, signal) => {
+      calls.killedPids.push({ pid, signal });
+      return true;
+    },
+    pidAlive: () => opts.pidAlive ?? true,
+    sleep: async () => {},
+    readRelayPort: () => (opts.relayPort === undefined ? 45678 : opts.relayPort),
+    httpPost: async (url, body) => {
+      calls.posts.push({ url, body });
+      return opts.httpResponse ?? { status: 200, body: { ok: true, threadId: "T1", queued: false, injected: "/impl 1" } };
+    },
+    out: (line) => calls.out.push(line),
+    err: (line) => calls.err.push(line),
+  };
+  return { fx, calls };
+}
+
+const STOP_OPTS = { graceMs: 0, statusWaitMs: 10, statusPollMs: 1 };
+
+describe("tmux セッション名マッピング", () => {
+  test("Supervisor の公式マッピング（claude-<threadId12>）と一致する", () => {
+    const threadId = "111122223333444455";
+    expect(tmuxNameForThread(threadId)).toBe(
+      SessionManager.tmuxSessionNameFor(threadId),
+    );
+    expect(tmuxNameForThread(threadId)).toBe("claude-111122223333");
+  });
+});
+
+describe("list", () => {
+  test("running なし → 案内を出して 0", async () => {
+    const { fx, calls } = fakeFx();
+    expect(await runSessionCtl(["list"], fx)).toBe(0);
+    expect(calls.out[0]).toContain("running セッションなし");
+  });
+
+  test("running 行を列挙して件数を出す（AC-1: sessions.db と一致）", async () => {
+    const rows = [row(), row({ id: "sess-2", thread_id: "999900001111222233", branch: "b2" })];
+    const { fx, calls } = fakeFx({ rows });
+    expect(await runSessionCtl(["list"], fx)).toBe(0);
+    expect(calls.out.filter((l) => l.startsWith("id=")).length).toBe(2);
+    expect(calls.out.join("\n")).toContain("sess-1");
+    expect(calls.out.join("\n")).toContain("sess-2");
+    expect(calls.out.at(-1)).toContain("計 2 件");
+  });
+
+  test("stopped 行は数えない", async () => {
+    const rows = [row({ status: "stopped", stopped_reason: "manual" })];
+    const { fx, calls } = fakeFx({ rows });
+    expect(await runSessionCtl(["list"], fx)).toBe(0);
+    expect(calls.out[0]).toContain("running セッションなし");
+  });
+});
+
+describe("status", () => {
+  test("未知 id → exit 1", async () => {
+    const { fx, calls } = fakeFx();
+    expect(await runSessionCtl(["status", "nope"], fx)).toBe(1);
+    expect(calls.err[0]).toContain("見つかりません");
+  });
+
+  test("running + pid/tmux alive → liveness=alive", async () => {
+    const { fx, calls } = fakeFx({ rows: [row()], tmuxAlive: true, pidAlive: true });
+    expect(await runSessionCtl(["status", "sess-1"], fx)).toBe(0);
+    expect(calls.out.join("\n")).toContain("liveness=alive");
+  });
+
+  test("tmux 消滅 → liveness=dead（DB より現実を優先）", async () => {
+    const { fx, calls } = fakeFx({ rows: [row()], tmuxAlive: false });
+    expect(await runSessionCtl(["status", "sess-1"], fx)).toBe(0);
+    expect(calls.out.join("\n")).toContain("liveness=dead");
+  });
+
+  test("claude_session_id でも引ける", async () => {
+    const { fx } = fakeFx({ rows: [row()] });
+    expect(
+      await runSessionCtl(["status", "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"], fx),
+    ).toBe(0);
+  });
+});
+
+describe("send", () => {
+  test("thread_id 指定で正しい tmux 名へ送信（AC-2）", async () => {
+    const { fx, calls } = fakeFx({ rows: [row()] });
+    expect(
+      await runSessionCtl(["send", "111122223333444455", "echo", "hello"], fx),
+    ).toBe(0);
+    expect(calls.sends).toEqual([
+      { tmuxName: "claude-111122223333", text: "echo hello" },
+    ]);
+  });
+
+  test("session id 指定でも同じセッションへ解決される", async () => {
+    const { fx, calls } = fakeFx({ rows: [row()] });
+    expect(await runSessionCtl(["send", "sess-1", "hi"], fx)).toBe(0);
+    expect(calls.sends[0]!.tmuxName).toBe("claude-111122223333");
+  });
+
+  test("running でないセッションには送らない", async () => {
+    const { fx, calls } = fakeFx({ rows: [row({ status: "stopped" })] });
+    expect(await runSessionCtl(["send", "sess-1", "hi"], fx)).toBe(1);
+    expect(calls.sends).toHaveLength(0);
+  });
+
+  test("tmux ペイン消滅 → 送信せずエラー", async () => {
+    const { fx, calls } = fakeFx({ rows: [row()], tmuxAlive: false });
+    expect(await runSessionCtl(["send", "sess-1", "hi"], fx)).toBe(1);
+    expect(calls.sends).toHaveLength(0);
+    expect(calls.err[0]).toContain("tmux");
+  });
+
+  test("引数不足 → usage エラー", async () => {
+    const { fx } = fakeFx({ rows: [row()] });
+    expect(await runSessionCtl(["send", "sess-1"], fx)).toBe(1);
+  });
+});
+
+describe("stop", () => {
+  test("SIGTERM → tmux kill の順で、DB へは書かず watcher 反映を読み取り確認（AC-3）", async () => {
+    const { fx, calls } = fakeFx({ rows: [row()], statusAfterKill: "stopped" });
+    expect(await runSessionCtl(["stop", "sess-1"], fx, STOP_OPTS)).toBe(0);
+    expect(calls.killedPids).toEqual([{ pid: 4242, signal: "SIGTERM" }]);
+    expect(calls.killedTmux).toEqual(["claude-111122223333"]);
+    const outText = calls.out.join("\n");
+    // worktree 非破壊（RW-046）: tmux_exited 経路は worktree を残す。
+    expect(outText).toContain("worktree は保持");
+    expect(outText).toContain("status=stopped");
+    expect(outText).toContain("tmux_exited");
+  });
+
+  test("Supervisor 停止中（status が反映されない）でも kill は完了し警告を出す", async () => {
+    const { fx, calls } = fakeFx({ rows: [row()] }); // statusAfterKill なし
+    expect(await runSessionCtl(["stop", "sess-1"], fx, STOP_OPTS)).toBe(0);
+    expect(calls.killedTmux).toEqual(["claude-111122223333"]);
+    expect(calls.out.join("\n")).toContain("Supervisor が停止中の可能性");
+  });
+
+  test("running でないセッション → exit 1（何も kill しない）", async () => {
+    const { fx, calls } = fakeFx({ rows: [row({ status: "stopped" })] });
+    expect(await runSessionCtl(["stop", "sess-1"], fx, STOP_OPTS)).toBe(1);
+    expect(calls.killedPids).toHaveLength(0);
+    expect(calls.killedTmux).toHaveLength(0);
+  });
+});
+
+describe("start-hub-worker", () => {
+  test("POST /hub-work に {branch, issueNumber, selector} を送る", async () => {
+    const { fx, calls } = fakeFx({ relayPort: 50123 });
+    expect(
+      await runSessionCtl(["start-hub-worker", "feat-320", "320", "pdca"], fx),
+    ).toBe(0);
+    expect(calls.posts).toEqual([
+      {
+        url: "http://127.0.0.1:50123/hub-work",
+        body: { branch: "feat-320", issueNumber: 320, selector: "pdca" },
+      },
+    ]);
+    expect(calls.out[0]).toContain("受け付けました");
+  });
+
+  test("selector 省略時は payload に含めない", async () => {
+    const { fx, calls } = fakeFx();
+    expect(await runSessionCtl(["start-hub-worker", "feat-320", "320"], fx)).toBe(0);
+    expect(calls.posts[0]!.body).toEqual({ branch: "feat-320", issueNumber: 320 });
+  });
+
+  test("ポートファイルなし（Supervisor 未起動）→ exit 1、HTTP は呼ばない", async () => {
+    const { fx, calls } = fakeFx({ relayPort: null });
+    expect(await runSessionCtl(["start-hub-worker", "b", "1"], fx)).toBe(1);
+    expect(calls.posts).toHaveLength(0);
+    expect(calls.err[0]).toContain("Supervisor");
+  });
+
+  test("issueNumber が整数でない → exit 1、HTTP は呼ばない", async () => {
+    const { fx, calls } = fakeFx();
+    expect(await runSessionCtl(["start-hub-worker", "b", "abc"], fx)).toBe(1);
+    expect(calls.posts).toHaveLength(0);
+  });
+
+  test("Supervisor がエラーを返す → exit 1 でエラー本文を表示", async () => {
+    const { fx, calls } = fakeFx({
+      httpResponse: { status: 400, body: { error: "branch 名が不正です" } },
+    });
+    expect(await runSessionCtl(["start-hub-worker", "b", "1"], fx)).toBe(1);
+    expect(calls.err[0]).toContain("branch 名が不正です");
+  });
+});
+
+describe("usage", () => {
+  test("help → 0", async () => {
+    const { fx, calls } = fakeFx();
+    expect(await runSessionCtl(["help"], fx)).toBe(0);
+    expect(calls.out[0]).toContain("session-ctl");
+  });
+
+  test("未知サブコマンド → 1", async () => {
+    const { fx } = fakeFx();
+    expect(await runSessionCtl(["frobnicate"], fx)).toBe(1);
+  });
+
+  test("引数なし → 1", async () => {
+    const { fx } = fakeFx();
+    expect(await runSessionCtl([], fx)).toBe(1);
+  });
+});
+
+describe("実 DB 読み取り（createRealEffects の store、読み取り専用）", () => {
+  test("実 sqlite ファイルから running 行を読める + readonly で開いている", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "session-ctl-test-"));
+    const dbPath = join(dir, "sessions.db");
+    const prevEnv = process.env.SUPERVISOR_DB_PATH;
+    try {
+      // Supervisor と同じスキーマ + WAL で行を用意する（書くのはテスト側のみ）。
+      const writer = new Database(dbPath);
+      writer.exec("PRAGMA journal_mode = WAL");
+      writer.exec(`
+        CREATE TABLE sessions (
+          id TEXT PRIMARY KEY,
+          channel_name TEXT NOT NULL,
+          thread_id TEXT,
+          project_dir TEXT NOT NULL,
+          pid INTEGER,
+          claude_session_id TEXT,
+          started_at TEXT NOT NULL,
+          last_activity_at TEXT NOT NULL,
+          status TEXT NOT NULL DEFAULT 'running',
+          stopped_reason TEXT,
+          branch TEXT
+        )
+      `);
+      writer
+        .prepare(
+          `INSERT INTO sessions (id, channel_name, thread_id, project_dir, pid, claude_session_id, started_at, last_activity_at, status, branch)
+           VALUES ('s1', 'claude-hub-work', 't1', '/x', 1, NULL, '2026-07-05T00:00:00Z', '2026-07-05T00:00:00Z', 'running', 'feat-320')`,
+        )
+        .run();
+      writer.close();
+
+      process.env.SUPERVISOR_DB_PATH = dbPath;
+      const fx = createRealEffects();
+      const rows = fx.store.listRunning();
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.id).toBe("s1");
+      expect(fx.store.findByKey("t1")?.id).toBe("s1");
+      expect(fx.store.findRunningByKey("s1")?.branch).toBe("feat-320");
+      // SessionStore には書き込み API が存在しない（読み取り専用の構造的担保）。
+      expect("insert" in fx.store).toBe(false);
+      expect("update" in fx.store).toBe(false);
+    } finally {
+      if (prevEnv === undefined) delete process.env.SUPERVISOR_DB_PATH;
+      else process.env.SUPERVISOR_DB_PATH = prevEnv;
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/supervisor/tools/session-ctl.ts
+++ b/supervisor/tools/session-ctl.ts
@@ -208,19 +208,30 @@ async function cmdStop(
   // 触れない: tmux セッション消滅を Supervisor の watchTmuxSession が検知し、
   // status='stopped' (tmux_exited) へ更新する。tmux_exited 経路は worktree を
   // 意図的に残すので、共有 worktree の破壊（RW-046）は構造的に起こらない。
-  if (row.pid != null) {
-    const delivered = fx.killPid(row.pid, "SIGTERM");
-    fx.out(
-      delivered
-        ? `SIGTERM を pid ${row.pid} へ送信しました（graceful 停止待ち ${graceMs}ms）`
-        : `pid ${row.pid} は既に終了しています`,
-    );
-  }
-  if (graceMs > 0) await fx.sleep(graceMs);
+  //
+  // PID 再利用ガード（PR #325 gemini high）: DB の pid は Supervisor 停止中や
+  // 長時間経過後に OS が別プロセスへ再利用している可能性がある。tmux セッション
+  // の生存を確認できた場合のみシグナルを送る（tmux が消えていれば元プロセスも
+  // 終了済みの可能性が極めて高く、送ると無関係プロセスを殺すリスクだけが残る）。
+  const tmuxName = row.thread_id ? tmuxNameForThread(row.thread_id) : null;
+  const tmuxAlive = tmuxName ? await fx.hasTmuxSession(tmuxName) : false;
 
-  if (row.thread_id) {
-    const tmuxName = tmuxNameForThread(row.thread_id);
-    await fx.killTmuxSession(tmuxName);
+  if (!tmuxAlive) {
+    fx.out(
+      `tmux セッション${tmuxName ? ` ${tmuxName}` : ""} が存在しないため SIGTERM / kill をスキップします` +
+        "（PID 再利用による誤 kill 防止。Supervisor が status を整合します）。",
+    );
+  } else {
+    if (row.pid != null) {
+      const delivered = fx.killPid(row.pid, "SIGTERM");
+      fx.out(
+        delivered
+          ? `SIGTERM を pid ${row.pid} へ送信しました（graceful 停止待ち ${graceMs}ms）`
+          : `pid ${row.pid} は既に終了しています`,
+      );
+      if (graceMs > 0) await fx.sleep(graceMs);
+    }
+    await fx.killTmuxSession(tmuxName!);
     fx.out(`tmux セッション ${tmuxName} を kill しました（worktree は保持されます）`);
   }
 

--- a/supervisor/tools/session-ctl.ts
+++ b/supervisor/tools/session-ctl.ts
@@ -1,0 +1,464 @@
+#!/usr/bin/env bun
+/**
+ * session-ctl — Supervisor 管理セッションへのローカル介入 CLI
+ * (Epic #316 Phase 3 / #320)。
+ *
+ * オーケストレーター CC セッション（ローカル）がワーカーセッションを
+ * 観測・介入するための薄い CLI。設計原則:
+ *
+ *   - **sessions.db は読み取り専用**（`bun:sqlite` の `{ readonly: true }`、
+ *     WAL モード前提）。DB への書き込みは Supervisor の専権であり、この CLI は
+ *     一切書かない。`stop` 後の status 反映も Supervisor の watchTmuxSession
+ *     （10s poll → status='stopped' reason='tmux_exited'）に委ねる。
+ *   - **send は relay.ts の {@link sendToPane} を共有**: copy-mode 解除 →
+ *     Escape → `send-keys -l`（argv-no-shell）→ C-m の実績経路（Issue #73 /
+ *     #32 / #33）をそのまま使う。tmux は Supervisor 専用 socket
+ *     `-L claude-hub`（RW-019、relay.ts の既定 TMUX_ARGS）。
+ *   - **stop は worktree を壊さない**（RW-046）: tmux kill 経由の停止は
+ *     Supervisor 側で `tmux_exited` として処理され、worktree は意図的に
+ *     残される（manager.ts watchTmuxSession のコメント参照）。共有 worktree の
+ *     破壊（isWorktreePathInUse で守られる /session stop 経路）はそもそも
+ *     通らない。
+ *   - **start-hub-worker は Supervisor の `POST /hub-work`**（loopback-only、
+ *     ADR-002 D5 の claude-hub work セッション経路）を叩く。ポートは
+ *     relay-server が書く runtime-dir のポートファイルから発見する。
+ *
+ * 使い方（cwd: ~/claude-hub）:
+ *   bun run supervisor/tools/session-ctl.ts list
+ *   bun run supervisor/tools/session-ctl.ts status <id>
+ *   bun run supervisor/tools/session-ctl.ts send <thread_id|session_id> <text...>
+ *   bun run supervisor/tools/session-ctl.ts stop <id>
+ *   bun run supervisor/tools/session-ctl.ts start-hub-worker <branch> <issueNumber> [selector]
+ *
+ * `<id>` は session row id / thread_id / claude_session_id のいずれでも可。
+ */
+
+import { existsSync, readFileSync } from "fs";
+import { Database } from "bun:sqlite";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import { resolveDbPath, type SessionRow } from "../src/infra/db";
+import { SessionManager } from "../src/session/manager";
+import { sendToPane } from "../src/session/relay";
+import { TMUX_PATH, TMUX_ARGS } from "../src/session/tmux";
+import { relayPortFilePath } from "../src/session/relay-server";
+import { GRACEFUL_KILL_TIMEOUT_MS } from "../src/config/channels";
+
+const execFileAsync = promisify(execFile);
+
+/** sessions.db への読み取り専用アクセス面（テストは fake を注入する）。 */
+export interface SessionStore {
+  listRunning(): SessionRow[];
+  /** id / thread_id / claude_session_id のいずれかで最新 1 行（status 不問）。 */
+  findByKey(key: string): SessionRow | undefined;
+  /** 同上、ただし status='running' のみ。 */
+  findRunningByKey(key: string): SessionRow | undefined;
+}
+
+/** 副作用アダプタ（テストは fake を注入する。実体は {@link createRealEffects}）。 */
+export interface SessionCtlEffects {
+  store: SessionStore;
+  /** relay.ts sendToPane 相当（copy-mode 解除 → Escape → -l → C-m、-L claude-hub）。 */
+  sendText(tmuxSessionName: string, text: string): Promise<void>;
+  hasTmuxSession(tmuxSessionName: string): Promise<boolean>;
+  killTmuxSession(tmuxSessionName: string): Promise<void>;
+  /** process.kill 相当。配達できたら true。 */
+  killPid(pid: number, signal: NodeJS.Signals): boolean;
+  pidAlive(pid: number): boolean;
+  sleep(ms: number): Promise<void>;
+  /** relay ポートファイルから Supervisor の relay ポートを読む（無ければ null）。 */
+  readRelayPort(): number | null;
+  httpPost(
+    url: string,
+    body: unknown,
+  ): Promise<{ status: number; body: unknown }>;
+  out(line: string): void;
+  err(line: string): void;
+}
+
+export interface SessionCtlOptions {
+  /** stop: SIGTERM 後 tmux kill までの猶予（既定 GRACEFUL_KILL_TIMEOUT_MS）。 */
+  graceMs?: number;
+  /** stop: Supervisor による status 反映を待つ上限（既定 30s）。 */
+  statusWaitMs?: number;
+  /** stop: status 反映のポーリング間隔（既定 2s）。 */
+  statusPollMs?: number;
+}
+
+export const USAGE = `session-ctl — Supervisor 管理セッションのローカル介入 CLI (#320)
+
+使い方 (cwd: ~/claude-hub):
+  bun run supervisor/tools/session-ctl.ts <subcommand> ...
+
+subcommands:
+  list
+      running セッション一覧 (sessions.db 読み取り専用)
+  status <id>
+      セッション詳細 + liveness。<id> は session_id / thread_id / claude_session_id
+  send <thread_id|session_id> <text...>
+      ワーカーの tmux ペインへテキスト送信 (argv-no-shell / -L claude-hub, RW-019)
+  stop <id>
+      SIGTERM → 猶予 → tmux kill-session。sessions.db への status 反映は
+      Supervisor の watcher が行う (この CLI は DB に書かない)。worktree は保持 (RW-046)
+  start-hub-worker <branch> <issueNumber> [selector]
+      claude-hub work セッションを corp チャンネル配下に起動 (POST /hub-work, ADR-002 D5)。
+      selector: impl / no-template / pdca / article / devcycle (省略時 impl)`;
+
+/** threadId → tmux セッション名（Supervisor と同一の公式マッピングを共有）。 */
+export function tmuxNameForThread(threadId: string): string {
+  return SessionManager.tmuxSessionNameFor(threadId);
+}
+
+function fmtRow(row: SessionRow): string {
+  return [
+    `id=${row.id}`,
+    `channel=${row.channel_name}`,
+    `thread=${row.thread_id ?? "-"}`,
+    `branch=${row.branch ?? "-"}`,
+    `status=${row.status}`,
+    `started=${row.started_at}`,
+    `last_activity=${row.last_activity_at}`,
+    `dir=${row.project_dir}`,
+  ].join("\t");
+}
+
+async function cmdList(fx: SessionCtlEffects): Promise<number> {
+  const rows = fx.store.listRunning();
+  if (rows.length === 0) {
+    fx.out("(running セッションなし)");
+    return 0;
+  }
+  for (const row of rows) fx.out(fmtRow(row));
+  fx.out(`計 ${rows.length} 件 (status=running)`);
+  return 0;
+}
+
+async function cmdStatus(fx: SessionCtlEffects, key: string): Promise<number> {
+  const row = fx.store.findByKey(key);
+  if (!row) {
+    fx.err(`セッションが見つかりません: ${key}`);
+    return 1;
+  }
+  fx.out(fmtRow(row));
+  fx.out(`claude_session_id=${row.claude_session_id ?? "-"}`);
+  fx.out(`pid=${row.pid ?? "-"}`);
+  fx.out(`stopped_reason=${row.stopped_reason ?? "-"}`);
+  if (row.thread_id) {
+    const tmuxName = tmuxNameForThread(row.thread_id);
+    const tmuxAlive = await fx.hasTmuxSession(tmuxName);
+    const pidAlive = row.pid != null ? fx.pidAlive(row.pid) : false;
+    // manager.livenessOf と同じ判定規則: DB running + pid alive + tmux alive。
+    const liveness =
+      row.status === "running" && pidAlive && tmuxAlive ? "alive" : "dead";
+    fx.out(`tmux=${tmuxName} (alive=${tmuxAlive})`);
+    fx.out(`pid_alive=${pidAlive}`);
+    fx.out(`liveness=${liveness}`);
+  } else {
+    fx.out("tmux=- (thread_id なし)");
+  }
+  return 0;
+}
+
+async function cmdSend(
+  fx: SessionCtlEffects,
+  key: string,
+  text: string,
+): Promise<number> {
+  if (!text.trim()) {
+    fx.err("送信テキストが空です。");
+    return 1;
+  }
+  const row = fx.store.findRunningByKey(key);
+  if (!row) {
+    fx.err(`running セッションが見つかりません: ${key}`);
+    return 1;
+  }
+  if (!row.thread_id) {
+    fx.err(`セッション ${row.id} に thread_id が記録されていません（送信不可）。`);
+    return 1;
+  }
+  const tmuxName = tmuxNameForThread(row.thread_id);
+  if (!(await fx.hasTmuxSession(tmuxName))) {
+    fx.err(
+      `tmux セッション ${tmuxName} が存在しません（セッションは既に終了している可能性）。`,
+    );
+    return 1;
+  }
+  await fx.sendText(tmuxName, text);
+  fx.out(`✅ ${tmuxName} (thread ${row.thread_id}) へ送信しました (${text.length} chars)`);
+  return 0;
+}
+
+async function cmdStop(
+  fx: SessionCtlEffects,
+  key: string,
+  opts: SessionCtlOptions,
+): Promise<number> {
+  const row = fx.store.findRunningByKey(key);
+  if (!row) {
+    fx.err(`running セッションが見つかりません: ${key}`);
+    return 1;
+  }
+  const graceMs = opts.graceMs ?? GRACEFUL_KILL_TIMEOUT_MS;
+  const statusWaitMs = opts.statusWaitMs ?? 30_000;
+  const statusPollMs = opts.statusPollMs ?? 2_000;
+
+  // Supervisor の stop() と同じ順序（SIGTERM → 猶予 → tmux kill）。ただし
+  // sessions.db には書かず（書き込みは Supervisor の専権）、worktree にも
+  // 触れない: tmux セッション消滅を Supervisor の watchTmuxSession が検知し、
+  // status='stopped' (tmux_exited) へ更新する。tmux_exited 経路は worktree を
+  // 意図的に残すので、共有 worktree の破壊（RW-046）は構造的に起こらない。
+  if (row.pid != null) {
+    const delivered = fx.killPid(row.pid, "SIGTERM");
+    fx.out(
+      delivered
+        ? `SIGTERM を pid ${row.pid} へ送信しました（graceful 停止待ち ${graceMs}ms）`
+        : `pid ${row.pid} は既に終了しています`,
+    );
+  }
+  if (graceMs > 0) await fx.sleep(graceMs);
+
+  if (row.thread_id) {
+    const tmuxName = tmuxNameForThread(row.thread_id);
+    await fx.killTmuxSession(tmuxName);
+    fx.out(`tmux セッション ${tmuxName} を kill しました（worktree は保持されます）`);
+  }
+
+  // Supervisor watcher (10s poll) による status 反映を確認する（読み取りのみ）。
+  let waited = 0;
+  while (waited < statusWaitMs) {
+    const latest = fx.store.findByKey(row.id);
+    if (latest && latest.status !== "running") {
+      fx.out(
+        `✅ sessions.db 反映確認: status=${latest.status} (reason=${latest.stopped_reason ?? "-"})`,
+      );
+      return 0;
+    }
+    await fx.sleep(statusPollMs);
+    waited += statusPollMs;
+  }
+  fx.out(
+    "⚠️ sessions.db の status がまだ running のままです。Supervisor が停止中の可能性があります" +
+      "（Supervisor 再起動時に supervisor_restart として整合されます）。",
+  );
+  return 0;
+}
+
+async function cmdStartHubWorker(
+  fx: SessionCtlEffects,
+  branch: string,
+  issueArg: string,
+  selector?: string,
+): Promise<number> {
+  if (!/^[0-9]+$/.test(issueArg)) {
+    fx.err("issueNumber は正の整数で指定してください。");
+    return 1;
+  }
+  const issueNumber = Number(issueArg);
+  const port = fx.readRelayPort();
+  if (port == null) {
+    fx.err(
+      "Supervisor の relay ポートを発見できません（ポートファイルなし）。" +
+        "Supervisor が起動しているか確認してください。",
+    );
+    return 1;
+  }
+  const payload: Record<string, unknown> = { branch, issueNumber };
+  if (selector !== undefined) payload.selector = selector;
+  let res: { status: number; body: unknown };
+  try {
+    res = await fx.httpPost(`http://127.0.0.1:${port}/hub-work`, payload);
+  } catch (err) {
+    fx.err(
+      `Supervisor への接続に失敗しました (port ${port}): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return 1;
+  }
+  const body = (res.body ?? {}) as Record<string, unknown>;
+  if (res.status === 200 && body.ok === true) {
+    fx.out(
+      `✅ claude-hub work セッションを受け付けました: thread=${String(body.threadId)} ` +
+        `queued=${String(body.queued)} injected=${String(body.injected)}`,
+    );
+    return 0;
+  }
+  fx.err(
+    `❌ hub work 起動に失敗しました (HTTP ${res.status}): ${typeof body.error === "string" ? body.error : JSON.stringify(res.body)}`,
+  );
+  return 1;
+}
+
+/**
+ * CLI エントリ本体（純粋オーケストレーション）。argv はサブコマンド以降
+ * （`process.argv.slice(2)` 相当）。テストは fake effects を注入して呼ぶ。
+ */
+export async function runSessionCtl(
+  argv: string[],
+  fx: SessionCtlEffects,
+  opts: SessionCtlOptions = {},
+): Promise<number> {
+  const [sub, ...rest] = argv;
+  switch (sub) {
+    case "list":
+      return cmdList(fx);
+    case "status": {
+      if (rest.length !== 1 || !rest[0]) {
+        fx.err("使い方: session-ctl status <id>");
+        return 1;
+      }
+      return cmdStatus(fx, rest[0]);
+    }
+    case "send": {
+      const [key, ...words] = rest;
+      if (!key || words.length === 0) {
+        fx.err("使い方: session-ctl send <thread_id|session_id> <text...>");
+        return 1;
+      }
+      return cmdSend(fx, key, words.join(" "));
+    }
+    case "stop": {
+      if (rest.length !== 1 || !rest[0]) {
+        fx.err("使い方: session-ctl stop <id>");
+        return 1;
+      }
+      return cmdStop(fx, rest[0], opts);
+    }
+    case "start-hub-worker": {
+      const [branch, issueArg, selector, ...extra] = rest;
+      if (!branch || !issueArg || extra.length > 0) {
+        fx.err(
+          "使い方: session-ctl start-hub-worker <branch> <issueNumber> [selector]",
+        );
+        return 1;
+      }
+      return cmdStartHubWorker(fx, branch, issueArg, selector);
+    }
+    case "help":
+    case "--help":
+    case "-h":
+      fx.out(USAGE);
+      return 0;
+    default:
+      fx.err(USAGE);
+      return 1;
+  }
+}
+
+/** 実 DB（読み取り専用）+ 実 tmux + 実 HTTP のアダプタを組み立てる。 */
+export function createRealEffects(): SessionCtlEffects {
+  let db: Database | null = null;
+  const getReadonlyDb = (): Database => {
+    if (!db) {
+      const path = resolveDbPath();
+      if (path !== ":memory:" && !existsSync(path)) {
+        throw new Error(
+          `sessions.db が見つかりません: ${path}（Supervisor 未初期化の可能性）`,
+        );
+      }
+      // 読み取り専用で開く（WAL 前提で Supervisor の書き込みと共存できる）。
+      // create しない・書かない = 「書き込みは Supervisor の専権」の機械的担保。
+      db = new Database(path, { readonly: true });
+    }
+    return db;
+  };
+
+  const store: SessionStore = {
+    listRunning: () =>
+      getReadonlyDb()
+        .prepare(
+          `SELECT * FROM sessions WHERE status = 'running' ORDER BY started_at`,
+        )
+        .all() as SessionRow[],
+    findByKey: (key) =>
+      getReadonlyDb()
+        .prepare(
+          `SELECT * FROM sessions
+           WHERE id = ? OR thread_id = ? OR claude_session_id = ?
+           ORDER BY started_at DESC LIMIT 1`,
+        )
+        .get(key, key, key) as SessionRow | undefined,
+    findRunningByKey: (key) =>
+      getReadonlyDb()
+        .prepare(
+          `SELECT * FROM sessions
+           WHERE status = 'running' AND (id = ? OR thread_id = ? OR claude_session_id = ?)
+           ORDER BY started_at DESC LIMIT 1`,
+        )
+        .get(key, key, key) as SessionRow | undefined,
+  };
+
+  return {
+    store,
+    // relay.ts の実績送信経路を共有（既定 TMUX_ARGS = -L claude-hub、RW-019）。
+    sendText: (tmuxName, text) => sendToPane(tmuxName, text),
+    hasTmuxSession: async (name) => {
+      try {
+        await execFileAsync(
+          TMUX_PATH,
+          [...TMUX_ARGS, "has-session", "-t", name],
+          { timeout: 5000 },
+        );
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    killTmuxSession: async (name) => {
+      try {
+        await execFileAsync(
+          TMUX_PATH,
+          [...TMUX_ARGS, "kill-session", "-t", name],
+          { timeout: 5000 },
+        );
+      } catch {
+        // 既に消えている場合は成功扱い（冪等）。
+      }
+    },
+    killPid: (pid, signal) => {
+      try {
+        process.kill(pid, signal);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    pidAlive: (pid) => {
+      try {
+        process.kill(pid, 0);
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+    readRelayPort: () => {
+      try {
+        const raw = readFileSync(relayPortFilePath(), "utf8");
+        const port = Number(raw.trim());
+        return Number.isSafeInteger(port) && port > 0 ? port : null;
+      } catch {
+        return null;
+      }
+    },
+    httpPost: async (url, body) => {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+      });
+      const json = await res.json().catch(() => null);
+      return { status: res.status, body: json };
+    },
+    out: (line) => console.log(line),
+    err: (line) => console.error(line),
+  };
+}
+
+if (import.meta.main) {
+  runSessionCtl(process.argv.slice(2), createRealEffects())
+    .then((code) => process.exit(code))
+    .catch((err) => {
+      console.error(err instanceof Error ? err.message : String(err));
+      process.exit(1);
+    });
+}


### PR DESCRIPTION
Closes #320（Epic #316 Phase 3）

## 概要

オーケストレーター CC セッションがワーカーへ介入するための **session-ctl ローカル CLI** と、CHANNEL_MAP 非経由（#208 案B / ADR-002 D5）で claude-hub タスクを実行する **work セッション経路**を純追加で実装する。

## 主な変更

### session-ctl ローカル CLI（`supervisor/tools/session-ctl.ts`）

- `list` / `status <id>` / `send <thread_id|session_id> <text...>` / `stop <id>` / `start-hub-worker <branch> <issueNumber> [selector]`
- sessions.db は **読み取り専用**（`bun:sqlite` `{readonly:true}`、WAL 前提。書き込みは Supervisor の専権 — Store 面に書き込み API が存在しないことをテストで固定）
- `send` は relay.ts の `sendToPane` を**共有**（copy-mode 解除 → Escape → `send-keys -l` → C-m、argv-no-shell、専用 socket `-L claude-hub` = RW-019）。関数抽出は不要だった（既に export 済み）ため既存コード変更なし
- `stop` は SIGTERM → 猶予（`GRACEFUL_KILL_TIMEOUT_MS`）→ `tmux kill-session`。sessions.db への status 反映は Supervisor の watchTmuxSession（`tmux_exited`）に委ね、CLI は読み取りで反映を確認するのみ。`tmux_exited` 経路は worktree を**意図的に残す**ため、共有 worktree の破壊（RW-046）は構造的に起こらない（`isWorktreePathInUse` で守られる `/session stop` 経路をそもそも通らない）
- fake adapters ユニットテスト（`tests/tools/session-ctl.test.ts`、25 tests）

### claude-hub work セッション経路（`supervisor/src/session/hub-work.ts`、ADR-002 D5 準拠）

- **CHANNEL_MAP に claude-hub を追加しない**（`channels.ts:141-147` FATAL guard 維持。テストで `CHANNEL_MAP.has("claude-hub") === false` を固定）
- ephemeral な `ChannelConfig`（`channelName=claude-hub-work` / `dir=~/claude-hub`）を `CHANNEL_MAP.get()` を通さず `runDispatch` → `SessionManager.start()` へ**明示渡し**（D5-2）。ephemeral config の CHANNEL_MAP 登録は contract として禁止
- ワーカースレッドは **corp チャンネル**配下（D5-3）
- selector 注入（`impl`/`no-template`/`pdca`/`article`/`devcycle` の閉集合 fail-closed）・FIFO キュー（`DispatchQueue`）・admission（WARN-first）・executor mode は**既存 dispatch と同一機構を再利用**（D4: 独自並列制御なし）
- 起動口: relay サーバ（loopback-only bind）の `POST /hub-work` + runtime dir の `relay-port` ポートファイル。`session-ctl start-hub-worker` から叩ける（README に外部起動方法を明記）
- claudeHubExit（hijoguchi）非干渉: access policy / 機械ゲート / `CLAUDE_HUB_HIJOGUCHI_SESSION` env に一切触れない（D5 非干渉条件 1〜5）。復旧経路の独立性は不変

### 既存機能の非破壊（BLOCKING 制約の遵守）

- 既存 `/session *`・`/dispatch`・relay・watchdog のコード経路の**振る舞い変更なし**。既存テストの変更 **0 件**
- 既存ファイルへの変更は全て純追加: relay-server.ts（`/hub-work` ルート + ポートファイル、既存ルート不変）/ bot.ts（ClientReady 内の `onHubWork` 結線のみ）/ db.ts（`resolveDbPath` の外出し、`DB_PATH` の値・評価タイミング不変）

## インターフェース契約（Phase 2 スキル / Phase 4 E2E 向け）

```bash
# cwd: ~/claude-hub（merge 後）
bun run supervisor/tools/session-ctl.ts list
bun run supervisor/tools/session-ctl.ts status <id>
bun run supervisor/tools/session-ctl.ts send <thread_id|session_id> <text...>
bun run supervisor/tools/session-ctl.ts stop <id>
bun run supervisor/tools/session-ctl.ts start-hub-worker <branch> <issueNumber> [selector]
```

起動 prompt の想定インターフェース例 `session-ctl start-hub-worker <branch> <issueNumber> [selector]` をそのまま実装（**契約変更なし**）。`POST /hub-work` の JSON は `{branch, issueNumber, selector?}` → `200 {ok, threadId, queued, injected}`。

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | session-ctl list が sessions.db と一致 | 実 DB（running 3 行）で `session-ctl list` と `sqlite3 ... WHERE status='running'` を照合 | 一致 | 3/3 行の id・channel・thread が完全一致、exit 0 | PASS |
| AC-2 | send がワーカーに届く | `-L claude-hub` socket 上のテスト pane（`cat`）へ `sendToPane` で marker 送信 → `capture-pane` で grep | pane に反映 | marker 2 出現（入力行 + cat エコー = literal と Enter の両方が到達） | PASS |
| AC-3 | stop 後の status 整合 | ユニットテスト（SIGTERM→tmux kill 順序 / DB 無書き込み / watcher 反映の読み取り確認 / worktree 保持） | green | `tests/tools/session-ctl.test.ts` stop 系 3 tests PASS。実機 E2E は Phase 4 #321（稼働中の実ワーカー 3 本を kill しない判断） | PASS（unit）|
| AC-4 | CHANNEL_MAP FATAL guard green | `bun test tests/session/hub-work.test.ts` | green | `CHANNEL_MAP.has("claude-hub")===false` 含む 3 guard tests PASS | PASS |
| AC-5 | 既存テスト全 green | ci.yml curated list を local 3 回実行 | green | 859 pass / 0 fail ×3。local 全体実行の mock-isolated 系 fail は origin/main でも再現する既知の環境起因（main 29 fail vs 本 branch 26 fail、新規 fail なし）。CI を正とする | PASS |

新規テスト: 62 tests / 132 expect（hub-work 22 + relay-server-hub-work 8 + session-ctl 32）。`bunx tsc --noEmit` / check-access-policy / lint-blocking-in-timers / lint-no-sync-exec / lint-gating-coverage すべて green。

## thin-scaffolding self-check

- [x] **6 か月先の model でも gain が残るか**: Y — CHANNEL_MAP 非経由の spawn 経路と読み取り専用 CLI は「復旧経路のメタ依存禁止」という構造制約の実装であり、model 賢化と独立
- [x] **model への指示で代替できないか**: N — Supervisor プロセス内のセッション起動・tmux 送達はコード経路が必要（指示では代替不能）
- [x] **責務は 1 つに絞れているか**: Y — session-ctl = 観測と介入の CLI（DB 書き込みなし）、hub-work = ephemeral config での dispatch 再利用。既存 dispatch/queue/admission は再利用のみで新規ワーカー機構なし
- [x] **失敗観測性はあるか**: Y — /hub-work は 400/500/503 を明示返却（fail-closed）、起動失敗はワーカースレッドへ ❌ 投稿、`[HubWork]` ログ。session-ctl は exit code + stderr
- [x] **対象外の経路を明記したか**: Y — 既存 `/session *`・`/dispatch`・relay・watchdog は非対象（変更 0）。hijoguchi 経路非干渉
- [x] **撤退基準**: session-ctl は Epic #316 の実利用（Phase 5 受け入れ実走）で 30 日間 consumer 不在なら deprecate（agent-output-quality #4）。hub work 経路は corp スレッド混在が運用上辛くなったら専用チャンネル案を再評価（ADR-002 Consequences 準拠）
- [x] **BLOCKING（exit 2）なら WARN-first か**: 対象外（hook ではない。/hub-work は loopback-only + fail-closed 検証）

## 関連

- ADR: `docs/adr/2026-07-05-corp-orchestration.md`（D1/D4/D5）
- RW-019（tmux 専用 socket）/ RW-045（branch guard 再利用）/ RW-046（worktree 共有破壊なし）
- Phase 4 #321 で実 Discord E2E + 既存コマンド回帰を検証予定

🤖 Generated with [Claude Code](https://claude.com/claude-code)
