### PR TITLE
feat(#313): watchdog に hang/dead 判定と Pushover/terminal-notifier 通知を追加（WARN-first）

### DIFF
--- a/scripts/start-hijoguchi.sh
+++ b/scripts/start-hijoguchi.sh
@@ -84,6 +84,187 @@ if [ "${HIJOGUCHI_IDLE_DECISION_ONLY:-0}" = "1" ]; then
 fi
 # ---------------------------------------------------------------------------
 
+# --- Health: hang / dead detection + notify (Issue #313, Epic #315) ---------
+# Folds hang/dead judgement into the existing 10s poll loop (no new resident
+# process). Reads the state files written by the #312 producer
+# (scripts/hijoguchi-record-turn-state.sh):
+#   bot-status.json  {state:"processing"|"idle", since, ...}
+#   heartbeat        mtime = last in-turn tool progress
+#
+# The producer's state flag is NEVER trusted alone (RW-023 push-and-trust): a
+# crash mid-turn leaves state=processing forever, so "hang" additionally
+# requires a stale progress clock AND no busy child process under the pane
+# (an in-flight long tool call is progress even before PostToolUse fires).
+#
+# WARN-first (thin-scaffolding): notify only — no automatic kill/reset here.
+# Escalation to auto-recovery is a separate decision after a false-positive-
+# free dogfood period.
+#
+# Notifications are EDGE-TRIGGERED via a sentinel file: one incident = one
+# push (hang or dead), one recovery = one push, nothing for idle/processing
+# (RW-058 "failure-transition-only" shape).
+HIJOGUCHI_HANG_SEC="${HIJOGUCHI_HANG_SEC:-540}"
+# Crash-loop: N session deaths within WINDOW seconds → "dead". launchd
+# KeepAlive absorbs a single crash silently (self-healing, not actionable);
+# only the loop is worth a push.
+HIJOGUCHI_CRASHLOOP_N="${HIJOGUCHI_CRASHLOOP_N:-3}"
+HIJOGUCHI_CRASHLOOP_WINDOW_SEC="${HIJOGUCHI_CRASHLOOP_WINDOW_SEC:-180}"
+BOT_STATUS_FILE="${CLAUDE_HUB_STATE_DIR}/bot-status.json"
+HEARTBEAT_FILE="${CLAUDE_HUB_STATE_DIR}/heartbeat"
+HEALTH_SENTINEL_FILE="${CLAUDE_HUB_STATE_DIR}/health-incident"
+RESTART_LOG_FILE="${CLAUDE_HUB_STATE_DIR}/restart-log"
+HIJOGUCHI_PUSHOVER_CMD="${HIJOGUCHI_PUSHOVER_CMD:-${HOME}/.claude/scripts/pushover-notify.sh}"
+HIJOGUCHI_NOTIFIER_CMD="${HIJOGUCHI_NOTIFIER_CMD:-/opt/homebrew/bin/terminal-notifier}"
+
+# GNU stat uses -c %Y for mtime; BSD/macOS uses -f %m. GNU must be tried
+# first: on GNU, `stat -f %m` SUCCEEDS but prints filesystem info, not mtime.
+hijoguchi_mtime_of() { stat -c %Y "$1" 2>/dev/null || stat -f %m "$1" 2>/dev/null; }
+
+# Best-effort dual notify (Pushover for iPhone, terminal-notifier for at-desk).
+# Both mockable via env for tests; a missing binary must never wedge the loop.
+hijoguchi_notify() { # $1 = title, $2 = message
+  if [ -r "${HIJOGUCHI_PUSHOVER_CMD}" ] || command -v "${HIJOGUCHI_PUSHOVER_CMD}" >/dev/null 2>&1; then
+    bash "${HIJOGUCHI_PUSHOVER_CMD}" "$1" "$2" >/dev/null 2>&1 || true
+  fi
+  if command -v "${HIJOGUCHI_NOTIFIER_CMD}" >/dev/null 2>&1; then
+    "${HIJOGUCHI_NOTIFIER_CMD}" -title "$1" -message "$2" >/dev/null 2>&1 || true
+  fi
+}
+
+# Busy-child probe (lightweight bash take on the #279/#307 busy primitive —
+# NO code coupling to auto-reap; hijoguchi is outside sessions.db). Any
+# descendant of the tmux pane beyond the claude process itself means a tool
+# subprocess is running = real work in flight. Overridable for tests. Any
+# probe failure reports busy (1): suppressing a hang push is the fail-safe
+# direction under WARN-first.
+hijoguchi_busy_children() {
+  if [ -n "${HIJOGUCHI_BUSY_OVERRIDE:-}" ]; then
+    printf '%s\n' "${HIJOGUCHI_BUSY_OVERRIDE}"
+    return 0
+  fi
+  local pane_pid kids k
+  pane_pid="$("${TMUX_BIN}" list-panes -t "${SESSION}" -F '#{pane_pid}' 2>/dev/null | head -1)"
+  if ! [[ "${pane_pid}" =~ ^[0-9]+$ ]]; then
+    echo 1; return 0   # cannot probe → assume busy (fail safe, no false push)
+  fi
+  kids="$(pgrep -P "${pane_pid}" 2>/dev/null)"
+  for k in ${kids}; do
+    if pgrep -P "${k}" >/dev/null 2>&1; then
+      echo 1; return 0
+    fi
+  done
+  echo 0
+}
+
+# Classify current health: prints "hang" or "ok". "dead" is judged separately
+# from the restart log (a dead session can't be probed from inside the poll
+# loop — the loop only runs while tmux has-session is true).
+hijoguchi_health_state() {
+  local hang_sec="${HIJOGUCHI_HANG_SEC}" state since hb last_progress now
+  if ! [[ "${hang_sec}" =~ ^[1-9][0-9]*$ ]]; then
+    echo ok; return 0   # opt-out / bad threshold → never flag
+  fi
+  [ -r "${BOT_STATUS_FILE}" ] || { echo ok; return 0; }
+  state="$(jq -r '.state // empty' "${BOT_STATUS_FILE}" 2>/dev/null)"
+  [ "${state}" = "processing" ] || { echo ok; return 0; }
+  since="$(jq -r '.since // empty' "${BOT_STATUS_FILE}" 2>/dev/null)"
+  [[ "${since}" =~ ^[0-9]+$ ]] || { echo ok; return 0; }
+  # Last progress = the NEWER of turn start and heartbeat mtime. A stale
+  # heartbeat left over from the previous turn must not flag a turn that has
+  # only just started (false hang at turn boundary).
+  last_progress="${since}"
+  hb="$(hijoguchi_mtime_of "${HEARTBEAT_FILE}")"
+  if [[ "${hb}" =~ ^[0-9]+$ ]] && [ "${hb}" -gt "${last_progress}" ]; then
+    last_progress="${hb}"
+  fi
+  now="${HIJOGUCHI_NOW_EPOCH:-$(date +%s)}"
+  if [ $(( now - last_progress )) -le "${hang_sec}" ]; then
+    echo ok; return 0
+  fi
+  if [ "$(hijoguchi_busy_children)" = "1" ]; then
+    echo ok; return 0   # long single tool call still running = progress
+  fi
+  echo hang
+}
+
+# One edge-triggered health tick. Called every poll while the session is
+# alive. Sentinel transitions:
+#   no sentinel + hang       → write sentinel(hang), notify HANG (once)
+#   sentinel(hang) + ok      → clear, notify RECOVERED
+#   sentinel(dead) + stable  → clear, notify RECOVERED (stable = last crash
+#                              older than the crash-loop window; clearing on
+#                              the first tick would re-arm and re-push on
+#                              every bounce of an ongoing crash loop)
+hijoguchi_health_tick() {
+  local st sentinel="" now last_crash
+  st="$(hijoguchi_health_state)"
+  [ -r "${HEALTH_SENTINEL_FILE}" ] && sentinel="$(cat "${HEALTH_SENTINEL_FILE}" 2>/dev/null)"
+  if [ "${st}" = "hang" ]; then
+    if [ -z "${sentinel}" ]; then
+      mkdir -p "${CLAUDE_HUB_STATE_DIR}" 2>/dev/null
+      printf 'hang\n' > "${HEALTH_SENTINEL_FILE}" 2>/dev/null || true
+      hijoguchi_notify "claudeHubExit HANG" \
+        "processing but no progress for >${HIJOGUCHI_HANG_SEC}s (heartbeat stale, no busy child). WARN-first: not auto-killed."
+    fi
+    return 0
+  fi
+  case "${sentinel}" in
+    hang)
+      rm -f "${HEALTH_SENTINEL_FILE}" 2>/dev/null
+      hijoguchi_notify "claudeHubExit RECOVERED" "recovered from hang (turn progressed or completed)."
+      ;;
+    dead)
+      now="${HIJOGUCHI_NOW_EPOCH:-$(date +%s)}"
+      last_crash="$(tail -1 "${RESTART_LOG_FILE}" 2>/dev/null)"
+      if ! [[ "${last_crash}" =~ ^[0-9]+$ ]] \
+         || [ $(( now - last_crash )) -gt "${HIJOGUCHI_CRASHLOOP_WINDOW_SEC}" ]; then
+        rm -f "${HEALTH_SENTINEL_FILE}" 2>/dev/null
+        hijoguchi_notify "claudeHubExit RECOVERED" "recovered from crash loop (session stable again)."
+      fi
+      ;;
+  esac
+  return 0
+}
+
+# Record one unexpected session death and judge crash-loop. Prints "DEAD" and
+# notifies (edge-triggered) when HIJOGUCHI_CRASHLOOP_N deaths landed within
+# HIJOGUCHI_CRASHLOOP_WINDOW_SEC; prints "OK" otherwise. Intentional idle
+# resets must NOT call this — they are scheduled, not crashes.
+hijoguchi_note_crash() {
+  local now pruned count sentinel=""
+  now="${HIJOGUCHI_NOW_EPOCH:-$(date +%s)}"
+  mkdir -p "${CLAUDE_HUB_STATE_DIR}" 2>/dev/null
+  printf '%s\n' "${now}" >> "${RESTART_LOG_FILE}" 2>/dev/null || true
+  # Prune entries older than the window (keeps the log tiny and the count O(N)).
+  pruned="$(awk -v cutoff=$(( now - HIJOGUCHI_CRASHLOOP_WINDOW_SEC )) \
+    '$1 ~ /^[0-9]+$/ && $1 >= cutoff' "${RESTART_LOG_FILE}" 2>/dev/null)"
+  printf '%s\n' "${pruned}" > "${RESTART_LOG_FILE}" 2>/dev/null || true
+  count="$(grep -c '[0-9]' "${RESTART_LOG_FILE}" 2>/dev/null || echo 0)"
+  if [ "${count}" -ge "${HIJOGUCHI_CRASHLOOP_N}" ]; then
+    [ -r "${HEALTH_SENTINEL_FILE}" ] && sentinel="$(cat "${HEALTH_SENTINEL_FILE}" 2>/dev/null)"
+    if [ "${sentinel}" != "dead" ]; then
+      printf 'dead\n' > "${HEALTH_SENTINEL_FILE}" 2>/dev/null || true
+      hijoguchi_notify "claudeHubExit DEAD" \
+        "crash loop: ${count} session deaths within ${HIJOGUCHI_CRASHLOOP_WINDOW_SEC}s (launchd keeps restarting)."
+    fi
+    echo "DEAD"; return 0
+  fi
+  echo "OK"; return 0
+}
+
+# Dry-run hooks for tests (same pattern as HIJOGUCHI_IDLE_DECISION_ONLY;
+# placed before the required-env checks so health logic is testable without
+# channel/bot IDs).
+if [ "${HIJOGUCHI_HEALTH_TICK_ONLY:-0}" = "1" ]; then
+  hijoguchi_health_tick
+  exit 0
+fi
+if [ "${HIJOGUCHI_CRASH_NOTE_ONLY:-0}" = "1" ]; then
+  hijoguchi_note_crash
+  exit 0
+fi
+# ---------------------------------------------------------------------------
+
 # System-prompt file for `claude --append-system-prompt`. Overridable via env
 # so tests / alt deploys can swap it. S3 (#49) populates the real content.
 SYSTEM_PROMPT_FILE="${SYSTEM_PROMPT_FILE:-${CLAUDE_HUB_DIR}/scripts/hijoguchi-system-prompt.md}"
@@ -269,15 +450,27 @@ while true; do
 
   # Block while the session exists. Every HIJOGUCHI_IDLE_POLL_SEC, re-check
   # whether the session has been idle past the reset threshold; if so, kill it
-  # so the outer loop restarts claude with a fresh context.
+  # so the outer loop restarts claude with a fresh context. The same tick also
+  # runs the hang/dead health judgement (#313) — no extra polling loop.
+  INTENTIONAL_RESTART=0
   while "${TMUX_BIN}" has-session -t "${SESSION}" 2>/dev/null; do
     if [ "$(hijoguchi_idle_should_reset)" = "RESET" ]; then
       echo "[hijoguchi] idle >= ${HIJOGUCHI_IDLE_RESET_MIN}min, resetting session for fresh context at $(date)" >&2
+      INTENTIONAL_RESTART=1
       "${TMUX_BIN}" kill-session -t "${SESSION}" 2>/dev/null
       break
     fi
+    hijoguchi_health_tick
     sleep "${HIJOGUCHI_IDLE_POLL_SEC}"
   done
+
+  # An unexpected death (not the scheduled idle reset) counts toward the
+  # crash-loop judgement; a scheduled reset is not a crash.
+  if [ "${INTENTIONAL_RESTART}" = "0" ]; then
+    if [ "$(hijoguchi_note_crash)" = "DEAD" ]; then
+      echo "[hijoguchi] crash loop detected (>=${HIJOGUCHI_CRASHLOOP_N} deaths in ${HIJOGUCHI_CRASHLOOP_WINDOW_SEC}s) at $(date)" >&2
+    fi
+  fi
 
   echo "[hijoguchi] session '${SESSION}' ended at $(date), backing off ${BACKOFF_SEC}s" >&2
   sleep "${BACKOFF_SEC}"

--- a/scripts/test-start-hijoguchi.sh
+++ b/scripts/test-start-hijoguchi.sh
@@ -385,6 +385,166 @@ t35_invalid_poll_sec_falls_back() {
     | grep -Fq "invalid HIJOGUCHI_IDLE_POLL_SEC"
 }
 
+# ----- health: hang / dead detection + edge-triggered notify (#313) ---------
+# All health tests run through the HIJOGUCHI_HEALTH_TICK_ONLY /
+# HIJOGUCHI_CRASH_NOTE_ONLY dry-run hooks with mocked notify commands that
+# append one line per call to a counter file — so "exactly one push per
+# incident" is asserted by line count, no real Pushover / terminal-notifier.
+
+# Create an isolated health-test env. Sets HDIR (state dir), NOTIFY_LOG and
+# exports a mock for both notify channels.
+health_env() {
+  HDIR="$(mktemp -d)"
+  NOTIFY_LOG="${HDIR}/notify.log"
+  MOCK_NOTIFY="${HDIR}/mock-notify.sh"
+  printf '#!/bin/bash\necho "$1" >> "%s"\n' "${NOTIFY_LOG}" > "${MOCK_NOTIFY}"
+  chmod +x "${MOCK_NOTIFY}"
+}
+
+# Run one health tick. Args are extra env VAR=VAL pairs.
+health_tick() {
+  env "$@" \
+    HIJOGUCHI_HEALTH_TICK_ONLY=1 \
+    CLAUDE_HUB_STATE_DIR="${HDIR}" \
+    HIJOGUCHI_PUSHOVER_CMD="${MOCK_NOTIFY}" \
+    HIJOGUCHI_NOTIFIER_CMD="${MOCK_NOTIFY}" \
+    bash "${TARGET}" >/dev/null 2>&1
+}
+
+# Record one crash via the dry-run hook; prints DEAD/OK on stdout.
+health_crash() {
+  env "$@" \
+    HIJOGUCHI_CRASH_NOTE_ONLY=1 \
+    CLAUDE_HUB_STATE_DIR="${HDIR}" \
+    HIJOGUCHI_PUSHOVER_CMD="${MOCK_NOTIFY}" \
+    HIJOGUCHI_NOTIFIER_CMD="${MOCK_NOTIFY}" \
+    bash "${TARGET}" 2>/dev/null
+}
+
+notify_count() { grep -c . "${NOTIFY_LOG}" 2>/dev/null || echo 0; }
+
+# Write a processing bot-status.json with the given since epoch.
+write_processing() {
+  printf '{"state":"processing","since":%s,"chat_id":"c1","mentioned":true,"last_outcome":null}\n' "$1" \
+    > "${HDIR}/bot-status.json"
+}
+
+# T36: processing + stale heartbeat + no busy child → exactly one HANG push
+# on each of the two notify channels (mock is shared → 2 lines).
+t36_hang_detected_notifies_once() {
+  health_env
+  write_processing 1577836000                 # turn started before the heartbeat
+  touch -t 202001010000 "${HDIR}/heartbeat"   # mtime = 1577836800 (2020-01-01)
+  health_tick HIJOGUCHI_NOW_EPOCH=1577840000 HIJOGUCHI_BUSY_OVERRIDE=0 || return 1
+  [ "$(cat "${HDIR}/health-incident" 2>/dev/null)" = "hang" ] \
+    && [ "$(notify_count)" = "2" ] \
+    && grep -Fq "claudeHubExit HANG" "${NOTIFY_LOG}"
+}
+
+# T37: repeated ticks in the same incident add no notifications (edge trigger).
+t37_hang_edge_triggered_no_repeat() {
+  health_env
+  write_processing 1577836000
+  touch -t 202001010000 "${HDIR}/heartbeat"
+  health_tick HIJOGUCHI_NOW_EPOCH=1577840000 HIJOGUCHI_BUSY_OVERRIDE=0 || return 1
+  health_tick HIJOGUCHI_NOW_EPOCH=1577840010 HIJOGUCHI_BUSY_OVERRIDE=0 || return 1
+  health_tick HIJOGUCHI_NOW_EPOCH=1577840020 HIJOGUCHI_BUSY_OVERRIDE=0 || return 1
+  [ "$(notify_count)" = "2" ]
+}
+
+# T38: back to idle → one RECOVERED push (2 mock lines) + sentinel cleared.
+t38_recovered_clears_sentinel() {
+  health_env
+  write_processing 1577836000
+  touch -t 202001010000 "${HDIR}/heartbeat"
+  health_tick HIJOGUCHI_NOW_EPOCH=1577840000 HIJOGUCHI_BUSY_OVERRIDE=0 || return 1
+  printf '{"state":"idle","since":1577840050,"chat_id":"c1","mentioned":true,"last_outcome":"completed"}\n' \
+    > "${HDIR}/bot-status.json"
+  health_tick HIJOGUCHI_NOW_EPOCH=1577840060 HIJOGUCHI_BUSY_OVERRIDE=0 || return 1
+  [ ! -e "${HDIR}/health-incident" ] \
+    && [ "$(notify_count)" = "4" ] \
+    && grep -Fq "claudeHubExit RECOVERED" "${NOTIFY_LOG}"
+}
+
+# T39: busy child present → no hang push even with a stale heartbeat
+# (a long-running single tool call is progress; devils-advocate F1 = always
+# AND with liveness).
+t39_busy_child_suppresses_hang() {
+  health_env
+  write_processing 1577836000
+  touch -t 202001010000 "${HDIR}/heartbeat"
+  health_tick HIJOGUCHI_NOW_EPOCH=1577840000 HIJOGUCHI_BUSY_OVERRIDE=1 || return 1
+  [ ! -e "${HDIR}/health-incident" ] && [ "$(notify_count)" = "0" ]
+}
+
+# T40: a turn that has only just started must not be flagged even though the
+# heartbeat file is stale from the PREVIOUS turn (last-progress = max(since,
+# heartbeat), false-hang-at-turn-boundary guard).
+t40_fresh_turn_stale_heartbeat_ok() {
+  health_env
+  write_processing 1577839990   # turn started 10s before "now"
+  touch -t 202001010000 "${HDIR}/heartbeat"
+  health_tick HIJOGUCHI_NOW_EPOCH=1577840000 HIJOGUCHI_BUSY_OVERRIDE=0 || return 1
+  [ ! -e "${HDIR}/health-incident" ] && [ "$(notify_count)" = "0" ]
+}
+
+# T41: idle / missing status file → never flags, never notifies.
+t41_idle_or_missing_status_ok() {
+  health_env
+  health_tick HIJOGUCHI_NOW_EPOCH=100000 HIJOGUCHI_BUSY_OVERRIDE=0 || return 1
+  printf '{"state":"idle","since":1000}\n' > "${HDIR}/bot-status.json"
+  health_tick HIJOGUCHI_NOW_EPOCH=100000 HIJOGUCHI_BUSY_OVERRIDE=0 || return 1
+  [ ! -e "${HDIR}/health-incident" ] && [ "$(notify_count)" = "0" ]
+}
+
+# T42: crash loop — 3rd death within the window prints DEAD and pushes once;
+# a 4th death does not re-push (edge trigger on the dead sentinel).
+t42_crashloop_dead_once() {
+  health_env
+  [ "$(health_crash HIJOGUCHI_NOW_EPOCH=100000)" = "OK" ] || return 1
+  [ "$(health_crash HIJOGUCHI_NOW_EPOCH=100020)" = "OK" ] || return 1
+  [ "$(health_crash HIJOGUCHI_NOW_EPOCH=100040)" = "DEAD" ] || return 1
+  [ "$(notify_count)" = "2" ] || return 1
+  grep -Fq "claudeHubExit DEAD" "${NOTIFY_LOG}" || return 1
+  [ "$(health_crash HIJOGUCHI_NOW_EPOCH=100060)" = "DEAD" ] || return 1
+  [ "$(notify_count)" = "2" ]
+}
+
+# T43: spaced-out single crashes never reach DEAD (launchd self-heals those).
+t43_spaced_crashes_ok() {
+  health_env
+  [ "$(health_crash HIJOGUCHI_NOW_EPOCH=100000)" = "OK" ] || return 1
+  [ "$(health_crash HIJOGUCHI_NOW_EPOCH=101000)" = "OK" ] || return 1
+  [ "$(health_crash HIJOGUCHI_NOW_EPOCH=102000)" = "OK" ] || return 1
+  [ "$(notify_count)" = "0" ]
+}
+
+# T44: dead sentinel is NOT cleared while crashes are still recent (would
+# re-arm and re-push every bounce), and IS cleared once the last crash ages
+# past the window.
+t44_dead_recovery_requires_stability() {
+  health_env
+  health_crash HIJOGUCHI_NOW_EPOCH=100000 >/dev/null
+  health_crash HIJOGUCHI_NOW_EPOCH=100020 >/dev/null
+  health_crash HIJOGUCHI_NOW_EPOCH=100040 >/dev/null   # → dead sentinel + push
+  printf '{"state":"idle","since":100050}\n' > "${HDIR}/bot-status.json"
+  health_tick HIJOGUCHI_NOW_EPOCH=100060 HIJOGUCHI_BUSY_OVERRIDE=0 || return 1
+  [ "$(cat "${HDIR}/health-incident" 2>/dev/null)" = "dead" ] || return 1   # still armed
+  [ "$(notify_count)" = "2" ] || return 1
+  health_tick HIJOGUCHI_NOW_EPOCH=100400 HIJOGUCHI_BUSY_OVERRIDE=0 || return 1  # window passed
+  [ ! -e "${HDIR}/health-incident" ] \
+    && [ "$(notify_count)" = "4" ] \
+    && grep -Fq "claudeHubExit RECOVERED" "${NOTIFY_LOG}"
+}
+
+# T45: hang threshold opt-out (non-numeric / empty) never flags.
+t45_hang_threshold_optout() {
+  health_env
+  write_processing 1000
+  health_tick HIJOGUCHI_NOW_EPOCH=100000 HIJOGUCHI_BUSY_OVERRIDE=0 HIJOGUCHI_HANG_SEC=abc || return 1
+  [ ! -e "${HDIR}/health-incident" ] && [ "$(notify_count)" = "0" ]
+}
+
 run "T1 channel ID expanded"          t1_channel_id_expanded
 run "T2 no residual {{}} tokens"      t2_no_residual_tokens
 run "T3 env override works"           t3_env_override
@@ -420,6 +580,16 @@ run "T32 hook writes in session"      t32_hook_writes_when_in_session
 run "T33 hook no-op without marker"   t33_hook_noop_without_marker
 run "T34 launch cmd has env prefix"   t34_launch_cmd_has_env_prefix
 run "T35 invalid poll sec falls back" t35_invalid_poll_sec_falls_back
+run "T36 hang detected notifies once" t36_hang_detected_notifies_once
+run "T37 hang edge trigger no repeat" t37_hang_edge_triggered_no_repeat
+run "T38 recovered clears sentinel"   t38_recovered_clears_sentinel
+run "T39 busy child suppresses hang"  t39_busy_child_suppresses_hang
+run "T40 fresh turn stale hb ok"      t40_fresh_turn_stale_heartbeat_ok
+run "T41 idle/missing status ok"      t41_idle_or_missing_status_ok
+run "T42 crash loop dead once"        t42_crashloop_dead_once
+run "T43 spaced crashes ok"           t43_spaced_crashes_ok
+run "T44 dead recovery needs stability" t44_dead_recovery_requires_stability
+run "T45 hang threshold opt-out"      t45_hang_threshold_optout
 
 if [ "${fail}" -eq 0 ]; then
   echo "ALL TESTS PASSED"


### PR DESCRIPTION
Closes #313（Epic #315 Phase 1）

## 目的

hijoguchi Bot の **hang（生存だがターンが終わらない）/ dead（crash-loop）** を既存 watchdog の 10 秒ループに畳み込んで検知し、異常遷移時のみ Pushover + terminal-notifier で通知する。新規常駐プロセス 0・WARN-first（自動 kill/reset なし）。

## 判定ロジック

| 状態 | 条件 |
|---|---|
| hang | `bot-status.json` が processing **AND** `now - max(since, heartbeat mtime) > HANG_SEC`（既定 540s、env 上書き可） **AND** busy 子プロセス無し |
| dead | 意図的 idle reset を除く crash が 180s 窓内に 3 回（launchd KeepAlive が自己回復する単発 crash は通知しない） |
| recovered | hang: 状態が ok に戻ったら 1 通 / dead: 最終 crash が窓を抜けて安定してから 1 通（bounce 毎の再通知防止） |

設計上の要点:

- **push-and-trust 禁止（RW-023 同型対策）**: state フラグ単独では判定せず、進捗時計（max(since, heartbeat)）+ busy 子プロセス probe と AND。turn 開始直後に前ターンの古い heartbeat で誤検知しないよう `since` との max を取る
- **busy probe**: tmux pane の子孫プロセス有無を pgrep で軽量確認（#279/#307 の発想のみ流用、コード結合なし）。probe 失敗時は busy 扱い = 通知抑制側に倒す
- **エッジトリガ**: sentinel ファイルで 1 インシデント 1 通知（RW-058「failure 遷移時のみ通知」と同型）
- 通知経路は env で mock 可能（`HIJOGUCHI_PUSHOVER_CMD` / `HIJOGUCHI_NOTIFIER_CMD`）

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | hang 状態で通知が各 1 通 | bash scripts/test-start-hijoguchi.sh（T36） | mock 呼出 2 行 | 2 行 | PASS |
| AC-2 | 追加 tick で再通知なし | 同上（T37） | 2 行のまま | 2 行 | PASS |
| AC-3 | idle 復帰で recovered 1 通 + sentinel 消滅 | 同上（T38） | 4 行 + sentinel 不在 | 一致 | PASS |
| AC-4 | crash-loop 3 回で DEAD 1 通・4 回目再通知なし | 同上（T42/T43/T44） | エッジトリガ動作 | 一致 | PASS |

全体: T36–T45 の 10 ケース + 既存 T1–T35 = 45/45 PASS。routing 29 / gate 19 も回帰なし。

注: AC-4 の実機（tmux kill → launchd 再起動）確認は、#312 producer と本 PR がマージされ Bot 再起動した後の Epic #315 クローズ判定時に実施する。

## WARN-first dogfood / 撤退基準

- 導入初期は通知のみ。数日 false positive ゼロを確認後に自動回収（既存 idle reset 委譲）を検討
- false positive が出たら `HIJOGUCHI_HANG_SEC` を 480–600s の範囲で緩める。同型 FP 3 回で設計見直し（Epic #315 撤退基準）

## 依存

- 実行時に #312 の producer（PR #330）が書く `bot-status.json` / `heartbeat` を読む。ファイル不在時は常に ok 判定（fail-safe）なので、マージ順序はどちらが先でも安全
