### PR TITLE
fix: rendered prompt のファイル渡し化で tmux command too long の crash-loop を解消

### DIFF
--- a/scripts/start-hijoguchi.sh
+++ b/scripts/start-hijoguchi.sh
@@ -399,7 +399,26 @@ fi
 # misclassify. The `env` prefix sets them on the claude process directly.
 CLAUDE_CMD=$(printf 'env CLAUDE_HUB_HIJOGUCHI_SESSION=1 CLAUDE_HUB_STATE_DIR=%q LAST_MSG_TS_FILE=%q HIJOGUCHI_CHANNEL_ID=%q HIJOGUCHI_BOT_MENTION=%q ' \
   "${CLAUDE_HUB_STATE_DIR}" "${LAST_MSG_TS_FILE}" "${HIJOGUCHI_CHANNEL_ID}" "${HIJOGUCHI_BOT_MENTION}")
-CLAUDE_CMD+=$(printf '%q ' "${CLAUDE_ARGV[@]}")
+# The rendered prompt must NOT be inlined (%q-escaped) into the tmux command
+# string: multibyte content escapes to ~3x its size and tmux rejects commands
+# over its ~16KB limit with "command too long" — the #311 prompt growth pushed
+# the inline form past that and crash-looped the Bot (Epic #315 hotfix). The
+# prompt is persisted to RENDERED_PROMPT_FILE below and the PANE SHELL expands
+# `"$(cat <file>)"` at launch, so the command string stays O(100B) no matter
+# how large the prompt grows. Command-substitution output is not re-parsed by
+# the shell, so prompt content still cannot leak into command evaluation; the
+# file path itself is %q-escaped.
+RENDERED_PROMPT_FILE="${RENDERED_PROMPT_FILE:-${CLAUDE_HUB_STATE_DIR}/rendered-system-prompt.md}"
+_prompt_value_next=0
+for _arg in "${CLAUDE_ARGV[@]}"; do
+  if [ "${_prompt_value_next}" = "1" ]; then
+    CLAUDE_CMD+="\"\$(cat $(printf '%q' "${RENDERED_PROMPT_FILE}"))\" "
+    _prompt_value_next=0
+    continue
+  fi
+  [ "${_arg}" = "--append-system-prompt" ] && _prompt_value_next=1
+  CLAUDE_CMD+="$(printf '%q ' "${_arg}")"
+done
 
 # Opt-in introspection for tests: print the fully-built launch command (incl.
 # the env prefix) and exit before any tmux / filesystem side effect.
@@ -411,6 +430,20 @@ fi
 # Create log dir only for real launches. Deferred past render-only / print-argv
 # so tests don't create directories as a side effect.
 mkdir -p "${LOG_DIR}"
+
+# Persist the rendered prompt for the pane shell's `"$(cat ...)"` expansion.
+# Fail loud (like the SYSTEM_PROMPT_FILE guard): a missing prompt file would
+# otherwise launch claude with an empty --append-system-prompt and silently
+# drop every routing/scope rule. Deferred past the dry-run exits above so
+# tests stay side-effect free. 0600 + state dir keeps the embedded channel /
+# bot IDs out of world-readable locations AND out of `ps` argv (the previous
+# inline form exposed them to any local process listing).
+mkdir -p "${CLAUDE_HUB_STATE_DIR}"
+if ! printf '%s' "${SYSTEM_PROMPT_CONTENT}" > "${RENDERED_PROMPT_FILE}"; then
+  echo "[hijoguchi] ERROR: cannot write rendered prompt to ${RENDERED_PROMPT_FILE}" >&2
+  exit 1
+fi
+chmod 600 "${RENDERED_PROMPT_FILE}" 2>/dev/null || true
 
 # Clean shutdown on SIGTERM from launchd
 trap 'echo "[hijoguchi] SIGTERM received, killing tmux session" >&2; "${TMUX_BIN}" kill-session -t "${SESSION}" 2>/dev/null; exit 0' TERM INT

--- a/scripts/test-start-hijoguchi.sh
+++ b/scripts/test-start-hijoguchi.sh
@@ -545,6 +545,62 @@ t45_hang_threshold_optout() {
   [ ! -e "${HDIR}/health-incident" ] && [ "$(notify_count)" = "0" ]
 }
 
+# ----- tmux command length (crash-loop hotfix, Epic #315) --------------------
+
+# T46: the launch command references the rendered-prompt FILE via a pane-shell
+# "$(cat ...)" expansion instead of inlining the (multibyte, %q-inflated)
+# prompt content. Inlining crash-looped the Bot with tmux "command too long"
+# after the #311 prompt growth.
+t46_launch_cmd_uses_prompt_file() {
+  local out
+  out=$(HIJOGUCHI_PRINT_CMD=1 bash "${TARGET}" 2>/dev/null)
+  echo "${out}" | grep -Fq -- '--append-system-prompt "$(cat ' \
+    && echo "${out}" | grep -Fq 'rendered-system-prompt.md' \
+    && ! echo "${out}" | grep -Fq '応答条件'
+}
+
+# T47: the command string stays small regardless of prompt size — the class
+# guard for tmux's ~16KB "command too long" limit. 4096 leaves ~4x headroom
+# for env-prefix growth while catching any re-inlining regression instantly.
+t47_launch_cmd_bounded() {
+  local n
+  n=$(HIJOGUCHI_PRINT_CMD=1 bash "${TARGET}" 2>/dev/null | wc -c)
+  [ "${n}" -lt 4096 ]
+}
+
+# T48: the pane-shell "$(cat file)" expansion hands claude EXACTLY the rendered
+# prompt. Re-parse the built command like tmux's child shell would (eval with a
+# stub claude that dumps its argv) and diff the received prompt value against
+# the render-only output.
+t48_pane_shell_expansion_roundtrip() {
+  local dir out cmd prompt_file
+  dir=$(mktemp -d)
+  # shellcheck disable=SC2064
+  trap "rm -rf '${dir}'" RETURN
+  # Stub `claude`: write the argument AFTER --append-system-prompt to a file.
+  cat > "${dir}/claude" <<'STUB'
+#!/bin/bash
+out="${CLAUDE_STUB_OUT:?}"
+grab=0
+for a in "$@"; do
+  if [ "${grab}" = "1" ]; then printf '%s' "${a}" > "${out}"; exit 0; fi
+  [ "${a}" = "--append-system-prompt" ] && grab=1
+done
+exit 1
+STUB
+  chmod +x "${dir}/claude"
+  prompt_file="${dir}/rendered-system-prompt.md"
+  HIJOGUCHI_RENDER_ONLY=1 bash "${TARGET}" 2>/dev/null > "${prompt_file}" || return 1
+  cmd=$(HIJOGUCHI_PRINT_CMD=1 RENDERED_PROMPT_FILE="${prompt_file}" bash "${TARGET}" 2>/dev/null) || return 1
+  # Substitute the stub for the real binary and evaluate like the pane shell.
+  cmd="${cmd/${HOME}\/.local\/bin\/claude/${dir}/claude}"
+  CLAUDE_STUB_OUT="${dir}/received" eval "${cmd}" || return 1
+  # Render-only output has a trailing newline (printf '%s\n'); "$(cat ...)"
+  # strips trailing newlines, so compare against the stripped form.
+  printf '%s' "$(cat "${prompt_file}")" > "${dir}/expected"
+  cmp -s "${dir}/expected" "${dir}/received"
+}
+
 run "T1 channel ID expanded"          t1_channel_id_expanded
 run "T2 no residual {{}} tokens"      t2_no_residual_tokens
 run "T3 env override works"           t3_env_override
@@ -590,6 +646,9 @@ run "T42 crash loop dead once"        t42_crashloop_dead_once
 run "T43 spaced crashes ok"           t43_spaced_crashes_ok
 run "T44 dead recovery needs stability" t44_dead_recovery_requires_stability
 run "T45 hang threshold opt-out"      t45_hang_threshold_optout
+run "T46 launch cmd uses prompt file" t46_launch_cmd_uses_prompt_file
+run "T47 launch cmd length bounded"   t47_launch_cmd_bounded
+run "T48 pane shell expansion roundtrip" t48_pane_shell_expansion_roundtrip
 
 if [ "${fail}" -eq 0 ]; then
   echo "ALL TESTS PASSED"


### PR DESCRIPTION
## 緊急度

**hotfix**: PR #331 マージ + Bot 再起動後、claudeHubExit が tmux「command too long」で crash-loop 中（Epic #315 デプロイで顕在化）。

## 原因（決定的検証済み）

- 検証コマンド: `HIJOGUCHI_PRINT_CMD=1 ... bash scripts/start-hijoguchi.sh | wc -c` → **実測 20374 bytes**（tmux 上限 約16384 超）
- `logs/hijoguchi.stderr.log` に `command too long` → `tmux session 'claudeHubExit' failed to start` の 5 秒周期ループを実測
- #311 で prompt が 4156 → 5966 bytes に増加。マルチバイトの %q エスケープは約 3 倍化するため、prompt 全文を tmux コマンド文字列に埋め込む従来方式が上限を突破した

## 修正

| 変更 | 内容 |
|---|---|
| `scripts/start-hijoguchi.sh` | rendered prompt を `~/.claude-hub-state/rendered-system-prompt.md`（0600）へ書き出し、tmux コマンドは pane shell の `"$(cat <file>)"` 展開に置換。コマンド長が prompt サイズと無関係になり、同クラス（prompt 増量→上限超過）を構造的に排除 |
| `scripts/test-start-hijoguchi.sh` | T46: コマンドがファイル参照であること / T47: コマンド長 < 4096 の恒常ガード / T48: eval roundtrip で claude が受け取る prompt が render 出力と byte 一致 |

セキュリティ: command substitution の出力は shell に再パースされないため注入経路は増えない。むしろ channel/bot ID が `ps` の argv に露出しなくなる改善。

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | コマンド長が上限内 | T47 | < 4096 bytes | PASS | PASS |
| AC-2 | prompt が正確に claude へ届く | T48 (eval roundtrip + cmp) | byte 一致 | PASS | PASS |
| AC-3 | 全既存テスト回帰なし | bash scripts/test-start-hijoguchi.sh | 48/48 | 48/48 | PASS |

マージ後、launchd kickstart で実機復旧を確認し結果を本 PR にコメントする。
