### PR TITLE
fix: session-ctl stop が headless ワーカーを停止できるようにする (#358)

### DIFF
--- a/supervisor/tests/tools/session-ctl.test.ts
+++ b/supervisor/tests/tools/session-ctl.test.ts
@@ -57,6 +57,10 @@ function fakeFx(opts: {
   httpResponse?: { status: number; body: unknown };
   /** stop 中、tmux kill 後に store が返す status（Supervisor watcher 反映の模擬）。 */
   statusAfterKill?: string;
+  /** `ps -p <pid> -o command=` の模擬値（#358）。null = プロセス不在。 */
+  pidCommand?: string | null;
+  /** true なら SIGTERM 後も pidAlive が true のまま（SIGKILL 昇格の模擬、#358）。 */
+  survivesSigterm?: boolean;
 } = {}): { fx: SessionCtlEffects; calls: FakeCalls } {
   const calls: FakeCalls = {
     sends: [],
@@ -68,6 +72,7 @@ function fakeFx(opts: {
   };
   const rows = opts.rows ?? [];
   let killed = false;
+  let sigtermed = false;
 
   const currentRows = (): SessionRow[] =>
     killed && opts.statusAfterKill
@@ -103,9 +108,13 @@ function fakeFx(opts: {
     },
     killPid: (pid, signal) => {
       calls.killedPids.push({ pid, signal });
+      if (signal === "SIGTERM" && !opts.survivesSigterm) sigtermed = true;
       return true;
     },
-    pidAlive: () => opts.pidAlive ?? true,
+    // #358: SIGTERM が効いたら以降 dead を返す（SIGKILL 昇格の分岐を出し分ける）。
+    pidAlive: () => (sigtermed ? false : opts.pidAlive ?? true),
+    readPidCommand: async () =>
+      opts.pidCommand === undefined ? null : opts.pidCommand,
     sleep: async () => {},
     readRelayPort: () => (opts.relayPort === undefined ? 45678 : opts.relayPort),
     httpPost: async (url, body) => {
@@ -245,6 +254,71 @@ describe("stop", () => {
     // できない限りシグナルを送らない（PR #325 gemini high）。
     expect(calls.killedPids).toHaveLength(0);
     expect(calls.killedTmux).toHaveLength(0);
+    expect(calls.out.join("\n")).toContain("スキップ");
+  });
+
+  // Issue #358: headless（`claude -p`）ワーカーは tmux を持たないため、tmux の
+  // 生存だけを条件にすると「止めたつもりで走り続ける」状態になっていた。
+  // 代替の本人確認としてコマンドライン中の claude_session_id（UUID）を照合する。
+  const HEADLESS_CMD =
+    "/Users/x/.local/bin/claude -p /pdca 268 --output-format json " +
+    "--dangerously-skip-permissions --session-id aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+  test("headless（tmux 不在）+ コマンドライン一致 → SIGTERM が届く（AC-1）", async () => {
+    const { fx, calls } = fakeFx({
+      rows: [row()],
+      tmuxAlive: false,
+      pidCommand: HEADLESS_CMD,
+    });
+    expect(await runSessionCtl(["stop", "sess-1"], fx, STOP_OPTS)).toBe(0);
+
+    expect(calls.killedPids).toEqual([{ pid: 4242, signal: "SIGTERM" }]);
+    // tmux は無いので kill-session は呼ばない。
+    expect(calls.killedTmux).toHaveLength(0);
+    expect(calls.out.join("\n")).toContain("SIGTERM で終了しました");
+  });
+
+  test("headless + SIGTERM で死なない → SIGKILL へ昇格（AC-1）", async () => {
+    const { fx, calls } = fakeFx({
+      rows: [row()],
+      tmuxAlive: false,
+      pidCommand: HEADLESS_CMD,
+      survivesSigterm: true,
+    });
+    expect(await runSessionCtl(["stop", "sess-1"], fx, STOP_OPTS)).toBe(0);
+
+    expect(calls.killedPids).toEqual([
+      { pid: 4242, signal: "SIGTERM" },
+      { pid: 4242, signal: "SIGKILL" },
+    ]);
+    expect(calls.out.join("\n")).toContain("SIGKILL");
+  });
+
+  test("pid は生存だがコマンドラインが別物 → kill しない（PID 再利用ガード、AC-2）", async () => {
+    // 元の headless プロセスは終了し、OS が同じ pid を無関係プロセスへ再利用した状況。
+    const { fx, calls } = fakeFx({
+      rows: [row()],
+      tmuxAlive: false,
+      pidCommand: "/usr/bin/some-unrelated-daemon --serve",
+    });
+    expect(await runSessionCtl(["stop", "sess-1"], fx, STOP_OPTS)).toBe(0);
+
+    expect(calls.killedPids).toHaveLength(0);
+    expect(calls.killedTmux).toHaveLength(0);
+    const out = calls.out.join("\n");
+    expect(out).toContain("スキップ");
+    // 「なぜ殺さなかったか」を必ず言う（silent に落とさない）。
+    expect(out).toContain("PID 再利用");
+  });
+
+  test("claude_session_id 未記録の行 → 照合できないので kill しない", async () => {
+    const { fx, calls } = fakeFx({
+      rows: [row({ claude_session_id: null })],
+      tmuxAlive: false,
+      pidCommand: HEADLESS_CMD,
+    });
+    expect(await runSessionCtl(["stop", "sess-1"], fx, STOP_OPTS)).toBe(0);
+    expect(calls.killedPids).toHaveLength(0);
     expect(calls.out.join("\n")).toContain("スキップ");
   });
 

--- a/supervisor/tools/session-ctl.ts
+++ b/supervisor/tools/session-ctl.ts
@@ -66,6 +66,11 @@ export interface SessionCtlEffects {
   /** process.kill 相当。配達できたら true。 */
   killPid(pid: number, signal: NodeJS.Signals): boolean;
   pidAlive(pid: number): boolean;
+  /**
+   * pid の実行中コマンドライン（`ps -p <pid> -o command=` 相当）。プロセスが
+   * 居なければ null。headless セッションの本人確認に使う（Issue #358）。
+   */
+  readPidCommand(pid: number): Promise<string | null>;
   sleep(ms: number): Promise<void>;
   /** relay ポートファイルから Supervisor の relay ポートを読む（無ければ null）。 */
   readRelayPort(): number | null;
@@ -193,6 +198,59 @@ async function cmdSend(
   return 0;
 }
 
+/**
+ * tmux を持たない headless ワーカーを pid 経由で停止する（Issue #358、案 A）。
+ *
+ * 本人確認は `ps` のコマンドラインに当該セッションの `claude_session_id`（UUID）が
+ * 含まれるかで行う。これが PID 再利用ガードの代替:
+ *
+ *   - UUID 不一致 → OS が pid を別プロセスへ再利用している（or そもそも別物）
+ *     → **何もしない**。無関係プロセスを殺さないことを最優先する
+ *   - 一致 → 紛れもなく当該ワーカー → SIGTERM → 猶予 → まだ生きていれば SIGKILL
+ *
+ * 戻り値で「殺さなかった理由」を呼び出し側に伝え、メッセージを出し分ける
+ * （どちらのスキップも silent にしない = agent-output-quality #1）。
+ * sessions.db には書かない（書き込みは Supervisor の専権）。
+ */
+type HeadlessStopOutcome =
+  /** 本人確認が取れてシグナルを送った（メッセージは本関数が出力済み）。 */
+  | "signalled"
+  /** pid は生存しているがコマンドラインが一致しない = PID 再利用の疑い。 */
+  | "identity-mismatch"
+  /** pid 不明 / session id 未記録 / 既に終了 — headless 停止の対象外。 */
+  | "not-applicable";
+
+async function stopHeadlessByPid(
+  fx: SessionCtlEffects,
+  row: SessionRow,
+  graceMs: number,
+): Promise<HeadlessStopOutcome> {
+  const pid = row.pid;
+  const claudeSessionId = row.claude_session_id;
+  if (pid == null || !claudeSessionId) return "not-applicable";
+  if (!fx.pidAlive(pid)) return "not-applicable";
+
+  const command = await fx.readPidCommand(pid);
+  // ps が読めない場合も一致とは見なさない（安全側 = 殺さない）。
+  if (!command || !command.includes(claudeSessionId)) return "identity-mismatch";
+
+  fx.out(
+    `tmux 不在（headless）。pid ${pid} のコマンドラインで session id を確認したため SIGTERM を送信します。`,
+  );
+  fx.killPid(pid, "SIGTERM");
+  if (graceMs > 0) await fx.sleep(graceMs);
+
+  if (fx.pidAlive(pid)) {
+    fx.killPid(pid, "SIGKILL");
+    fx.out(
+      `猶予 ${graceMs}ms 経過後も生存していたため SIGKILL を送信しました（pid ${pid}）。`,
+    );
+  } else {
+    fx.out(`pid ${pid} は SIGTERM で終了しました。`);
+  }
+  return "signalled";
+}
+
 async function cmdStop(
   fx: SessionCtlEffects,
   key: string,
@@ -221,10 +279,28 @@ async function cmdStop(
   const tmuxAlive = tmuxName ? await fx.hasTmuxSession(tmuxName) : false;
 
   if (!tmuxAlive) {
-    fx.out(
-      `tmux セッション${tmuxName ? ` ${tmuxName}` : ""} が存在しないため SIGTERM / kill をスキップします` +
-        "（PID 再利用による誤 kill 防止。Supervisor が status を整合します）。",
-    );
+    // Issue #358: headless（`claude -p`）ワーカーは tmux を持たない。上の
+    // ガードは「tmux が無い = もう死んでいる」と見なすため、headless では
+    // SIGTERM がスキップされ、プロセスが生きたまま「停止した」ように見えていた。
+    // 暴走ワーカーを止める最後の手段が効かず、記事投稿・SNS 連携のような不可逆な
+    // 外部副作用を伴うタスクで特に危険（2026-08-01 の誤 dispatch で実際に踏んだ）。
+    //
+    // PID 再利用ガードの意図は保つ: tmux の代わりに **コマンドラインが当該
+    // セッションのものか** を照合する。headless argv には必ず
+    // `--session-id <uuid>` が入る（manager.ts buildHeadlessClaudeFlags 直後で
+    // 付与）ので、UUID 一致は事実上衝突しない本人確認になる。
+    const outcome = await stopHeadlessByPid(fx, row, graceMs);
+    if (outcome === "identity-mismatch") {
+      fx.out(
+        `pid ${row.pid} は生存していますが、コマンドラインに session id ${row.claude_session_id} を含みません。` +
+          "SIGTERM / kill をスキップします（PID 再利用による誤 kill 防止）。",
+      );
+    } else if (outcome === "not-applicable") {
+      fx.out(
+        `tmux セッション${tmuxName ? ` ${tmuxName}` : ""} が存在しないため SIGTERM / kill をスキップします` +
+          "（PID 再利用による誤 kill 防止。Supervisor が status を整合します）。",
+      );
+    }
   } else {
     if (row.pid != null) {
       const delivered = fx.killPid(row.pid, "SIGTERM");
@@ -492,6 +568,22 @@ export function createRealEffects(): SessionCtlEffects {
         return true;
       } catch {
         return false;
+      }
+    },
+    readPidCommand: async (pid) => {
+      // `ps -p <pid> -o command=` は macOS / Linux 共通で full argv を返す
+      // （`=` でヘッダ抑止）。argv 配列で渡すので shell は介さない。
+      // プロセス不在なら ps は非 0 で終わる → null（呼び出し側は kill しない）。
+      try {
+        const { stdout } = await execFileAsync(
+          "/bin/ps",
+          ["-p", String(pid), "-o", "command="],
+          { timeout: 5000 },
+        );
+        const line = stdout.trim();
+        return line || null;
+      } catch {
+        return null;
       }
     },
     pidAlive: (pid) => {


### PR DESCRIPTION
Closes #358

## 直した挙動

`session-ctl stop <id>` が **headless（`claude -p`）ワーカーを停止できず、止めたつもりで走り続けていた**問題を解消します。

tmux セッションの存在を kill の前提にしていたため、tmux を持たない headless ワーカーでは
SIGTERM がスキップされ、`sessions.db` の status だけが「停止処理した」ように見えていました。
暴走・誤 dispatch ワーカーを止める最後の手段が効かないため、記事投稿・SNS 連携のような
**不可逆な外部副作用**を伴うタスクで特に危険です（2026-08-01 の誤 dispatch を止めた際に
実際に踏み、`ps` + `kill` の手動運用へ落ちました）。

## 方針: 案 A（コマンドライン照合）

PID 再利用ガード（PR #325 gemini high）を弱めずに headless を止めたいので、
**tmux の代わりにコマンドラインで本人確認**します。

headless の argv には必ず `--session-id <uuid>` が入ります
（`manager.ts` の spawn 直前、`buildHeadlessClaudeFlags` の戻りに追加）。
`sessions.db` の `claude_session_id` と突き合わせれば、UUID なので事実上衝突しません。

| 状況 | 挙動 |
|---|---|
| pid 生存 + コマンドラインに session id あり | SIGTERM → 猶予 → まだ生きていれば **SIGKILL** |
| pid 生存 + コマンドラインが別物 | **kill しない**（PID 再利用）。理由を出力 |
| `ps` が読めない | **kill しない**（安全側）。理由を出力 |
| pid 不明 / session id 未記録 / 既に終了 | 従来どおりスキップ |

戻り値を 3 値（`signalled` / `identity-mismatch` / `not-applicable`）にして
「なぜ殺さなかったか」を出し分けています。**どのスキップも silent にしません**
（`agent-output-quality.md` #1）。

`sessions.db` に書かない方針（書き込みは Supervisor の専権）は不変です。

## AC 検証結果

Issue の統合ジャーニーAC に対応します。

| AC | 検証内容 | 期待 | 実測 | 判定 |
|---|---|---|---|---|
| AC-1 | headless を stop → プロセス終了 | SIGTERM 到達、死ななければ SIGKILL | 一致時 `[{pid,SIGTERM}]` / 耐性時 `[SIGTERM, SIGKILL]` | PASS |
| AC-2 | 終了済み id の stop で別プロセスを殺さない | kill 0 回 + 理由出力 | `killedPids` 0 件、「PID 再利用」出力あり | PASS |
| AC-3 | tmux 経路の回帰なし | 既存テスト継続 pass | session-ctl 36/36 pass | PASS |
| AC-4 | 型 | exit 0 | exit 0 | PASS |
| AC-5 | 全体リグレッション | main(66a4db4) と同数 | 差分 1 件は `cleanup-idle-claude.sh` の flake（単体 2/2 pass・full 再実行で消失、実プロセスを覗くテストで無関係） | PASS |

### OS 依存部（`ps`）の実プロセス検証

ユニットテストは fake なので、`ps` 連携だけは**実プロセス**で確認しました:

```
$ /bin/sh -c 'while :; do sleep 1; done' aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee &
readPidCommand: /bin/sh -c while :; do sleep 1; done aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee
AC-a contains uuid      -> PASS
AC-b pidAlive true      -> PASS
AC-c other uuid miss    -> PASS   （別 UUID では一致しない = 誤 kill しない側）
AC-d dead after TERM    -> PASS
AC-e cmd null when gone -> PASS
```

## 残る制約

- `ps` 前提のため **OS 依存**（macOS / Linux で同一書式。Windows は対象外）。案 A 採用時に想定済みのトレードオフです
- 実際の headless dispatch ワーカーに対する end-to-end 実行は、実ワーカーの起動が必要なため未実施です。停止ロジックはユニットテストで、`ps` 連携は上記の実プロセスで、それぞれ決定的に検証しています

<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/miyashita337/claude-hub/pull/367" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - ヘッドレスセッションの停止処理を改善しました。
  - 対象プロセスを正しく確認してから停止するため、別のプロセスを誤って終了するリスクを低減しました。
  - 通常の終了要求で停止しないプロセスは、必要に応じて強制終了します。
  - セッション情報が確認できない場合や、対象プロセスがすでに終了している場合は、安全のため停止処理をスキップします。
  - tmux が利用できない環境でも、条件を満たすプロセスを停止できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->