### PR TITLE
perf(#310): hook fan-out 計測ハーネス + 登録削減レポート（spawn -56〜-75%）

### DIFF
--- a/docs/hook-fanout-reduction-310.md
+++ b/docs/hook-fanout-reduction-310.md
@@ -1,0 +1,86 @@
+# hook fan-out 削減レポート（Issue #310）
+
+日付: 2026-07-06 / 親: #302（TUI 描画とは別軸の hook spawn 負荷）
+
+## 計測手段
+
+`scripts/measure-hook-fanout.py` — 全 hook ソース（`~/.claude/settings.json`・
+installed_plugins.json が指す ECC plugin hooks.json・project settings.json）を parse し、
+matcher 適用後の per-call spawn 数を決定的に算出。`--time` で各 hook を合成 payload
+（`cwd` は throwaway /tmp dir → supervisor relay hook は早期 exit）で実行し median ms を計測。
+
+注意: ms は**逐次合計**（Claude Code は hook を並列実行するため latency ではなく CPU 総量の proxy）。
+
+## 結果（before → after）
+
+| tool | spawns | 逐次合計 ms |
+|---|---|---|
+| Bash | 19 → **8**（-58%） | 3,899 → 2,016（-48%） |
+| Edit | 16 → **7**（-56%） | 10,717 → 2,189（-80%） |
+| Read | 4 → **1**（-75%） | 179 → 119 |
+| UserPromptSubmit（per prompt） | 14 → **12** | — |
+
+raw JSON: 計測時の `/tmp/hook-fanout-baseline.json` / `/tmp/hook-fanout-after.json`（値は本表と Issue #310 コメントに転記済み）。
+
+## 削減内容（計 35 登録）
+
+### `~/.claude/settings.json`（22 件、backup: `~/.claude/backups/settings.json.20260706-010649.issue310.bak`）
+
+| 分類 | 件数 | 内容 | 根拠 |
+|---|---|---|---|
+| 死んだ登録 | 17 | `log-*.sh` 全系 + `compact-intent-check.sh` + `log-skill-invocation.sh` | スクリプト実体が `~/.claude/hooks/` に不存在（spawn→即失敗のみ）。agent-base repo 側でも削除済み＝上流削除後の stale 登録 |
+| 重複 | 2 | `reset-retry-circuit [.*]` / `handle-retry-circuit [.*]` | narrow matcher 版（`Bash\|Edit\|Write\|mcp__claude-in-chrome__.*`）が併存し、agent-base 上流は narrow 版のみ登録。`.*` 版削除で上流と収束 |
+| 上流削除済み orphan | 3 | `enforce-pr-issue-link` / `enforce-sub-issue`（Pre[Bash]）、`check-broken-symlinks`（Post[Write\|Edit]、**3.2s/edit**） | agent-base repo に実体なし（上流で削除済み）。ローカルの残置ファイル+登録のみ |
+
+### ECC plugin hooks.json（13 件、backup: `~/.claude/backups/ecc-hooks.json.20260706-010649.issue310.bak`）
+
+対象: `~/.claude/plugins/cache/everything-claude-code/everything-claude-code/1.8.0/hooks/hooks.json`
+（installed_plugins.json が 1.8.0 を pin。plugin 更新時は再適用が必要 — 下記 follow-up）
+
+| 分類 | 内容 | 根拠 |
+|---|---|---|
+| body 無効化済みで spawn だけ残存 | `observe.sh`（Pre[*]/Post[*]）、`session-start.js` | `ECC_DISABLED_HOOKS=session:start,pre:observe,post:observe` で body skip 済み。登録削除で spawn 自体を除去（#310 本文の run-with-flags.js:88-100 検証どおり） |
+| reminder 系 | `pre-bash-tmux-reminder` / `pre-bash-git-push-reminder` / `doc-file-warning` / `suggest-compact` / `auto-tmux-dev` | stderr へ注意書きを出すのみ or 未使用機能。push 系は agent-base の BLOCKING `check-direct-push-policy.sh` が、compact 系は `context-budget-check.sh` が上位互換 |
+| stderr ログのみ | `post-bash-pr-created` / `post-bash-build-complete` | 実装確認済み: `console.error` 1 行のみで機能なし |
+| agent-base と重複 | `post-edit-format`（auto-format.sh と重複）/ `post-edit-typecheck`（CI・/verify が担当、871ms/edit）/ `post-edit-console-warn`（quality-gate.js が console 検査を包含） | validation-layers.md の責務分担に整合 |
+
+### KEEP（全数維持を回帰で確認）
+
+block-dangerous / check-direct-push-policy / check-gh-account-match / check-lockfile-consistency /
+check-rm-aliased-target / save-work-state / protect-config / mcp-pretool-block /
+journey-ac-check / repro-evidence-check / context-budget-check / check-file-loss-claim /
+work-blocker-check / rw-context-inject / inject-work-context / progress-relay / stop-relay /
+reset-retry-circuit（narrow）/ handle-retry-circuit（narrow）/ classify-* / handle-*-failure /
+auto-format / ECC insaits-security-wrapper / ECC quality-gate / ECC Stop 系（per-turn のため対象外）
+
+## 回帰確認（T5）
+
+- 安全 hook 登録の全数チェック: **26/26 PASS**（スクリプトで settings.json を機械検査）
+- `block-dangerous.sh` 機能テスト: force-push main payload → **exit 2 BLOCK** / safe → exit 0
+  （かつ本セッション内の実ツール呼び出しでも発火を実地確認）
+- agent-base `tests/run-all.sh`: **52 PASS / 1 FAIL / 6 SKIP**
+  - FAIL は `test_check_stale_assets.sh` のみ。同スクリプトは agent-base repo 資産の git 履歴を
+    スキャンするもので、今回変更したファイル（`~/.claude/settings.json`・ECC hooks.json）への
+    参照ゼロ＝**本変更と無関係**（agent-base 側 follow-up 候補）
+
+## go/no-go 判定: **GO**
+
+spawn 数 -56〜-75%・機能欠落なし（安全 hook 全数維持 + BLOCK 動作実証）。
+
+## 多セッション load（統合ジャーニーAC #3、参考値）
+
+環境依存の参考値。#292/#302 計測時は load 26.7 / 10 cores（5 セッション並列 + observe 有効時代）。
+適用後の単発観測: load 6.20（1 分平均、セッション 1 本 + 通常負荷）。同条件 5 セッション並列での
+再計測は #302 の継続観測に委ねる（本 issue の主 AC は per-call spawn 数の削減で達成済み）。
+
+## follow-up
+
+1. **agent-base**: `~/.claude/settings.json` がテンプレ配布後に手元で drift する構造の恒久対策
+   （上流で hook を削除しても手元登録が残る = 今回の死んだ登録 17 件の発生機構）。
+   併せて repo-only の新 hook（check-dispatch-base-freshness / check-article-close-gate /
+   check-mycontext-staleness）が手元に未インストールである点も install 経路で解消する
+2. **agent-base**: `save-work-state.sh`（〜0.5-2.5s/edit）と `block-dangerous.sh`（〜0.5s/bash）の
+   内部最適化（登録削減ではなく実行時間の削減。本 issue の非目標）
+3. **ECC plugin 更新時**: hooks.json が cache 再展開で復元されるため、本レポートの削減リストを
+   再適用する（`scripts/measure-hook-fanout.py` で fan-out が戻っていないか検知可能）
+4. **agent-base**: `test_check_stale_assets.sh` の FAIL（本変更と無関係、既存）

--- a/scripts/measure-hook-fanout.py
+++ b/scripts/measure-hook-fanout.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Measure Claude Code hook fan-out per tool call (Issue #310).
+
+For each representative tool (Bash / Read / Edit) this script:
+  1. Parses every active hook source (user settings.json, ECC plugin
+     hooks.json resolved via installed_plugins.json, project settings.json)
+  2. Applies the event matcher to compute the exact number of hook commands
+     Claude Code spawns for one tool call (PreToolUse + PostToolUse)
+  3. Optionally (--time) runs each matching hook once with a synthetic JSON
+     payload and reports wall-clock per hook (median of N runs)
+
+UserPromptSubmit is reported as a separate per-prompt line.
+
+Usage:
+  python3 scripts/measure-hook-fanout.py [--time] [--runs 3] [--json OUT]
+
+The measurement is read-only with respect to hook registration; --time
+executes hook commands with harmless synthetic payloads (cwd points at a
+throwaway /tmp dir so supervisor relay hooks exit early).
+"""
+
+import argparse
+import json
+import os
+import re
+import statistics
+import subprocess
+import sys
+import tempfile
+import time
+
+HOME = os.path.expanduser("~")
+USER_SETTINGS = os.path.join(HOME, ".claude", "settings.json")
+USER_SETTINGS_LOCAL = os.path.join(HOME, ".claude", "settings.local.json")
+INSTALLED_PLUGINS = os.path.join(HOME, ".claude", "plugins", "installed_plugins.json")
+
+TOOLS = ["Bash", "Read", "Edit"]
+EVENTS = ["PreToolUse", "PostToolUse"]
+
+
+def load_json(path):
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def plugin_hook_sources():
+    """Resolve hooks.json paths for installed plugins (installPath is authoritative)."""
+    data = load_json(INSTALLED_PLUGINS) or {}
+    sources = []
+    for name, entries in (data.get("plugins") or {}).items():
+        for e in entries:
+            hooks_path = os.path.join(e.get("installPath", ""), "hooks", "hooks.json")
+            if os.path.isfile(hooks_path):
+                sources.append((f"plugin:{name}@{e.get('version')}", hooks_path))
+    return sources
+
+
+def iter_hooks(config, source_label):
+    """Yield (event, matcher, command) from a settings-style hooks dict."""
+    hooks = (config or {}).get("hooks") or {}
+    for event, groups in hooks.items():
+        if not isinstance(groups, list):
+            continue
+        for g in groups:
+            matcher = g.get("matcher", "")
+            for h in g.get("hooks", []):
+                if h.get("type") == "command":
+                    yield {
+                        "source": source_label,
+                        "event": event,
+                        "matcher": matcher,
+                        "command": h.get("command", ""),
+                    }
+
+
+def matcher_matches(matcher, tool):
+    if matcher in ("", "*", None):
+        return True
+    try:
+        return re.fullmatch(matcher, tool) is not None
+    except re.error:
+        return matcher == tool
+
+
+def collect_sources(project_dir):
+    sources = []
+    if os.path.isfile(USER_SETTINGS):
+        sources.append(("user:settings.json", USER_SETTINGS))
+    if os.path.isfile(USER_SETTINGS_LOCAL):
+        sources.append(("user:settings.local.json", USER_SETTINGS_LOCAL))
+    for label, path in plugin_hook_sources():
+        sources.append((label, path))
+    if project_dir:
+        for name in ("settings.json", "settings.local.json"):
+            p = os.path.join(project_dir, ".claude", name)
+            if os.path.isfile(p):
+                sources.append((f"project:{name}", p))
+    return sources
+
+
+def synthetic_payload(event, tool, cwd):
+    payload = {
+        "session_id": "hook-fanout-measure",
+        "transcript_path": "/tmp/hook-fanout-measure-transcript.jsonl",
+        "cwd": cwd,
+        "hook_event_name": event,
+        "tool_name": tool,
+    }
+    sample = os.path.join(cwd, "sample.txt")
+    if tool == "Bash":
+        payload["tool_input"] = {"command": "echo hookmeasure", "description": "measure"}
+    elif tool == "Read":
+        payload["tool_input"] = {"file_path": sample}
+    elif tool == "Edit":
+        payload["tool_input"] = {"file_path": sample, "old_string": "a", "new_string": "b"}
+    if event == "PostToolUse":
+        payload["tool_response"] = {"stdout": "hookmeasure", "stderr": "", "interrupted": False}
+    return json.dumps(payload)
+
+
+def time_hook(command, payload, env, runs, timeout=15):
+    samples = []
+    for _ in range(runs):
+        t0 = time.monotonic()
+        try:
+            subprocess.run(
+                ["bash", "-c", command],
+                input=payload,
+                capture_output=True,
+                text=True,
+                env=env,
+                timeout=timeout,
+            )
+        except subprocess.TimeoutExpired:
+            samples.append(timeout * 1000.0)
+            continue
+        samples.append((time.monotonic() - t0) * 1000.0)
+    return statistics.median(samples)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--time", action="store_true", help="also run each hook and measure wall-clock")
+    ap.add_argument("--runs", type=int, default=3)
+    ap.add_argument("--json", help="write machine-readable result to this path")
+    ap.add_argument("--project-dir", default=os.environ.get("CLAUDE_PROJECT_DIR", os.getcwd()))
+    args = ap.parse_args()
+
+    all_hooks = []
+    for label, path in collect_sources(args.project_dir):
+        all_hooks.extend(iter_hooks(load_json(path), label))
+
+    work = tempfile.mkdtemp(prefix="hook-fanout-measure-")
+    with open(os.path.join(work, "sample.txt"), "w") as f:
+        f.write("a\n")
+
+    env = dict(os.environ)
+    env["CLAUDE_PROJECT_DIR"] = args.project_dir
+    # Replicate the env Claude Code injects from settings.json "env"
+    settings_env = (load_json(USER_SETTINGS) or {}).get("env") or {}
+    env.update({k: str(v) for k, v in settings_env.items()})
+
+    result = {"tools": {}, "user_prompt_submit": None}
+
+    for tool in TOOLS:
+        tool_res = {"events": {}, "total_spawns": 0, "total_ms": None}
+        total_ms = 0.0
+        timed_any = False
+        for event in EVENTS:
+            matching = [h for h in all_hooks if h["event"] == event and matcher_matches(h["matcher"], tool)]
+            entries = []
+            for h in matching:
+                entry = {"source": h["source"], "matcher": h["matcher"] or "(all)",
+                         "command": h["command"][:100], "ms": None}
+                if args.time:
+                    payload = synthetic_payload(event, tool, work)
+                    entry["ms"] = round(time_hook(h["command"], payload, env, args.runs), 1)
+                    total_ms += entry["ms"]
+                    timed_any = True
+                entries.append(entry)
+            tool_res["events"][event] = entries
+            tool_res["total_spawns"] += len(entries)
+        if timed_any:
+            tool_res["total_ms"] = round(total_ms, 1)
+        result["tools"][tool] = tool_res
+
+    ups = [h for h in all_hooks if h["event"] == "UserPromptSubmit"]
+    result["user_prompt_submit"] = {"total_spawns": len(ups),
+                                    "sources": sorted({h["source"] for h in ups})}
+
+    print(f"{'tool':<6} {'Pre':>4} {'Post':>5} {'total':>6} {'ms(seq sum)':>12}")
+    for tool, tr in result["tools"].items():
+        pre = len(tr["events"]["PreToolUse"])
+        post = len(tr["events"]["PostToolUse"])
+        ms = f"{tr['total_ms']:.0f}" if tr["total_ms"] is not None else "-"
+        print(f"{tool:<6} {pre:>4} {post:>5} {tr['total_spawns']:>6} {ms:>12}")
+    print(f"UserPromptSubmit per-prompt spawns: {result['user_prompt_submit']['total_spawns']}")
+
+    if args.time:
+        print("\nPer-hook timing (median ms):")
+        for tool, tr in result["tools"].items():
+            for event, entries in tr["events"].items():
+                for e in entries:
+                    print(f"  {tool:<5} {event:<12} {e['ms']:>8} ms  [{e['matcher']}] {e['source']}: {e['command'][:60]}")
+
+    if args.json:
+        with open(args.json, "w") as f:
+            json.dump(result, f, indent=1, ensure_ascii=False)
+        print(f"\nwrote {args.json}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 概要

Issue #310（#302 sub）: 毎ツール呼び出しの hook Node spawn fan-out を、安全ガードを一切落とさずに削減した。本 PR は計測ハーネスと削減レポートを追加する（削減本体は `~/.claude/settings.json` と ECC plugin hooks.json への machine-local 変更。backup 取得済み）。

## 実測結果（before → after）

| tool | spawns | 逐次合計 ms |
|---|---|---|
| Bash | 19 → **8**（-58%） | 3,899 → 2,016 |
| Edit | 16 → **7**（-56%） | 10,717 → 2,189 |
| Read | 4 → **1**（-75%） | 179 → 119 |
| prompt | 14 → **12** | — |

## 主な変更点

- `scripts/measure-hook-fanout.py`: 全 hook ソース（user settings / ECC plugin / project settings）を parse し、matcher 適用後の per-call spawn 数と per-hook wall-clock を決定的に計測
- `docs/hook-fanout-reduction-310.md`: 削減 35 登録の分類（死んだ登録 17 / 重複 2 / 上流削除済み orphan 3 / ECC reminder・重複・body 無効化済み 13）、回帰確認、follow-up

## テスト・検証

- 安全 hook 登録の全数チェック: 26/26 PASS
- block-dangerous.sh 機能テスト: 危険 payload → exit 2 BLOCK（本セッション実発火でも確認）
- agent-base tests/run-all.sh: 52 PASS / 1 FAIL（FAIL は test_check_stale_assets.sh、今回変更ファイルへの参照ゼロで無関係・既存）

## 関連

- Closes #310
- 親: #302（結果を集約コメント済み）

🤖 Generated with [Claude Code](https://claude.com/claude-code)
