### PR TITLE
chore(#198): 既存 launchd plist 2件のユーザーパスを placeholder 化して統一

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,6 +253,11 @@ jobs:
       - name: Run claudeHubExit turn-state producer tests (#312)
         run: bash scripts/test-hijoguchi-record-turn-state.sh
 
+      # Guards the launchd plist install convention (#198). The placeholder
+      # check is portable; plutil -lint self-skips on Linux (macOS-only tool).
+      - name: Run launchd plist placeholder tests (#198)
+        run: bash scripts/test-plist-placeholders.sh
+
   # E2E verification of the Discord ↔ Supervisor ↔ Claude Code relay chain.
   # Covers AC-4/5/6/7 hermetically (tmux + mock claude + relay-server HTTP).
   # AC-1/2/3 require a live Discord bot token and are documented as manual

--- a/README.md
+++ b/README.md
@@ -32,12 +32,21 @@ cp .env.example .env  # トークン設定
 # 開発
 bun run supervisor/index.ts
 
-# 常駐 (launchd)
+# 常駐 (launchd)。plist 内の /Users/YOUR_USER プレースホルダを $HOME に置換して配置する
+mkdir -p ~/claude-hub/logs
+sed "s|/Users/YOUR_USER|$HOME|g" com.claude-hub.supervisor.plist > ~/Library/LaunchAgents/com.claude-hub.supervisor.plist
 launchctl load ~/Library/LaunchAgents/com.claude-hub.supervisor.plist
+# 再設置時の注意: 上の sed は installed plist を上書きするため、手動記入した
+# HIJOGUCHI_CHANNEL_ID (channel id は非コミット。Issue #63) が消える。再記入 +
+# bootout/bootstrap で再ロードすること。詳細は docs/bot-operations.md を参照
 
 # 添付ファイルの日次GC (launchd, 04:00 に tmp/attachments の30日超を削除。Issue #151/#280)
 bash scripts/install-gc-attachments.sh
 ```
+
+launchd plist は全て `/Users/YOUR_USER` プレースホルダで管理し、install 時に `$HOME` へ置換する
+（Issue #198）。ハードコードされたユーザーパスの再混入は CI で機械検知する:
+`bash scripts/test-plist-placeholders.sh`
 
 ## ローカル E2E 検証
 

--- a/README.md
+++ b/README.md
@@ -33,8 +33,10 @@ cp .env.example .env  # トークン設定
 bun run supervisor/index.ts
 
 # 常駐 (launchd)。plist 内の /Users/YOUR_USER プレースホルダを $HOME に置換して配置する
+# source は絶対パスで指定する: 相対パスだと cwd 違いで sed が失敗しても > が
+# installed plist を空ファイルに切り詰めてしまう
 mkdir -p ~/claude-hub/logs
-sed "s|/Users/YOUR_USER|$HOME|g" com.claude-hub.supervisor.plist > ~/Library/LaunchAgents/com.claude-hub.supervisor.plist
+sed "s|/Users/YOUR_USER|$HOME|g" ~/claude-hub/com.claude-hub.supervisor.plist > ~/Library/LaunchAgents/com.claude-hub.supervisor.plist
 launchctl load ~/Library/LaunchAgents/com.claude-hub.supervisor.plist
 # 再設置時の注意: 上の sed は installed plist を上書きするため、手動記入した
 # HIJOGUCHI_CHANNEL_ID (channel id は非コミット。Issue #63) が消える。再記入 +

--- a/com.claude-hub.supervisor.plist
+++ b/com.claude-hub.supervisor.plist
@@ -8,9 +8,10 @@
       Paths use a /Users/YOUR_USER placeholder; substitute $HOME on install so
       the job works on any machine (Issue #198 — same convention as
       com.claude-hub.gc-attachments.plist).
-      Install:
+      Install (source path absolute on purpose: with a relative path a wrong cwd
+      makes sed fail while the redirect still truncates the installed plist):
         mkdir -p ~/claude-hub/logs
-        sed "s|/Users/YOUR_USER|$HOME|g" com.claude-hub.supervisor.plist \
+        sed "s|/Users/YOUR_USER|$HOME|g" ~/claude-hub/com.claude-hub.supervisor.plist \
           > ~/Library/LaunchAgents/com.claude-hub.supervisor.plist
         launchctl load ~/Library/LaunchAgents/com.claude-hub.supervisor.plist
       CAUTION on re-install: the command above OVERWRITES the installed plist,

--- a/com.claude-hub.supervisor.plist
+++ b/com.claude-hub.supervisor.plist
@@ -3,6 +3,23 @@
   "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <!--
+      Channel-Supervisor resident job (Bun + discord.js, caffeinate-wrapped).
+      Paths use a /Users/YOUR_USER placeholder; substitute $HOME on install so
+      the job works on any machine (Issue #198 — same convention as
+      com.claude-hub.gc-attachments.plist).
+      Install:
+        mkdir -p ~/claude-hub/logs
+        sed "s|/Users/YOUR_USER|$HOME|g" com.claude-hub.supervisor.plist \
+          > ~/Library/LaunchAgents/com.claude-hub.supervisor.plist
+        launchctl load ~/Library/LaunchAgents/com.claude-hub.supervisor.plist
+      CAUTION on re-install: the command above OVERWRITES the installed plist,
+      clearing the manually-filled HIJOGUCHI_CHANNEL_ID below (blank in source
+      by design). Re-fill it and reload with bootout+bootstrap, otherwise the
+      claudeHubExit `/session compact` route silently stays disabled. See
+      docs/bot-operations.md § "Required env vars (claudeHubExit)".
+    -->
+
     <key>Label</key>
     <string>com.claude-hub.supervisor</string>
 
@@ -10,18 +27,18 @@
     <array>
         <string>/usr/bin/caffeinate</string>
         <string>-dimsu</string>
-        <string>/Users/harieshokunin/.bun/bin/bun</string>
+        <string>/Users/YOUR_USER/.bun/bin/bun</string>
         <string>run</string>
-        <string>/Users/harieshokunin/claude-hub/supervisor/index.ts</string>
+        <string>/Users/YOUR_USER/claude-hub/supervisor/index.ts</string>
     </array>
 
     <key>WorkingDirectory</key>
-    <string>/Users/harieshokunin/claude-hub/supervisor</string>
+    <string>/Users/YOUR_USER/claude-hub/supervisor</string>
 
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/Users/harieshokunin/.local/bin:/Users/harieshokunin/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>/Users/YOUR_USER/.local/bin:/Users/YOUR_USER/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
         <!-- Issue #199 AC1: claudeHubExit primary channel id. When set, `/session
              compact` invoked in that channel routes to the claudeHubExit tmux
              session (default socket) instead of showing the thread-only hint.
@@ -45,9 +62,9 @@
     <integer>10</integer>
 
     <key>StandardOutPath</key>
-    <string>/Users/harieshokunin/claude-hub/logs/supervisor.stdout.log</string>
+    <string>/Users/YOUR_USER/claude-hub/logs/supervisor.stdout.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/harieshokunin/claude-hub/logs/supervisor.stderr.log</string>
+    <string>/Users/YOUR_USER/claude-hub/logs/supervisor.stderr.log</string>
 
     <key>RunAtLoad</key>
     <true/>

--- a/scripts/test-plist-placeholders.sh
+++ b/scripts/test-plist-placeholders.sh
@@ -1,0 +1,92 @@
+#!/bin/bash
+# Guards the launchd plist install convention (Issue #198).
+#
+# Every tracked plist template must keep operator paths as a placeholder, never
+# a hardcoded /Users/<login>, so a fresh machine can install it with a single
+# sed. PR #194 (#151) fixed com.claude-hub.gc-attachments.plist and #198 fixed
+# the remaining two — this test stops the next one from regressing.
+#
+# Portable on purpose: the placeholder check — the regression this test exists
+# for — runs on Linux CI too. `plutil -lint` is macOS-only, so it is an extra
+# assertion that SKIPs elsewhere rather than a hard requirement.
+#
+# Deliberately NOT asserting strict XML well-formedness: launchd/plutil use a
+# lenient parser and accept `--` inside comments (com.claude-hub.gc-attachments
+# .plist documents `install-gc-attachments.sh --uninstall` that way), which a
+# spec-strict XML parser rejects. Gating on a stricter parser than the actual
+# consumer would only force us to mangle copy-pasteable commands.
+#
+# Read-only: never touches ~/Library/LaunchAgents or launchctl.
+#
+# Usage: bash scripts/test-plist-placeholders.sh
+
+set -euo pipefail
+
+REPO_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_DIR"
+
+TMPDIR_TEST=$(mktemp -d)
+trap 'rm -rf "$TMPDIR_TEST"' EXIT
+
+PASS=0
+FAIL=0
+SKIP=0
+assert() {
+  local desc="$1"; shift
+  if "$@"; then
+    echo "PASS: $desc"; PASS=$((PASS + 1))
+  else
+    echo "FAIL: $desc"; FAIL=$((FAIL + 1))
+  fi
+}
+
+quiet() {
+  "$@" >/dev/null 2>&1
+}
+
+# PLIST_TEST_NO_PLUTIL=1 forces the no-plutil path so the Linux CI branch can be
+# exercised from macOS.
+have_plutil=0
+if [ "${PLIST_TEST_NO_PLUTIL:-0}" != "1" ] && command -v plutil >/dev/null 2>&1; then
+  have_plutil=1
+fi
+
+# Only tracked templates are in scope. Generated plists (e.g.
+# com.claude-hub.hijoguchi.plist, gitignored) legitimately contain real paths.
+TEMPLATES=$(git ls-files '*.plist' '*.plist.template')
+assert "tracked plist templates found" test -n "$TEMPLATES"
+
+for tpl in $TEMPLATES; do
+  # 1. No hardcoded operator home — the regression this test exists for.
+  #    /Users/YOUR_USER is the sanctioned placeholder; __HOME__ (hijoguchi
+  #    template) carries no /Users prefix at all.
+  hardcoded=$(grep -oE '/Users/[A-Za-z0-9._-]+' "$tpl" | grep -v '^/Users/YOUR_USER$' | sort -u || true)
+  if [ -n "$hardcoded" ]; then
+    echo "FAIL: $tpl has hardcoded home path(s): $(echo "$hardcoded" | tr '\n' ' ')"
+    echo "      Use the /Users/YOUR_USER placeholder and substitute \$HOME on install."
+    FAIL=$((FAIL + 1))
+  else
+    echo "PASS: $tpl has no hardcoded /Users/<login> path"
+    PASS=$((PASS + 1))
+  fi
+
+  # 2. The documented install substitution round-trips: after replacing the
+  #    placeholder with $HOME, nothing unresolved is left.
+  out="$TMPDIR_TEST/$(echo "$tpl" | tr '/' '_')"
+  sed -e "s|/Users/YOUR_USER|$HOME|g" -e "s|__HOME__|$HOME|g" "$tpl" > "$out"
+  assert "$tpl leaves no placeholder after substitution" \
+    test -z "$(grep -oE 'YOUR_USER|__HOME__' "$out" || true)"
+
+  # 3. Both the template (placeholders are plain strings) and the substituted
+  #    output must stay valid plists per the platform's own parser.
+  if [ "$have_plutil" -eq 1 ]; then
+    assert "$tpl passes plutil -lint" quiet plutil -lint "$tpl"
+    assert "$tpl substitutes to a plutil-valid plist" quiet plutil -lint "$out"
+  else
+    echo "SKIP: $tpl plutil -lint (macOS-only tool not available)"
+    SKIP=$((SKIP + 2))
+  fi
+done
+
+echo "Results: $PASS passed, $FAIL failed, $SKIP skipped"
+[ "$FAIL" -eq 0 ]

--- a/supervisor/com.channel.supervisor.plist
+++ b/supervisor/com.channel.supervisor.plist
@@ -3,23 +3,33 @@
   "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+    <!--
+      LEGACY template, not the job that runs today. The resident Supervisor is
+      `com.claude-hub.supervisor` (repo root plist); this one targets
+      ~/channel/supervisor/index.ts, a path that no longer exists, and is not
+      loaded in launchctl. Kept only so the two templates share one install
+      convention; removal is tracked in Issue #359.
+      Paths use a /Users/YOUR_USER placeholder; substitute $HOME on install
+      (Issue #198 — same convention as com.claude-hub.gc-attachments.plist).
+    -->
+
     <key>Label</key>
     <string>com.channel.supervisor</string>
 
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/harieshokunin/.bun/bin/bun</string>
+        <string>/Users/YOUR_USER/.bun/bin/bun</string>
         <string>run</string>
-        <string>/Users/harieshokunin/channel/supervisor/index.ts</string>
+        <string>/Users/YOUR_USER/channel/supervisor/index.ts</string>
     </array>
 
     <key>WorkingDirectory</key>
-    <string>/Users/harieshokunin/channel/supervisor</string>
+    <string>/Users/YOUR_USER/channel/supervisor</string>
 
     <key>EnvironmentVariables</key>
     <dict>
         <key>PATH</key>
-        <string>/Users/harieshokunin/.local/bin:/Users/harieshokunin/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+        <string>/Users/YOUR_USER/.local/bin:/Users/YOUR_USER/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
     </dict>
 
     <key>KeepAlive</key>
@@ -32,9 +42,9 @@
     <integer>10</integer>
 
     <key>StandardOutPath</key>
-    <string>/Users/harieshokunin/channel/logs/supervisor.stdout.log</string>
+    <string>/Users/YOUR_USER/channel/logs/supervisor.stdout.log</string>
     <key>StandardErrorPath</key>
-    <string>/Users/harieshokunin/channel/logs/supervisor.stderr.log</string>
+    <string>/Users/YOUR_USER/channel/logs/supervisor.stderr.log</string>
 
     <key>RunAtLoad</key>
     <true/>


### PR DESCRIPTION
Closes #198

## 目的

PR #194 (#151) で `com.claude-hub.gc-attachments.plist` のみ `/Users/YOUR_USER` プレースホルダ化されており、既存 2 plist が `/Users/harieshokunin` ハードコードのまま残って install 慣例が分岐していた。次のセットアップ/移行時の混乱を防ぐため統一する。

## 主な変更

| ファイル | 変更 |
|---|---|
| `com.claude-hub.supervisor.plist` | `/Users/YOUR_USER` プレースホルダ化（6 箇所）+ install 手順コメント |
| `supervisor/com.channel.supervisor.plist` | 同（6 箇所）+ legacy である旨のコメント |
| `README.md` | `launchctl load` 手順に `mkdir` + `sed` 置換を追加。plist 慣例の節を追記 |
| `scripts/test-plist-placeholders.sh` | 新規。ハードコード再混入の機械検知 |
| `.github/workflows/ci.yml` | 上記テストを `routing-tests` job に結線 |

## 落とし穴を 1 つ塞いだ

`com.claude-hub.supervisor.plist` の `HIJOGUCHI_CHANNEL_ID` はソースでは意図的に空で、installed plist に手動記入する運用（channel id は非コミット。#63 fail-closed）。

Issue 記載の `sed ... > ~/Library/LaunchAgents/...` を**再実行すると installed plist を上書きして、この手動記入値が消える**。消えても launchd は起動するが claudeHubExit の `/session compact` 経路だけが無言で無効化される（fail-safe だが silent degradation）。plist コメントと README の両方に再記入 + bootout/bootstrap の注意を明記した。

## 再発防止（機械検知）

`scripts/test-plist-placeholders.sh` は tracked な plist / template 全件に対して次を検査する。

1. `/Users/<login>` ハードコードが無いこと（`/Users/YOUR_USER` のみ許可）
2. プレースホルダ置換後に未解決の placeholder が残らないこと
3. template と置換結果の両方が `plutil -lint` を通ること

**移植性**: 1 と 2 は POSIX のみで、Linux CI でも動く（本 Issue の再発防止本体）。3 の `plutil` は macOS 専用ツールなので Linux では self-skip する。既存の `test-install-gc-attachments.sh` が CI 未結線なのは plutil 依存が理由で、本テストはその制約を回避して CI 結線した。

`plutil` を通るが厳格な XML パーサでは落ちる件（`gc-attachments.plist` のコメント内 `--uninstall`。XML はコメント内の `--` を禁止）については、**実際の consumer である launchd/plutil が寛容なので厳格チェックは入れていない**。consumer より厳しいパーサで gate すると、コピペ可能なコマンド例を壊すだけになるため。判断根拠はスクリプト冒頭のコメントに記載。

## 検証

| # | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | 2 plist にハードコードが残らない | `grep -c harieshokunin <両plist>` | 0 | 0 | PASS |
| AC-2 | 全 plist が plutil -lint を通る | `bash scripts/test-plist-placeholders.sh` | exit 0 | 17 passed / 0 failed, exit 0 | PASS |
| AC-3 | sed 置換が元の絶対パスを完全復元する | 置換結果 vs `git show HEAD:<plist>` の diff | path 差分 0 / 削除行 0 | 両ファイルで削除 0 行・`<string>` 差分 0 行（追加はコメント行のみ） | PASS |
| AC-4 | ハードコード再混入を検知する（negative test） | logs パスを `/Users/harieshokunin` に戻して guard 実行 | exit 1 | exit 1 + 該当ファイル名を FAIL 出力 | PASS |
| AC-5 | plutil 不在（Linux CI）でも検知が機能する | `PLIST_TEST_NO_PLUTIL=1` で正常系 / 再混入 | 0 / 1 | 正常 exit 0（9 passed, 8 skipped）、再混入 exit 1 | PASS |
| AC-6 | 同 job の既存テストが壊れない | routing-tests の 4 テスト実行 | 全 exit 0 | 4/4 exit 0 | PASS |
| AC-7 | ci.yml が妥当かつ step が登録される | `actionlint` + YAML パース | clean / step 有 | actionlint clean、step 6 件目に登録 | PASS |
| AC-8 | 本番 launchd に触れていない | `launchctl list` + installed plist の mtime / channel id | 変化なし | PID 2176 のまま、mtime Jul 5 02:29 のまま、channel id 19 桁保持 | PASS |

全体: 8/8 PASS。`shellcheck` も clean。

本 PR は **repo の template のみ**を変更し、`~/Library/LaunchAgents/` と稼働中の launchd job には一切触れていない（ADR `docs/adr/2026-07-05-corp-orchestration.md` の「work セッションは常駐プロセスに触らない」に従う）。したがって稼働中 Supervisor への影響はなく、既存インストールの再設置も不要。

## 統合ジャーニーAC

不要（Issue 記載通り）。launchd 設定ファイル・README・CI のみの変更で、ユーザー操作フローを伴わない。

## スコープ外（分離した項目）

調査中に `supervisor/com.channel.supervisor.plist` が **dead artifact** であることを確認した。

| 観測 | 実測 |
|---|---|
| launchd ロード状態 | 未ロード（ロード中は supervisor / gc-attachments / hijoguchi の 3 件のみ） |
| 対象パス `~/channel/supervisor/index.ts` | 存在しない（`~/channel` には `.claude/` と `logs/` のみ） |

`agent-base` の `agent-output-quality.md` #4「使われない機能の継続保守の禁止」に照らせば削除候補だが、Issue #198 のスコープは placeholder 化 + README 統一なので、削除判断と `docs/bot-operations.md` の記述修正（この plist を「caffeinate wrapper 付き」と説明しているが caffeinate は入っていない）は **Issue #359** に分離した。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/miyashita337/claude-hub/pull/362" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->