### PR TITLE
fix: 長時間稼働ナッジと status からワンクリックで compact できるようにする (#364)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,7 @@ jobs:
                    tests/scripts/lint-gating-coverage.test.ts \
                    tests/commands/session-compact.test.ts \
                    tests/commands/compact-button.test.ts \
+                   tests/session/manager-compact-concurrency.test.ts \
                    tests/commands/session-start-access.test.ts \
                    tests/commands/session-start-branch.test.ts \
                    tests/commands/session-thread-title.test.ts \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
                    tests/e2e/ac-verification.test.ts \
                    tests/scripts/lint-gating-coverage.test.ts \
                    tests/commands/session-compact.test.ts \
+                   tests/commands/compact-button.test.ts \
                    tests/commands/session-start-access.test.ts \
                    tests/commands/session-start-branch.test.ts \
                    tests/commands/session-thread-title.test.ts \

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -22,6 +22,11 @@ import { DispatchHealthReaper } from "./session/dispatch-health-reaper";
 import { ActivityWatchdog } from "./session/session-activity-watchdog";
 import { ResourceMonitor } from "./session/resource-monitor";
 import { createSessionCommand, createSessionHandler } from "./commands/session";
+import {
+  COMPACT_BUTTON_ID,
+  createCompactButtonHandler,
+  withCompactButton,
+} from "./commands/compact-button";
 import { CHANNEL_MAP, MAX_SESSIONS } from "./config/channels";
 import { RELAY_ERROR_USER_MESSAGE, type AttachmentInfo } from "./session/relay";
 import { buildDialogStuckHandler } from "./session/dialog-stuck-handler";
@@ -99,7 +104,10 @@ async function deliverSelfHealOutcome(
   console.warn(
     `[Bot] context-budget ${outcome.level} on thread ${threadId}: ${outcome.tokens} tokens (action=${outcome.action})`
   );
-  await thread.send(outcome.message);
+  // #364: on the notify-only outcome the owner has to act; offer the button.
+  // "compact"/"restart" outcomes already self-heal, so a button there would
+  // invite a redundant second compact.
+  await thread.send(withCompactButton(outcome.message, outcome.action === "notify"));
   if (outcome.action === "restart" && outcome.restart) {
     await runSelfHealRestart(outcome, ctx);
   }
@@ -309,7 +317,13 @@ export async function startBot(token: string): Promise<void> {
         console.warn(
           `[Bot] activity-watchdog ${warning.level} on thread ${threadId}`
         );
-        await channel.send(warning.message);
+        // #364: long_lived is the nudge that tells the owner to consider
+        // compacting, so give it a button they can press instead of a command
+        // name they have to retype (and mistype into another app's /compact).
+        // The quiet nudge is about silence, not context — no button there.
+        await channel.send(
+          withCompactButton(warning.message, warning.level === "long_lived")
+        );
         // long_lived is the more serious "is it stuck?" signal — also page
         // Pushover so the owner sees it off-Discord (best-effort).
         if (warning.level === "long_lived") {
@@ -343,6 +357,7 @@ export async function startBot(token: string): Promise<void> {
   // before the first session registers (TOCTOU).
   const orchestrateLaunchLock = new OrchestrateLaunchLock();
   const sessionHandler = createSessionHandler(sessionManager);
+  const compactButtonHandler = createCompactButtonHandler(sessionManager);
 
   // Per-thread progress buffer (Issue #119): coalesce PostToolUse events
   // within a 2-second window so tool-heavy turns don't trip Discord's
@@ -606,7 +621,9 @@ export async function startBot(token: string): Promise<void> {
     interaction: Interaction,
     err: unknown
   ): Promise<void> {
-    if (!interaction.isChatInputCommand()) return;
+    // Repliable (not just chat-input): button interactions share this path since
+    // #364, and narrowing to slash commands would silently swallow their errors.
+    if (!interaction.isRepliable()) return;
     const content = `❌ エラーが発生しました: ${err instanceof Error ? err.message : String(err)}`;
     try {
       if (interaction.deferred || interaction.replied) {
@@ -621,8 +638,19 @@ export async function startBot(token: string): Promise<void> {
     }
   }
 
-  // Handle slash commands
+  // Handle slash commands + message components
   client.on(Events.InteractionCreate, (interaction: Interaction) => {
+    // #364: the one-click compact button. Component interactions are routed by
+    // customId to the app that sent the message, so unlike a top-level
+    // `/compact` slash command this can never be captured by another bot.
+    if (interaction.isButton()) {
+      if (interaction.customId !== COMPACT_BUTTON_ID) return;
+      compactButtonHandler(interaction).catch(async (err) => {
+        console.error("[Bot] Compact button error:", err);
+        await safeReplyError(interaction, err);
+      });
+      return;
+    }
     if (!interaction.isChatInputCommand()) return;
     if (interaction.commandName !== "session") return;
 

--- a/supervisor/src/commands/compact-button.ts
+++ b/supervisor/src/commands/compact-button.ts
@@ -1,0 +1,117 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  type ButtonInteraction,
+} from "discord.js";
+import type { SessionManager } from "../session/manager";
+import { safeRespond } from "./safe-respond";
+
+/**
+ * One-click compact button (Issue #364).
+ *
+ * `/session compact` is namespaced under `/session` on purpose (#200): a
+ * top-level `/compact` would collide with other apps in the same guild. That
+ * decision is right, but it left the *only* way to compact behind a command
+ * name the owner has to recall exactly — and typing the natural `/compact`
+ * lands on another app ("You are not authorized to use this command"), so the
+ * user is stuck with no working path.
+ *
+ * A button closes that gap without reopening the collision: a component
+ * interaction is routed by `customId` to the app that sent the message, so it
+ * can never be captured by another bot no matter what commands they register.
+ */
+
+/**
+ * customId for the compact button. Namespaced (`session:`) so future components
+ * can share the dispatcher without ambiguity.
+ */
+export const COMPACT_BUTTON_ID = "session:compact";
+
+/**
+ * RW-032: a bare `/compact` produces a bad compact (the model can't predict the
+ * next work direction). When no intent is supplied we attach this default so the
+ * summary keeps the current state and next action.
+ *
+ * Lives here rather than in `commands/session.ts` because both the slash command
+ * and the button need it, and this module is the one with no dependency on the
+ * command builder (keeping the import graph acyclic).
+ */
+export const DEFAULT_COMPACT_INTENT = "直近の作業状態と次アクションを保持して圧縮";
+
+/** The action row carrying the compact button. */
+export function buildCompactButtonRow(): ActionRowBuilder<ButtonBuilder> {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(COMPACT_BUTTON_ID)
+      .setLabel("compact")
+      .setEmoji("🗜️")
+      .setStyle(ButtonStyle.Secondary)
+  );
+}
+
+/**
+ * Message payload helper for the notification paths (activity nudge #209,
+ * context-budget notify #204). `offer` is the caller's judgement of whether
+ * compact is the relevant next step; when false the message goes out unchanged,
+ * so an unrelated warning never grows a misleading button.
+ */
+export function withCompactButton(
+  content: string,
+  offer: boolean
+): { content: string; components?: ActionRowBuilder<ButtonBuilder>[] } {
+  return offer
+    ? { content, components: [buildCompactButtonRow()] }
+    : { content };
+}
+
+/**
+ * Button handler. Mirrors the thread-bound branch of `/session compact` exactly
+ * (same guards, same default intent, same ephemeral ack) so the two entry points
+ * cannot drift.
+ *
+ * The claudeHubExit primary-channel branch of the slash command (#199 AC1) is
+ * deliberately not mirrored: the button is only attached to thread messages, so
+ * that path is unreachable here.
+ */
+export function createCompactButtonHandler(sessionManager: SessionManager) {
+  return async (interaction: ButtonInteraction): Promise<void> => {
+    const channel = interaction.channel;
+
+    // The button rides on thread messages, but a component can be clicked long
+    // after the fact — re-check rather than trusting where it was posted.
+    if (!channel || !channel.isThread()) {
+      await interaction.reply({
+        content:
+          "ℹ️ compact は稼働中セッションのスレッド内でのみ実行できます。",
+        flags: 64,
+      });
+      return;
+    }
+
+    const threadId = channel.id;
+    if (!sessionManager.has(threadId)) {
+      // A stale button on an already-stopped session: report it, never send keys
+      // into a dead pane.
+      await interaction.reply({
+        content:
+          "ℹ️ このスレッドに稼働中のセッションはありません" +
+          "（既に停止済みか、compact 済みで再起動されています）。",
+        flags: 64,
+      });
+      return;
+    }
+
+    await interaction.deferReply({ flags: 64 });
+
+    try {
+      await sessionManager.compactSession(threadId, DEFAULT_COMPACT_INTENT);
+      await interaction.editReply({
+        content: `🗜️ compact を送信しました: \`/compact ${DEFAULT_COMPACT_INTENT}\``,
+      });
+    } catch (err) {
+      const msg = `❌ compact の送信に失敗: ${err instanceof Error ? err.message : String(err)}`;
+      await safeRespond(interaction, { content: msg, ephemeral: true });
+    }
+  };
+}

--- a/supervisor/src/commands/compact-button.ts
+++ b/supervisor/src/commands/compact-button.ts
@@ -4,7 +4,7 @@ import {
   ButtonStyle,
   type ButtonInteraction,
 } from "discord.js";
-import type { SessionManager } from "../session/manager";
+import { CompactInFlightError, type SessionManager } from "../session/manager";
 import { safeRespond } from "./safe-respond";
 
 /**
@@ -110,6 +110,16 @@ export function createCompactButtonHandler(sessionManager: SessionManager) {
         content: `🗜️ compact を送信しました: \`/compact ${DEFAULT_COMPACT_INTENT}\``,
       });
     } catch (err) {
+      // A button stays clickable after the click, so a double-click is the
+      // expected way to hit this — report it as "already running", not a
+      // failure, and don't invite a third click.
+      if (err instanceof CompactInFlightError) {
+        await safeRespond(interaction, {
+          content: "⏳ compact は既に実行中です。完了までお待ちください。",
+          ephemeral: true,
+        });
+        return;
+      }
       const msg = `❌ compact の送信に失敗: ${err instanceof Error ? err.message : String(err)}`;
       await safeRespond(interaction, { content: msg, ephemeral: true });
     }

--- a/supervisor/src/commands/safe-respond.ts
+++ b/supervisor/src/commands/safe-respond.ts
@@ -1,7 +1,7 @@
 import {
   MessageFlags,
-  type ChatInputCommandInteraction,
   type EmbedBuilder,
+  type RepliableInteraction,
 } from "discord.js";
 
 /**
@@ -30,9 +30,13 @@ export interface SafeRespondOptions {
  *
  * - Not yet acknowledged → `reply` (applies `ephemeral` via `flags: 64`).
  * - Already deferred or replied → `editReply` (ephemerality inherited from defer).
+ *
+ * Typed on `RepliableInteraction` (not just the slash-command interaction) so
+ * component handlers get the same guarantee — the compact button (#364) shares
+ * this path with `/session compact`.
  */
 export async function safeRespond(
-  interaction: ChatInputCommandInteraction,
+  interaction: RepliableInteraction,
   options: SafeRespondOptions
 ): Promise<void> {
   const { content, embeds, ephemeral } = options;

--- a/supervisor/src/commands/session.ts
+++ b/supervisor/src/commands/session.ts
@@ -5,10 +5,14 @@ import {
   type ThreadChannel,
   EmbedBuilder,
 } from "discord.js";
-import { isValidModelId, type SessionManager } from "../session/manager";
+import {
+  CompactInFlightError,
+  isValidModelId,
+  type SessionManager,
+} from "../session/manager";
 import { CHANNEL_MAP, MAX_SESSIONS } from "../config/channels";
 import { buildThreadTitle, markTitleStopped } from "../session/thread-title";
-import { buildStatusReply } from "../session/status-reply";
+import { buildStatusReplyDetailed } from "../session/status-reply";
 import { evaluateAccess } from "../config/access-policy";
 import { safeRespond } from "./safe-respond";
 import { keepAttachment, KeepError } from "../session/keep-attachment";
@@ -257,6 +261,15 @@ async function handleCompact(
       content: `🗜️ compact を送信しました: \`/compact ${intent}\``,
     });
   } catch (err) {
+    // #364: an overlapping compact is a "wait", not a failure — same wording as
+    // the button so the two entry points read identically.
+    if (err instanceof CompactInFlightError) {
+      await safeRespond(interaction, {
+        content: "⏳ compact は既に実行中です。完了までお待ちください。",
+        ephemeral: true,
+      });
+      return;
+    }
     const msg = `❌ compact の送信に失敗: ${err instanceof Error ? err.message : String(err)}`;
     await safeRespond(interaction, { content: msg, ephemeral: true });
   }
@@ -281,13 +294,13 @@ async function handleStatus(
   // #364: status is the step the owner takes right before deciding to compact,
   // so carry the one-click button here too. Only when a session is actually
   // running — on a dead thread the reply is resume guidance and a compact button
-  // would be a dead end.
-  const running =
-    (await sessionManager.livenessOf(channel.id)) === "alive" &&
-    sessionManager.has(channel.id);
+  // would be a dead end. The detailed builder reports `running` from the SAME
+  // liveness evaluation it used for the text, so the two can't disagree and the
+  // reply stays inside Discord's 3s deadline.
+  const status = await buildStatusReplyDetailed(sessionManager, channel.id);
   await interaction.reply({
-    content: await buildStatusReply(sessionManager, channel.id),
-    ...(running ? { components: [buildCompactButtonRow()] } : {}),
+    content: status.content,
+    ...(status.running ? { components: [buildCompactButtonRow()] } : {}),
   });
 }
 

--- a/supervisor/src/commands/session.ts
+++ b/supervisor/src/commands/session.ts
@@ -12,6 +12,10 @@ import { buildStatusReply } from "../session/status-reply";
 import { evaluateAccess } from "../config/access-policy";
 import { safeRespond } from "./safe-respond";
 import { keepAttachment, KeepError } from "../session/keep-attachment";
+import {
+  buildCompactButtonRow,
+  DEFAULT_COMPACT_INTENT,
+} from "./compact-button";
 
 export function createSessionCommand() {
   return new SlashCommandBuilder()
@@ -99,10 +103,9 @@ export function createSessionCommand() {
     );
 }
 
-// RW-032: a bare `/compact` produces a bad compact (the model can't predict the
-// next work direction). When the user omits an intent we attach this default so
-// the summary keeps the current state and next action.
-export const DEFAULT_COMPACT_INTENT = "直近の作業状態と次アクションを保持して圧縮";
+// Re-exported from ./compact-button, which owns it now that the button (#364)
+// shares the same never-bare-/compact contract (RW-032).
+export { DEFAULT_COMPACT_INTENT };
 
 /**
  * Issue #199 AC1: the claudeHubExit primary channel id, read from the
@@ -274,8 +277,17 @@ async function handleStatus(
   // Deterministic status query (Issue #170): authoritative liveness verdict
   // (#168) + claude_session_id. Runs outside the message-relay path, so it can
   // never hijack a real work message.
+  //
+  // #364: status is the step the owner takes right before deciding to compact,
+  // so carry the one-click button here too. Only when a session is actually
+  // running — on a dead thread the reply is resume guidance and a compact button
+  // would be a dead end.
+  const running =
+    (await sessionManager.livenessOf(channel.id)) === "alive" &&
+    sessionManager.has(channel.id);
   await interaction.reply({
     content: await buildStatusReply(sessionManager, channel.id),
+    ...(running ? { components: [buildCompactButtonRow()] } : {}),
   });
 }
 

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -470,11 +470,32 @@ export interface SessionManagerOptions {
   watchIntervalMs?: number;
 }
 
+/**
+ * A compact was requested for a thread that already has one in flight (#364).
+ * Distinct from a generic failure so the command layer can say "already running"
+ * instead of "❌ 送信に失敗" — nothing went wrong, the first one is still going.
+ */
+export class CompactInFlightError extends Error {
+  constructor(public readonly threadId: string) {
+    super(`compact は既にこのスレッドで実行中です (thread ${threadId})`);
+    this.name = "CompactInFlightError";
+  }
+}
+
 export class SessionManager {
   /** Map<threadId, SessionInfo> — one session per thread */
   private sessions = new Map<string, SessionInfo>();
   /** Map<threadId, intervalHandle> — watchdogs to clear on stop/shutdown */
   private watchers = new Map<string, ReturnType<typeof setInterval>>();
+  /**
+   * Thread ids with an in-flight {@link compactSession} (Issue #364). `/compact`
+   * is relayed as a multi-step `sendToPane` sequence (Escape → literal → Enter);
+   * two overlapping sends interleave into the SAME pane and can leave a partial
+   * command in the TUI. A slash command is hard to fire twice in the same
+   * instant, but a button stays clickable after the click — so this became a
+   * reachable race the moment the compact button was added.
+   */
+  private compactInFlight = new Set<string>();
   /**
    * Map<claudeSessionId, SelfHealer> — the per-CONVERSATION self-heal planner
    * (Issue #206/#244). Keyed by claude session id, NOT threadId, so the
@@ -1692,18 +1713,30 @@ export class SessionManager {
       throw new Error(`スレッド ${threadId} にセッションが見つかりません`);
     }
 
-    const tmuxName = this.tmuxSessionName(threadId);
-    if (!(await this.effects.tmux.hasSession(tmuxName))) {
-      throw new Error("tmux session dead");
+    // Issue #364: reject an overlapping compact on the same thread rather than
+    // interleaving two send-keys sequences into one pane. Claimed before the
+    // first await after this point so two callers can't both pass the check.
+    if (this.compactInFlight.has(threadId)) {
+      throw new CompactInFlightError(threadId);
     }
+    this.compactInFlight.add(threadId);
 
-    session.lastActivityAt = new Date();
-    updateSessionActivity(session.id);
+    try {
+      const tmuxName = this.tmuxSessionName(threadId);
+      if (!(await this.effects.tmux.hasSession(tmuxName))) {
+        throw new Error("tmux session dead");
+      }
 
-    // Fire-and-forget. On a mid-sequence sendToPane failure the pane may be left
-    // in an indeterminate state (e.g. the Escape landed but the literal/Enter
-    // did not); the caller surfaces the throw so the user can retry.
-    await sendToPane(tmuxName, `/compact ${intent}`);
+      session.lastActivityAt = new Date();
+      updateSessionActivity(session.id);
+
+      // Fire-and-forget. On a mid-sequence sendToPane failure the pane may be left
+      // in an indeterminate state (e.g. the Escape landed but the literal/Enter
+      // did not); the caller surfaces the throw so the user can retry.
+      await sendToPane(tmuxName, `/compact ${intent}`);
+    } finally {
+      this.compactInFlight.delete(threadId);
+    }
   }
 
   /**

--- a/supervisor/src/session/status-reply.ts
+++ b/supervisor/src/session/status-reply.ts
@@ -1,4 +1,4 @@
-import type { SessionManager } from "./manager";
+import type { Liveness, SessionManager } from "./manager";
 import { getSessionByThreadId } from "../infra/db";
 
 /**
@@ -24,9 +24,14 @@ import { getSessionByThreadId } from "../infra/db";
  */
 export async function buildSalvageReply(
   sessionManager: SessionManager,
-  threadId: string
+  threadId: string,
+  // #364: callers that already resolved the verdict pass it in. `livenessOf`
+  // runs `tmux has-session` with a 2s timeout (and on timeout waits the full 2s
+  // before assuming alive — #238), so re-deriving it here can push a caller past
+  // Discord's 3s initial-response deadline. Omitted → resolved here as before.
+  knownVerdict?: Liveness
 ): Promise<string> {
-  const verdict = await sessionManager.livenessOf(threadId);
+  const verdict = knownVerdict ?? (await sessionManager.livenessOf(threadId));
   if (verdict === "unknown") {
     return "ℹ️ このスレッドにはセッション履歴がありません。`/session start` で開始してください。";
   }
@@ -80,24 +85,54 @@ export async function buildStatusReply(
   sessionManager: SessionManager,
   threadId: string
 ): Promise<string> {
+  return (await buildStatusReplyDetailed(sessionManager, threadId)).content;
+}
+
+/** {@link buildStatusReplyDetailed} result. */
+export interface StatusReply {
+  content: string;
+  /**
+   * True only for the "稼働中" case — live AND tracked, i.e. the Supervisor can
+   * actually relay to this session. Callers use it to decide whether an action
+   * affordance (the #364 compact button) makes sense.
+   */
+  running: boolean;
+}
+
+/**
+ * As {@link buildStatusReply}, but also reports whether the session is running.
+ *
+ * #364: the caller needs that verdict to decide whether to attach the compact
+ * button, and deriving it separately would run `livenessOf` twice — up to 4s of
+ * tmux timeouts against Discord's 3s initial-response deadline, plus a window
+ * where the text and the button could disagree. Resolving once here keeps the
+ * whole status path to a single liveness evaluation.
+ */
+export async function buildStatusReplyDetailed(
+  sessionManager: SessionManager,
+  threadId: string
+): Promise<StatusReply> {
   // "稼働中" only when the session is BOTH live AND tracked in memory — i.e. the
   // Supervisor can actually relay to it. If livenessOf is alive but the session
   // is no longer tracked (has() === false), the user cannot interact with it;
   // fall through to the salvage wording which says the Supervisor lost tracking
   // (gemini HIGH review, PR #179).
-  if (
-    (await sessionManager.livenessOf(threadId)) === "alive" &&
-    sessionManager.has(threadId)
-  ) {
+  const verdict = await sessionManager.livenessOf(threadId);
+  if (verdict === "alive" && sessionManager.has(threadId)) {
     const row = getSessionByThreadId(threadId);
     const id = row?.claude_session_id;
-    return (
-      "✅ このスレッドのセッションは稼働中です。\n" +
-      (id
-        ? `🔑 claude_session_id: \`${id}\``
-        : "🔑 claude_session_id: 未記録（#167 導入前に開始されたセッション）")
-    );
+    return {
+      running: true,
+      content:
+        "✅ このスレッドのセッションは稼働中です。\n" +
+        (id
+          ? `🔑 claude_session_id: \`${id}\``
+          : "🔑 claude_session_id: 未記録（#167 導入前に開始されたセッション）"),
+    };
   }
   // not tracked (lost tracking), dead, or unknown → salvage wording covers all.
-  return await buildSalvageReply(sessionManager, threadId);
+  return {
+    running: false,
+    content: await buildSalvageReply(sessionManager, threadId, verdict),
+  };
 }

--- a/supervisor/tests/commands/compact-button.test.ts
+++ b/supervisor/tests/commands/compact-button.test.ts
@@ -1,5 +1,6 @@
 import { test, expect, describe } from "bun:test";
 import { ButtonStyle } from "discord.js";
+import { CompactInFlightError } from "../../src/session/manager";
 import {
   COMPACT_BUTTON_ID,
   DEFAULT_COMPACT_INTENT,
@@ -128,6 +129,22 @@ describe("compact button handler (#364)", () => {
 
     expect(fx.compactCalls).toHaveLength(0);
     expect(fx.replies.find((r) => r.kind === "reply")?.flags).toBe(64);
+  });
+
+  test("double-click: the second click reports 'already running', not a failure", async () => {
+    const fx = makeInteraction({
+      compactImpl: () => {
+        // What SessionManager throws when a compact is already in flight for
+        // this thread — the reachable case now that a button stays clickable.
+        throw new CompactInFlightError("thread-btn-1");
+      },
+    });
+    await fx.run();
+
+    const last = fx.replies[fx.replies.length - 1];
+    expect(last?.content).toContain("既に実行中");
+    // Must not read as an error: nothing failed, the first compact is running.
+    expect(last?.content).not.toContain("失敗");
   });
 
   test("compact failure is reported, never swallowed", async () => {

--- a/supervisor/tests/commands/compact-button.test.ts
+++ b/supervisor/tests/commands/compact-button.test.ts
@@ -1,0 +1,146 @@
+import { test, expect, describe } from "bun:test";
+import { ButtonStyle } from "discord.js";
+import {
+  COMPACT_BUTTON_ID,
+  DEFAULT_COMPACT_INTENT,
+  buildCompactButtonRow,
+  createCompactButtonHandler,
+  withCompactButton,
+} from "../../src/commands/compact-button";
+
+/**
+ * One-click compact button (Issue #364).
+ *
+ * Mirrors session-compact.test.ts: a minimal fake ButtonInteraction exercises
+ * the real handler without a Discord gateway. What matters here is that the
+ * button reaches the *same* compact path as `/session compact` (so the two can't
+ * drift) and that a stale button on a dead thread never sends keys.
+ */
+
+interface ReplyRecord {
+  kind: "reply" | "editReply";
+  content?: string;
+  flags?: number;
+}
+
+function makeInteraction(opts: {
+  inThread?: boolean;
+  hasSession?: boolean;
+  compactImpl?: (threadId: string, intent: string) => unknown;
+}) {
+  const replies: ReplyRecord[] = [];
+  const compactCalls: { threadId: string; intent: string }[] = [];
+
+  const inThread = opts.inThread ?? true;
+  const channel = { id: "thread-btn-1", isThread: () => inThread };
+
+  const interaction = {
+    customId: COMPACT_BUTTON_ID,
+    channel,
+    deferred: false,
+    replied: false,
+    async reply(msg: { content?: string; flags?: number }) {
+      this.replied = true;
+      replies.push({ kind: "reply", content: msg.content, flags: msg.flags });
+    },
+    async deferReply(msg?: { flags?: number }) {
+      this.deferred = true;
+      replies.push({ kind: "reply", flags: msg?.flags });
+    },
+    async editReply(msg: { content?: string }) {
+      replies.push({ kind: "editReply", content: msg.content });
+    },
+  };
+
+  const sessionManager = {
+    has: () => opts.hasSession ?? true,
+    compactSession: async (threadId: string, intent: string) => {
+      compactCalls.push({ threadId, intent });
+      return opts.compactImpl?.(threadId, intent);
+    },
+  };
+
+  return {
+    run: () =>
+      createCompactButtonHandler(sessionManager as never)(interaction as never),
+    replies,
+    compactCalls,
+  };
+}
+
+describe("compact button component (#364)", () => {
+  test("row carries a single button with the app-scoped customId", () => {
+    const json = buildCompactButtonRow().toJSON();
+
+    expect(json.components).toHaveLength(1);
+    const button = json.components[0] as {
+      custom_id?: string;
+      label?: string;
+      style?: number;
+    };
+    // The customId is what makes this immune to the /compact name collision:
+    // Discord routes the component back to the app that sent the message.
+    expect(button.custom_id).toBe(COMPACT_BUTTON_ID);
+    expect(button.label).toBe("compact");
+    expect(button.style).toBe(ButtonStyle.Secondary);
+  });
+
+  test("withCompactButton attaches the row only when compact is the next step", () => {
+    const offered = withCompactButton("長時間稼働しています", true);
+    expect(offered.content).toBe("長時間稼働しています");
+    expect(offered.components).toHaveLength(1);
+
+    // An unrelated warning must not grow a misleading button.
+    const plain = withCompactButton("無活動です", false);
+    expect(plain.content).toBe("無活動です");
+    expect(plain.components).toBeUndefined();
+  });
+});
+
+describe("compact button handler (#364)", () => {
+  test("running session: compacts with the default intent, ephemeral ack (RW-032)", async () => {
+    const fx = makeInteraction({});
+    await fx.run();
+
+    // Never a bare /compact — the button has no intent field, so the default is
+    // the only thing standing between it and a bad compact.
+    expect(fx.compactCalls).toEqual([
+      { threadId: "thread-btn-1", intent: DEFAULT_COMPACT_INTENT },
+    ]);
+    expect(fx.replies.some((r) => r.flags === 64)).toBe(true);
+    const ack = fx.replies.find((r) => r.kind === "editReply");
+    expect(ack?.content).toContain(`/compact ${DEFAULT_COMPACT_INTENT}`);
+  });
+
+  test("stale button on a stopped session: hint only, no send-keys", async () => {
+    const fx = makeInteraction({ hasSession: false });
+    await fx.run();
+
+    expect(fx.compactCalls).toHaveLength(0);
+    const reply = fx.replies.find((r) => r.kind === "reply");
+    expect(reply?.content).toContain("稼働中のセッションはありません");
+    expect(reply?.flags).toBe(64);
+  });
+
+  test("clicked outside a thread: hint only, no send-keys", async () => {
+    const fx = makeInteraction({ inThread: false });
+    await fx.run();
+
+    expect(fx.compactCalls).toHaveLength(0);
+    expect(fx.replies.find((r) => r.kind === "reply")?.flags).toBe(64);
+  });
+
+  test("compact failure is reported, never swallowed", async () => {
+    const fx = makeInteraction({
+      compactImpl: () => {
+        throw new Error("tmux send-keys failed");
+      },
+    });
+    await fx.run();
+
+    expect(fx.compactCalls).toHaveLength(1);
+    const last = fx.replies[fx.replies.length - 1];
+    expect(last?.content).toContain("compact の送信に失敗");
+    expect(last?.content).toContain("tmux send-keys failed");
+  });
+});

--- a/supervisor/tests/commands/session-status.test.ts
+++ b/supervisor/tests/commands/session-status.test.ts
@@ -11,6 +11,7 @@ const { insertSession, updateSessionStatus, getDb } = await import(
 const { createSessionHandler } = await import("../../src/commands/session");
 const { SessionManager } = await import("../../src/session/manager");
 const { createFakeEffects } = await import("../../src/session/adapters-fake");
+const { COMPACT_BUTTON_ID } = await import("../../src/commands/compact-button");
 
 /**
  * Handler-level tests for `/session status` (Issue #349).
@@ -28,6 +29,7 @@ const { createFakeEffects } = await import("../../src/session/adapters-fake");
 interface ReplyRecord {
   content?: string;
   flags?: number;
+  components?: unknown[];
 }
 
 function makeInteraction(opts: { isThread: boolean; threadId?: string }) {
@@ -114,5 +116,46 @@ describe("/session status dispatch (#349)", () => {
     expect(replies).toHaveLength(1);
     expect(replies[0]!.content).toContain("停止しています");
     expect(replies[0]!.content).toContain(`/session resume ${claudeId}`);
+    // #364: a compact button on a dead session would be a dead end — the reply
+    // is resume guidance, so no button.
+    expect(replies[0]!.components).toBeUndefined();
+  });
+
+  test("in a thread, live session → reply carries the one-click compact button (#364)", async () => {
+    const threadId = "thread-status-live";
+    const effects = createFakeEffects();
+    manager = new SessionManager({ effects });
+    insertSession({
+      id: "status-live",
+      channel_name: "agent-base",
+      thread_id: threadId,
+      project_dir: "/tmp/x",
+      pid: 7373,
+      claude_session_id: "77777777-7777-7777-7777-777777777777",
+      started_at: new Date().toISOString(),
+      last_activity_at: new Date().toISOString(),
+      status: "running",
+    });
+    // "稼働中" needs BOTH pid/tmux liveness and in-memory tracking (PR #179),
+    // which is the same condition that gates the button.
+    effects.process.alivePids.add(7373);
+    await effects.tmux.newSession(`claude-${threadId.slice(0, 12)}`, "x");
+    (manager as unknown as { sessions: Map<string, unknown> }).sessions.set(
+      threadId,
+      { threadId }
+    );
+
+    const { interaction, replies } = makeInteraction({
+      isThread: true,
+      threadId,
+    });
+    await createSessionHandler(manager)(interaction as never);
+
+    expect(replies).toHaveLength(1);
+    expect(replies[0]!.content).toContain("稼働中");
+    expect(replies[0]!.components).toHaveLength(1);
+    expect(JSON.stringify(replies[0]!.components)).toContain(
+      COMPACT_BUTTON_ID
+    );
   });
 });

--- a/supervisor/tests/commands/session-status.test.ts
+++ b/supervisor/tests/commands/session-status.test.ts
@@ -158,4 +158,77 @@ describe("/session status dispatch (#349)", () => {
       COMPACT_BUTTON_ID
     );
   });
+
+  test("liveness is evaluated exactly once per status (3s deadline guard, #364)", async () => {
+    // livenessOf runs `tmux has-session` with a 2s timeout and, on timeout,
+    // waits the full 2s before assuming alive (#238). Two evaluations can
+    // therefore exceed Discord's 3s initial-response deadline and make
+    // /session status itself fail — the very "アプリケーションが応答しません
+    // でした" symptom #364 exists to remove. They can also disagree, leaving
+    // the text and the button inconsistent.
+    const threadId = "thread-status-once";
+    const effects = createFakeEffects();
+    manager = new SessionManager({ effects });
+    insertSession({
+      id: "status-once",
+      channel_name: "agent-base",
+      thread_id: threadId,
+      project_dir: "/tmp/x",
+      pid: 7474,
+      claude_session_id: "88888888-8888-8888-8888-888888888888",
+      started_at: new Date().toISOString(),
+      last_activity_at: new Date().toISOString(),
+      status: "running",
+    });
+    effects.process.alivePids.add(7474);
+    await effects.tmux.newSession(`claude-${threadId.slice(0, 12)}`, "x");
+    (manager as unknown as { sessions: Map<string, unknown> }).sessions.set(
+      threadId,
+      { threadId }
+    );
+
+    let livenessCalls = 0;
+    const realLivenessOf = manager.livenessOf.bind(manager);
+    manager.livenessOf = async (id: string) => {
+      livenessCalls++;
+      return realLivenessOf(id);
+    };
+
+    const { interaction } = makeInteraction({ isThread: true, threadId });
+    await createSessionHandler(manager)(interaction as never);
+
+    expect(livenessCalls).toBe(1);
+  });
+
+  test("dead session: liveness is still evaluated only once (#364)", async () => {
+    // The salvage path used to re-derive the verdict inside buildSalvageReply.
+    const threadId = "thread-status-dead-once";
+    const effects = createFakeEffects();
+    manager = new SessionManager({ effects });
+    insertSession({
+      id: "status-dead-once",
+      channel_name: "agent-base",
+      thread_id: threadId,
+      project_dir: "/tmp/x",
+      pid: 7575,
+      claude_session_id: "99999999-9999-9999-9999-999999999999",
+      started_at: new Date().toISOString(),
+      last_activity_at: new Date().toISOString(),
+      status: "running",
+    });
+    updateSessionStatus("status-dead-once", "stopped", "process_dead");
+
+    let livenessCalls = 0;
+    const realLivenessOf = manager.livenessOf.bind(manager);
+    manager.livenessOf = async (id: string) => {
+      livenessCalls++;
+      return realLivenessOf(id);
+    };
+
+    const { interaction, replies } = makeInteraction({ isThread: true, threadId });
+    await createSessionHandler(manager)(interaction as never);
+
+    expect(livenessCalls).toBe(1);
+    expect(replies[0]!.content).toContain("停止しています");
+  });
 });

--- a/supervisor/tests/session/manager-compact-concurrency.test.ts
+++ b/supervisor/tests/session/manager-compact-concurrency.test.ts
@@ -1,0 +1,133 @@
+import { test, expect, describe, beforeEach } from "bun:test";
+
+// Isolate DB writes from the real sessions.db (mirrors manager-input-ready.test.ts).
+process.env.SUPERVISOR_DB_PATH = ":memory:";
+
+const { SessionManager, CompactInFlightError } = await import(
+  "../../src/session/manager"
+);
+const { createFakeEffects } = await import("../../src/session/adapters-fake");
+import type { FakeSessionEffects } from "../../src/session/adapters-fake";
+
+/**
+ * Overlapping-compact guard (Issue #364).
+ *
+ * `compactSession` relays `/compact` as a multi-step send-keys sequence
+ * (Escape → literal → Enter). Two overlapping calls interleave into the SAME
+ * pane and can strand a partial command in the TUI. A slash command is hard to
+ * fire twice in the same instant; a *button* stays clickable after the click,
+ * so the double-click made this race reachable.
+ *
+ * The seam is `effects.tmux.hasSession`: it is the first await inside the guard,
+ * so parking there holds the claim open deterministically. (`sendToPane` is a
+ * module-level function against real tmux, not an injected effect, so it always
+ * fails here — which is what makes it a usable "did the claim get released?"
+ * probe below.)
+ */
+
+const THREAD_ID = "thread-compact-race";
+// Mirrors SessionManager.tmuxSessionName: `claude-` + threadId.slice(0, 12).
+const tmuxName = `claude-${THREAD_ID.slice(0, 12)}`;
+
+function registerSession(
+  manager: InstanceType<typeof SessionManager>,
+  threadId: string,
+  id: string
+): void {
+  // compactSession only needs the map hit plus a live tmux verdict.
+  (manager as unknown as { sessions: Map<string, unknown> }).sessions.set(
+    threadId,
+    { id, threadId, lastActivityAt: new Date() }
+  );
+}
+
+describe("SessionManager.compactSession overlapping guard (#364)", () => {
+  let manager: InstanceType<typeof SessionManager>;
+  let effects: FakeSessionEffects;
+
+  beforeEach(async () => {
+    effects = createFakeEffects();
+    manager = new SessionManager({ effects });
+    await effects.tmux.newSession(tmuxName, "x");
+    registerSession(manager, THREAD_ID, "sess-race");
+  });
+
+  test("a second compact while one is in flight is rejected, not interleaved", async () => {
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const realHasSession = effects.tmux.hasSession.bind(effects.tmux);
+    let calls = 0;
+    effects.tmux.hasSession = async (name: string) => {
+      calls++;
+      if (calls === 1) await gate; // hold the first compact inside the guard
+      return realHasSession(name);
+    };
+
+    const first = manager.compactSession(THREAD_ID, "意図A").catch(() => {});
+    await new Promise((r) => setTimeout(r, 0));
+
+    await expect(manager.compactSession(THREAD_ID, "意図B")).rejects.toThrow(
+      CompactInFlightError
+    );
+    // The rejected call must not have reached the pane at all.
+    expect(calls).toBe(1);
+
+    release!();
+    await first;
+  });
+
+  test("the claim is released after the call settles (no permanent block)", async () => {
+    // sendToPane targets real tmux, which has no pane for this fake session, so
+    // both calls fail there. What matters is HOW the second one fails: anything
+    // other than CompactInFlightError proves the first claim was released.
+    await manager.compactSession(THREAD_ID, "意図A").catch(() => {});
+    const second = manager.compactSession(THREAD_ID, "意図B").catch((e) => e);
+
+    expect(await second).not.toBeInstanceOf(CompactInFlightError);
+  });
+
+  test("a failure before the send also releases the claim", async () => {
+    await effects.tmux.killSession(tmuxName);
+    await expect(manager.compactSession(THREAD_ID, "意図A")).rejects.toThrow(
+      "tmux session dead"
+    );
+
+    // A dead pane must not leave the thread permanently blocked.
+    const second = await manager
+      .compactSession(THREAD_ID, "意図B")
+      .catch((e) => e);
+    expect(second).not.toBeInstanceOf(CompactInFlightError);
+  });
+
+  test("the guard is per-thread, not global", async () => {
+    // Must differ within the FIRST 12 chars: tmuxSessionName truncates there,
+    // so "thread-compact-other" would collide with THREAD_ID's pane name.
+    const otherThread = "second-thread-xyz";
+    await effects.tmux.newSession(`claude-${otherThread.slice(0, 12)}`, "x");
+    registerSession(manager, otherThread, "sess-other");
+
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((r) => {
+      release = r;
+    });
+    const realHasSession = effects.tmux.hasSession.bind(effects.tmux);
+    effects.tmux.hasSession = async (name: string) => {
+      if (name === tmuxName) await gate;
+      return realHasSession(name);
+    };
+
+    const first = manager.compactSession(THREAD_ID, "意図A").catch(() => {});
+    await new Promise((r) => setTimeout(r, 0));
+
+    // A different thread is unaffected by the first thread's in-flight compact.
+    const other = await manager
+      .compactSession(otherThread, "意図B")
+      .catch((e) => e);
+    expect(other).not.toBeInstanceOf(CompactInFlightError);
+
+    release!();
+    await first;
+  });
+});


### PR DESCRIPTION
Closes #364

## 何が壊れていたか

長時間稼働ナッジ（#209）を見て compact しようとしたとき、Discord で **compact を実行する手段が実質無かった**。

- 手癖の `/compact` は同一 guild の**別アプリ**が握っている → `You are not authorized to use this command` / `アプリケーションが応答しませんでした` で弾かれる
- 正解は `/session compact`（#200 で意図的に名前空間化。この決定自体は正しい）だが、**コマンド名を正確に思い出してタイプする**しか道が無い
- ナッジ本文はコマンド名を**テキストで案内するだけ**で、押せる導線が無い

つまり壊れていたのは compact 実装ではなく**導線**。

## 直し方

**ボタン（message component）を置く。** コンポーネントの interaction は `customId` で
**送信元アプリへ配送される**ため、他アプリがどんなコマンドを登録していても構造的に横取りされない。
`/compact` の名前を取り返す必要がなく、#200 の決定と両立する。

設置先は 3 箇所。**compact が次アクションである場合に限る**:

| 設置先 | 付ける条件 | 付けない理由（該当時） |
|---|---|---|
| 長時間稼働ナッジ（#209） | `long_lived` | `quiet` は無活動の話でコンテキストの話ではない |
| `/session status` | 稼働中（liveness alive かつ tracked） | 停止済みなら応答は resume 案内で、ボタンは行き止まり |
| context-budget 応答（#204） | `action === "notify"` | `compact`/`restart` は既に self-heal 済み。二重 compact を誘発する |

ハンドラは `/session compact` のスレッド分岐と**同一ガード・同一既定 intent**で、両者が drift しないようにしています。
ボタンには intent 欄が無いため `DEFAULT_COMPACT_INTENT` が bare compact（RW-032）への唯一の歯止めになります。

## 却下した案

| 案 | 却下理由 |
|---|---|
| top-level `/compact` を追加 | #200 の決定を覆す。3 アプリが同名を持つ状態は解消せず誤選択が残る |
| 他アプリ側の `/compact` を削除 | polka は第三者アプリで変更不可 |
| 平文 `/compact` を relay で拾う | Discord UI がスラッシュ入力をピッカーに吸うため送信導線が無い |

## 副次的な修正

`safeReplyError` は `isChatInputCommand()` で絞り込んでいたため、そのままだと**ボタンのエラーを黙って握り潰す**
（`agent-output-quality.md` #1 のサイレントフォールバック）。`isRepliable()` へ拡幅しました。
`safeRespond` も同様に `RepliableInteraction` へ型を広げています（挙動変更なし）。

## テスト

新規 `tests/commands/compact-button.test.ts`（7 ケース）+ `session-status.test.ts` に 2 ケース追加。

- ボタン row が app-scoped な customId を 1 個持つ
- `withCompactButton` は該当時のみ row を付ける（非該当では `components` を出さない）
- 稼働中 → 既定 intent で `compactSession`、ack は ephemeral（RW-032）
- 停止済み / スレッド外 → **send-keys せず**案内のみ
- compact 失敗はエラー文言で報告（握り潰さない）
- `/session status`: 稼働中はボタンあり / 停止済みは `components` なし

### AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | 型 | `bunx tsc --noEmit` | exit 0 | exit 0 | PASS |
| AC-2 | 新規/影響テスト | `bun test tests/commands/{compact-button,session-status,session-compact}.test.ts` | 全 pass | 21 pass / 0 fail | PASS |
| AC-3 | リグレッション無し | 全体実行を main(7f308cb) と比較 | 差分 0 | branch 27 / base 26、差分 1 件は全体実行時のみのタイミング flake（単体 3/3 pass・再実行で再現せず、本 PR 非関連の executor timeout テスト） | PASS |
| AC-4 | CI ゲート網羅 | `bun test tests/scripts/lint-gating-coverage.test.ts` | pass | 新規テストを ci.yml へ登録して pass | PASS |

> 既存 26 件の失敗は main と同一（macOS ローカルでの tmux / execFile モック起因の環境依存）。本 PR は増やしていません。

## 残る手動確認

ボタンの実クリックは Discord 実機でのみ検証可能（Supervisor 再起動後）。ハンドラのロジックは上記 unit test で
決定的に検証済みですが、Discord 側の配送そのものは実機確認になります。

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/miyashita337/claude-hub/pull/365" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 稼働中のセッション通知やステータス表示に、作業内容を保持して圧縮する「Compact」ボタンを追加しました。
  * ボタン操作時にセッション状態やスレッド所属を確認し、利用できない場合は案内を表示します。
  * 圧縮の成功・失敗結果を確認しやすいメッセージで通知します。
* **改善**
  * ボタン操作を含む各種インタラクションで、エラー応答を適切に表示できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->