### PR TITLE
feat(#312): hijoguchi 状態ファイル producer（bot-status.json + heartbeat）

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -193,6 +193,30 @@
           {
             "type": "command",
             "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/hijoguchi-record-channel-context.sh"
+          },
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/hijoguchi-record-turn-state.sh"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/hijoguchi-record-turn-state.sh"
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/scripts/hijoguchi-record-turn-state.sh"
           }
         ]
       }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,6 +245,9 @@ jobs:
       - name: Run claudeHubExit mechanical mention gate tests (#267)
         run: bash scripts/test-hijoguchi-discord-gate.sh
 
+      - name: Run claudeHubExit turn-state producer tests (#312)
+        run: bash scripts/test-hijoguchi-record-turn-state.sh
+
   # E2E verification of the Discord ↔ Supervisor ↔ Claude Code relay chain.
   # Covers AC-4/5/6/7 hermetically (tmux + mock claude + relay-server HTTP).
   # AC-1/2/3 require a live Discord bot token and are documented as manual

--- a/scripts/hijoguchi-record-turn-state.sh
+++ b/scripts/hijoguchi-record-turn-state.sh
@@ -41,7 +41,10 @@ INPUT="$(cat 2>/dev/null)" || exit 0
 # Scope to the hijoguchi session only.
 [ "${CLAUDE_HUB_HIJOGUCHI_SESSION:-0}" = "1" ] || exit 0
 
-STATE_DIR="${CLAUDE_HUB_STATE_DIR:-${HOME}/.claude-hub-state}"
+# ${HOME:-} (not ${HOME}): under set -u an unset HOME (restricted daemon env)
+# would abort here and violate the always-exit-0 contract; with the empty
+# fallback the later mkdir simply fails and we exit 0 without a write.
+STATE_DIR="${CLAUDE_HUB_STATE_DIR:-${HOME:-}/.claude-hub-state}"
 STATUS_FILE="${STATE_DIR}/bot-status.json"
 HEARTBEAT_FILE="${STATE_DIR}/heartbeat"
 

--- a/scripts/hijoguchi-record-turn-state.sh
+++ b/scripts/hijoguchi-record-turn-state.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Turn-state producer for the claudeHubExit (hijoguchi) Bot session (#312).
+#
+# One script, three hook events (dispatched on hook_event_name):
+#
+#   UserPromptSubmit → bot-status.json {state:"processing", since, chat_id,
+#                      mentioned, last_outcome} — a turn has started. When the
+#                      incoming Discord message targets a non-primary channel
+#                      without an @mention, last_outcome:"gate_silenced" is
+#                      pre-recorded (the PreToolUse gate will deny any reply,
+#                      so the turn is intentionally silent; Mac-side log only).
+#   Stop             → bot-status.json {state:"idle", ...} — the turn ended.
+#                      chat_id / mentioned are carried over from the processing
+#                      record; last_outcome becomes "completed" unless the turn
+#                      was gate-silenced (then "gate_silenced" is kept).
+#   PostToolUse      → touch heartbeat — mtime = last in-turn progress. This is
+#                      what lets a reader distinguish a long-but-alive turn
+#                      (heartbeat advancing) from a hung one.
+#
+# FAILSAFE — readers MUST NOT trust `state` alone (push-and-trust is the
+# RW-023 failure shape): if the session crashes mid-turn, Stop never fires and
+# `state:"processing"` sticks forever. Any consumer (the watchdog hang/dead
+# judge, #313) must AND this file with (a) file mtime freshness / heartbeat
+# mtime and (b) liveness of the Bot process before concluding anything.
+#
+# Registered in .claude/settings.json (UserPromptSubmit / Stop / PostToolUse).
+# UserPromptSubmit and Stop have no matcher support and PostToolUse is matched
+# broadly, so scoping is done in-code via CLAUDE_HUB_HIJOGUCHI_SESSION=1: an
+# ordinary `claude` session opened in ~/claude-hub exits after one cheap env
+# check and never writes Bot state. State lives in ~/.claude-hub-state/ (Bot
+# dir, NOT a HOME-global file — RW-058: never let one session's state hook
+# leak into every session on the machine).
+#
+# ALWAYS exits 0: a producer that blocked the prompt/tool path would be worse
+# than a missed status write (readers fail safe on stale/missing files).
+set -u
+
+# Drain stdin first (Claude passes hook JSON) so the producer never blocks.
+INPUT="$(cat 2>/dev/null)" || exit 0
+
+# Scope to the hijoguchi session only.
+[ "${CLAUDE_HUB_HIJOGUCHI_SESSION:-0}" = "1" ] || exit 0
+
+STATE_DIR="${CLAUDE_HUB_STATE_DIR:-${HOME}/.claude-hub-state}"
+STATUS_FILE="${STATE_DIR}/bot-status.json"
+HEARTBEAT_FILE="${STATE_DIR}/heartbeat"
+
+EVENT="$(printf '%s' "${INPUT}" | jq -r '.hook_event_name // empty' 2>/dev/null)" || exit 0
+[ -n "${EVENT}" ] || exit 0
+
+mkdir -p "${STATE_DIR}" 2>/dev/null || exit 0
+NOW="$(date +%s)"
+
+# Atomic publish (temp + mv, same shape as hijoguchi-record-channel-context.sh)
+# so a reader never sees a torn JSON document. $1 = JSON body.
+publish_status() {
+  local tmp="${STATE_DIR}/.bot-status.$$"
+  if printf '%s\n' "$1" > "${tmp}" 2>/dev/null; then
+    mv -f "${tmp}" "${STATUS_FILE}" 2>/dev/null || rm -f "${tmp}" 2>/dev/null || true
+  else
+    rm -f "${tmp}" 2>/dev/null || true
+  fi
+}
+
+case "${EVENT}" in
+  UserPromptSubmit)
+    PROMPT="$(printf '%s' "${INPUT}" | jq -r '.prompt // empty' 2>/dev/null)" || PROMPT=""
+    CHAT_ID=""
+    MENTIONED=""   # "" = not a Discord-envelope prompt → recorded as null
+    OUTCOME=""
+    case "${PROMPT}" in
+      *'source="plugin:discord:discord"'*)
+        # Same envelope parsing as hijoguchi-record-channel-context.sh.
+        CHAT_ID="$(printf '%s' "${PROMPT}" | grep -oE 'chat_id="[0-9]+"' | head -1 | tr -dc '0-9')"
+        MENTIONED=0
+        BOT_MENTION="${HIJOGUCHI_BOT_MENTION:-}"
+        if [ -n "${BOT_MENTION}" ]; then
+          case "${PROMPT}" in
+            *"${BOT_MENTION}"*) MENTIONED=1 ;;
+          esac
+        fi
+        # Non-primary + not mentioned = the gate will silence this turn. An
+        # unset HIJOGUCHI_CHANNEL_ID also lands here: the gate fails closed in
+        # that configuration, so "silenced" is the truthful prediction.
+        if [ -n "${CHAT_ID}" ] && [ "${MENTIONED}" != "1" ] \
+           && [ "${CHAT_ID}" != "${HIJOGUCHI_CHANNEL_ID:-}" ]; then
+          OUTCOME="gate_silenced"
+        fi
+        ;;
+    esac
+    BODY="$(jq -n --argjson since "${NOW}" \
+      --arg chat_id "${CHAT_ID}" --arg mentioned "${MENTIONED}" --arg outcome "${OUTCOME}" \
+      '{state: "processing", since: $since,
+        chat_id: (if $chat_id == "" then null else $chat_id end),
+        mentioned: (if $mentioned == "" then null else $mentioned == "1" end),
+        last_outcome: (if $outcome == "" then null else $outcome end)}' 2>/dev/null)" || exit 0
+    publish_status "${BODY}"
+    ;;
+  Stop)
+    PREV="$(cat "${STATUS_FILE}" 2>/dev/null || true)"
+    if printf '%s' "${PREV}" | jq -e 'type == "object"' >/dev/null 2>&1; then
+      BODY="$(printf '%s' "${PREV}" | jq --argjson since "${NOW}" \
+        '.state = "idle" | .since = $since
+         | .last_outcome = (if .last_outcome == "gate_silenced"
+                            then "gate_silenced" else "completed" end)' 2>/dev/null)" || exit 0
+    else
+      # No / corrupt processing record (e.g. state dir wiped mid-turn): still
+      # publish a well-formed idle record rather than nothing.
+      BODY="$(jq -n --argjson since "${NOW}" \
+        '{state: "idle", since: $since, chat_id: null, mentioned: null,
+          last_outcome: "completed"}' 2>/dev/null)" || exit 0
+    fi
+    publish_status "${BODY}"
+    ;;
+  PostToolUse)
+    # mtime-only heartbeat: proof of in-turn progress for the hang judge.
+    touch "${HEARTBEAT_FILE}" 2>/dev/null || true
+    ;;
+esac
+exit 0

--- a/scripts/test-hijoguchi-record-turn-state.sh
+++ b/scripts/test-hijoguchi-record-turn-state.sh
@@ -25,8 +25,14 @@ run() {
   if "$@"; then echo "PASS ${name}"; else echo "FAIL ${name}"; fail=1; fi
 }
 
+# Track every temp state dir and remove them all on exit (no /tmp leak).
+TEMP_DIRS=()
+cleanup() { [ "${#TEMP_DIRS[@]}" -gt 0 ] && rm -rf "${TEMP_DIRS[@]}"; }
+trap cleanup EXIT
+
 new_state() {
   STATE="$(mktemp -d)"
+  TEMP_DIRS+=("${STATE}")
   export CLAUDE_HUB_STATE_DIR="${STATE}"
 }
 
@@ -149,21 +155,18 @@ run "Stop: corrupt prior record → recovers with idle record" t_stop_with_corru
 
 # ----- PostToolUse (heartbeat) -----
 
-# GNU stat uses -c %Y for mtime; BSD/macOS stat uses -f %m. Try GNU first:
-# on BSD, stat -c errors out and we fall back. (The reverse order is wrong —
-# on GNU, stat -f %m SUCCEEDS but prints filesystem info, not mtime.)
-mtime_of() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"; }
-
 t_heartbeat_touch_and_advance() {
   new_state
   invoke "$(posttool_payload)" || return 1
   [ -e "$(heartbeat_file)" ] || return 1
-  local m1 m2
-  m1="$(mtime_of "$(heartbeat_file)")"
+  # Portable mtime-advance check: mark a reference file AFTER the first touch,
+  # then assert the second touch lands newer via the shell's -nt operator —
+  # no dependency on GNU vs BSD stat flag dialects.
+  local ref="${CLAUDE_HUB_STATE_DIR}/ref"
+  touch "${ref}"
   sleep 1
   invoke "$(posttool_payload)" || return 1
-  m2="$(mtime_of "$(heartbeat_file)")"
-  [ "${m2}" -gt "${m1}" ]
+  [ "$(heartbeat_file)" -nt "${ref}" ]
 }
 run "PostToolUse: heartbeat created and mtime advances" t_heartbeat_touch_and_advance
 

--- a/scripts/test-hijoguchi-record-turn-state.sh
+++ b/scripts/test-hijoguchi-record-turn-state.sh
@@ -1,0 +1,192 @@
+#!/bin/bash
+# Unit tests for the claudeHubExit turn-state producer (#312).
+#
+#   scripts/hijoguchi-record-turn-state.sh
+#     UserPromptSubmit → bot-status.json state=processing (+ gate_silenced
+#                        prediction for non-primary non-mention messages)
+#     Stop             → bot-status.json state=idle (chat ctx carried over)
+#     PostToolUse      → touch heartbeat (mtime advances)
+#
+# Run standalone: bash scripts/test-hijoguchi-record-turn-state.sh
+# Exits 0 on all-pass, 1 on any failure.
+# shellcheck disable=SC2329
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PRODUCER="${SCRIPT_DIR}/hijoguchi-record-turn-state.sh"
+
+PRIMARY="100000000000000001"
+NONPRIM="200000000000000002"
+BOT_MENTION="<@900000000000000009>"
+
+fail=0
+run() {
+  local name="$1"; shift
+  if "$@"; then echo "PASS ${name}"; else echo "FAIL ${name}"; fail=1; fi
+}
+
+new_state() {
+  STATE="$(mktemp -d)"
+  export CLAUDE_HUB_STATE_DIR="${STATE}"
+}
+
+status_file() { echo "${CLAUDE_HUB_STATE_DIR}/bot-status.json"; }
+heartbeat_file() { echo "${CLAUDE_HUB_STATE_DIR}/heartbeat"; }
+
+# UserPromptSubmit payload with a Discord channel envelope. $1=chat_id $2=body
+ups_payload() {
+  local chat="$1" body="$2"
+  local env="<channel source=\"plugin:discord:discord\" chat_id=\"${chat}\" message_id=\"m1\" user=\"u\" ts=\"t\">
+${body}
+</channel>"
+  jq -n --arg p "${env}" '{hook_event_name:"UserPromptSubmit", prompt:$p}'
+}
+
+stop_payload() { jq -n '{hook_event_name:"Stop"}'; }
+posttool_payload() { jq -n '{hook_event_name:"PostToolUse", tool_name:"Bash", tool_response:{}}'; }
+
+invoke() {
+  # $1=payload; remaining env is inherited from the caller's exports.
+  printf '%s' "$1" | CLAUDE_HUB_HIJOGUCHI_SESSION=1 \
+    HIJOGUCHI_CHANNEL_ID="${PRIMARY}" HIJOGUCHI_BOT_MENTION="${BOT_MENTION}" \
+    bash "${PRODUCER}"
+}
+
+jget() { jq -r "$1" "$(status_file)" 2>/dev/null; }
+
+# ----- scope -----
+
+t_scope_off_writes_nothing() {
+  new_state
+  printf '%s' "$(ups_payload "${PRIMARY}" "hello")" | CLAUDE_HUB_HIJOGUCHI_SESSION=0 \
+    bash "${PRODUCER}" || return 1
+  [ ! -e "$(status_file)" ] && [ ! -e "$(heartbeat_file)" ]
+}
+run "scope: env!=1 writes nothing" t_scope_off_writes_nothing
+
+# ----- UserPromptSubmit -----
+
+t_ups_primary_processing() {
+  new_state
+  invoke "$(ups_payload "${PRIMARY}" "hello")" || return 1
+  [ "$(jget .state)" = "processing" ] \
+    && [ "$(jget .chat_id)" = "${PRIMARY}" ] \
+    && [ "$(jget .mentioned)" = "false" ] \
+    && [ "$(jget .last_outcome)" = "null" ] \
+    && jget .since | grep -qE '^[0-9]+$'
+}
+run "UPS: primary message → processing, no gate_silenced" t_ups_primary_processing
+
+t_ups_nonprimary_mentioned() {
+  new_state
+  invoke "$(ups_payload "${NONPRIM}" "hey ${BOT_MENTION} please")" || return 1
+  [ "$(jget .state)" = "processing" ] \
+    && [ "$(jget .mentioned)" = "true" ] \
+    && [ "$(jget .last_outcome)" = "null" ]
+}
+run "UPS: non-primary + mention → processing, no gate_silenced" t_ups_nonprimary_mentioned
+
+t_ups_nonprimary_unmentioned_silenced() {
+  new_state
+  invoke "$(ups_payload "${NONPRIM}" "no mention here")" || return 1
+  [ "$(jget .state)" = "processing" ] \
+    && [ "$(jget .chat_id)" = "${NONPRIM}" ] \
+    && [ "$(jget .mentioned)" = "false" ] \
+    && [ "$(jget .last_outcome)" = "gate_silenced" ]
+}
+run "UPS: non-primary no-mention → last_outcome=gate_silenced" t_ups_nonprimary_unmentioned_silenced
+
+t_ups_non_discord_prompt() {
+  new_state
+  local payload
+  payload="$(jq -n '{hook_event_name:"UserPromptSubmit", prompt:"plain local prompt"}')"
+  invoke "${payload}" || return 1
+  [ "$(jget .state)" = "processing" ] \
+    && [ "$(jget .chat_id)" = "null" ] \
+    && [ "$(jget .mentioned)" = "null" ] \
+    && [ "$(jget .last_outcome)" = "null" ]
+}
+run "UPS: non-Discord prompt → processing with null chat ctx" t_ups_non_discord_prompt
+
+# ----- Stop -----
+
+t_stop_after_processing() {
+  new_state
+  invoke "$(ups_payload "${PRIMARY}" "hello")" || return 1
+  invoke "$(stop_payload)" || return 1
+  [ "$(jget .state)" = "idle" ] \
+    && [ "$(jget .chat_id)" = "${PRIMARY}" ] \
+    && [ "$(jget .last_outcome)" = "completed" ]
+}
+run "Stop: after processing → idle, ctx carried, completed" t_stop_after_processing
+
+t_stop_keeps_gate_silenced() {
+  new_state
+  invoke "$(ups_payload "${NONPRIM}" "no mention")" || return 1
+  invoke "$(stop_payload)" || return 1
+  [ "$(jget .state)" = "idle" ] \
+    && [ "$(jget .last_outcome)" = "gate_silenced" ]
+}
+run "Stop: after silenced turn → idle, gate_silenced kept" t_stop_keeps_gate_silenced
+
+t_stop_without_prior_record() {
+  new_state
+  invoke "$(stop_payload)" || return 1
+  [ "$(jget .state)" = "idle" ] \
+    && [ "$(jget .chat_id)" = "null" ] \
+    && [ "$(jget .last_outcome)" = "completed" ]
+}
+run "Stop: no prior record → well-formed idle record" t_stop_without_prior_record
+
+t_stop_with_corrupt_record() {
+  new_state
+  mkdir -p "${CLAUDE_HUB_STATE_DIR}"
+  printf 'not json' > "$(status_file)"
+  invoke "$(stop_payload)" || return 1
+  [ "$(jget .state)" = "idle" ] && [ "$(jget .last_outcome)" = "completed" ]
+}
+run "Stop: corrupt prior record → recovers with idle record" t_stop_with_corrupt_record
+
+# ----- PostToolUse (heartbeat) -----
+
+t_heartbeat_touch_and_advance() {
+  new_state
+  invoke "$(posttool_payload)" || return 1
+  [ -e "$(heartbeat_file)" ] || return 1
+  local m1 m2
+  m1="$(stat -f %m "$(heartbeat_file)" 2>/dev/null || stat -c %Y "$(heartbeat_file)")"
+  sleep 1
+  invoke "$(posttool_payload)" || return 1
+  m2="$(stat -f %m "$(heartbeat_file)" 2>/dev/null || stat -c %Y "$(heartbeat_file)")"
+  [ "${m2}" -gt "${m1}" ]
+}
+run "PostToolUse: heartbeat created and mtime advances" t_heartbeat_touch_and_advance
+
+t_posttool_does_not_touch_status() {
+  new_state
+  invoke "$(ups_payload "${PRIMARY}" "hello")" || return 1
+  local before after
+  before="$(cat "$(status_file)")"
+  invoke "$(posttool_payload)" || return 1
+  after="$(cat "$(status_file)")"
+  [ "${before}" = "${after}" ]
+}
+run "PostToolUse: bot-status.json untouched" t_posttool_does_not_touch_status
+
+# ----- robustness -----
+
+t_bad_json_exits_zero() {
+  new_state
+  printf 'garbage not json' | CLAUDE_HUB_HIJOGUCHI_SESSION=1 bash "${PRODUCER}"
+}
+run "robustness: garbage stdin → exit 0" t_bad_json_exits_zero
+
+t_atomic_no_temp_leftover() {
+  new_state
+  invoke "$(ups_payload "${PRIMARY}" "hello")" || return 1
+  invoke "$(stop_payload)" || return 1
+  ! ls "${CLAUDE_HUB_STATE_DIR}"/.bot-status.* >/dev/null 2>&1
+}
+run "atomic: no temp files left behind" t_atomic_no_temp_leftover
+
+exit "${fail}"

--- a/scripts/test-hijoguchi-record-turn-state.sh
+++ b/scripts/test-hijoguchi-record-turn-state.sh
@@ -149,15 +149,20 @@ run "Stop: corrupt prior record → recovers with idle record" t_stop_with_corru
 
 # ----- PostToolUse (heartbeat) -----
 
+# GNU stat uses -c %Y for mtime; BSD/macOS stat uses -f %m. Try GNU first:
+# on BSD, stat -c errors out and we fall back. (The reverse order is wrong —
+# on GNU, stat -f %m SUCCEEDS but prints filesystem info, not mtime.)
+mtime_of() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1"; }
+
 t_heartbeat_touch_and_advance() {
   new_state
   invoke "$(posttool_payload)" || return 1
   [ -e "$(heartbeat_file)" ] || return 1
   local m1 m2
-  m1="$(stat -f %m "$(heartbeat_file)" 2>/dev/null || stat -c %Y "$(heartbeat_file)")"
+  m1="$(mtime_of "$(heartbeat_file)")"
   sleep 1
   invoke "$(posttool_payload)" || return 1
-  m2="$(stat -f %m "$(heartbeat_file)" 2>/dev/null || stat -c %Y "$(heartbeat_file)")"
+  m2="$(mtime_of "$(heartbeat_file)")"
   [ "${m2}" -gt "${m1}" ]
 }
 run "PostToolUse: heartbeat created and mtime advances" t_heartbeat_touch_and_advance


### PR DESCRIPTION
Closes #312（Epic #315 Phase 1）

## 目的

hijoguchi Bot の状態（processing / idle / 心拍）を `~/.claude-hub-state/` にイベント駆動で書き出す producer を追加する。ポーリング新設なし・新規常駐プロセスなし。後続 #313（watchdog hang/dead 判定）の source of truth になる。

## 主な変更

| ファイル | 内容 |
|---|---|
| `scripts/hijoguchi-record-turn-state.sh` | 新規。単一スクリプトで UserPromptSubmit（processing）/ Stop（idle）/ PostToolUse（heartbeat touch）を `hook_event_name` で分岐 |
| `.claude/settings.json` | Stop / PostToolUse hook を新規登録、UserPromptSubmit に producer を追加 |
| `scripts/test-hijoguchi-record-turn-state.sh` | 新規。13 ケース（scope / envelope 解析 / gate_silenced / Stop 遷移 / heartbeat / robustness / atomic） |
| `.github/workflows/ci.yml` | routing-tests ジョブに新テストを追加 |

## 設計ポイント（Issue #312 準拠）

- atomic 書込（temp+mv、既存 record-channel-context.sh と同型）
- `CLAUDE_HUB_HIJOGUCHI_SESSION=1` で Bot セッションのみに scope
- 非 Primary + 非メンション → `last_outcome: "gate_silenced"` を併記（Mac 側ログ用、gate の判定と同一述語）
- queued(N) は非実装（--channels plugin の直列化により観測不能、Issue 記載通り）
- **push-and-trust 禁止**: 読む側は「mtime 鮮度 + プロセス生存」と AND で判定する前提をスクリプトヘッダに明記（RW-023 同型対策）
- 状態 dir は `~/.claude-hub-state/` 限定（RW-058: HOME 直下グローバル状態の禁止）

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | ターン開始で state=processing | bash scripts/test-hijoguchi-record-turn-state.sh（UPS 4 ケース） | PASS | PASS | PASS |
| AC-2 | ターン完了で state=idle + since 更新 | 同上（Stop 4 ケース） | PASS | PASS | PASS |
| AC-3 | ツール実行で heartbeat mtime 単調増加 | 同上（PostToolUse 2 ケース） | PASS | PASS | PASS |

全体: 13/13 PASS（unit）。既存回帰: test-start-hijoguchi 35 PASS / test-hijoguchi-routing 29 PASS / test-hijoguchi-discord-gate 19 PASS。

注: 統合ジャーニーAC の実 Discord 経由確認は hook payload を忠実に再現した hermetic テストで代替（実 Bot での通し確認は #313 の watchdog 結線時に実施予定）。

## テスト方法

```bash
bash scripts/test-hijoguchi-record-turn-state.sh
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ターン状態を記録・更新する新しい仕組みが追加されました。
  * 実行中の状態やハートビートを保持し、処理の進行状況をより追跡しやすくなりました。

* **Tests**
  * ターン状態の記録・復旧・更新に関するテストが追加されました。
  * CI でも関連テストが自動実行されるようになりました。

* **Chores**
  * フック設定にターン状態記録の処理が組み込まれました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->