### PR TITLE
test(#349): /session stop・list・status のハンドラレベル回帰テストを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,9 @@ jobs:
                    tests/commands/session-start-access.test.ts \
                    tests/commands/session-start-branch.test.ts \
                    tests/commands/session-thread-title.test.ts \
+                   tests/commands/session-stop.test.ts \
+                   tests/commands/session-list.test.ts \
+                   tests/commands/session-status.test.ts \
                    tests/config/access-policy.test.ts \
                    tests/config/check-access-policy.test.ts \
                    tests/discord/in-memory-client.test.ts \

--- a/supervisor/tests/commands/session-list.test.ts
+++ b/supervisor/tests/commands/session-list.test.ts
@@ -1,0 +1,132 @@
+import { test, expect, describe } from "bun:test";
+import type { EmbedBuilder } from "discord.js";
+import { createSessionHandler } from "../../src/commands/session";
+
+/**
+ * Handler-level tests for `/session list` (Issue #349).
+ *
+ * See session-stop.test.ts for the rationale (closing the same class of
+ * "handler forgets to read/format state correctly" regression that Issue #349
+ * was opened for, for the subcommands `/session start` and `/session resume`
+ * didn't already cover). No real Discord gateway; `SessionManager` is a
+ * hand-rolled fake.
+ */
+
+interface ReplyPayload {
+  content?: string;
+  flags?: number;
+  embeds?: EmbedBuilder[];
+}
+
+function makeInteraction(opts: {
+  sessions?: Array<{
+    channelName: string;
+    projectDir: string;
+    threadId: string;
+    claudeSessionId?: string;
+    startedAt: Date;
+    lastActivityAt: Date;
+  }>;
+  listImpl?: () => unknown;
+}) {
+  const replies: ReplyPayload[] = [];
+
+  const interaction = {
+    options: {
+      getSubcommand: () => "list",
+      getString: () => null,
+    },
+    channel: null,
+    deferred: false,
+    replied: false,
+    async reply(msg: ReplyPayload) {
+      this.replied = true;
+      replies.push(msg);
+    },
+    async deferReply() {
+      this.deferred = true;
+    },
+    async editReply(msg: ReplyPayload) {
+      replies.push(msg);
+    },
+  };
+
+  const sessionManager = {
+    listRunning: () => {
+      if (opts.listImpl) return opts.listImpl();
+      return opts.sessions ?? [];
+    },
+  };
+
+  return {
+    run: () =>
+      createSessionHandler(sessionManager as never)(interaction as never),
+    replies,
+  };
+}
+
+describe("/session list dispatch (#349)", () => {
+  test("no running sessions → ephemeral info reply, no embed", async () => {
+    const h = makeInteraction({ sessions: [] });
+    await h.run();
+
+    expect(h.replies).toHaveLength(1);
+    expect(h.replies[0]!.flags).toBe(64); // ephemeral
+    expect(h.replies[0]!.content).toContain("稼働中のセッションはありません");
+    expect(h.replies[0]!.embeds).toBeUndefined();
+  });
+
+  test("running sessions → embed reply with one field per session", async () => {
+    const now = new Date();
+    const h = makeInteraction({
+      sessions: [
+        {
+          channelName: "agent-base",
+          projectDir: "/Users/x/agent-base",
+          threadId: "thread-list-1",
+          claudeSessionId: "sess-abc",
+          startedAt: now,
+          lastActivityAt: now,
+        },
+        {
+          channelName: "team-salary",
+          projectDir: "/Users/x/team_salary",
+          threadId: "thread-list-2",
+          startedAt: now,
+          lastActivityAt: now,
+        },
+      ],
+    });
+    await h.run();
+
+    expect(h.replies).toHaveLength(1);
+    expect(h.replies[0]!.content).toBeUndefined();
+    const embeds = h.replies[0]!.embeds;
+    expect(embeds).toHaveLength(1);
+
+    const data = (embeds![0] as unknown as { data: { fields?: unknown[] } })
+      .data;
+    expect(data.fields).toHaveLength(2);
+
+    const fieldValues = (data.fields as { name: string; value: string }[]).map(
+      (f) => f.value
+    );
+    expect(fieldValues[0]).toContain("/Users/x/agent-base");
+    expect(fieldValues[0]).toContain("sess-abc");
+    expect(fieldValues[1]).toContain("/Users/x/team_salary");
+    // No claudeSessionId on the second session → no "🔑 Session:" line.
+    expect(fieldValues[1]).not.toContain("🔑 Session:");
+  });
+
+  test("listRunning() throws → error surfaced, no crash", async () => {
+    const h = makeInteraction({
+      listImpl: () => {
+        throw new Error("db read failed");
+      },
+    });
+    await h.run();
+
+    expect(h.replies).toHaveLength(1);
+    expect(h.replies[0]!.content).toContain("セッション一覧の取得に失敗");
+  });
+});

--- a/supervisor/tests/commands/session-status.test.ts
+++ b/supervisor/tests/commands/session-status.test.ts
@@ -1,0 +1,118 @@
+// Isolate DB writes from the real sessions.db (mirrors tests/session/salvage-reply.test.ts).
+// Must be set before any module that transitively loads infra/db is imported,
+// so everything below uses dynamic import after the env is in place.
+process.env.SUPERVISOR_DB_PATH = ":memory:";
+
+import { test, expect, describe, beforeEach } from "bun:test";
+
+const { insertSession, updateSessionStatus, getDb } = await import(
+  "../../src/infra/db"
+);
+const { createSessionHandler } = await import("../../src/commands/session");
+const { SessionManager } = await import("../../src/session/manager");
+const { createFakeEffects } = await import("../../src/session/adapters-fake");
+
+/**
+ * Handler-level tests for `/session status` (Issue #349).
+ *
+ * `buildStatusReply` itself is already thoroughly covered by
+ * tests/session/salvage-reply.test.ts (Issue #170). What's new here is the
+ * thin `/session status` slash-command dispatch wrapper: the "must run inside
+ * a thread" guard and that the handler actually forwards the real
+ * `SessionManager` + thread id into `buildStatusReply` and relays its output
+ * verbatim. Uses the real `SessionManager` class with fake in-memory effects
+ * (no real tmux/process, same pattern as salvage-reply.test.ts) rather than a
+ * hand-rolled stub, since `buildStatusReply` needs genuine liveness logic.
+ */
+
+interface ReplyRecord {
+  content?: string;
+  flags?: number;
+}
+
+function makeInteraction(opts: { isThread: boolean; threadId?: string }) {
+  const replies: ReplyRecord[] = [];
+  const channel = opts.isThread
+    ? { id: opts.threadId ?? "thread-status-1", isThread: () => true }
+    : { id: "channel-not-thread", isThread: () => false };
+
+  const interaction = {
+    options: {
+      getSubcommand: () => "status",
+      getString: () => null,
+    },
+    channel,
+    deferred: false,
+    replied: false,
+    async reply(msg: ReplyRecord) {
+      this.replied = true;
+      replies.push(msg);
+    },
+    async deferReply() {
+      this.deferred = true;
+    },
+    async editReply(msg: ReplyRecord) {
+      replies.push(msg);
+    },
+  };
+
+  return { interaction, replies };
+}
+
+describe("/session status dispatch (#349)", () => {
+  let manager: InstanceType<typeof SessionManager>;
+
+  beforeEach(() => {
+    getDb().run("DELETE FROM sessions");
+    manager = new SessionManager({ effects: createFakeEffects() });
+  });
+
+  test("outside a thread → usage error, no DB/liveness lookup needed", async () => {
+    const { interaction, replies } = makeInteraction({ isThread: false });
+    await createSessionHandler(manager)(interaction as never);
+
+    expect(replies).toHaveLength(1);
+    expect(replies[0]!.flags).toBe(64); // ephemeral
+    expect(replies[0]!.content).toContain(
+      "セッションスレッド内で実行してください"
+    );
+  });
+
+  test("in a thread, no session history → salvage 'no history' wording", async () => {
+    const { interaction, replies } = makeInteraction({
+      isThread: true,
+      threadId: "thread-status-none",
+    });
+    await createSessionHandler(manager)(interaction as never);
+
+    expect(replies).toHaveLength(1);
+    expect(replies[0]!.content).toContain("セッション履歴がありません");
+  });
+
+  test("in a thread, stopped session → 停止 wording with resume command (real handler → buildStatusReply)", async () => {
+    const claudeId = "66666666-6666-6666-6666-666666666666";
+    const threadId = "thread-status-dead";
+    insertSession({
+      id: "status-dead",
+      channel_name: "agent-base",
+      thread_id: threadId,
+      project_dir: "/tmp/x",
+      pid: 7171,
+      claude_session_id: claudeId,
+      started_at: new Date().toISOString(),
+      last_activity_at: new Date().toISOString(),
+      status: "running",
+    });
+    updateSessionStatus("status-dead", "stopped", "process_dead");
+
+    const { interaction, replies } = makeInteraction({
+      isThread: true,
+      threadId,
+    });
+    await createSessionHandler(manager)(interaction as never);
+
+    expect(replies).toHaveLength(1);
+    expect(replies[0]!.content).toContain("停止しています");
+    expect(replies[0]!.content).toContain(`/session resume ${claudeId}`);
+  });
+});

--- a/supervisor/tests/commands/session-stop.test.ts
+++ b/supervisor/tests/commands/session-stop.test.ts
@@ -1,0 +1,138 @@
+import { test, expect, describe } from "bun:test";
+import { createSessionHandler } from "../../src/commands/session";
+
+/**
+ * Handler-level tests for `/session stop` (Issue #349).
+ *
+ * Issue #349's trigger was a Discord slash command handler regression
+ * (`/session start <branch>` silently forgetting to read the `branch` option)
+ * that shipped without a CI-executable E2E to catch it. `/session start` and
+ * `/session resume` already had handler-level dispatch coverage
+ * (session-start-branch.test.ts / session-resume.test.ts, Issue #154 / #161).
+ * `/session stop` had none — this file closes that gap using the same
+ * mock-`ChatInputCommandInteraction` approach (no real Discord gateway, no
+ * real tmux; `SessionManager` is a hand-rolled fake so no process is spawned).
+ */
+
+interface ReplyRecord {
+  kind: "reply" | "editReply";
+  content?: string;
+  flags?: number;
+}
+
+function makeInteraction(opts: {
+  isThread?: boolean;
+  hasSession?: boolean;
+  stopImpl?: (...args: unknown[]) => unknown;
+}) {
+  const replies: ReplyRecord[] = [];
+  const stopCalls: unknown[][] = [];
+  const setNameCalls: string[] = [];
+  const setArchivedCalls: boolean[] = [];
+
+  const channel = {
+    id: "thread-stop-1",
+    name: "🟢 feature-foo | agent-base",
+    isThread: () => opts.isThread ?? true,
+    setName: async (name: string) => {
+      setNameCalls.push(name);
+    },
+    setArchived: async (archived: boolean) => {
+      setArchivedCalls.push(archived);
+    },
+  };
+
+  const interaction = {
+    options: {
+      getSubcommand: () => "stop",
+      getString: () => null,
+    },
+    channel,
+    deferred: false,
+    replied: false,
+    async reply(msg: { content?: string; flags?: number }) {
+      this.replied = true;
+      replies.push({ kind: "reply", content: msg.content, flags: msg.flags });
+    },
+    async deferReply() {
+      this.deferred = true;
+    },
+    async editReply(msg: { content?: string }) {
+      replies.push({ kind: "editReply", content: msg.content });
+    },
+  };
+
+  const sessionManager = {
+    has: (_threadId: string) => opts.hasSession ?? true,
+    stop: async (...args: unknown[]) => {
+      stopCalls.push(args);
+      return opts.stopImpl?.(...args);
+    },
+  };
+
+  return {
+    run: () =>
+      createSessionHandler(sessionManager as never)(interaction as never),
+    replies,
+    stopCalls,
+    setNameCalls,
+    setArchivedCalls,
+  };
+}
+
+describe("/session stop dispatch (#349)", () => {
+  test("outside a thread → usage hint, stop() never called", async () => {
+    const h = makeInteraction({ isThread: false });
+    await h.run();
+
+    expect(h.stopCalls).toHaveLength(0);
+    expect(h.replies).toHaveLength(1);
+    expect(h.replies[0]!.kind).toBe("reply");
+    expect(h.replies[0]!.flags).toBe(64); // ephemeral
+    expect(h.replies[0]!.content).toContain("セッションスレッド内で実行");
+  });
+
+  test("in a thread with no tracked session → info reply, stop() never called", async () => {
+    const h = makeInteraction({ isThread: true, hasSession: false });
+    await h.run();
+
+    expect(h.stopCalls).toHaveLength(0);
+    expect(h.replies).toHaveLength(1);
+    expect(h.replies[0]!.content).toContain("稼働中のセッションはありません");
+  });
+
+  test("active session → stop() called with (threadId, \"manual\"), thread archived", async () => {
+    const h = makeInteraction({ isThread: true, hasSession: true });
+    await h.run();
+
+    expect(h.stopCalls).toHaveLength(1);
+    expect(h.stopCalls[0]).toEqual(["thread-stop-1", "manual"]);
+    expect(h.setNameCalls).toHaveLength(1);
+    expect(h.setArchivedCalls).toEqual([true]);
+
+    const editReplies = h.replies.filter((r) => r.kind === "editReply");
+    expect(editReplies).toHaveLength(1);
+    expect(editReplies[0]!.content).toContain("停止しました");
+  });
+
+  test("stop() failure → error surfaced, thread not renamed/archived", async () => {
+    const h = makeInteraction({
+      isThread: true,
+      hasSession: true,
+      stopImpl: () => {
+        throw new Error("tmux kill-session failed");
+      },
+    });
+    await h.run();
+
+    expect(h.stopCalls).toHaveLength(1);
+    expect(h.setNameCalls).toHaveLength(0);
+    expect(h.setArchivedCalls).toHaveLength(0);
+
+    const editReplies = h.replies.filter((r) => r.kind === "editReply");
+    expect(editReplies.length).toBeGreaterThan(0);
+    expect(editReplies[editReplies.length - 1]!.content).toContain(
+      "セッション停止に失敗"
+    );
+  });
+});


### PR DESCRIPTION
## 背景

miyashita337/claude-hub#349: 2026-07-07 の Supervisor OOM ダウンを機に、「Discord slash コマンドのハンドラ回帰（例: `/session start <branch>` の branch option を読まなくなる）」を CI で機械検知する E2E の有無を調査した。

## 調査結果（着手前の棚卸し）

`/session start <branch>` の branch 有無パターン（Issue #349 の AC-1 / AC-2 に相当）は、**既に** `supervisor/tests/commands/session-start-branch.test.ts`（Issue #154）が mock `ChatInputCommandInteraction` + `createSessionHandler(sessionManager)` 直叩き方式でカバーしており、`.github/workflows/ci.yml` の Unit Tests ステップで既に gate 済みだった（実行して確認: 23 tests pass）。同様に `/session resume` も `session-resume.test.ts`（Issue #161）で同パターンがカバー・gate 済み。

一方、同じ dispatch 方式のテストが **`/session stop` / `/session list` / `/session status` には存在しなかった**（Issue #349 の「余力があれば」の横展開対象）。本 PR はこの 3 サブコマンドのハンドラレベル回帰テストを追加し、`createSessionHandler` の全 dispatch 分岐（`compact` / `keep` を除く）を CI ガード下に置く。

## やったこと

- `supervisor/tests/commands/session-stop.test.ts`（新規）: スレッド外実行時のガード / 未稼働セッションの info reply / `stop(threadId, "manual")` 呼び出し + thread rename + archive / `stop()` 失敗時のエラー表示、を mock interaction で検証
- `supervisor/tests/commands/session-list.test.ts`（新規）: 0 件時の ephemeral info reply / 複数セッション時の embed 生成（フィールド数・内容） / `listRunning()` 例外時のエラー表示、を mock interaction で検証
- `supervisor/tests/commands/session-status.test.ts`（新規）: スレッド外実行時のガード / 履歴なしスレッドの salvage 文言 / 停止済みセッションの resume ヒント文言、を実 `SessionManager` + fake effects（`adapters-fake.ts`、実 tmux/process なし）+ in-memory DB で検証（`buildStatusReply` 自体の詳細は `tests/session/salvage-reply.test.ts` で既に厚くカバー済みのため重複させず、ハンドラの薄い dispatch/ガード層のみ検証）
- `.github/workflows/ci.yml`: 上記 3 ファイルを Unit Tests ステップの `bun test` 対象リストに追加（`lint-gating-coverage.ts` が新規テストの ungated を検知して落ちることを確認した上での対応）

実 Discord Gateway・実 tmux・実 claude 起動・実課金・実投稿は一切なし（既存パターンを踏襲した mock 境界）。既存ハンドラのシグネチャ・挙動は変更していない（純追加）。

## 統合ジャーニーAC 検証結果

| # | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | `/session start <branch>`（branch あり）→ start が試みられ「branch 必須」エラーが出ない | `bun test tests/commands/session-start-branch.test.ts`（既存、Issue #154） | PASS | 4/4 pass | PASS（既存カバー確認） |
| AC-2 | `/session start`（branch なし）→ migration hint reply、start 未呼び出し | 同上 | PASS | 上記に含む | PASS（既存カバー確認） |
| AC-3 | CI に組み込まれ green | `.github/workflows/ci.yml` Unit Tests ステップに新規3ファイル追加 | PR CI green | 下記ローカル実測で再現 | 実測PASS（CI 実行はこの PR で確認） |
| 追加 | `/session stop` dispatch 回帰 | `bun test tests/commands/session-stop.test.ts` | PASS | 4/4 pass | PASS |
| 追加 | `/session list` dispatch 回帰 | `bun test tests/commands/session-list.test.ts` | PASS | 3/3 pass | PASS |
| 追加 | `/session status` dispatch 回帰 | `bun test tests/commands/session-status.test.ts` | PASS | 3/3 pass | PASS |
| 追加 | `lint-gating-coverage`（新規テストの CI 未gate検知） | `bun scripts/lint-gating-coverage.ts` | ungated 0 | `83 test file(s) — 80 gated, 3 excluded, 0 ungated.` | PASS |
| 追加 | 型チェック | `bunx tsc --noEmit` | エラー0 | エラー0 | PASS |
| 追加 | 既存 Unit Tests 回帰なし | ci.yml「Run tests」ステップと同一ファイル集合を実行 | 全 PASS | `908 pass / 13 skip / 0 fail`（74 files） | PASS |
| 追加 | mock-isolated 系（`adapters-hassession` / `adapters` / `tmux` / `relay-nonblocking`） | 個別 `bun test` | 全 PASS | 4/4, 17/17, 8/8, 2/2 pass | PASS |

## 関連

- miyashita337/claude-hub#349
- Issue #154（`/session start` branch 必須化・既存カバレッジの起点）
- Issue #161（`/session resume`・既存カバレッジの起点）
- Issue #170（`buildStatusReply`・既存カバレッジの起点、`tests/session/salvage-reply.test.ts`）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/miyashita337/claude-hub/pull/350" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * `/session stop`、`/session list`、`/session status` の主要な動作を検証するテストを追加しました。
  * セッションがない場合、停止済みの場合、エラー発生時などの表示や応答を確認します。
* **CI**
  * 継続的インテグレーションで、追加されたセッション関連テストも自動実行されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->