### PR TITLE
security(#236): relay 外側 catch の生エラー転送を定型文へ置換

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,7 @@ jobs:
                    tests/session/dialog-detect.test.ts \
                    tests/session/dialog-watchdog.test.ts \
                    tests/session/relay-send-failure.test.ts \
+                   tests/session/relay-error-notice.test.ts \
                    tests/scripts/lint-blocking-in-timers.test.ts \
                    tests/scripts/lint-no-sync-exec.test.ts \
                    tests/session/notify-pushover.test.ts \

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -23,7 +23,7 @@ import { ActivityWatchdog } from "./session/session-activity-watchdog";
 import { ResourceMonitor } from "./session/resource-monitor";
 import { createSessionCommand, createSessionHandler } from "./commands/session";
 import { CHANNEL_MAP, MAX_SESSIONS } from "./config/channels";
-import type { AttachmentInfo } from "./session/relay";
+import { RELAY_ERROR_USER_MESSAGE, type AttachmentInfo } from "./session/relay";
 import { buildDialogStuckHandler } from "./session/dialog-stuck-handler";
 import { notifyPushover, warnIfPushoverUnconfigured } from "./session/notify-pushover";
 import { startActionReceiver, stopActionReceiver } from "./action/receiver";
@@ -1352,11 +1352,12 @@ export async function startBot(token: string): Promise<void> {
         relaySucceeded = !result.error;
 
       } catch (err) {
+        // Issue #236: log the raw cause (object, so the stack survives) but post
+        // only the canned notice — `err.message` can embed absolute paths and
+        // `String(err)` anything at all. Same split as #74's send-keys path.
         console.error(`[Bot] Relay error in thread ${threadId}:`, err);
         try {
-          await thread.send(
-            `⚠️ Claude Code への中継中にエラーが発生しました: ${(err instanceof Error ? err.message : String(err)).slice(0, 1900)}`
-          );
+          await thread.send(RELAY_ERROR_USER_MESSAGE);
         } catch (sendErr) {
           console.error(`[Bot] Failed to send error notification to thread ${threadId}:`, sendErr);
         }

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -318,9 +318,13 @@ export interface RelayMessageOptions {
  * straight into a Discord chunk, so the thread showed bogus "responses" (the
  * #74 screenshot: `not in a mode` posted 5×). This message is deliberately
  * free of tmux internals; the raw cause is preserved in logs + `RelayResult.error`.
+ *
+ * Issue #236: the original wording pointed at `/session restart`, which is not a
+ * real subcommand (`session.ts` registers start/stop/list/status/resume/compact/
+ * keep). Recovery guidance now names commands that exist.
  */
 export const SEND_FAILURE_USER_MESSAGE =
-  "⚠️ メッセージを Claude Code セッションに送信できませんでした（セッションが応答不能、または画面が一時的に固まっている可能性があります）。少し待って再送するか、`/session restart` で再開してください。";
+  "⚠️ メッセージを Claude Code セッションに送信できませんでした（セッションが応答不能、または画面が一時的に固まっている可能性があります）。少し待って再送するか、`/session stop` → `/session start` で再起動してください。";
 
 /**
  * Issue #236 (follow-up of #74): user-facing notice for a failure caught by the
@@ -340,7 +344,7 @@ export const SEND_FAILURE_USER_MESSAGE =
  * user, raw cause preserved in `console.error` for diagnostics.
  */
 export const RELAY_ERROR_USER_MESSAGE =
-  "⚠️ Claude Code への中継中にエラーが発生しました（一時的な障害の可能性があります）。`/session status` で状態を確認し、少し待ってから再送するか、`/session restart` で再開してください。詳細は Supervisor のログに記録されています。";
+  "⚠️ Claude Code への中継中にエラーが発生しました（一時的な障害の可能性があります）。`/session status` で状態を確認し、少し待ってから再送してください。復旧しない場合は `/session stop` → `/session start` で再起動するか、`/session resume` で会話履歴付きに復帰してください。詳細は Supervisor のログに記録されています。";
 
 /**
  * Build the {@link RelayResult} for a send-keys failure. Pure + exported so a

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -323,6 +323,26 @@ export const SEND_FAILURE_USER_MESSAGE =
   "⚠️ メッセージを Claude Code セッションに送信できませんでした（セッションが応答不能、または画面が一時的に固まっている可能性があります）。少し待って再送するか、`/session restart` で再開してください。";
 
 /**
+ * Issue #236 (follow-up of #74): user-facing notice for a failure caught by the
+ * relay block's OUTER catch in `bot.ts` — i.e. anything awaited in that block
+ * that has no inner catch (the session-teardown race in `sendMessage`, a
+ * `bun:sqlite` write, a `thread.send` DiscordAPIError, or any throw a future
+ * change adds there).
+ *
+ * That catch used to interpolate `err.message` (sliced at 1900 chars) straight
+ * into the Discord message. Node/Bun `Error.message` embeds absolute paths —
+ * `ENOENT: no such file or directory, open '/Users/<name>/...'` — and
+ * `String(err)` on a non-Error throwable can carry anything, so the shape
+ * itself is the vulnerability: one new fs/child-process throw in that block and
+ * a home path is posted to a thread that may have non-owner readers.
+ *
+ * Same contract as {@link SEND_FAILURE_USER_MESSAGE}: clean + actionable for the
+ * user, raw cause preserved in `console.error` for diagnostics.
+ */
+export const RELAY_ERROR_USER_MESSAGE =
+  "⚠️ Claude Code への中継中にエラーが発生しました（一時的な障害の可能性があります）。`/session status` で状態を確認し、少し待ってから再送するか、`/session restart` で再開してください。詳細は Supervisor のログに記録されています。";
+
+/**
  * Build the {@link RelayResult} for a send-keys failure. Pure + exported so a
  * unit test can lock that raw tmux internals never reach the user-facing chunk
  * while the diagnostic cause is still carried in `error` (Issue #74). By the

--- a/supervisor/tests/session/relay-error-notice.test.ts
+++ b/supervisor/tests/session/relay-error-notice.test.ts
@@ -1,0 +1,80 @@
+import { test, expect, describe } from "bun:test";
+import { RELAY_ERROR_USER_MESSAGE } from "../../src/session/relay";
+
+/**
+ * Issue #236 (follow-up of #74): the relay block's OUTER catch in bot.ts used
+ * to interpolate `err.message` straight into a Discord message:
+ *
+ *   `⚠️ ...エラーが発生しました: ${(err instanceof Error ? err.message : String(err)).slice(0, 1900)}`
+ *
+ * #74 closed the send-keys path (`buildSendFailureResult`), but this catch is a
+ * second, independent egress: everything awaited inside the ~100-line relay
+ * block that has no inner catch lands here. Node/Bun `Error.message` routinely
+ * embeds absolute filesystem paths (`ENOENT: ... open '/Users/<name>/...'`), and
+ * `String(err)` on a non-Error throwable can carry anything at all — so the
+ * unbounded interpolation (sliced at 1900 chars, i.e. nearly a whole Discord
+ * message) posts internal detail into a thread that can have non-owner readers.
+ *
+ * The fix mirrors #74: Discord gets a fixed, actionable notice; the raw cause
+ * stays in `console.error` only.
+ *
+ * The relay handler is a closure inside `startBot`, so it cannot be called
+ * directly from a unit test. The wired guard below therefore asserts the
+ * call site at the source level — the same technique
+ * `tests/guards/access-enforcement-wired.test.ts` uses for the access gate.
+ */
+/**
+ * Extract the relay block's outer `catch (err) { ... }` body from bot.ts,
+ * anchored on its log marker so an unrelated catch elsewhere in the file can
+ * never be inspected by mistake.
+ *
+ * Comments are stripped: the catch is documented with the very tokens the
+ * assertions forbid (`err.message`, `String(err)`), and a comment explaining
+ * why they are banned must not itself trip the guard — the same false-fire
+ * concern `scripts/lint-no-sync-exec.ts` solves with an AST. This block has no
+ * string literal containing `//`, so the regex strip is safe here.
+ */
+async function readRelayCatchBlock(): Promise<string> {
+  const src = await Bun.file("src/bot.ts").text();
+  const marker = src.indexOf("[Bot] Relay error in thread");
+  expect(marker).toBeGreaterThan(-1);
+  const start = src.lastIndexOf("catch (err) {", marker);
+  const end = src.indexOf("} finally {", marker);
+  expect(start).toBeGreaterThan(-1);
+  expect(end).toBeGreaterThan(start);
+  return src
+    .slice(start, end)
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/^\s*\/\/.*$/gm, "");
+}
+
+describe("relay outer-catch notice leaks nothing (#236)", () => {
+  test("the canned notice carries no internal detail", () => {
+    // No filesystem paths, no error-object shape, no tmux/SQL internals.
+    expect(RELAY_ERROR_USER_MESSAGE).not.toMatch(/\/Users\/|\/home\/|\/var\/|\/tmp\//);
+    expect(RELAY_ERROR_USER_MESSAGE).not.toMatch(/ENOENT|EACCES|SQLITE|DiscordAPIError/i);
+    expect(RELAY_ERROR_USER_MESSAGE).not.toMatch(/Error:|\bat \w+ \(|Command failed|tmux/i);
+    // Actionable: tells the user how to recover (same contract as #74).
+    expect(RELAY_ERROR_USER_MESSAGE).toContain("/session restart");
+  });
+
+  test("bot.ts outer catch sends the canned notice, not the raw error", async () => {
+    const block = await readRelayCatchBlock();
+
+    // The user-facing send must be the constant.
+    expect(block).toContain("RELAY_ERROR_USER_MESSAGE");
+    // No raw error content may be interpolated into the Discord message. The
+    // diagnostic `console.error` passes the `err` OBJECT (preserving the stack),
+    // so neither stringification form should appear anywhere in this block.
+    expect(block).not.toContain("err.message");
+    expect(block).not.toContain("String(err)");
+  });
+
+  test("bot.ts still logs the raw cause for diagnostics", async () => {
+    const block = await readRelayCatchBlock();
+    // Sanitizing the user-facing path must not silently drop the diagnostic
+    // (agent-output-quality #1: no silent fallback). The err OBJECT is passed,
+    // so the stack survives in the Supervisor log.
+    expect(block).toMatch(/console\.error\(`\[Bot\] Relay error in thread[^`]*`,\s*err\s*\)/);
+  });
+});

--- a/supervisor/tests/session/relay-error-notice.test.ts
+++ b/supervisor/tests/session/relay-error-notice.test.ts
@@ -86,8 +86,12 @@ describe("relay outer-catch notice leaks nothing (#236)", () => {
   test("bot.ts outer catch sends the canned notice, not the raw error", async () => {
     const block = await readRelayCatchBlock();
 
-    // The user-facing send must be the constant.
-    expect(block).toContain("RELAY_ERROR_USER_MESSAGE");
+    // The user-facing send must be the constant AND NOTHING ELSE. Asserting
+    // mere presence of the identifier would still admit
+    // `thread.send(`${RELAY_ERROR_USER_MESSAGE}: ${err}`)` — a bare `${err}`
+    // is neither `err.message` nor `String(err)`, so the negative checks below
+    // would not catch it (CodeRabbit on PR #361).
+    expect(block).toMatch(/await\s+thread\.send\(\s*RELAY_ERROR_USER_MESSAGE\s*\);/);
     // No raw error content may be interpolated into the Discord message. The
     // diagnostic `console.error` passes the `err` OBJECT (preserving the stack),
     // so neither stringification form should appear anywhere in this block.

--- a/supervisor/tests/session/relay-error-notice.test.ts
+++ b/supervisor/tests/session/relay-error-notice.test.ts
@@ -1,5 +1,8 @@
 import { test, expect, describe } from "bun:test";
-import { RELAY_ERROR_USER_MESSAGE } from "../../src/session/relay";
+import {
+  RELAY_ERROR_USER_MESSAGE,
+  SEND_FAILURE_USER_MESSAGE,
+} from "../../src/session/relay";
 
 /**
  * Issue #236 (follow-up of #74): the relay block's OUTER catch in bot.ts used
@@ -55,7 +58,29 @@ describe("relay outer-catch notice leaks nothing (#236)", () => {
     expect(RELAY_ERROR_USER_MESSAGE).not.toMatch(/ENOENT|EACCES|SQLITE|DiscordAPIError/i);
     expect(RELAY_ERROR_USER_MESSAGE).not.toMatch(/Error:|\bat \w+ \(|Command failed|tmux/i);
     // Actionable: tells the user how to recover (same contract as #74).
-    expect(RELAY_ERROR_USER_MESSAGE).toContain("/session restart");
+    expect(RELAY_ERROR_USER_MESSAGE).toContain("/session status");
+    expect(RELAY_ERROR_USER_MESSAGE).toContain("/session start");
+  });
+
+  test("recovery guidance only names subcommands that actually exist", async () => {
+    // Both notices used to point at `/session restart`, which was never
+    // registered (#236): session.ts declares start/stop/list/status/resume/
+    // compact/keep. Telling a user to run a command that does not exist turns a
+    // transient failure into a dead end, so pin the guidance to the real
+    // registry rather than to a hand-copied list.
+    const cmdSrc = await Bun.file("src/commands/session.ts").text();
+    const registered = new Set(
+      [...cmdSrc.matchAll(/sub\s*(?:\n\s*)?\.setName\("([a-z]+)"\)/g)].map((m) => m[1]!)
+    );
+    expect(registered.size).toBeGreaterThan(0);
+
+    for (const notice of [RELAY_ERROR_USER_MESSAGE, SEND_FAILURE_USER_MESSAGE]) {
+      const referenced = [...notice.matchAll(/\/session\s+([a-z]+)/g)].map((m) => m[1]!);
+      expect(referenced.length).toBeGreaterThan(0);
+      for (const sub of referenced) {
+        expect(registered).toContain(sub);
+      }
+    }
   });
 
   test("bot.ts outer catch sends the canned notice, not the raw error", async () => {

--- a/supervisor/tests/session/relay-send-failure.test.ts
+++ b/supervisor/tests/session/relay-send-failure.test.ts
@@ -45,8 +45,10 @@ describe("relay send-keys failure does not leak tmux internals (#74)", () => {
 
   test("the canned message is clean and actionable", () => {
     expect(SEND_FAILURE_USER_MESSAGE).not.toMatch(/not in a mode|tmux|send-keys/i);
-    // Actionable: tells the user how to recover.
-    expect(SEND_FAILURE_USER_MESSAGE).toContain("/session restart");
+    // Actionable: tells the user how to recover. (#236 corrected the wording —
+    // it used to name `/session restart`, which is not a registered subcommand.
+    // tests/session/relay-error-notice.test.ts enforces that mechanically.)
+    expect(SEND_FAILURE_USER_MESSAGE).toContain("/session start");
   });
 
   test("handles non-Error throwables without leaking", () => {


### PR DESCRIPTION
Closes #236

## 目的

relay ブロックの**外側 catch** が `err.message` を最大 1900 文字そのまま Discord に転送していた経路を塞ぐ。
#74 は send-keys 失敗経路（`buildSendFailureResult`）を塞いだが、この catch は独立した第 2 の出口として残っていた。

## 再現（修正前）

実ソースから当該 catch ブロックを抽出し、テンプレートを現実的な Error で評価した結果（詳細手順は Issue #236 本文）:

```
--- string actually posted to the Discord thread ---
⚠️ Claude Code への中継中にエラーが発生しました: ENOENT: no such file or directory, open '/Users/harieshokunin/claude-hub/.claude/settings.local.json'
```

`err.message` に絶対パスが載ることは probe で実測済み:

```
SQLITE: unable to open database file
FS   : ENOENT: no such file or directory, open '/Users/PROBE_USER/secret-project/.env'
```

## 監査結果（外側 catch への到達経路）

Issue で挙がっていた候補を実読して確認した。**到達しない**ものが大半だった:

| throw 元 | 到達性 | 理由 |
|---|---|---|
| `waitForRelay` | なし | reject せず必ず resolve する |
| `downloadAttachment` | なし | `relayMessage` 内で per-attachment catch |
| `persistAttachments` | なし | fail-open（mkdir/copy 失敗は warn + tmp パス返却） |
| `sendToPane` | なし | #74 の `buildSendFailureResult` が吸収 |
| `recordRelayLatency` / `tracker.flush` | なし | fail-open |
| `sendMessage` のセッション不在 throw | **あり** | enqueue 後に `/session stop` が入るティアダウン競合 |
| `updateSessionClaudeId`（bun:sqlite） | **あり** | SQLite エラー文（実測上パスは載らない） |
| `thread.send(chunk)`（DiscordAPIError） | **あり** | Discord API エラー文 |

**現行の到達経路でトークン等の資格情報は確認できなかった。** 一方で `fs` 由来 Error の `message` は絶対パスを埋め込むため、
「`err.message` を無条件に転送する」という**形自体**が脆弱で、このブロックに fs / 子プロセス系の throw が 1 つ増えた時点で
ホームパスが流出する。よって形を塞ぐ方針を採った。

## 変更内容

- `supervisor/src/session/relay.ts`: `RELAY_ERROR_USER_MESSAGE`（定型文）を追加。`SEND_FAILURE_USER_MESSAGE` の隣に置き、#74 と同じ契約であることを明示
- `supervisor/src/bot.ts`: 外側 catch のユーザー向け送信を定型文へ置換。`console.error` は **err オブジェクトのまま**渡してスタックを保持（silent fallback にしない）
- `supervisor/tests/session/relay-error-notice.test.ts`: 回帰テスト（新規）
- `.github/workflows/ci.yml`: 新規テストを curated list に追加（#248 gating lint 対応）

## テスト方針

ハンドラが `startBot` 内のクロージャで直接呼べないため、`tests/guards/access-enforcement-wired.test.ts` と同じ
**source-level wired guard** で呼び出し側を固定した。コメントは strip してから検査する（禁止トークンを説明するコメント自身が
false-fire しないように。`lint-no-sync-exec.ts` が AST で解いているのと同じ懸念）。

guard が空振りでないことも確認済み — 修正前（`git show HEAD:...`）のソースに同じ抽出＋判定を当てると:

```
pre-fix contains RELAY_ERROR_USER_MESSAGE: false (expect false)
pre-fix contains err.message           : true (expect true)
pre-fix contains String(err)           : true (expect true)
```

## 検証結果

| 項目 | コマンド | 結果 |
|---|---|---|
| 新規回帰テスト | `bun test tests/session/relay-error-notice.test.ts` | 3 pass / 0 fail |
| 型チェック | `bunx tsc --noEmit` | PASS |
| CI lint 4 種 | `lint-gating-coverage` / `lint-blocking-in-timers` / `lint-no-sync-exec` / `check-access-policy --ci` | 全 PASS（gating: 85 files, 0 ungated） |
| curated CI スイート | `bun test <ci.yml の 77 files>` | 922 pass / 7 fail |

7 件の fail は **本変更前（`git stash` で HEAD に戻した状態）でも同様に失敗する既存の環境依存**:
`cleanup-idle-claude` / `list-claude-processes` / `lint-blocking-in-timers` のツリー走査は 5s タイムアウト、
`dialog-stall` E2E は本番 tmux socket `-L claude-hub` を掴むためローカルの稼働中 Supervisor と衝突する。
いずれも `bot.ts` の relay catch とは無関係。

## スコープ外（follow-up）

監査中に見つかった**同型の残存経路**は #360 に切り出した（`safeReplyError` = 全スラッシュコマンドのエラー返信、
`commands/session.ts` の各 catch、self-heal の自動 compact 失敗メッセージ、channel-post / hub-work の `error` フィールド）。

## 統合ジャーニーAC

不要（Issue #236 に理由記載）。内部エラー文字列のサニタイズで正常系のユーザー操作フローは不変、
漏洩しないことは上記 wired guard で決定的に担保する。

---

## 追加変更（自己レビュー + CodeRabbit 対応）

### 607c24e — 存在しないコマンドの案内を修正

定型文が案内していた `/session restart` は **登録されていないサブコマンド** だった
（`session.ts` が登録するのは start / stop / list / status / resume / compact / keep）。
新設した `RELAY_ERROR_USER_MESSAGE` だけでなく **#74 の `SEND_FAILURE_USER_MESSAGE` にも元からあった**ため両方修正。

- `relay-send-failure.test.ts` の `toContain("/session restart")` → `"/session start"`（**#74 が固定していた文言の変更点**）
- 再発防止として、両定型文の `/session <sub>` を `session.ts` の登録一覧と突き合わせる機械チェックを追加
  （手書きの許可リストではなくレジストリ自体を parse するのでサブコマンドの増減に追従する）

### 2e738f5 — wired guard を引数完全一致へ強化（CodeRabbit 指摘）

`toContain("RELAY_ERROR_USER_MESSAGE")` は識別子の存在しか見ないため
`thread.send(\`${RELAY_ERROR_USER_MESSAGE}: ${err}\`)` を素通しする（bare な `${err}` は
`err.message` でも `String(err)` でもないので否定チェックにも掛からない）。引数の完全一致に変更した。

## 最終検証

| 項目 | コマンド | 結果 |
|---|---|---|
| 回帰テスト | `bun test tests/session/relay-error-notice.test.ts tests/session/relay-send-failure.test.ts` | 9 pass / 0 fail |
| 型チェック | `bunx tsc --noEmit` | PASS |
| guard 空振り検査（#236 本体） | 修正前ソースへ同判定を適用 | `err.message: true` / `RELAY_ERROR_USER_MESSAGE: false` → 検知する |
| guard 空振り検査（コマンド実在） | 旧文言 `/session restart` を投入 | `all registered? false` → 検知する |
| guard 空振り検査（引数完全一致） | 補間版を投入 | `bad passes: false` → 検知する |
| CI（初回 run） | GitHub Actions | Type Check / Unit Tests / E2E / Routing / codecov/patch / CodeRabbit / Devin すべて pass |
