### PR TITLE
fix(#308): bun test が本番 sessions.db を truncate する問題を preload + fail-fast ガードで解消

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,6 +119,7 @@ jobs:
                    tests/commands/session-resume.test.ts \
                    tests/hooks/stop-relay.test.ts \
                    tests/infra/db.test.ts \
+                   tests/infra/db-isolation.test.ts \
                    tests/session/dialog-detect.test.ts \
                    tests/session/dialog-watchdog.test.ts \
                    tests/session/relay-send-failure.test.ts \

--- a/supervisor/bunfig.toml
+++ b/supervisor/bunfig.toml
@@ -5,5 +5,14 @@
 # and production start-up are unaffected. All test invocations (CI ci.yml,
 # scripts/e2e-orchestrate.sh) run `bun test` from this directory, so this
 # bunfig is always picked up.
+#
+# Issue #308: the same hook point isolates sessions.db. db.ts resolves its path
+# at module load and caches a singleton, so a per-file `SUPERVISOR_DB_PATH`
+# assignment loses the race whenever another file imports db.ts first — which
+# let `bun test` truncate the LIVE sessions.db. The preload runs before any test
+# file, so the singleton binds to `:memory:`.
 [test]
-preload = ["./tests/setup/runtime-dir-isolation.ts"]
+preload = [
+  "./tests/setup/runtime-dir-isolation.ts",
+  "./tests/setup/db-isolation.ts",
+]

--- a/supervisor/src/infra/db.ts
+++ b/supervisor/src/infra/db.ts
@@ -1,19 +1,74 @@
 import { Database } from "bun:sqlite";
 import { resolve } from "path";
-import { homedir } from "os";
+import { homedir, tmpdir } from "os";
+
+/**
+ * テスト実行中か（Issue #308）。`bun test` は NODE_ENV を "test" に設定する
+ * （Bun 1.3.11 で実測: `env -u NODE_ENV bun test` でも "test"）。
+ * SUPERVISOR_TEST_ISOLATION は tests/setup/db-isolation.ts preload が立てる
+ * マーカーで、NODE_ENV を上書きされてもガードが外れないようにする二重化。
+ */
+function isUnderTest(env: Record<string, string | undefined>): boolean {
+  return env.NODE_ENV === "test" || env.SUPERVISOR_TEST_ISOLATION === "1";
+}
+
+/**
+ * テスト実行中に開いてよい sqlite パスか。`:memory:`（および URI 形式）と
+ * 一時ディレクトリ配下のみを許可する allowlist ＝「permissive より restrictive」
+ * （rules/general/defensive-programming.md）。本番 sessions.db はもちろん、
+ * 将来うっかり指定された任意の実ファイルも弾く。
+ */
+function isTestSafeDbPath(path: string): boolean {
+  // Bun/sqlite で filesystem に触れない形式。"" は bun:sqlite の匿名 in-memory。
+  if (path === "" || path.includes(":memory:")) return true;
+  // macOS の tmpdir() は /var/folders/...、/tmp は /private/tmp への symlink。
+  // mkdtemp(join(tmpdir(), …)) 由来のパス（tests/tools/session-ctl.test.ts）を
+  // 通しつつ、いずれの表記でも一時領域だけを許可する。
+  return [tmpdir(), "/tmp", "/private/tmp"]
+    .map((root) => root.replace(/\/+$/, "") + "/")
+    .some((root) => path.startsWith(root));
+}
+
+/**
+ * Fail-fast ガード（Issue #308）: テスト実行中に本番 sessions.db を開こうと
+ * したら即座に throw する。
+ *
+ * 背景: preload（tests/setup/db-isolation.ts）が一次防御だが、preload が外され
+ * た・新しい入口が env を無視した、といった経路が残る。実測では隔離が壊れると
+ * テストは 72 pass / 0 fail のまま本番の行を消す（silent data loss）ため、
+ * 「黙って壊す」より「その場で落ちる」方を選ぶ。
+ */
+export function assertTestDbIsolation(
+  path: string,
+  env: Record<string, string | undefined> = process.env,
+): void {
+  if (!isUnderTest(env)) return;
+  if (isTestSafeDbPath(path)) return;
+  throw new Error(
+    `[db] テスト実行中に隔離されていない sessions.db を開こうとしました: ${path}\n` +
+      `これは本番のセッション行を破壊しうるため中断しました（Issue #308）。\n` +
+      `対処: SUPERVISOR_DB_PATH=":memory:" を設定するか、一時ディレクトリ配下の ` +
+      `パスを指定してください。通常は supervisor/bunfig.toml の ` +
+      `[test].preload（tests/setup/db-isolation.ts）が自動で設定します。`,
+  );
+}
 
 /**
  * sessions.db の実パスを解決する（#320 で外出し）。Supervisor 本体（下の
  * DB_PATH、モジュールロード時に固定）と読み取り専用 CLI（tools/session-ctl.ts、
  * 呼び出し時に解決）が同じ規則を共有するための single source of truth。
+ *
+ * 解決と同時に #308 のガードを通すので、パスを得る経路すべて（singleton /
+ * session-ctl / e2e-live）が自動的に保護される。
  */
 export function resolveDbPath(
   env: Record<string, string | undefined> = process.env,
 ): string {
-  return (
+  const path =
     env.SUPERVISOR_DB_PATH ??
-    resolve(homedir(), "claude-hub", "supervisor", "sessions.db")
-  );
+    resolve(homedir(), "claude-hub", "supervisor", "sessions.db");
+  assertTestDbIsolation(path, env);
+  return path;
 }
 
 const DB_PATH = resolveDbPath();

--- a/supervisor/tests/infra/db-isolation.test.ts
+++ b/supervisor/tests/infra/db-isolation.test.ts
@@ -1,0 +1,115 @@
+import { test, expect, describe } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { homedir, tmpdir } from "os";
+import { join, resolve } from "path";
+import { assertTestDbIsolation, resolveDbPath } from "../../src/infra/db";
+
+/**
+ * Issue #308: locks the hermetic sessions.db isolation in place.
+ *
+ * Before this guard existed, `bun test` truncated the LIVE
+ * ~/claude-hub/supervisor/sessions.db: db.ts pins its path at module load, so a
+ * test file that imported it without setting SUPERVISOR_DB_PATH bound the
+ * singleton to production, and a later file's `DELETE FROM sessions` wiped real
+ * rows while the suite still reported 0 fail.
+ *
+ * Two independent defenses are asserted here:
+ *   1. the bun-test preload (bunfig.toml → tests/setup/db-isolation.ts) makes
+ *      `:memory:` the default before any test file loads, and
+ *   2. `assertTestDbIsolation` fails fast if a non-isolated path is resolved
+ *      anyway (preload removed, new entry point, explicit bad env value).
+ * Removing either one fails a test here instead of silently re-exposing the
+ * production DB.
+ */
+describe("sessions.db test isolation (Issue #308)", () => {
+  const productionPath = resolve(
+    homedir(),
+    "claude-hub",
+    "supervisor",
+    "sessions.db",
+  );
+
+  describe("preload (primary defense)", () => {
+    test("SUPERVISOR_DB_PATH is isolated for every test file, with no per-file opt-in", () => {
+      // The preload sets this before any test file body runs. This file itself
+      // never assigns it — that is the point: isolation must not be opt-in.
+      expect(process.env.SUPERVISOR_DB_PATH).toBe(":memory:");
+    });
+
+    test("the preload marker is set, so removing the preload breaks this test", () => {
+      expect(process.env.SUPERVISOR_TEST_ISOLATION).toBe("1");
+    });
+
+    test("resolveDbPath() under test resolves to in-memory, never the production file", () => {
+      const path = resolveDbPath();
+      expect(path).toBe(":memory:");
+      expect(path).not.toBe(productionPath);
+    });
+  });
+
+  describe("fail-fast guard (defense in depth)", () => {
+    test("refuses the production sessions.db path while under test", () => {
+      expect(() =>
+        assertTestDbIsolation(productionPath, { NODE_ENV: "test" }),
+      ).toThrow(/隔離されていない sessions\.db/);
+    });
+
+    test("refuses any non-isolated real path, not just the default one", () => {
+      expect(() =>
+        assertTestDbIsolation("/Users/someone/elsewhere/sessions.db", {
+          NODE_ENV: "test",
+        }),
+      ).toThrow(/Issue #308/);
+    });
+
+    test("stays armed via the preload marker even if NODE_ENV is overridden", () => {
+      expect(() =>
+        assertTestDbIsolation(productionPath, {
+          NODE_ENV: "production",
+          SUPERVISOR_TEST_ISOLATION: "1",
+        }),
+      ).toThrow();
+    });
+
+    test("allows :memory: and its URI form", () => {
+      const env = { NODE_ENV: "test" };
+      expect(() => assertTestDbIsolation(":memory:", env)).not.toThrow();
+      expect(() =>
+        assertTestDbIsolation("file::memory:?cache=shared", env),
+      ).not.toThrow();
+    });
+
+    test("allows a mkdtemp path, so the real-sqlite reader test keeps working", () => {
+      // Mirrors tests/tools/session-ctl.test.ts, which opens a genuine sqlite
+      // file under tmpdir() to exercise createRealEffects().
+      const dir = mkdtempSync(join(tmpdir(), "db-isolation-test-"));
+      try {
+        expect(() =>
+          assertTestDbIsolation(join(dir, "sessions.db"), { NODE_ENV: "test" }),
+        ).not.toThrow();
+      } finally {
+        rmSync(dir, { recursive: true, force: true });
+      }
+    });
+
+    test("does not fire outside tests, so the live Supervisor and session-ctl still open the real DB", () => {
+      // tools/session-ctl.ts and tools/e2e-live.ts run under plain `bun`, where
+      // NODE_ENV is not "test" — they must keep reading production.
+      expect(() =>
+        assertTestDbIsolation(productionPath, { NODE_ENV: "production" }),
+      ).not.toThrow();
+      expect(() => assertTestDbIsolation(productionPath, {})).not.toThrow();
+    });
+
+    test("resolveDbPath throws when handed an explicit production path under test", () => {
+      // An explicit-but-wrong SUPERVISOR_DB_PATH is surfaced, not silently
+      // rewritten to :memory: by the preload.
+      expect(() =>
+        resolveDbPath({
+          NODE_ENV: "test",
+          SUPERVISOR_DB_PATH: productionPath,
+        }),
+      ).toThrow(/隔離されていない sessions\.db/);
+    });
+  });
+});

--- a/supervisor/tests/setup/db-isolation.ts
+++ b/supervisor/tests/setup/db-isolation.ts
@@ -1,0 +1,38 @@
+// Issue #308: hermetic test isolation for sessions.db.
+//
+// `src/infra/db.ts` resolves its path ONCE at module load
+// (`const DB_PATH = resolveDbPath()`) and caches the Database as a singleton.
+// A test file that sets `process.env.SUPERVISOR_DB_PATH = ":memory:"` in its own
+// body therefore only wins if it is the FIRST file in the process to pull in
+// db.ts. Bun runs many test files in one process, so a single file that touches
+// the DB without setting the env binds the singleton to the REAL
+// ~/claude-hub/supervisor/sessions.db — and every later `DELETE FROM sessions`
+// + fixture insert then truncates production. Measured before this preload
+// existed (sandbox HOME, marker row `PRECIOUS-ROW`):
+//
+//   bun test tests/session/manager.test.ts tests/session/manager-liveness.test.ts
+//   → 72 pass / 0 fail, yet PRECIOUS-ROW gone and 2 `/tmp/livenes-test`
+//     fixtures left behind — green tests, silent data loss.
+//
+// Fix: this bun-test preload (wired via bunfig.toml `[test].preload`) runs once
+// per `bun test` process, BEFORE any test file loads, so db.ts's module-level
+// resolution already sees `:memory:`. Enforced mechanically for every current
+// AND future test file — no per-file opt-in to forget. Same isolation spirit as
+// runtime-dir-isolation.ts (#341) and SUPERVISOR_TMUX_SOCKET=claude-hub-test
+// (RW-019); this is the sessions.db axis of it.
+//
+// Unlike the runtime-dir preload we do NOT unconditionally override: an
+// explicitly provided SUPERVISOR_DB_PATH is a deliberate choice (CI and
+// scripts/e2e-orchestrate.sh pass ":memory:"; tests/tools/session-ctl.test.ts
+// points at a mkdtemp file to exercise the real sqlite reader). Explicit values
+// that are NOT isolated are rejected by the fail-fast guard in db.ts rather than
+// silently rewritten here, so a bad value surfaces instead of disappearing.
+if (!process.env.SUPERVISOR_DB_PATH) {
+  process.env.SUPERVISOR_DB_PATH = ":memory:";
+}
+
+// Marker consumed by db.ts's guard (`isUnderTest`) and asserted by
+// tests/infra/db-isolation.test.ts. Keeps the guard armed even if a caller
+// overrides NODE_ENV, and makes removal of this preload a test failure rather
+// than a silent re-exposure of the production DB.
+process.env.SUPERVISOR_TEST_ISOLATION = "1";


### PR DESCRIPTION
Closes #308

## 背景

`bun test` が **本番の `~/claude-hub/supervisor/sessions.db` を truncate し、稼働中/停止済みのセッション行を silent に消失させる**問題（#308）を解消する。

`src/infra/db.ts` はパスを**モジュールロード時に一度だけ**解決して Database を singleton でキャッシュする（`const DB_PATH = resolveDbPath()`）。そのためテストファイル側で `process.env.SUPERVISOR_DB_PATH = ":memory:"` を設定しても、**そのファイルがプロセス内で最初に db.ts を import した場合しか勝てない**。Bun は多数のテストファイルを 1 プロセスで走らせるため、env を設定しないファイルが 1 つでも先に DB に触れると singleton が本番 DB に束縛され、以降の `DELETE FROM sessions` + フィクスチャ投入が本番を破壊する。

## 変更点

1. **preload による一次防御**: `tests/setup/db-isolation.ts` を新設し `bunfig.toml` の `[test].preload` に結線。`bun test` プロセスごとに**どのテストファイルより先に**走るため、db.ts のモジュールレベル解決時点で既に `:memory:` が見えている。ファイル単位の opt-in が不要（付け忘れが起きない）
2. **fail-fast ガード（二次防御）**: `resolveDbPath` に `assertTestDbIsolation` を通し、テスト実行中に隔離されていないパスを開こうとしたら即 throw。allowlist は `:memory:` と一時ディレクトリ配下のみ（restrictive 既定）
3. **preload の撤去を検知**: `SUPERVISOR_TEST_ISOLATION=1` マーカーを立て、`tests/infra/db-isolation.test.ts` がアサート。preload を外すと**テストが落ちる**（silent な再露出にならない）
4. **CI 結線**: `tests/infra/db-isolation.test.ts` を ci.yml の gating list に追加

明示指定された `SUPERVISOR_DB_PATH` は上書きしない（CI と `scripts/e2e-orchestrate.sh` は `:memory:`、`tests/tools/session-ctl.test.ts` は mkdtemp の実ファイルを使う）。不正な明示値は黙って書き換えず fail-fast ガードで表面化させる。

## 検証（ワーカー実測）

隔離が壊れている状態の再現（sandbox HOME・マーカー行 `PRECIOUS-ROW`）:

```
bun test tests/session/manager.test.ts tests/session/manager-liveness.test.ts
→ 72 pass / 0 fail、しかし PRECIOUS-ROW は消失し /tmp/livenes-test フィクスチャが残存
```

**テストは green のままデータが消える**（silent data loss）ため、「黙って壊す」より「その場で落ちる」を選んだ。

## 補足（この PR の来歴・レビュー時の注意）

本 PR は corp `/orchestrate-runner` の dispatch ワーカーが実装したもの。ワーカーは **commit までは完了していたが push / PR 作成の前に headless プロセスが turn 終了で exit** したため、HQ がブランチを回収して PR 化した（claude-hub#342 と同系統の経路。#456 では commit 前に落ちて作業が失われたが、本件は commit 済みで全量が保全されている）。

ワーカーのローカル実測は上記のとおりだが、**HQ 側では再実測していない**（`bun test` を手元で走らせること自体が #308 の対象行為であり、修正前の環境で実行するリスクを避けたため）。CI の gating suite での検証を正とする。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/miyashita337/claude-hub/pull/363" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
  - テスト実行時にデータベースを自動的に分離し、実際のデータベースへ接続しないようにしました。
  - テスト用データベースとしてメモリ上のデータベースを使用します。
  - 設定ミスにより本番データベースへ接続しようとした場合、早期にエラーを通知します。
  - 一時的なテスト用データベースの利用を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->