### PR TITLE
fix(#341): hermetic テストが本番 Supervisor の relay-port を消さないよう runtime dir を隔離

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,6 +179,7 @@ jobs:
                    tests/session/hub-work.test.ts \
                    tests/session/relay-server-hub-work.test.ts \
                    tests/session/relay-server-channel-post.test.ts \
+                   tests/session/relay-port-isolation.test.ts \
                    tests/tools/session-ctl.test.ts
 
       # #238 regression: realTmuxAdapter.hasSession must treat a tmux

--- a/supervisor/bunfig.toml
+++ b/supervisor/bunfig.toml
@@ -1,0 +1,9 @@
+# Issue #341: isolate the per-user runtime dir for `bun test` so hermetic tests
+# never write/unlink the LIVE Supervisor's relay-port file. The preload runs
+# once per `bun test` process, before any test file, and repoints
+# XDG_RUNTIME_DIR at a throwaway temp dir. Scoped to `[test]` only — `bun run`
+# and production start-up are unaffected. All test invocations (CI ci.yml,
+# scripts/e2e-orchestrate.sh) run `bun test` from this directory, so this
+# bunfig is always picked up.
+[test]
+preload = ["./tests/setup/runtime-dir-isolation.ts"]

--- a/supervisor/tests/session/relay-port-isolation.test.ts
+++ b/supervisor/tests/session/relay-port-isolation.test.ts
@@ -34,7 +34,14 @@ describe("relay-port isolation (Issue #341)", () => {
 
   test("start/stop touches only the isolated dir; the well-known production path is left intact", () => {
     const user = process.env.USER || "default";
-    const wellKnown = `/tmp/claude-hub-supervisor-${user}/relay-port`;
+    // The REAL production path for THIS platform, reconstructed from the XDG
+    // value the preload captured before overriding it — so the guard is accurate
+    // on Linux CI (XDG = /run/user/<uid>) too, not just the macOS /tmp fallback.
+    // Mirrors relayPortFilePath()'s own resolution.
+    const originalXdg = process.env.ORIGINAL_XDG_RUNTIME_DIR;
+    const wellKnown = originalXdg
+      ? `${originalXdg}/claude-hub-supervisor/relay-port`
+      : `/tmp/claude-hub-supervisor-${user}/relay-port`;
     // Read-only snapshot of the real path (present or absent) — this test must
     // never itself mutate the production file it is guarding.
     const before = existsSync(wellKnown)

--- a/supervisor/tests/session/relay-port-isolation.test.ts
+++ b/supervisor/tests/session/relay-port-isolation.test.ts
@@ -1,0 +1,54 @@
+import { test, expect, describe, afterEach } from "bun:test";
+import { existsSync, readFileSync } from "fs";
+import {
+  startRelayServer,
+  stopRelayServer,
+  relayPortFilePath,
+} from "../../src/session/relay-server";
+
+// Issue #341: locks the hermetic runtime-dir isolation in place. The bun-test
+// preload (bunfig.toml → tests/setup/runtime-dir-isolation.ts) sets
+// XDG_RUNTIME_DIR to a throwaway temp dir so start/stopRelayServer() in the
+// whole suite writes/unlinks there — never the well-known production path the
+// LIVE Supervisor and tools/e2e-live.ts preflight depend on. If the preload is
+// ever removed, these assertions fail (cross-platform: the marker check catches
+// it even on Linux where XDG is normally /run/user/<uid>).
+describe("relay-port isolation (Issue #341)", () => {
+  afterEach(() => stopRelayServer());
+
+  test("preload repoints XDG_RUNTIME_DIR at a throwaway temp dir", () => {
+    const xdg = process.env.XDG_RUNTIME_DIR;
+    expect(xdg).toBeTruthy();
+    // Stable marker written by the preload's mkdtemp prefix.
+    expect(xdg).toContain("claude-hub-supervisor-test-");
+  });
+
+  test("relayPortFilePath resolves under the isolated dir, not the well-known user path", () => {
+    const path = relayPortFilePath();
+    expect(path).toContain(process.env.XDG_RUNTIME_DIR ?? "\0never");
+    expect(path.endsWith("/claude-hub-supervisor/relay-port")).toBe(true);
+    // Must not be the production /tmp fallback the live preflight reads.
+    const user = process.env.USER || "default";
+    expect(path).not.toBe(`/tmp/claude-hub-supervisor-${user}/relay-port`);
+  });
+
+  test("start/stop touches only the isolated dir; the well-known production path is left intact", () => {
+    const user = process.env.USER || "default";
+    const wellKnown = `/tmp/claude-hub-supervisor-${user}/relay-port`;
+    // Read-only snapshot of the real path (present or absent) — this test must
+    // never itself mutate the production file it is guarding.
+    const before = existsSync(wellKnown)
+      ? readFileSync(wellKnown, "utf8")
+      : null;
+
+    startRelayServer();
+    const isolated = relayPortFilePath();
+    expect(isolated).not.toBe(wellKnown);
+    expect(existsSync(isolated)).toBe(true);
+    stopRelayServer();
+    expect(existsSync(isolated)).toBe(false);
+
+    const after = existsSync(wellKnown) ? readFileSync(wellKnown, "utf8") : null;
+    expect(after).toBe(before);
+  });
+});

--- a/supervisor/tests/setup/runtime-dir-isolation.ts
+++ b/supervisor/tests/setup/runtime-dir-isolation.ts
@@ -35,11 +35,27 @@ const isolatedRuntimeDir = mkdtempSync(
 process.env.XDG_RUNTIME_DIR = isolatedRuntimeDir;
 
 // Best-effort cleanup so repeated runs don't litter the temp root. Fail-soft:
-// an unremovable temp dir must never fail the test run.
-process.on("exit", () => {
+// an unremovable temp dir must never fail the test run. Idempotent (rmSync with
+// force), so running it from both a signal handler and the subsequent `exit`
+// event is harmless.
+const cleanup = () => {
   try {
     rmSync(isolatedRuntimeDir, { recursive: true, force: true });
   } catch {
     // ignore — OS will reclaim the temp dir eventually
   }
+};
+
+// Normal termination.
+process.on("exit", cleanup);
+// SIGINT (Ctrl+C) / SIGTERM do NOT fire the `exit` event, so an interrupted
+// `bun test` would otherwise leak the temp dir. Clean up, then re-exit with the
+// conventional 128+signal code to preserve interrupt semantics.
+process.on("SIGINT", () => {
+  cleanup();
+  process.exit(130);
+});
+process.on("SIGTERM", () => {
+  cleanup();
+  process.exit(143);
 });

--- a/supervisor/tests/setup/runtime-dir-isolation.ts
+++ b/supervisor/tests/setup/runtime-dir-isolation.ts
@@ -32,6 +32,14 @@ import { join } from "path";
 const isolatedRuntimeDir = mkdtempSync(
   join(tmpdir(), "claude-hub-supervisor-test-"),
 );
+// Preserve the pre-override value so the regression guard
+// (tests/session/relay-port-isolation.test.ts) can reconstruct the REAL
+// production relay-port path for THIS platform and assert it stays untouched:
+// Linux CI → $XDG_RUNTIME_DIR/claude-hub-supervisor/… (XDG is normally
+// /run/user/<uid>), macOS → the /tmp/claude-hub-supervisor-<USER>/… fallback.
+// Empty string encodes "was unset" (→ /tmp fallback), matching
+// relayPortFilePath()'s own resolution.
+process.env.ORIGINAL_XDG_RUNTIME_DIR = process.env.XDG_RUNTIME_DIR ?? "";
 process.env.XDG_RUNTIME_DIR = isolatedRuntimeDir;
 
 // Best-effort cleanup so repeated runs don't litter the temp root. Fail-soft:

--- a/supervisor/tests/setup/runtime-dir-isolation.ts
+++ b/supervisor/tests/setup/runtime-dir-isolation.ts
@@ -1,0 +1,45 @@
+// Issue #341: hermetic test isolation for the per-user runtime dir.
+//
+// `relayPortFilePath()` (relay-server.ts) and `relayUrlFilePath()` (manager.ts)
+// both resolve a single well-known path per user:
+//   $XDG_RUNTIME_DIR/claude-hub-supervisor/…   (when XDG is set), else
+//   /tmp/claude-hub-supervisor-<USER>/…
+// A LIVE Supervisor writes its relay-port there and `tools/e2e-live.ts`'s
+// preflight reads it. Because the path is process-shared, any hermetic test
+// that calls start/stopRelayServer() would writeFile (start) then unlink (stop)
+// the LIVE Supervisor's port file — destroying port discovery for
+// session-ctl / /orchestrate and making the live E2E preflight structurally
+// FAIL (self-inflicted). See the issue's decisive reproduction.
+//
+// Fix (案A): this bun-test preload (wired via bunfig.toml `[test].preload`)
+// runs once per `bun test` process, BEFORE any test file loads, and points
+// XDG_RUNTIME_DIR at a throwaway temp dir. Every runtime-file resolution in the
+// suite then lands under that temp dir, so tests can never touch the well-known
+// production path. Same isolation spirit as SUPERVISOR_TMUX_SOCKET=claude-hub-test
+// (RW-019), but applied to the runtime dir and enforced mechanically for every
+// current AND future test file (no per-file opt-in to forget).
+//
+// We ALWAYS override (not "only when unset"): on Linux dev/CI machines XDG is
+// normally set to /run/user/<uid>, and we must not touch that either.
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+// Prefix carries a stable marker (`claude-hub-supervisor-test`) that the
+// regression guard (tests/session/relay-port-isolation.test.ts) asserts on, so
+// removing this preload is caught by a failing test rather than silently
+// re-exposing the production path.
+const isolatedRuntimeDir = mkdtempSync(
+  join(tmpdir(), "claude-hub-supervisor-test-"),
+);
+process.env.XDG_RUNTIME_DIR = isolatedRuntimeDir;
+
+// Best-effort cleanup so repeated runs don't litter the temp root. Fail-soft:
+// an unremovable temp dir must never fail the test run.
+process.on("exit", () => {
+  try {
+    rmSync(isolatedRuntimeDir, { recursive: true, force: true });
+  } catch {
+    // ignore — OS will reclaim the temp dir eventually
+  }
+});


### PR DESCRIPTION
## 概要

Fixes #341

hermetic テスト（`start/stopRelayServer()` を呼ぶ全 test）が、本番 Supervisor と**共有された単一固定パス**の relay-port ファイル（`$XDG_RUNTIME_DIR/claude-hub-supervisor/relay-port`、無ければ `/tmp/claude-hub-supervisor-<USER>/relay-port`）を `writeFile`（start）→ `unlink`（stop）していた。このため:

- `scripts/e2e-orchestrate.sh` が hermetic → live 順で走ると、**live preflight が構造的に必ず FAIL**（自壊）
- 運用中に誰かが supervisor テストを走らせるだけで `session-ctl` / `/orchestrate` の port discovery が「Supervisor 未起動」扱いで壊れる

## 対処（案A: テスト側 runtime dir 隔離）

`bun test` の `[test].preload`（`bunfig.toml`）で、**全 test プロセス開始時に一度だけ** `XDG_RUNTIME_DIR` を使い捨て temp dir へ向ける。`relayPortFilePath()` / `relayUrlFilePath()` は XDG を優先するため、テストの write/unlink が本番 well-known path に触れなくなる。既存の `SUPERVISOR_TMUX_SOCKET=claude-hub-test`（RW-019）と同じ隔離思想を runtime dir に適用したもの。

**preload を選んだ理由**: 6 個の既存 test file に加え、**将来追加される全 test file も自動的に保護**される（各ファイルで隔離を書き忘れる再発リスクをゼロにする、機械的担保）。

## 変更点

| ファイル | 内容 |
|---|---|
| `supervisor/bunfig.toml` | `[test].preload` を追加（`bun test` 限定。`bun run`・本番起動は不変） |
| `supervisor/tests/setup/runtime-dir-isolation.ts` | `XDG_RUNTIME_DIR` を temp dir へ隔離。process exit で fail-soft cleanup |
| `supervisor/tests/session/relay-port-isolation.test.ts` | 隔離の回帰ガード（3 test）。本番 well-known path は **read-only** で検証し自身も非破壊 |
| `.github/workflows/ci.yml` | 新 test を gating batch へ追加（`lint-gating-coverage` guard 準拠） |

## AC 検証結果

| AC | 検証内容 | 実測 | 判定 |
|---|---|---|---|
| AC-1 | e2e-orchestrate の hermetic 一括実行後も本番 port file が残る | 実 port file（内容 `53320`）が `ac-verification + relay + dialog-stall`（36 pass）実行後も不変 | PASS（機構）※ |
| AC-2 | `bun test relay-server-hub-work.test.ts + relay.test.ts` で本番 port file 不変 | before/after ともに `53320`（修正前は削除されていた） | PASS |
| AC-3 | 既存テストスイート全 green（非破壊） | 影響 file を CI と同じ個別プロセスで実行し全 pass。全 suite 単一プロセス実行の fail/error 集合は baseline と一致（純増 0） | PASS |

※ AC-1 のライブ preflight PASS は**稼働中 Supervisor**が前提。本 PR 環境では live Supervisor 未稼働のため end-to-end は未実走だが、破壊経路（hermetic による port file 消去）は決定的に閉じたことを実測で確認済み。

## 再現（修正前 RED / 修正後 GREEN）

```bash
# 本番相当の port file を用意
printf '53320' > /tmp/claude-hub-supervisor-$USER/relay-port
cd supervisor && SUPERVISOR_DB_PATH=":memory:" bun test tests/session/relay-server-hub-work.test.ts
ls /tmp/claude-hub-supervisor-$USER/relay-port
```

- 修正前: `No such file or directory`（本番 port file が消える）
- 修正後: `53320`（不変）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/miyashita337/claude-hub/pull/356" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * リレー用ポートファイルがテスト専用の一時ディレクトリに隔離されることを検証するテストを追加しました。
  * テスト実行時に本番環境のランタイムファイルへアクセスしないよう、隔離された実行環境を設定しました。
  * CIで新しい隔離テストを実行するよう更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->