### PR TITLE
feat(#339): オーケストレーター報告を corp チャンネル直下へ投稿する channel-post 経路

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,6 +175,7 @@ jobs:
                    tests/action/receiver.test.ts \
                    tests/session/hub-work.test.ts \
                    tests/session/relay-server-hub-work.test.ts \
+                   tests/session/relay-server-channel-post.test.ts \
                    tests/tools/session-ctl.test.ts
 
       # #238 regression: realTmuxAdapter.hasSession must treat a tmux

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -6,6 +6,7 @@ import {
   Events,
   type Interaction,
   type Message,
+  type Channel,
   type ThreadChannel,
   type TextChannel,
 } from "discord.js";
@@ -554,8 +555,18 @@ export async function startBot(token: string): Promise<void> {
           error: `スレッドではありません: ${threadId}`,
         };
       }
-      const parent = thread.parent;
-      if (!parent || !parent.isTextBased()) {
+      // thread.parent はキャッシュ依存のゲッターで、起動直後などキャッシュ外
+      // だと実在する親でも null を返す（PR #340 gemini high）。parentId からの
+      // 明示 fetch にフォールバックする。
+      let parent: Channel | null = thread.parent;
+      if (!parent && thread.parentId) {
+        try {
+          parent = await client.channels.fetch(thread.parentId);
+        } catch {
+          // fetch 失敗は下の null チェックで 404 に落とす。
+        }
+      }
+      if (!parent || !parent.isTextBased() || parent.isDMBased()) {
         return {
           ok: false,
           status: 404,

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -575,9 +575,23 @@ export async function startBot(token: string): Promise<void> {
       }
       // 長文（Mermaid 含む最終レポート）は relay 本文と同じ整形で分割送信する。
       const chunks = formatForDiscord(text).filter((c) => c.trim());
-      for (const chunk of chunks) {
-        // send 失敗は relay-server 側の catch で 500 として返る（握りつぶさない）。
-        await parent.send(chunk);
+      // 途中 chunk の send 失敗時は送信済み件数をエラーに含め、呼び出し元
+      // （session-ctl post-channel / オーケストレーター）が再試行時の重複投稿
+      // リスクを判断できるようにする（PR #340 coderabbit major）。
+      let sentCount = 0;
+      try {
+        for (const chunk of chunks) {
+          await parent.send(chunk);
+          sentCount++;
+        }
+      } catch (err) {
+        return {
+          ok: false,
+          status: 502,
+          error:
+            `送信中にエラー（${sentCount}/${chunks.length} chunks 送信済み。` +
+            `再試行すると重複投稿の可能性があります）: ${err instanceof Error ? err.message : String(err)}`,
+        };
       }
       console.log(
         `[Bot] channel-post: thread ${threadId} → #${parent.name} (${chunks.length} chunks, ${text.length} chars)`,

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -36,6 +36,7 @@ import {
   onLateResponse,
   onSessionsQuery,
   onHubWork,
+  onChannelPost,
 } from "./session/relay-server";
 import { runHubWork, HUB_WORK_PARENT_CHANNEL } from "./session/hub-work";
 import {
@@ -529,6 +530,49 @@ export async function startBot(token: string): Promise<void> {
         },
       }),
     );
+
+    // Issue #339: オーケストレーターの進捗・最終レポートをスレッドの**親
+    // チャンネル直下**へ投稿する経路（POST /channel-post/:threadId →
+    // session-ctl post-channel が叩く）。投稿先は threadId から解決した親
+    // チャンネルに構造的に限定される（任意チャンネル ID を受け取らない）。
+    onChannelPost(async (threadId, text) => {
+      let thread;
+      try {
+        thread = await client.channels.fetch(threadId);
+      } catch (err) {
+        // Unknown Channel 等の Discord API エラーは呼び出し側の指定ミス扱い。
+        return {
+          ok: false,
+          status: 404,
+          error: `スレッドを取得できません: ${threadId} (${err instanceof Error ? err.message : String(err)})`,
+        };
+      }
+      if (!thread?.isThread()) {
+        return {
+          ok: false,
+          status: 404,
+          error: `スレッドではありません: ${threadId}`,
+        };
+      }
+      const parent = thread.parent;
+      if (!parent || !parent.isTextBased()) {
+        return {
+          ok: false,
+          status: 404,
+          error: `親チャンネルを解決できません: ${threadId}`,
+        };
+      }
+      // 長文（Mermaid 含む最終レポート）は relay 本文と同じ整形で分割送信する。
+      const chunks = formatForDiscord(text).filter((c) => c.trim());
+      for (const chunk of chunks) {
+        // send 失敗は relay-server 側の catch で 500 として返る（握りつぶさない）。
+        await parent.send(chunk);
+      }
+      console.log(
+        `[Bot] channel-post: thread ${threadId} → #${parent.name} (${chunks.length} chunks, ${text.length} chars)`,
+      );
+      return { ok: true, channelId: parent.id, chunks: chunks.length };
+    });
   });
 
   // Safe reply helper: never throws. Used in error paths where the interaction may

--- a/supervisor/src/session/relay-server.ts
+++ b/supervisor/src/session/relay-server.ts
@@ -60,6 +60,21 @@ export type HubWorkHandler = (
   body: Record<string, unknown>,
 ) => Promise<HubWorkResponse>;
 
+// Issue #339: オーケストレーターの進捗・最終レポートを corp チャンネル**直下**へ
+// 届ける経路。ローカルの CC セッション（session-ctl post-channel）が
+// `POST /channel-post/:threadId` に {text} を投げると、bot.ts が登録した
+// ハンドラが threadId のスレッドを解決し、その**親チャンネル**へ投稿する。
+// 投稿先は構造的に「そのスレッドの親」に限定される（任意チャンネル投稿は不可）。
+// loopback-only bind + ハンドラ未登録 503 の fail-closed は /hub-work と同じ
+// 信頼境界。
+export type ChannelPostResponse =
+  | { ok: true; channelId: string; chunks: number }
+  | { ok: false; status: number; error: string };
+export type ChannelPostHandler = (
+  threadId: string,
+  text: string,
+) => Promise<ChannelPostResponse>;
+
 type ProgressCallback = (event: ProgressEvent) => void;
 type LateResponseCallback = (event: LateResponseEvent) => void;
 type AskUserCallback = (event: AskUserEvent) => void;
@@ -112,6 +127,7 @@ let lateResponseCallback: LateResponseCallback | null = null;
 let askUserCallback: AskUserCallback | null = null;
 let sessionsProvider: SessionsProvider | null = null;
 let hubWorkHandler: HubWorkHandler | null = null;
+let channelPostHandler: ChannelPostHandler | null = null;
 
 /**
  * Well-known file that carries the relay server's ephemeral port (#320).
@@ -185,6 +201,15 @@ export function onAskUser(callback: AskUserCallback): void {
  */
 export function onHubWork(handler: HubWorkHandler): void {
   hubWorkHandler = handler;
+}
+
+/**
+ * Register the handler that backs `POST /channel-post/:threadId` (#339). When
+ * no handler is registered the endpoint answers 503 (fail-closed) — a channel
+ * post can never silently no-op.
+ */
+export function onChannelPost(handler: ChannelPostHandler): void {
+  channelPostHandler = handler;
 }
 
 /**
@@ -277,6 +302,65 @@ export function startRelayServer(): void {
           );
         } catch (err) {
           console.error("[relay-server] hubWorkHandler error:", err);
+          return Response.json(
+            { error: err instanceof Error ? err.message : String(err) },
+            { status: 500 },
+          );
+        }
+      }
+
+      // Issue #339: オーケストレーターの進捗・最終レポートをスレッドの親
+      // チャンネル直下へ投稿する経路。loopback-only なのでローカルの
+      // session-ctl / オーケストレーター CC セッションだけが叩ける。
+      // ハンドラ未登録は 503（fail-closed、/hub-work と同型）。
+      const channelPostMatch = url.pathname.match(/^\/channel-post\/(.+)$/);
+      if (channelPostMatch && req.method === "POST") {
+        const rawThreadId = channelPostMatch[1];
+        if (!rawThreadId) {
+          return Response.json({ error: "Invalid thread ID" }, { status: 400 });
+        }
+        // manager.ts / session-ctl と対称（encodeURIComponent で送られてくる）。
+        let threadId: string;
+        try {
+          threadId = decodeURIComponent(rawThreadId);
+        } catch {
+          return Response.json(
+            { error: "Invalid thread ID encoding" },
+            { status: 400 },
+          );
+        }
+        let body: Record<string, unknown>;
+        try {
+          const parsed = (await req.json()) as unknown;
+          if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+            return Response.json({ error: "Invalid JSON body" }, { status: 400 });
+          }
+          body = parsed as Record<string, unknown>;
+        } catch {
+          return Response.json({ error: "Invalid JSON" }, { status: 400 });
+        }
+        const text = typeof body.text === "string" ? body.text : "";
+        if (!text.trim()) {
+          return Response.json({ error: "text is required" }, { status: 400 });
+        }
+        const handler = channelPostHandler;
+        if (!handler) {
+          return Response.json(
+            { error: "channel post handler not registered (Supervisor 起動中?)" },
+            { status: 503 },
+          );
+        }
+        try {
+          const result = await handler(threadId, text);
+          if (result.ok) {
+            return Response.json(result, { status: 200 });
+          }
+          return Response.json(
+            { error: result.error },
+            { status: result.status },
+          );
+        } catch (err) {
+          console.error("[relay-server] channelPostHandler error:", err);
           return Response.json(
             { error: err instanceof Error ? err.message : String(err) },
             { status: 500 },
@@ -523,6 +607,7 @@ export function stopRelayServer(): void {
   askUserCallback = null;
   sessionsProvider = null;
   hubWorkHandler = null;
+  channelPostHandler = null;
   removeRelayPortFile();
 }
 

--- a/supervisor/tests/session/relay-server-channel-post.test.ts
+++ b/supervisor/tests/session/relay-server-channel-post.test.ts
@@ -1,0 +1,128 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import {
+  startRelayServer,
+  stopRelayServer,
+  getRelayPort,
+  onChannelPost,
+} from "../../src/session/relay-server";
+
+/**
+ * `POST /channel-post/:threadId`（Issue #339）の追加分だけを検証する。
+ * 既存 relay-server.test.ts / relay-server-hub-work.test.ts には触れない
+ * （既存テスト変更 0 件の BLOCKING 制約、AC-3）。
+ */
+
+function channelPostUrl(threadId: string): string {
+  return `http://127.0.0.1:${getRelayPort()}/channel-post/${encodeURIComponent(threadId)}`;
+}
+
+describe("POST /channel-post/:threadId", () => {
+  beforeEach(() => {
+    startRelayServer();
+  });
+
+  afterEach(() => {
+    stopRelayServer();
+  });
+
+  test("ハンドラ未登録は 503（fail-closed、黙って no-op しない）", async () => {
+    const res = await fetch(channelPostUrl("111122223333444455"), {
+      method: "POST",
+      body: JSON.stringify({ text: "progress" }),
+    });
+    expect(res.status).toBe(503);
+  });
+
+  test("不正 JSON は 400", async () => {
+    onChannelPost(async () => {
+      throw new Error("should not be called");
+    });
+    const res = await fetch(channelPostUrl("111122223333444455"), {
+      method: "POST",
+      body: "{oops",
+    });
+    expect(res.status).toBe(400);
+  });
+
+  test("text 欠落 / 空白のみは 400", async () => {
+    onChannelPost(async () => {
+      throw new Error("should not be called");
+    });
+    for (const body of [{}, { text: "   " }, { text: 42 }]) {
+      const res = await fetch(channelPostUrl("111122223333444455"), {
+        method: "POST",
+        body: JSON.stringify(body),
+      });
+      expect(res.status).toBe(400);
+    }
+  });
+
+  test("threadId の不正エンコーディングは 400", async () => {
+    onChannelPost(async () => {
+      throw new Error("should not be called");
+    });
+    const res = await fetch(
+      `http://127.0.0.1:${getRelayPort()}/channel-post/%ZZ`,
+      { method: "POST", body: JSON.stringify({ text: "t" }) },
+    );
+    expect(res.status).toBe(400);
+  });
+
+  test("ok ハンドラ結果は 200 + JSON パススルー（threadId はデコード済みで渡る）", async () => {
+    let received: unknown = null;
+    onChannelPost(async (threadId, text) => {
+      received = { threadId, text };
+      return { ok: true, channelId: "C1", chunks: 2 };
+    });
+    const res = await fetch(channelPostUrl("111122223333444455"), {
+      method: "POST",
+      body: JSON.stringify({ text: "## 進捗\n```mermaid\ngraph TD\n```" }),
+    });
+    expect(res.status).toBe(200);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.ok).toBe(true);
+    expect(json.channelId).toBe("C1");
+    expect(json.chunks).toBe(2);
+    expect(received).toEqual({
+      threadId: "111122223333444455",
+      text: "## 進捗\n```mermaid\ngraph TD\n```",
+    });
+  });
+
+  test("ハンドラの ok:false は status/error をそのまま返す", async () => {
+    onChannelPost(async () => ({
+      ok: false,
+      status: 404,
+      error: "スレッドが見つかりません",
+    }));
+    const res = await fetch(channelPostUrl("000000000000000000"), {
+      method: "POST",
+      body: JSON.stringify({ text: "t" }),
+    });
+    expect(res.status).toBe(404);
+    const json = (await res.json()) as Record<string, unknown>;
+    expect(json.error).toContain("スレッド");
+  });
+
+  test("ハンドラ throw は 500（unhandled で落ちない）", async () => {
+    onChannelPost(async () => {
+      throw new Error("kaboom");
+    });
+    const res = await fetch(channelPostUrl("111122223333444455"), {
+      method: "POST",
+      body: JSON.stringify({ text: "t" }),
+    });
+    expect(res.status).toBe(500);
+  });
+
+  test("stopRelayServer でハンドラがリセットされる（再 start 後は 503）", async () => {
+    onChannelPost(async () => ({ ok: true, channelId: "C1", chunks: 1 }));
+    stopRelayServer();
+    startRelayServer();
+    const res = await fetch(channelPostUrl("111122223333444455"), {
+      method: "POST",
+      body: JSON.stringify({ text: "t" }),
+    });
+    expect(res.status).toBe(503);
+  });
+});

--- a/supervisor/tests/tools/session-ctl.test.ts
+++ b/supervisor/tests/tools/session-ctl.test.ts
@@ -366,3 +366,69 @@ describe("実 DB 読み取り（createRealEffects の store、読み取り専用
     }
   });
 });
+
+describe("post-channel (#339)", () => {
+  test("引数不足（thread_id のみ）は usage エラーで 1", async () => {
+    const { fx, calls } = fakeFx();
+    expect(await runSessionCtl(["post-channel", "111122223333444455"], fx)).toBe(1);
+    expect(calls.err[0]).toContain("使い方");
+    expect(calls.posts).toHaveLength(0);
+  });
+
+  test("thread_id が snowflake 形式でない場合は 1", async () => {
+    const { fx, calls } = fakeFx();
+    expect(await runSessionCtl(["post-channel", "not-a-thread", "hello"], fx)).toBe(1);
+    expect(calls.err[0]).toContain("thread_id");
+    expect(calls.posts).toHaveLength(0);
+  });
+
+  test("ポートファイルなし → Supervisor 未起動の案内で 1", async () => {
+    const { fx, calls } = fakeFx({ relayPort: null });
+    expect(
+      await runSessionCtl(["post-channel", "111122223333444455", "hello"], fx),
+    ).toBe(1);
+    expect(calls.err[0]).toContain("Supervisor");
+    expect(calls.posts).toHaveLength(0);
+  });
+
+  test("成功: /channel-post/<threadId> へ {text} を POST し ✅ を出す", async () => {
+    const { fx, calls } = fakeFx({
+      httpResponse: { status: 200, body: { ok: true, channelId: "C1", chunks: 2 } },
+    });
+    expect(
+      await runSessionCtl(
+        ["post-channel", "111122223333444455", "##", "進捗", "レポート"],
+        fx,
+      ),
+    ).toBe(0);
+    expect(calls.posts).toHaveLength(1);
+    expect(calls.posts[0]!.url).toBe(
+      "http://127.0.0.1:45678/channel-post/111122223333444455",
+    );
+    expect(calls.posts[0]!.body).toEqual({ text: "## 進捗 レポート" });
+    expect(calls.out[0]).toContain("✅");
+    expect(calls.out[0]).toContain("C1");
+  });
+
+  test("HTTP エラー（404 等）はエラー内容を表示して 1", async () => {
+    const { fx, calls } = fakeFx({
+      httpResponse: { status: 404, body: { error: "スレッドが見つかりません" } },
+    });
+    expect(
+      await runSessionCtl(["post-channel", "111122223333444455", "hello"], fx),
+    ).toBe(1);
+    expect(calls.err[0]).toContain("404");
+    expect(calls.err[0]).toContain("スレッドが見つかりません");
+  });
+
+  test("接続失敗（httpPost throw）は接続エラー案内で 1", async () => {
+    const { fx, calls } = fakeFx();
+    fx.httpPost = async () => {
+      throw new Error("connect ECONNREFUSED");
+    };
+    expect(
+      await runSessionCtl(["post-channel", "111122223333444455", "hello"], fx),
+    ).toBe(1);
+    expect(calls.err[0]).toContain("接続に失敗");
+  });
+});

--- a/supervisor/tools/session-ctl.ts
+++ b/supervisor/tools/session-ctl.ts
@@ -29,6 +29,7 @@
  *   bun run supervisor/tools/session-ctl.ts send <thread_id|session_id> <text...>
  *   bun run supervisor/tools/session-ctl.ts stop <id>
  *   bun run supervisor/tools/session-ctl.ts start-hub-worker <branch> <issueNumber> [selector]
+ *   bun run supervisor/tools/session-ctl.ts post-channel <thread_id> <text...>
  *
  * `<id>` は session row id / thread_id / claude_session_id のいずれでも可。
  */
@@ -102,7 +103,10 @@ subcommands:
       Supervisor の watcher が行う (この CLI は DB に書かない)。worktree は保持 (RW-046)
   start-hub-worker <branch> <issueNumber> [selector]
       claude-hub work セッションを corp チャンネル配下に起動 (POST /hub-work, ADR-002 D5)。
-      selector: impl / no-template / pdca / article / devcycle (省略時 impl)`;
+      selector: impl / no-template / pdca / article / devcycle (省略時 impl)
+  post-channel <thread_id> <text...>
+      スレッドの親チャンネル直下へテキスト投稿 (POST /channel-post, #339)。
+      オーケストレーターの進捗・最終レポートを corp チャンネル直下へ届ける用途`;
 
 /** threadId → tmux セッション名（Supervisor と同一の公式マッピングを共有）。 */
 export function tmuxNameForThread(threadId: string): string {
@@ -299,6 +303,55 @@ async function cmdStartHubWorker(
   return 1;
 }
 
+async function cmdPostChannel(
+  fx: SessionCtlEffects,
+  threadId: string,
+  text: string,
+): Promise<number> {
+  // Discord thread ID は snowflake（数値列）。書式で早期に弾いて、Supervisor
+  // への無駄な往復と紛らわしい 404 を避ける。
+  if (!/^[0-9]+$/.test(threadId)) {
+    fx.err(`thread_id は Discord スレッド ID（数値列）で指定してください: ${threadId}`);
+    return 1;
+  }
+  if (!text.trim()) {
+    fx.err("投稿テキストが空です。");
+    return 1;
+  }
+  const port = fx.readRelayPort();
+  if (port == null) {
+    fx.err(
+      "Supervisor の relay ポートを発見できません（ポートファイルなし）。" +
+        "Supervisor が起動しているか確認してください。",
+    );
+    return 1;
+  }
+  let res: { status: number; body: unknown };
+  try {
+    res = await fx.httpPost(
+      `http://127.0.0.1:${port}/channel-post/${encodeURIComponent(threadId)}`,
+      { text },
+    );
+  } catch (err) {
+    fx.err(
+      `Supervisor への接続に失敗しました (port ${port}): ${err instanceof Error ? err.message : String(err)}`,
+    );
+    return 1;
+  }
+  const body = (res.body ?? {}) as Record<string, unknown>;
+  if (res.status === 200 && body.ok === true) {
+    fx.out(
+      `✅ スレッド ${threadId} の親チャンネル (${String(body.channelId)}) へ投稿しました ` +
+        `(${String(body.chunks)} chunks)`,
+    );
+    return 0;
+  }
+  fx.err(
+    `❌ チャンネル投稿に失敗しました (HTTP ${res.status}): ${typeof body.error === "string" ? body.error : JSON.stringify(res.body)}`,
+  );
+  return 1;
+}
+
 /**
  * CLI エントリ本体（純粋オーケストレーション）。argv はサブコマンド以降
  * （`process.argv.slice(2)` 相当）。テストは fake effects を注入して呼ぶ。
@@ -343,6 +396,14 @@ export async function runSessionCtl(
         return 1;
       }
       return cmdStartHubWorker(fx, branch, issueArg, selector);
+    }
+    case "post-channel": {
+      const [threadId, ...words] = rest;
+      if (!threadId || words.length === 0) {
+        fx.err("使い方: session-ctl post-channel <thread_id> <text...>");
+        return 1;
+      }
+      return cmdPostChannel(fx, threadId, words.join(" "));
     }
     case "help":
     case "--help":


### PR DESCRIPTION
## 概要

Closes #339

Epic #316 Phase 5 実走で、オーケストレーターの進捗・最終レポートがスレッド内にのみ投稿され、corp チャンネル直下で状況を把握できなかった問題への対応。Issue 記載の**実現案 A（推奨）**を実装した。

## 主な変更

| ファイル | 変更 |
|---|---|
| `supervisor/src/session/relay-server.ts` | loopback-only `POST /channel-post/:threadId` を追加。`onChannelPost(handler)` 登録式、未登録は 503（fail-closed、`/hub-work` と同型の信頼境界） |
| `supervisor/src/bot.ts` | ハンドラ結線: threadId からスレッドを fetch → **親チャンネル**を解決 → `formatForDiscord` 分割で投稿。投稿先は構造的に「そのスレッドの親」に限定（任意チャンネル ID は受け取らない） |
| `supervisor/tools/session-ctl.ts` | `post-channel <thread_id> <text...>` サブコマンド追加（relay ポートファイル発見 → POST） |
| `supervisor/tests/...` | 新規 `relay-server-channel-post.test.ts`（8 件）+ `session-ctl.test.ts` に post-channel describe 追記（6 件）。**既存テスト変更 0 件**（append-only、diff で deletions 0 を確認） |
| `.github/workflows/ci.yml` | 新規テストファイルを curated list にゲート（`lint-gating-coverage` PASS） |

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-3 | 既存機能非破壊（既存テスト全 green・既存テスト変更 0 件） | `bun test <relay-server 系 5 ファイル>` / `git diff` | 0 fail / deletions 0 | 107 pass 0 fail / test diff deletions 0 | PASS |
| - | typecheck | `bunx tsc --noEmit` | exit 0 | exit 0 | PASS |
| - | CI lint 4 種 | `check-access-policy --ci` ほか | 全 PASS | 全 PASS | PASS |
| AC-1/2 | corp チャンネル直下への進捗・最終レポート投稿（実機） | corp で /orchestrate 実走 | チャンネル直下に mermaid 付き報告 | **未検証**（Supervisor 再起動 + agent-base SKILL.md C-6 更新後の実機確認が必要） | 保留 |

> フルスイートの 27-37 fail は clean HEAD（origin/main tip）でも同数発生する既存の環境起因フレーク（tmux adapter の mock.module 干渉系 + db.ts:70 の既存 shell-safe 指摘）で、本 PR と無関係。CI では該当ファイルは分離プロセスでゲートされる。

## 残作業（別対応）

- agent-base `skills/orchestrate-runner/SKILL.md` C-6 の報告カデンス更新（進捗・最終レポートを `session-ctl post-channel` でチャンネル直下へ）: Issue 記載どおり**別小 PR**（agent-base リポ）
- 実機 E2E（AC-1/2）: Supervisor 再起動後の /orchestrate 実走で確認

## テスト方法

```bash
cd supervisor
bun test tests/session/relay-server-channel-post.test.ts tests/tools/session-ctl.test.ts
bunx tsc --noEmit
bun scripts/lint-gating-coverage.ts
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * スレッドIDを指定して、親チャンネルへテキストを投稿できる機能を追加しました。
  * 進捗や最終レポートを親チャンネルへ自動で送れるようになりました。

* **Bug Fixes**
  * 不正な入力や未対応の状態では、わかりやすいエラーを返すよう改善しました。
  * サーバー停止後に状態が残らないようにし、再起動時の不整合を防ぎました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->