### PR TITLE
fix: headless dispatch の背景タスク置き去り silent failure を二層で塞ぐ (#342)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -150,6 +150,7 @@ jobs:
                    tests/guards/access-enforcement-wired.test.ts \
                    tests/hooks/ask-user-relay.test.ts \
                    tests/hooks/auto-approve-permission.test.ts \
+                   tests/hooks/headless-pending-guard.test.ts \
                    tests/hooks/progress-relay.test.ts \
                    tests/scripts/cleanup-idle-claude.test.ts \
                    tests/scripts/setup-agent-base.test.ts \
@@ -163,6 +164,7 @@ jobs:
                    tests/session/adapters-executor.test.ts \
                    tests/session/manager-headless.test.ts \
                    tests/session/headless-liveness.test.ts \
+                   tests/session/pending-work.test.ts \
                    tests/session/reaper.test.ts \
                    tests/session/dispatch-queue.test.ts \
                    tests/session/admission.test.ts \

--- a/supervisor/hooks/headless-pending-guard.ts
+++ b/supervisor/hooks/headless-pending-guard.ts
@@ -1,0 +1,147 @@
+#!/usr/bin/env bun
+/**
+ * Stop hook: keep a headless dispatch worker alive while it still has pending
+ * background work (Issue #342, Layer 1 / prevention).
+ *
+ * A `claude -p` worker exits at turn end, killing any in-flight background
+ * task and orphaning any ScheduleWakeup reservation — observed live as
+ * exit-0 / no-PR silent failures (#338, agent-base#456). Prompt-level rules
+ * alone were proven insufficient (#456 was dispatched WITH an explicit
+ * "finish in one turn" instruction and still went to the background via a
+ * foreground timeout it did not recognise as one).
+ *
+ * This hook is injected ONLY into headless dispatch children via `--settings`
+ * (see `buildPendingGuardFlags` in `src/session/manager.ts`); interactive and
+ * tmux sessions never load it. On each Stop event it parses the session
+ * transcript with the shared deterministic detector (`pending-work.ts`) and,
+ * while pending work remains, answers `{"decision":"block"}` so the harness
+ * gives the worker another turn with concrete instructions to finish the
+ * wait synchronously. Empirically verified under `claude -p`: the Stop hook
+ * fires, `decision:block` forces continuation, and `stop_hook_active` is set
+ * on the follow-up Stop (real runs, 2026-08-06).
+ *
+ * Fail-safe posture:
+ *   - Bounded: at most HEADLESS_PENDING_GUARD_MAX_BLOCKS (default 20) blocks
+ *     per session (counter file in the OS tmpdir), so a worker that cannot
+ *     drain its work is eventually allowed to stop — Layer 2
+ *     (`manager.runHeadless`'s completion probe) then reports it as pending
+ *     instead of clean, and the worktree is retained.
+ *   - Internal failures (unreadable transcript, bad stdin) allow the stop and
+ *     log to stderr; they never wedge the worker. Layer 2 independently
+ *     reports `completion: unknown` for an unreadable transcript, so this
+ *     hook degrading is loud downstream, not silent (review condition 3).
+ *   - Kill switch: HEADLESS_PENDING_GUARD=off disables blocking entirely.
+ */
+
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  probePendingWork,
+  describePendingWork,
+} from "../src/session/pending-work";
+
+const DEFAULT_MAX_BLOCKS = 20;
+
+interface StopHookInput {
+  session_id?: string;
+  transcript_path?: string;
+  stop_hook_active?: boolean;
+}
+
+function counterPath(sessionId: string): string {
+  // sessionId is a UUID we pinned ourselves (`--session-id`), but sanitise
+  // anyway so a hostile value cannot traverse out of the tmpdir.
+  const safe = sessionId.replace(/[^A-Za-z0-9-]/g, "_");
+  return join(tmpdir(), `headless-pending-guard-${safe}.blocks`);
+}
+
+function readCount(path: string): number {
+  try {
+    const n = Number.parseInt(readFileSync(path, "utf8").trim(), 10);
+    return Number.isFinite(n) && n >= 0 ? n : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function main(): void {
+  if (process.env.HEADLESS_PENDING_GUARD === "off") {
+    return; // kill switch: allow every stop
+  }
+
+  let input: StopHookInput;
+  try {
+    input = JSON.parse(readFileSync(0, "utf8")) as StopHookInput;
+  } catch (err) {
+    console.error(`[headless-pending-guard] stdin unparsable, allowing stop: ${err}`);
+    return;
+  }
+
+  const sessionId = input.session_id;
+  const transcriptPath = input.transcript_path;
+  if (!sessionId || !transcriptPath) {
+    console.error(
+      "[headless-pending-guard] missing session_id/transcript_path, allowing stop",
+    );
+    return;
+  }
+
+  const probe = probePendingWork(transcriptPath);
+  if (!probe.ok) {
+    // Fail-loud downstream: Layer 2 reports `completion: unknown` for this.
+    console.error(
+      `[headless-pending-guard] ${probe.error} — allowing stop (Layer 2 will flag the run)`,
+    );
+    return;
+  }
+
+  const work = probe.value;
+  const hasPending = work.pendingTasks.length > 0 || work.pendingWakeup;
+  const counter = counterPath(sessionId);
+
+  if (!hasPending) {
+    try {
+      unlinkSync(counter); // housekeeping; absence is fine
+    } catch {
+      /* counter never existed — nothing to clean */
+    }
+    return;
+  }
+
+  const maxBlocks = (() => {
+    const n = Number.parseInt(process.env.HEADLESS_PENDING_GUARD_MAX_BLOCKS ?? "", 10);
+    return Number.isFinite(n) && n > 0 ? n : DEFAULT_MAX_BLOCKS;
+  })();
+  const blocks = readCount(counter);
+  if (blocks >= maxBlocks) {
+    console.error(
+      `[headless-pending-guard] pending work remains after ${blocks} blocks — ` +
+        `allowing stop; Layer 2 will report it (${describePendingWork(work)})`,
+    );
+    return;
+  }
+
+  try {
+    writeFileSync(counter, String(blocks + 1), "utf8");
+  } catch (err) {
+    // Without a counter the bound cannot be enforced — allow the stop rather
+    // than risk an unbounded block loop.
+    console.error(`[headless-pending-guard] counter write failed, allowing stop: ${err}`);
+    return;
+  }
+
+  const reason =
+    `この実行は headless（claude -p）のため、turn を終了するとプロセスごと終了し、` +
+    `背景タスクと ScheduleWakeup 予約は失われます（Issue claude-hub#342 の silent failure）。\n` +
+    `検出された未完了: ${describePendingWork(work)}\n\n` +
+    `対応してから終了してください:\n` +
+    `- 背景タスク: TaskOutput(task_id, block=true) で完了まで同期的に待つか、` +
+    `出力ファイルを Read で確認しながら完了を待つ（10 分を超える待ちは短い確認を繰り返す）\n` +
+    `- ScheduleWakeup: stop:true で解除し、待ち時間は同期ポーリングで消化する\n` +
+    `- すべて完了・回収したら、成果（commit / push / PR / Issue コメント）まで仕上げて終了する`;
+
+  process.stdout.write(JSON.stringify({ decision: "block", reason }));
+}
+
+main();

--- a/supervisor/src/session/dispatch-report.ts
+++ b/supervisor/src/session/dispatch-report.ts
@@ -30,6 +30,16 @@ export interface DispatchReportFields {
   durationMs: number;
   /** `claude -p` exit code, or `null` when the run was killed (e.g. timeout). */
   exitCode: number | null;
+  /**
+   * Completion verdict (Issue #342). ADDITIVE to the machine contract: corp
+   * reconcile keys off the heading and the existing `- key: value` lines, so
+   * appending new keys is backwards-compatible. `clean` runs still emit the
+   * line (a reader can distinguish "verified clean" from "predates #342").
+   * Optional so callers without a probe (none today) simply omit the lines.
+   */
+  completion?: "clean" | "pending" | "unknown";
+  /** Human-readable pending/unknown evidence; omitted when empty. */
+  completionDetail?: string;
 }
 
 /**
@@ -46,5 +56,18 @@ export function formatDispatchReport(fields: DispatchReportFields): string {
   }
   lines.push(`- duration_ms: ${fields.durationMs}`);
   lines.push(`- exit_code: ${fields.exitCode === null ? "null" : fields.exitCode}`);
+  if (fields.completion) {
+    lines.push(`- completion: ${fields.completion}`);
+    if (fields.completionDetail) {
+      lines.push(`- completion_detail: ${fields.completionDetail}`);
+    }
+    if (fields.completion !== "clean") {
+      lines.push(
+        "",
+        "⚠️ この run は正常完了と確認できていません（Issue claude-hub#342）。" +
+          "worktree は復旧用に保全されています。同じブランチへの再 dispatch で作業状態を引き継げます。",
+      );
+    }
+  }
   return lines.join("\n") + "\n";
 }

--- a/supervisor/src/session/dispatch.ts
+++ b/supervisor/src/session/dispatch.ts
@@ -200,6 +200,14 @@ export interface DispatchHeadlessOutcome {
   stdout: string;
   stderr: string;
   timedOut: boolean;
+  /**
+   * Completion verdict from the manager's post-exit probe (Issue #342).
+   * `pending`/`unknown` runs are surfaced as warnings in the thread even on
+   * exit 0 — the two observed silent failures both exited 0. Optional so a
+   * minimal fake (or an older manager) still satisfies the seam; absent means
+   * "no probe ran" and no completion warning is posted.
+   */
+  completion?: { status: "clean" | "pending" | "unknown"; detail: string };
 }
 
 /**
@@ -517,6 +525,17 @@ async function postHeadlessOutcome(
     );
   } else {
     chunks.push(...formatForDiscord(outcome.stdout));
+  }
+
+  // Issue #342: a pending/unknown completion is a warning REGARDLESS of the
+  // exit code — both observed silent failures exited 0 with work in flight.
+  const completion = outcome.completion;
+  if (completion && completion.status !== "clean") {
+    chunks.push(
+      `⚠️ この run は正常完了と確認できていません（completion: ${completion.status}）。` +
+        `${completion.detail ? `\n検出内容: ${completion.detail}` : ""}\n` +
+        `worktree は復旧用に保全されています。同じブランチへの再 dispatch で作業状態を引き継げます（Issue claude-hub#342）。`,
+    );
   }
 
   try {

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -1221,25 +1221,39 @@ export class SessionManager {
     cwd: string,
     claudeSessionId: string,
   ): HeadlessCompletion {
-    const groupAlive = pid !== null && this.effects.process.isAlive(-pid);
+    // The probe is observability, not control flow: a throw here would reject
+    // runHeadless AFTER the child exited, skipping finishHeadless and leaking
+    // the session slot (PR #368 review). Any internal failure degrades to
+    // `unknown` — loud downstream, but the teardown always runs.
+    try {
+      const groupAlive = pid !== null && this.effects.process.isAlive(-pid);
 
-    const transcriptPath = deriveTranscriptPath(cwd, claudeSessionId);
-    const probe = this.probePendingWorkFn(transcriptPath);
+      const transcriptPath = deriveTranscriptPath(cwd, claudeSessionId);
+      const probe = this.probePendingWorkFn(transcriptPath);
 
-    const details: string[] = [];
-    if (groupAlive) {
-      details.push(`プロセスグループ ${pid} に生存プロセスあり`);
+      const details: string[] = [];
+      if (groupAlive) {
+        details.push(`プロセスグループ ${pid} に生存プロセスあり`);
+      }
+      if (!probe.ok) {
+        details.push(`transcript 検証不能 (${probe.error})`);
+        return {
+          status: groupAlive ? "pending" : "unknown",
+          detail: details.join(" / "),
+        };
+      }
+      const summary = describePendingWork(probe.value);
+      if (summary) details.push(summary);
+      if (groupAlive || summary) {
+        return { status: "pending", detail: details.join(" / ") };
+      }
+      return { status: "clean", detail: "" };
+    } catch (err) {
+      return {
+        status: "unknown",
+        detail: `completion probe failed: ${err instanceof Error ? err.message : String(err)}`,
+      };
     }
-    if (!probe.ok) {
-      details.push(`transcript 検証不能 (${probe.error})`);
-      return { status: groupAlive ? "pending" : "unknown", detail: details.join(" / ") };
-    }
-    const summary = describePendingWork(probe.value);
-    if (summary) details.push(summary);
-    if (groupAlive || summary) {
-      return { status: "pending", detail: details.join(" / ") };
-    }
-    return { status: "clean", detail: "" };
   }
 
   private async finishHeadless(

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -2,6 +2,7 @@ import { randomUUID } from "crypto";
 import { existsSync, unlinkSync } from "fs";
 import { dirname, resolve } from "path";
 import { homedir } from "os";
+import { fileURLToPath } from "url";
 import type { SessionInfo, SessionHealthInfo, StopReason } from "./types";
 import type { ChannelConfig } from "../config/channels";
 import {
@@ -41,6 +42,12 @@ import {
 } from "./self-heal";
 import { compactClaudeHubExit } from "./primary-compact";
 import { formatDispatchReport } from "./dispatch-report";
+import {
+  deriveTranscriptPath,
+  describePendingWork,
+  probePendingWork,
+  type PendingWorkProbe,
+} from "./pending-work";
 
 const DEFAULT_CLAUDE_PATH = resolve(homedir(), ".local", "bin", "claude");
 const TMUX_SESSION_PREFIX = "claude-";
@@ -326,6 +333,69 @@ export function buildHeadlessClaudeFlags(
 }
 
 /**
+ * Absolute path to the Stop hook that keeps a headless worker alive while it
+ * still has pending background work (Issue #342, Layer 1). Resolved from this
+ * module's location so it always points at the checkout the Supervisor is
+ * actually running from (main or a worktree).
+ */
+const PENDING_GUARD_HOOK_PATH = fileURLToPath(
+  new URL("../../hooks/headless-pending-guard.ts", import.meta.url),
+);
+
+/**
+ * Build the `--settings` flag that injects the pending-work Stop hook into a
+ * headless child (Issue #342). Scoped injection: only headless dispatch
+ * children receive the hook — interactive/tmux sessions and the user's own
+ * settings are untouched. `--settings <json>` and Stop-hook `decision:block`
+ * under `claude -p` were both verified against real runs (v2.x, 2026-08-06).
+ *
+ * Kill switch: `HEADLESS_PENDING_GUARD=off` disables the injection entirely
+ * (the hook script honours the same variable as a second layer). The hook is
+ * run with the same bun binary that runs the Supervisor (`process.execPath`)
+ * so no PATH assumption leaks into the child.
+ */
+export function buildPendingGuardFlags(
+  env: Record<string, string | undefined> = process.env,
+): string[] {
+  if (env.HEADLESS_PENDING_GUARD === "off") return [];
+  const settings = {
+    hooks: {
+      Stop: [
+        {
+          hooks: [
+            {
+              type: "command",
+              command: `"${process.execPath}" "${PENDING_GUARD_HOOK_PATH}"`,
+            },
+          ],
+        },
+      ],
+    },
+  };
+  return ["--settings", JSON.stringify(settings)];
+}
+
+/**
+ * Completion verdict for a finished headless run (Issue #342, Layer 2).
+ *
+ *   - `clean`:   no pending signal — safe to reclaim the worktree.
+ *   - `pending`: the child left work in flight (surviving process-group
+ *                members, unfinished background tasks, or an unfired
+ *                ScheduleWakeup). The run is NOT a success even on exit 0.
+ *   - `unknown`: the transcript could not be read/parsed, so completion could
+ *                not be verified. Deliberately NOT folded into `clean`
+ *                (fail-loud): treating "could not check" as "checked OK" would
+ *                re-create the silent failure this exists to remove.
+ */
+export type HeadlessCompletionStatus = "clean" | "pending" | "unknown";
+
+export interface HeadlessCompletion {
+  status: HeadlessCompletionStatus;
+  /** Human-readable evidence (pending task ids / probe error), "" when clean. */
+  detail: string;
+}
+
+/**
  * Environment for a headless child (Epic #285 Phase 2). Bun.spawn REPLACES the
  * environment, so this returns a COMPLETE env derived from the supervisor's:
  *   - ANTHROPIC_API_KEY removed → use the Claude Max subscription (mirrors the
@@ -374,6 +444,8 @@ export interface HeadlessSessionResult {
   sessionId: string;
   /** The pinned `--session-id` value handed to the child. */
   claudeSessionId: string;
+  /** Completion verdict (Issue #342): pending/unknown runs are not successes. */
+  completion: HeadlessCompletion;
 }
 
 /**
@@ -468,6 +540,13 @@ export interface SessionManagerOptions {
    * Defaults to 10_000.
    */
   watchIntervalMs?: number;
+  /**
+   * Test seam for the headless completion probe (Issue #342): overrides the
+   * transcript read+parse (`probePendingWork`) so unit tests control the
+   * pending verdict without writing real files under `~/.claude/projects`.
+   * Production leaves this undefined.
+   */
+  probePendingWorkFn?: (transcriptPath: string) => PendingWorkProbe;
 }
 
 /**
@@ -544,6 +623,9 @@ export class SessionManager {
   private readonly inputReadyPollAttempts: number;
   private readonly inputReadyPollIntervalMs: number;
   private readonly watchIntervalMs: number;
+  private readonly probePendingWorkFn: (
+    transcriptPath: string,
+  ) => PendingWorkProbe;
 
   constructor(options: SessionManagerOptions = {}) {
     this.effects = {
@@ -568,6 +650,7 @@ export class SessionManager {
     this.inputReadyPollIntervalMs =
       options.inputReadyPollIntervalMs ?? 1000;
     this.watchIntervalMs = options.watchIntervalMs ?? 10_000;
+    this.probePendingWorkFn = options.probePendingWorkFn ?? probePendingWork;
 
     // Issue #227 (PR-4): ensureSocketConfigured is async now. The constructor
     // cannot await, so fire-and-forget it — it is idempotent and re-applied in
@@ -994,6 +1077,10 @@ export class SessionManager {
           initialCommand,
           resolveDispatchModel(),
         ),
+        // Issue #342 Layer 1: inject the pending-work Stop hook so the worker
+        // cannot end its turn (= kill the process) while background tasks or a
+        // ScheduleWakeup reservation are still in flight.
+        ...buildPendingGuardFlags(),
         // Pin the session id like launchStart so the DB row captures it
         // deterministically (Issue #167). randomUUID() is shell-safe, though
         // there is no shell here.
@@ -1002,6 +1089,11 @@ export class SessionManager {
       ];
       const now = new Date();
 
+      // Issue #342 Layer 2: the child's pid doubles as its process-GROUP id
+      // (the executor spawns with `detached: true`), so it is kept for the
+      // post-exit orphan probe.
+      let spawnedPid: number | null = null;
+
       const result = await this.effects.executor.runHeadless({
         claudePath: claudePath(),
         args,
@@ -1009,6 +1101,7 @@ export class SessionManager {
         env: buildHeadlessEnv(),
         timeoutMs: headlessTimeoutMs(),
         onSpawn: (pid) => {
+          spawnedPid = pid;
           // Register the session synchronously the moment the child exists, so
           // MAX_SESSIONS / count() reflect the in-flight run and the reapers can
           // observe it. Hand off pendingStarts → sessions (mirrors launchStart).
@@ -1051,6 +1144,22 @@ export class SessionManager {
       // Fail-soft: a crash / timeout that left no valid JSON yields the raw
       // output and null tokens rather than throwing.
       const parsed = parseHeadlessOutput(result.stdout);
+
+      // Issue #342 Layer 2: verify the run actually FINISHED its work before
+      // treating exit 0 as success. Both observed silent failures (#338,
+      // agent-base#456) exited 0 with pending background work.
+      const completion = this.probeHeadlessCompletion(
+        spawnedPid,
+        projectDir,
+        claudeSessionId,
+      );
+      if (completion.status !== "clean") {
+        console.warn(
+          `[SessionManager] Headless run for thread ${threadId} ended ` +
+            `${completion.status}: ${completion.detail}`,
+        );
+      }
+
       const outcome: HeadlessSessionResult = {
         exitCode: result.exitCode,
         stdout: parsed.text,
@@ -1060,6 +1169,7 @@ export class SessionManager {
         tokens: parsed.tokens,
         sessionId,
         claudeSessionId,
+        completion,
       };
 
       // Post the Dispatch 実行レポート to the target Issue BEFORE finishHeadless
@@ -1072,7 +1182,7 @@ export class SessionManager {
       // Child exited → close the session (frees the slot). Even if onSpawn never
       // fired (should not happen unless the adapter misbehaves), finishHeadless
       // is a no-op safe cleanup.
-      await this.finishHeadless(threadId, sessionId, result, worktree);
+      await this.finishHeadless(threadId, sessionId, result, worktree, completion);
 
       return outcome;
     } finally {
@@ -1092,11 +1202,52 @@ export class SessionManager {
    * The DB reason distinguishes a timeout so operators can audit wedged runs; the
    * success/failure detail itself is surfaced to the thread by the caller (AC-5).
    */
+  /**
+   * Post-exit completion probe (Issue #342 Layer 2). Two deterministic signals,
+   * neither of which depends on the model's prose:
+   *
+   *   1. Process-group survival: the executor spawns the child `detached`, so
+   *      its pid is the group id. `isAlive(-pid)` (POSIX group-target kill 0)
+   *      after exit means orphaned tool subprocesses are still running — work
+   *      was abandoned mid-flight. Version-independent.
+   *   2. Transcript parse (`pending-work.ts`): unfinished background tasks /
+   *      an unfired ScheduleWakeup reservation.
+   *
+   * Fail-LOUD: an unreadable transcript yields `unknown`, never `clean` — the
+   * whole point is that "could not verify" must not masquerade as success.
+   */
+  private probeHeadlessCompletion(
+    pid: number | null,
+    cwd: string,
+    claudeSessionId: string,
+  ): HeadlessCompletion {
+    const groupAlive = pid !== null && this.effects.process.isAlive(-pid);
+
+    const transcriptPath = deriveTranscriptPath(cwd, claudeSessionId);
+    const probe = this.probePendingWorkFn(transcriptPath);
+
+    const details: string[] = [];
+    if (groupAlive) {
+      details.push(`プロセスグループ ${pid} に生存プロセスあり`);
+    }
+    if (!probe.ok) {
+      details.push(`transcript 検証不能 (${probe.error})`);
+      return { status: groupAlive ? "pending" : "unknown", detail: details.join(" / ") };
+    }
+    const summary = describePendingWork(probe.value);
+    if (summary) details.push(summary);
+    if (groupAlive || summary) {
+      return { status: "pending", detail: details.join(" / ") };
+    }
+    return { status: "clean", detail: "" };
+  }
+
   private async finishHeadless(
     threadId: string,
     sessionId: string,
     result: HeadlessRunResult,
     worktree: SessionInfo["worktree"],
+    completion: HeadlessCompletion,
   ): Promise<void> {
     this.sessions.delete(threadId);
     this.emitSessionEnd(threadId); // Phase 5c: free a dispatch queue slot (#294)
@@ -1109,7 +1260,16 @@ export class SessionManager {
     // SUPERVISOR_RELAY_URL and the headless child never writes one (stdout is
     // captured directly), so there is nothing the progress-relay hook could
     // have dropped for this cwd.
-    if (worktree && !this.isWorktreePathInUse(worktree.path)) {
+    if (worktree && completion.status !== "clean") {
+      // Issue #342: a pending/unknown run is not a success — keep the worktree
+      // (and its uncommitted work) recoverable instead of `--force`-removing it
+      // under possibly-live orphan processes (RW-046 class). `worktree.ensure`
+      // reuses an existing worktree, so a re-dispatch of the same branch picks
+      // the state right back up.
+      console.warn(
+        `[SessionManager] Headless run ended ${completion.status} — retaining worktree ${worktree.path} for recovery (${completion.detail})`,
+      );
+    } else if (worktree && !this.isWorktreePathInUse(worktree.path)) {
       await this.removeWorktreeBestEffort(worktree);
     } else if (worktree) {
       console.log(
@@ -1117,7 +1277,7 @@ export class SessionManager {
       );
     }
     console.log(
-      `[SessionManager] Headless session for thread ${threadId} closed (reason: ${reason}, exit: ${result.exitCode})`,
+      `[SessionManager] Headless session for thread ${threadId} closed (reason: ${reason}, exit: ${result.exitCode}, completion: ${completion.status})`,
     );
   }
 
@@ -1139,6 +1299,8 @@ export class SessionManager {
       tokens: outcome.tokens,
       durationMs: outcome.durationMs,
       exitCode: outcome.exitCode,
+      completion: outcome.completion.status,
+      completionDetail: outcome.completion.detail || undefined,
     });
     try {
       await this.effects.issueReporter.postComment({ cwd, issueNumber, body });

--- a/supervisor/src/session/pending-work.ts
+++ b/supervisor/src/session/pending-work.ts
@@ -1,0 +1,276 @@
+/**
+ * Pending-work detection for headless dispatch runs (Issue #342).
+ *
+ * A headless worker (`claude -p`) dies at turn end. Anything it left in
+ * flight — a `run_in_background` Bash/Agent task, a foreground Bash that hit
+ * its timeout and was auto-moved to the background, or a `ScheduleWakeup`
+ * reservation — is silently lost: the child exits 0, no PR exists, and the
+ * dispatch report looks like a success (observed live twice: #338 and
+ * agent-base#456; see the Issue for the transcripts).
+ *
+ * This module is the SHARED pure core for both defence layers:
+ *   - Layer 1 (prevention): `hooks/headless-pending-guard.ts`, a Stop hook
+ *     injected via `--settings` into headless children, blocks the turn end
+ *     while pending work remains (empirically verified: Stop hooks fire and
+ *     `decision:block` forces continuation under `claude -p`, v2.x).
+ *   - Layer 2 (detection): `manager.runHeadless` parses the transcript after
+ *     the child exits and surfaces `pending` / `unknown` in the dispatch
+ *     report instead of tearing the worktree down as if the run were clean.
+ *
+ * Detection uses ONLY deterministic signals (AgentTeams review, #342):
+ * structural JSONL fields and CLI-emitted literals pinned by fixture tests.
+ * Free-text matching of the model's own prose ("I'll continue when it
+ * finishes") is deliberately NOT used — that would be the RW-027/RW-047
+ * string-match anti-pattern applied to model output.
+ */
+
+import { readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+/** One background task that was started but never reported back. */
+export interface PendingTask {
+  /** The Bash/Agent `tool_use` id that started the task. */
+  toolUseId: string;
+  /** The harness task id, when the start carried one (timeout-backgrounded). */
+  taskId?: string;
+  /**
+   * How the task went to the background:
+   *   - `run_in_background`: the tool call asked for it explicitly.
+   *   - `timeout_backgrounded`: a foreground Bash exceeded its timeout and the
+   *     harness moved it to the background (tool_result literal, see below).
+   */
+  source: "run_in_background" | "timeout_backgrounded";
+}
+
+/** Deterministic pending-work summary parsed from a session transcript. */
+export interface PendingWork {
+  /** Background tasks with no matching `<task-notification>` afterwards. */
+  pendingTasks: PendingTask[];
+  /**
+   * True when a non-stop `ScheduleWakeup` was called and neither a later
+   * `stop: true` call nor a later injected user prompt (= the wakeup firing)
+   * appears in the transcript. In a headless run such a reservation can never
+   * fire — the process exits at turn end.
+   */
+  pendingWakeup: boolean;
+  /** Lines that failed to parse as JSON (diagnostic; >0 weakens confidence). */
+  skippedLines: number;
+}
+
+export type PendingWorkProbe =
+  | { ok: true; value: PendingWork }
+  | { ok: false; error: string };
+
+/**
+ * CLI-emitted literal for a foreground command that was auto-moved to the
+ * background on timeout. Pinned against a real v2.x transcript
+ * (agent-base#456, tool_result of `toolu_01EKmsva…`):
+ *
+ *   "Command did not complete within its 600s timeout and was moved to the
+ *    background (ID: bas5ws1zh). Output is being written to: …"
+ *
+ * This is harness output, not model prose. If a CLI update rewords it the
+ * match degrades to a false negative — which Layer 2's process-group probe
+ * (manager.ts) still catches, and the fixture test documents the contract.
+ */
+const TIMEOUT_BACKGROUNDED_RE = /moved to the background \(ID: ([A-Za-z0-9_-]+)\)/;
+
+/** `<tool-use-id>` values inside a `<task-notification>` completion block. */
+const NOTIFICATION_TOOL_USE_ID_RE = /<tool-use-id>([^<]+)<\/tool-use-id>/g;
+
+/**
+ * Derive the transcript path Claude Code writes for a session: the cwd with
+ * every non-alphanumeric character folded to `-`, under `~/.claude/projects`.
+ * Verified against real dirs (e.g. `/Users/x/agent-base/.claude/worktrees/
+ * corp-dispatch-456` → `-Users-x-agent-base--claude-worktrees-corp-dispatch-456`).
+ */
+export function deriveTranscriptPath(
+  cwd: string,
+  claudeSessionId: string,
+  home: string = homedir(),
+): string {
+  const key = cwd.replace(/[^A-Za-z0-9]/g, "-");
+  return join(home, ".claude", "projects", key, `${claudeSessionId}.jsonl`);
+}
+
+/** Extract the plain-text pieces of a tool_result `content` (string or array). */
+function toolResultText(content: unknown): string {
+  if (typeof content === "string") return content;
+  if (Array.isArray(content)) {
+    return content
+      .map((c) =>
+        c && typeof c === "object" && (c as { type?: string }).type === "text"
+          ? String((c as { text?: unknown }).text ?? "")
+          : "",
+      )
+      .join("\n");
+  }
+  return "";
+}
+
+/**
+ * True when a `user`-typed entry is an actual injected prompt (the initial
+ * `-p` command, or a fired ScheduleWakeup) rather than a tool_result carrier
+ * or a `<task-notification>` injection. Used to decide whether a scheduled
+ * wakeup ever fired: firing is the only way a headless run gets a new plain
+ * user prompt mid-session.
+ */
+function isPlainUserPrompt(entry: Record<string, unknown>): boolean {
+  if (entry.type !== "user") return false;
+  const message = entry.message;
+  if (!message || typeof message !== "object") return false;
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") {
+    return !content.includes("<task-notification>");
+  }
+  if (Array.isArray(content)) {
+    const hasToolResult = content.some(
+      (c) => c && typeof c === "object" && (c as { type?: string }).type === "tool_result",
+    );
+    if (hasToolResult) return false;
+    const text = content
+      .map((c) =>
+        c && typeof c === "object" && (c as { type?: string }).type === "text"
+          ? String((c as { text?: unknown }).text ?? "")
+          : "",
+      )
+      .join("");
+    return text.length > 0 && !text.includes("<task-notification>");
+  }
+  return false;
+}
+
+/**
+ * Parse a session transcript (JSONL text) into its pending-work summary.
+ * Pure and synchronous so both the Stop hook and the manager probe share it
+ * and unit tests can pin the contract with fixture lines.
+ */
+export function parsePendingWork(jsonlText: string): PendingWork {
+  const starts = new Map<string, PendingTask>();
+  const completedToolUseIds = new Set<string>();
+  let skippedLines = 0;
+
+  // Wakeup bookkeeping: index of the last un-consumed non-stop ScheduleWakeup,
+  // and the index of the last plain user prompt (a fired wakeup appears as one).
+  let lastWakeupIdx = -1;
+  let lastPlainUserIdx = -1;
+
+  const lines = jsonlText.split("\n");
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (line.trim() === "") continue;
+
+    // Completion notifications carry the XML literally inside the JSON string,
+    // in both `queue-operation` entries and injected user messages — a raw-line
+    // scan covers every container shape without depending on any of them.
+    if (line.includes("<task-notification>")) {
+      for (const m of line.matchAll(NOTIFICATION_TOOL_USE_ID_RE)) {
+        completedToolUseIds.add(m[1]!);
+      }
+    }
+
+    let entry: Record<string, unknown>;
+    try {
+      entry = JSON.parse(line) as Record<string, unknown>;
+    } catch {
+      skippedLines++;
+      continue;
+    }
+
+    if (isPlainUserPrompt(entry)) {
+      lastPlainUserIdx = i;
+    }
+
+    const message = entry.message;
+    if (!message || typeof message !== "object") continue;
+    const content = (message as { content?: unknown }).content;
+    if (!Array.isArray(content)) continue;
+
+    for (const item of content) {
+      if (!item || typeof item !== "object") continue;
+      const c = item as {
+        type?: string;
+        id?: string;
+        name?: string;
+        input?: unknown;
+        tool_use_id?: string;
+        content?: unknown;
+      };
+
+      if (c.type === "tool_use" && typeof c.id === "string") {
+        const input =
+          c.input && typeof c.input === "object"
+            ? (c.input as Record<string, unknown>)
+            : undefined;
+        if (input?.run_in_background === true) {
+          starts.set(c.id, { toolUseId: c.id, source: "run_in_background" });
+        }
+        if (c.name === "ScheduleWakeup") {
+          if (input?.stop === true) {
+            lastWakeupIdx = -1; // reservation explicitly cancelled
+          } else {
+            lastWakeupIdx = i;
+          }
+        }
+      }
+
+      if (c.type === "tool_result" && typeof c.tool_use_id === "string") {
+        const text = toolResultText(c.content);
+        const m = TIMEOUT_BACKGROUNDED_RE.exec(text);
+        if (m) {
+          starts.set(c.tool_use_id, {
+            toolUseId: c.tool_use_id,
+            taskId: m[1]!,
+            source: "timeout_backgrounded",
+          });
+        }
+      }
+    }
+  }
+
+  const pendingTasks = [...starts.values()].filter(
+    (t) => !completedToolUseIds.has(t.toolUseId),
+  );
+  // A wakeup is pending unless a plain user prompt LANDED AFTER it (= it fired).
+  const pendingWakeup = lastWakeupIdx >= 0 && lastPlainUserIdx <= lastWakeupIdx;
+
+  return { pendingTasks, pendingWakeup, skippedLines };
+}
+
+/**
+ * Read + parse a transcript file, fail-LOUD (Issue #342 review condition 3):
+ * an unreadable or empty transcript returns `{ ok: false }` so callers report
+ * `completion: unknown` instead of silently treating the run as clean — the
+ * exact self-defeat the fix exists to prevent.
+ */
+export function probePendingWork(transcriptPath: string): PendingWorkProbe {
+  let text: string;
+  try {
+    text = readFileSync(transcriptPath, "utf8");
+  } catch (err) {
+    return {
+      ok: false,
+      error: `transcript unreadable: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  if (text.trim() === "") {
+    return { ok: false, error: "transcript is empty" };
+  }
+  return { ok: true, value: parsePendingWork(text) };
+}
+
+/** Human-readable one-line summary for reports / hook block reasons. */
+export function describePendingWork(work: PendingWork): string {
+  const parts: string[] = [];
+  if (work.pendingTasks.length > 0) {
+    const ids = work.pendingTasks
+      .map((t) => t.taskId ?? t.toolUseId)
+      .join(", ");
+    parts.push(`未完了の背景タスク ${work.pendingTasks.length} 件 (${ids})`);
+  }
+  if (work.pendingWakeup) {
+    parts.push("未発火の ScheduleWakeup 予約");
+  }
+  return parts.join(" / ");
+}

--- a/supervisor/src/session/pending-work.ts
+++ b/supervisor/src/session/pending-work.ts
@@ -156,19 +156,23 @@ export function parsePendingWork(jsonlText: string): PendingWork {
   let lastWakeupIdx = -1;
   let lastPlainUserIdx = -1;
 
+  // Collect completion ids only from the containers that actually carry
+  // notifications: `queue-operation` entries and user-message TEXT (the
+  // injected `<task-notification>` prompt). Deliberately NOT from tool_result
+  // bodies or a raw-line scan — a worker that happens to echo the XML (e.g. by
+  // Reading a file that quotes it) must not fake-complete a running task
+  // (PR #368 review).
+  const collectNotificationIds = (text: string): void => {
+    if (!text.includes("<task-notification>")) return;
+    for (const m of text.matchAll(NOTIFICATION_TOOL_USE_ID_RE)) {
+      completedToolUseIds.add(m[1]!);
+    }
+  };
+
   const lines = jsonlText.split("\n");
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
     if (line.trim() === "") continue;
-
-    // Completion notifications carry the XML literally inside the JSON string,
-    // in both `queue-operation` entries and injected user messages — a raw-line
-    // scan covers every container shape without depending on any of them.
-    if (line.includes("<task-notification>")) {
-      for (const m of line.matchAll(NOTIFICATION_TOOL_USE_ID_RE)) {
-        completedToolUseIds.add(m[1]!);
-      }
-    }
 
     let entry: Record<string, unknown>;
     try {
@@ -178,6 +182,10 @@ export function parsePendingWork(jsonlText: string): PendingWork {
       continue;
     }
 
+    if (entry.type === "queue-operation" && typeof entry.content === "string") {
+      collectNotificationIds(entry.content);
+    }
+
     if (isPlainUserPrompt(entry)) {
       lastPlainUserIdx = i;
     }
@@ -185,6 +193,9 @@ export function parsePendingWork(jsonlText: string): PendingWork {
     const message = entry.message;
     if (!message || typeof message !== "object") continue;
     const content = (message as { content?: unknown }).content;
+    if (entry.type === "user" && typeof content === "string") {
+      collectNotificationIds(content);
+    }
     if (!Array.isArray(content)) continue;
 
     for (const item of content) {
@@ -196,7 +207,12 @@ export function parsePendingWork(jsonlText: string): PendingWork {
         input?: unknown;
         tool_use_id?: string;
         content?: unknown;
+        text?: unknown;
       };
+
+      if (entry.type === "user" && c.type === "text" && typeof c.text === "string") {
+        collectNotificationIds(c.text);
+      }
 
       if (c.type === "tool_use" && typeof c.id === "string") {
         const input =
@@ -257,7 +273,17 @@ export function probePendingWork(transcriptPath: string): PendingWorkProbe {
   if (text.trim() === "") {
     return { ok: false, error: "transcript is empty" };
   }
-  return { ok: true, value: parsePendingWork(text) };
+  const value = parsePendingWork(text);
+  // Fail-loud on corruption too (PR #368 review): a skipped line could have
+  // held the only background start or ScheduleWakeup, so a partially parsable
+  // transcript cannot vouch for a clean completion.
+  if (value.skippedLines > 0) {
+    return {
+      ok: false,
+      error: `transcript has ${value.skippedLines} unparsable line(s)`,
+    };
+  }
+  return { ok: true, value };
 }
 
 /** Human-readable one-line summary for reports / hook block reasons. */

--- a/supervisor/tests/hooks/headless-pending-guard.test.ts
+++ b/supervisor/tests/hooks/headless-pending-guard.test.ts
@@ -1,0 +1,156 @@
+// supervisor/tests/hooks/headless-pending-guard.test.ts (Issue #342 Layer 1)
+//
+// Black-box test for hooks/headless-pending-guard.ts: the Stop hook injected
+// into headless dispatch children. Runs the hook as a real subprocess (the
+// same way `claude -p` invokes it) with fixture transcripts and asserts the
+// block / allow decisions, the block bound, and the kill switch.
+import { test, expect, describe } from "bun:test";
+import { spawnSync } from "child_process";
+import { resolve } from "path";
+import { mkdtempSync, writeFileSync, readFileSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+const HOOK_PATH = resolve(import.meta.dir, "../../hooks/headless-pending-guard.ts");
+
+/** Run the hook once with the given Stop-event stdin and env; capture output. */
+function runHook(
+  input: Record<string, unknown>,
+  env: Record<string, string> = {},
+): { stdout: string; stderr: string; exitCode: number } {
+  const r = spawnSync(process.execPath, [HOOK_PATH], {
+    input: JSON.stringify(input),
+    env: { ...process.env, ...env },
+    encoding: "utf8",
+  });
+  return { stdout: r.stdout ?? "", stderr: r.stderr ?? "", exitCode: r.status ?? -1 };
+}
+
+function pendingTranscript(): string {
+  return (
+    JSON.stringify({
+      type: "assistant",
+      message: {
+        content: [
+          {
+            type: "tool_use",
+            id: "toolu_bg1",
+            name: "Bash",
+            input: { command: "make test", run_in_background: true },
+          },
+        ],
+      },
+    }) + "\n"
+  );
+}
+
+function cleanTranscript(): string {
+  return (
+    JSON.stringify({
+      type: "assistant",
+      message: { content: [{ type: "text", text: "done" }] },
+    }) + "\n"
+  );
+}
+
+function writeTranscript(content: string): string {
+  const dir = mkdtempSync(join(tmpdir(), "pending-guard-test-"));
+  const p = join(dir, "transcript.jsonl");
+  writeFileSync(p, content, "utf8");
+  return p;
+}
+
+describe("headless-pending-guard hook", () => {
+  test("blocks the stop while a background task is pending, with instructions", () => {
+    const transcript = writeTranscript(pendingTranscript());
+    const sessionId = `test-block-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const r = runHook({
+      session_id: sessionId,
+      transcript_path: transcript,
+      stop_hook_active: false,
+    });
+
+    expect(r.exitCode).toBe(0);
+    const decision = JSON.parse(r.stdout) as { decision: string; reason: string };
+    expect(decision.decision).toBe("block");
+    expect(decision.reason).toContain("toolu_bg1");
+    expect(decision.reason).toContain("TaskOutput");
+    expect(decision.reason).toContain("#342");
+    // A counter file now bounds the loop.
+    const counter = join(tmpdir(), `headless-pending-guard-${sessionId}.blocks`);
+    expect(readFileSync(counter, "utf8").trim()).toBe("1");
+  });
+
+  test("allows the stop when nothing is pending and clears the counter", () => {
+    const transcript = writeTranscript(cleanTranscript());
+    const sessionId = `test-clean-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    const counter = join(tmpdir(), `headless-pending-guard-${sessionId}.blocks`);
+    writeFileSync(counter, "3", "utf8"); // stale counter from earlier blocks
+
+    const r = runHook({
+      session_id: sessionId,
+      transcript_path: transcript,
+      stop_hook_active: true,
+    });
+
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe("");
+    expect(existsSync(counter)).toBe(false);
+  });
+
+  test("stops blocking once the bound is reached (never wedges the worker)", () => {
+    const transcript = writeTranscript(pendingTranscript());
+    const sessionId = `test-bound-${Date.now()}-${Math.random().toString(36).slice(2)}`;
+
+    const first = runHook(
+      { session_id: sessionId, transcript_path: transcript },
+      { HEADLESS_PENDING_GUARD_MAX_BLOCKS: "2" },
+    );
+    expect(JSON.parse(first.stdout).decision).toBe("block");
+
+    const second = runHook(
+      { session_id: sessionId, transcript_path: transcript },
+      { HEADLESS_PENDING_GUARD_MAX_BLOCKS: "2" },
+    );
+    expect(JSON.parse(second.stdout).decision).toBe("block");
+
+    // Bound reached → allow, and say so on stderr (observable, not silent).
+    const third = runHook(
+      { session_id: sessionId, transcript_path: transcript },
+      { HEADLESS_PENDING_GUARD_MAX_BLOCKS: "2" },
+    );
+    expect(third.stdout.trim()).toBe("");
+    expect(third.stderr).toContain("allowing stop");
+    expect(third.exitCode).toBe(0);
+  });
+
+  test("unreadable transcript allows the stop and logs loudly (Layer 2 flags it)", () => {
+    const r = runHook({
+      session_id: `test-noread-${Date.now()}`,
+      transcript_path: "/nonexistent/transcript.jsonl",
+    });
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe("");
+    expect(r.stderr).toContain("allowing stop");
+  });
+
+  test("HEADLESS_PENDING_GUARD=off is a full kill switch", () => {
+    const transcript = writeTranscript(pendingTranscript());
+    const r = runHook(
+      { session_id: `test-off-${Date.now()}`, transcript_path: transcript },
+      { HEADLESS_PENDING_GUARD: "off" },
+    );
+    expect(r.exitCode).toBe(0);
+    expect(r.stdout.trim()).toBe("");
+  });
+
+  test("malformed stdin never breaks the stop (fail-open with a loud stderr)", () => {
+    const r = spawnSync(process.execPath, [HOOK_PATH], {
+      input: "not json",
+      env: process.env,
+      encoding: "utf8",
+    });
+    expect(r.status).toBe(0);
+    expect(r.stderr).toContain("allowing stop");
+  });
+});

--- a/supervisor/tests/session/dispatch-headless.test.ts
+++ b/supervisor/tests/session/dispatch-headless.test.ts
@@ -296,3 +296,91 @@ describe("runDispatch headless", () => {
     expect(sent).toEqual(["/impl 1"]);
   });
 });
+
+// Issue #342: pending/unknown completion is warned in the thread even on exit 0.
+describe("headless completion warning (#342)", () => {
+  test("exit 0 + completion pending posts the ⚠️ pending warning", async () => {
+    const { manager } = harness({
+      exitCode: 0,
+      stdout: "作業中の報告テキスト",
+      stderr: "",
+      timedOut: false,
+      completion: {
+        status: "pending",
+        detail: "未完了の背景タスク 1 件 (bas5ws1zh)",
+      },
+    });
+    const posts: string[] = [];
+    const r = await runDispatch({
+      config,
+      branch: "b",
+      issueNumber: 456,
+      command: "pdca",
+      sessionManager: manager,
+      executorMode: "headless",
+      createThread: async () => ({ id: "t" }),
+      postToThread: async (_id, c) => {
+        posts.push(c);
+      },
+    });
+    expect(r.ok).toBe(true);
+    const all = posts.join("\n");
+    expect(all).toContain("正常完了と確認できていません");
+    expect(all).toContain("completion: pending");
+    expect(all).toContain("bas5ws1zh");
+    expect(all).toContain("worktree は復旧用に保全");
+  });
+
+  test("completion unknown also warns (fail-loud)", async () => {
+    const { manager } = harness({
+      exitCode: 0,
+      stdout: "done",
+      stderr: "",
+      timedOut: false,
+      completion: { status: "unknown", detail: "transcript 検証不能 (ENOENT)" },
+    });
+    const posts: string[] = [];
+    await runDispatch({
+      config,
+      branch: "b",
+      issueNumber: 1,
+      command: "impl",
+      sessionManager: manager,
+      executorMode: "headless",
+      createThread: async () => ({ id: "t" }),
+      postToThread: async (_id, c) => {
+        posts.push(c);
+      },
+    });
+    expect(posts.join("\n")).toContain("completion: unknown");
+  });
+
+  test("completion clean posts no warning; absent completion stays pre-#342 silent", async () => {
+    for (const completion of [
+      { status: "clean" as const, detail: "" },
+      undefined,
+    ]) {
+      const { manager } = harness({
+        exitCode: 0,
+        stdout: "done",
+        stderr: "",
+        timedOut: false,
+        completion,
+      });
+      const posts: string[] = [];
+      await runDispatch({
+        config,
+        branch: "b",
+        issueNumber: 1,
+        command: "impl",
+        sessionManager: manager,
+        executorMode: "headless",
+        createThread: async () => ({ id: "t" }),
+        postToThread: async (_id, c) => {
+          posts.push(c);
+        },
+      });
+      expect(posts.join("\n")).not.toContain("正常完了と確認できていません");
+    }
+  });
+});

--- a/supervisor/tests/session/dispatch-report.test.ts
+++ b/supervisor/tests/session/dispatch-report.test.ts
@@ -71,4 +71,52 @@ describe("formatDispatchReport", () => {
       expect(body.split("\n")).toContain(line);
     }
   });
+
+  // Issue #342: completion lines are ADDITIVE to the corp reconcile contract.
+  describe("completion lines (#342)", () => {
+    test("clean run emits the completion line, no warning", () => {
+      const body = formatDispatchReport({
+        tokens: 1,
+        durationMs: 2,
+        exitCode: 0,
+        completion: "clean",
+      });
+      expect(body.split("\n")).toContain("- completion: clean");
+      expect(body).not.toContain("⚠️");
+    });
+
+    test("pending run emits detail + a human warning", () => {
+      const body = formatDispatchReport({
+        tokens: 34602,
+        durationMs: 2757370,
+        exitCode: 0,
+        completion: "pending",
+        completionDetail: "未完了の背景タスク 1 件 (bas5ws1zh)",
+      });
+      expect(body.split("\n")).toContain("- completion: pending");
+      expect(body).toContain("- completion_detail: 未完了の背景タスク 1 件 (bas5ws1zh)");
+      expect(body).toContain("正常完了と確認できていません");
+      expect(body).toContain("worktree は復旧用に保全");
+    });
+
+    test("unknown run also warns (fail-loud, not folded into clean)", () => {
+      const body = formatDispatchReport({
+        tokens: null,
+        durationMs: 5,
+        exitCode: 0,
+        completion: "unknown",
+        completionDetail: "transcript 検証不能 (ENOENT)",
+      });
+      expect(body.split("\n")).toContain("- completion: unknown");
+      expect(body).toContain("正常完了と確認できていません");
+    });
+
+    test("omitting completion keeps the pre-#342 shape byte-identical", () => {
+      const body = formatDispatchReport({ tokens: 7, durationMs: 3, exitCode: 9 });
+      expect(body).not.toContain("completion");
+      expect(body).toBe(
+        "## Dispatch 実行レポート\n\n- tokens: 7\n- duration_ms: 3\n- exit_code: 9\n",
+      );
+    });
+  });
 });

--- a/supervisor/tests/session/manager-headless.test.ts
+++ b/supervisor/tests/session/manager-headless.test.ts
@@ -5,6 +5,7 @@ import { resolve } from "path";
 import {
   SessionManager,
   buildHeadlessClaudeFlags,
+  buildPendingGuardFlags,
   resolveDispatchModel,
 } from "../../src/session/manager";
 import {
@@ -313,6 +314,121 @@ describe("SessionManager.runHeadless", () => {
       } finally {
         if (prev !== undefined) process.env.DISPATCH_CLAUDE_MODEL = prev;
       }
+    });
+  });
+
+  // Issue #342: completion probe (Layer 2) + Stop-hook injection (Layer 1).
+  describe("headless completion probe (#342)", () => {
+    const cleanProbe = () =>
+      ({
+        ok: true as const,
+        value: { pendingTasks: [], pendingWakeup: false, skippedLines: 0 },
+      });
+    const pendingProbe = () =>
+      ({
+        ok: true as const,
+        value: {
+          pendingTasks: [
+            {
+              toolUseId: "toolu_bg1",
+              taskId: "bas5ws1zh",
+              source: "timeout_backgrounded" as const,
+            },
+          ],
+          pendingWakeup: false,
+          skippedLines: 0,
+        },
+      });
+
+    function makeManager(
+      probe: () => import("../../src/session/pending-work").PendingWorkProbe,
+    ): { mgr: SessionManager; fx: FakeSessionEffects } {
+      const fx = createFakeEffects();
+      const mgr = new SessionManager({
+        effects: fx,
+        gracefulKillTimeoutMs: 0,
+        probePendingWorkFn: probe,
+      });
+      return { mgr, fx };
+    }
+
+    test("clean run removes the worktree and reports completion: clean", async () => {
+      const { mgr, fx } = makeManager(cleanProbe);
+      const res = await mgr.runHeadless(config, "t-clean", "/impl 1", "corp-dispatch-1", 1);
+
+      expect(res.completion.status).toBe("clean");
+      expect(fx.worktree.removeCalls).toHaveLength(1);
+      const report = fx.issueReporter.postCommentCalls[0]!.body;
+      expect(report).toContain("- completion: clean");
+      expect(report).not.toContain("正常完了と確認できていません");
+      await mgr.shutdownAll();
+    });
+
+    test("pending run RETAINS the worktree and reports completion: pending (#456 regression)", async () => {
+      const { mgr, fx } = makeManager(pendingProbe);
+      const res = await mgr.runHeadless(config, "t-pend", "/impl 2", "corp-dispatch-2", 2);
+
+      // exit 0 だが pending — これが 2 例の実測 silent failure の形。
+      expect(res.exitCode).toBe(0);
+      expect(res.completion.status).toBe("pending");
+      expect(res.completion.detail).toContain("bas5ws1zh");
+      // Worktree is kept for recovery, session slot is still freed.
+      expect(fx.worktree.removeCalls).toHaveLength(0);
+      expect(mgr.has("t-pend")).toBe(false);
+      const report = fx.issueReporter.postCommentCalls[0]!.body;
+      expect(report).toContain("- completion: pending");
+      expect(report).toContain("- completion_detail:");
+      expect(report).toContain("正常完了と確認できていません");
+      await mgr.shutdownAll();
+    });
+
+    test("unreadable transcript is fail-loud: completion unknown, worktree retained", async () => {
+      const { mgr, fx } = makeManager(() => ({
+        ok: false as const,
+        error: "transcript unreadable: ENOENT",
+      }));
+      const res = await mgr.runHeadless(config, "t-unk", "/impl 3", "corp-dispatch-3", 3);
+
+      expect(res.completion.status).toBe("unknown");
+      expect(fx.worktree.removeCalls).toHaveLength(0);
+      expect(fx.issueReporter.postCommentCalls[0]!.body).toContain("- completion: unknown");
+      await mgr.shutdownAll();
+    });
+
+    test("surviving process group forces pending even when the transcript looks clean", async () => {
+      const { mgr, fx } = makeManager(cleanProbe);
+      // The fake executor reports pid 20000 via onSpawn; mark its process
+      // GROUP (-pid) alive so the orphan probe fires.
+      fx.process.alivePids.add(-20000);
+      const res = await mgr.runHeadless(config, "t-orphan", "/impl 4", "corp-dispatch-4", 4);
+
+      expect(res.completion.status).toBe("pending");
+      expect(res.completion.detail).toContain("プロセスグループ");
+      expect(fx.worktree.removeCalls).toHaveLength(0);
+      await mgr.shutdownAll();
+    });
+
+    test("injects the pending-guard Stop hook via --settings (Layer 1)", async () => {
+      const { mgr, fx } = makeManager(cleanProbe);
+      await mgr.runHeadless(config, "t-guard", "/impl 5", "corp-dispatch-5");
+
+      const args = fx.executor.runHeadlessCalls[0]!.args;
+      const i = args.indexOf("--settings");
+      expect(i).toBeGreaterThanOrEqual(0);
+      const settings = JSON.parse(args[i + 1]!) as {
+        hooks?: { Stop?: { hooks: { type: string; command: string }[] }[] };
+      };
+      const hook = settings.hooks?.Stop?.[0]?.hooks?.[0];
+      expect(hook?.type).toBe("command");
+      expect(hook?.command).toContain("headless-pending-guard.ts");
+      await mgr.shutdownAll();
+    });
+
+    test("HEADLESS_PENDING_GUARD=off disables the Stop-hook injection", () => {
+      expect(buildPendingGuardFlags({ HEADLESS_PENDING_GUARD: "off" })).toEqual([]);
+      const flags = buildPendingGuardFlags({});
+      expect(flags[0]).toBe("--settings");
+      expect(flags[1]).toContain("headless-pending-guard.ts");
     });
   });
 });

--- a/supervisor/tests/session/manager-headless.test.ts
+++ b/supervisor/tests/session/manager-headless.test.ts
@@ -395,6 +395,22 @@ describe("SessionManager.runHeadless", () => {
       await mgr.shutdownAll();
     });
 
+    test("a throwing probe degrades to unknown and never leaks the slot (PR #368 review)", async () => {
+      const { mgr, fx } = makeManager(() => {
+        throw new Error("boom in probe");
+      });
+      const res = await mgr.runHeadless(config, "t-throw", "/impl 6", "corp-dispatch-6", 6);
+
+      expect(res.completion.status).toBe("unknown");
+      expect(res.completion.detail).toContain("boom in probe");
+      // Teardown still ran: slot freed, report posted, worktree retained.
+      expect(mgr.has("t-throw")).toBe(false);
+      expect(mgr.count()).toBe(0);
+      expect(fx.issueReporter.postCommentCalls[0]!.body).toContain("- completion: unknown");
+      expect(fx.worktree.removeCalls).toHaveLength(0);
+      await mgr.shutdownAll();
+    });
+
     test("surviving process group forces pending even when the transcript looks clean", async () => {
       const { mgr, fx } = makeManager(cleanProbe);
       // The fake executor reports pid 20000 via onSpawn; mark its process

--- a/supervisor/tests/session/pending-work.test.ts
+++ b/supervisor/tests/session/pending-work.test.ts
@@ -1,0 +1,261 @@
+import { test, expect, describe } from "bun:test";
+import { mkdtempSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  parsePendingWork,
+  probePendingWork,
+  deriveTranscriptPath,
+  describePendingWork,
+} from "../../src/session/pending-work";
+
+/**
+ * Issue #342: deterministic pending-work detection. Fixture lines mirror the
+ * REAL transcript shapes observed in the two live silent failures:
+ *   - #338: background E2E + ScheduleWakeup reservation left at turn end
+ *   - agent-base#456: foreground Bash auto-moved to background on its 600s
+ *     timeout ("moved to the background (ID: …)" tool_result literal), then
+ *     the turn ended while it was still running.
+ */
+
+/** An assistant entry carrying one tool_use content item. */
+function assistantToolUse(
+  id: string,
+  name: string,
+  input: Record<string, unknown>,
+): string {
+  return JSON.stringify({
+    type: "assistant",
+    message: { content: [{ type: "tool_use", id, name, input }] },
+  });
+}
+
+/** A user entry carrying one tool_result content item. */
+function userToolResult(toolUseId: string, content: unknown): string {
+  return JSON.stringify({
+    type: "user",
+    message: {
+      content: [{ type: "tool_result", tool_use_id: toolUseId, content }],
+    },
+  });
+}
+
+/** The completion notification as it appears in `queue-operation` entries. */
+function queueNotification(toolUseId: string, taskId: string): string {
+  return JSON.stringify({
+    type: "queue-operation",
+    operation: "enqueue",
+    content:
+      `<task-notification>\n<task-id>${taskId}</task-id>\n` +
+      `<tool-use-id>${toolUseId}</tool-use-id>\n<status>completed</status>\n</task-notification>`,
+  });
+}
+
+/** A plain injected user prompt (what a fired ScheduleWakeup looks like). */
+function plainUserPrompt(text: string): string {
+  return JSON.stringify({ type: "user", message: { content: text } });
+}
+
+describe("parsePendingWork", () => {
+  test("explicit run_in_background start with no notification is pending", () => {
+    const jsonl = [
+      assistantToolUse("toolu_bg1", "Bash", {
+        command: "make test",
+        run_in_background: true,
+      }),
+    ].join("\n");
+
+    const work = parsePendingWork(jsonl);
+    expect(work.pendingTasks).toHaveLength(1);
+    expect(work.pendingTasks[0]).toEqual({
+      toolUseId: "toolu_bg1",
+      source: "run_in_background",
+    });
+    expect(work.pendingWakeup).toBe(false);
+  });
+
+  test("a matching <task-notification> completes the task (queue-operation shape)", () => {
+    const jsonl = [
+      assistantToolUse("toolu_bg1", "Bash", { run_in_background: true }),
+      queueNotification("toolu_bg1", "bas5ws1zh"),
+    ].join("\n");
+
+    expect(parsePendingWork(jsonl).pendingTasks).toHaveLength(0);
+  });
+
+  test("timeout-backgrounded Bash (agent-base#456 shape) is pending until notified", () => {
+    // Real literal from the #456 transcript (tool_result of toolu_01EKmsva…).
+    const movedText =
+      "Command did not complete within its 600s timeout and was moved to the " +
+      "background (ID: bas5ws1zh). Output is being written to: /tmp/x.output.";
+    const started = [
+      assistantToolUse("toolu_fg1", "Bash", { command: "make test", timeout: 600000 }),
+      userToolResult("toolu_fg1", movedText),
+    ];
+
+    const pending = parsePendingWork(started.join("\n"));
+    expect(pending.pendingTasks).toEqual([
+      { toolUseId: "toolu_fg1", taskId: "bas5ws1zh", source: "timeout_backgrounded" },
+    ]);
+
+    const completed = parsePendingWork(
+      [...started, queueNotification("toolu_fg1", "bas5ws1zh")].join("\n"),
+    );
+    expect(completed.pendingTasks).toHaveLength(0);
+  });
+
+  test("tool_result content as text-array is also recognised", () => {
+    const jsonl = [
+      assistantToolUse("toolu_fg2", "Bash", { command: "sleep 1000" }),
+      userToolResult("toolu_fg2", [
+        { type: "text", text: "… was moved to the background (ID: abc123zzz). …" },
+      ]),
+    ].join("\n");
+
+    expect(parsePendingWork(jsonl).pendingTasks).toEqual([
+      { toolUseId: "toolu_fg2", taskId: "abc123zzz", source: "timeout_backgrounded" },
+    ]);
+  });
+
+  test("non-stop ScheduleWakeup with no later plain user prompt is pending (#338 shape)", () => {
+    const jsonl = [
+      assistantToolUse("toolu_w1", "ScheduleWakeup", {
+        delaySeconds: 1800,
+        prompt: "resume E2E collection",
+      }),
+    ].join("\n");
+
+    expect(parsePendingWork(jsonl).pendingWakeup).toBe(true);
+  });
+
+  test("ScheduleWakeup stop:true cancels the reservation", () => {
+    const jsonl = [
+      assistantToolUse("toolu_w1", "ScheduleWakeup", { delaySeconds: 1800, prompt: "x" }),
+      assistantToolUse("toolu_w2", "ScheduleWakeup", { stop: true }),
+    ].join("\n");
+
+    expect(parsePendingWork(jsonl).pendingWakeup).toBe(false);
+  });
+
+  test("a plain user prompt AFTER the wakeup means it fired (not pending)", () => {
+    const jsonl = [
+      assistantToolUse("toolu_w1", "ScheduleWakeup", { delaySeconds: 60, prompt: "go on" }),
+      plainUserPrompt("go on"),
+    ].join("\n");
+
+    expect(parsePendingWork(jsonl).pendingWakeup).toBe(false);
+  });
+
+  test("a task-notification user injection does NOT count as a fired wakeup", () => {
+    const jsonl = [
+      assistantToolUse("toolu_bg1", "Bash", { run_in_background: true }),
+      assistantToolUse("toolu_w1", "ScheduleWakeup", { delaySeconds: 60, prompt: "x" }),
+      plainUserPrompt("<task-notification>…</task-notification>"),
+    ].join("\n");
+
+    expect(parsePendingWork(jsonl).pendingWakeup).toBe(true);
+  });
+
+  test("a tool_result-carrying user entry does NOT count as a fired wakeup", () => {
+    const jsonl = [
+      assistantToolUse("toolu_w1", "ScheduleWakeup", { delaySeconds: 60, prompt: "x" }),
+      userToolResult("toolu_other", "some result"),
+    ].join("\n");
+
+    expect(parsePendingWork(jsonl).pendingWakeup).toBe(true);
+  });
+
+  test("clean transcript (no background, no wakeup) reports nothing pending", () => {
+    const jsonl = [
+      plainUserPrompt("/impl 42"),
+      assistantToolUse("toolu_x", "Bash", { command: "git status" }),
+      userToolResult("toolu_x", "clean"),
+    ].join("\n");
+
+    const work = parsePendingWork(jsonl);
+    expect(work.pendingTasks).toHaveLength(0);
+    expect(work.pendingWakeup).toBe(false);
+    expect(work.skippedLines).toBe(0);
+  });
+
+  test("unparsable lines are skipped and counted, not fatal", () => {
+    const jsonl = [
+      "not json at all {",
+      assistantToolUse("toolu_bg1", "Bash", { run_in_background: true }),
+    ].join("\n");
+
+    const work = parsePendingWork(jsonl);
+    expect(work.skippedLines).toBe(1);
+    expect(work.pendingTasks).toHaveLength(1);
+  });
+});
+
+describe("probePendingWork (fail-loud file wrapper)", () => {
+  test("missing transcript returns ok:false, never a clean verdict", () => {
+    const probe = probePendingWork("/nonexistent/path/to/transcript.jsonl");
+    expect(probe.ok).toBe(false);
+  });
+
+  test("empty transcript returns ok:false", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pending-work-"));
+    const p = join(dir, "empty.jsonl");
+    writeFileSync(p, "   \n", "utf8");
+    expect(probePendingWork(p).ok).toBe(false);
+  });
+
+  test("readable transcript parses through to a value", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pending-work-"));
+    const p = join(dir, "t.jsonl");
+    writeFileSync(
+      p,
+      assistantToolUse("toolu_bg1", "Bash", { run_in_background: true }),
+      "utf8",
+    );
+    const probe = probePendingWork(p);
+    expect(probe.ok).toBe(true);
+    if (probe.ok) expect(probe.value.pendingTasks).toHaveLength(1);
+  });
+});
+
+describe("deriveTranscriptPath", () => {
+  test("folds every non-alphanumeric char to '-' (verified real-dir shape)", () => {
+    // Real observed mapping: /Users/x/agent-base/.claude/worktrees/corp-dispatch-456
+    // → ~/.claude/projects/-Users-x-agent-base--claude-worktrees-corp-dispatch-456/
+    const p = deriveTranscriptPath(
+      "/Users/x/agent-base/.claude/worktrees/corp-dispatch-456",
+      "821ceb5d-002e-48f2-b103-ec84af54ed57",
+      "/home/fake",
+    );
+    expect(p).toBe(
+      "/home/fake/.claude/projects/-Users-x-agent-base--claude-worktrees-corp-dispatch-456/821ceb5d-002e-48f2-b103-ec84af54ed57.jsonl",
+    );
+  });
+
+  test("underscores fold to '-' too (team_salary shape)", () => {
+    const p = deriveTranscriptPath("/Users/x/team_salary", "sid", "/h");
+    expect(p).toBe("/h/.claude/projects/-Users-x-team-salary/sid.jsonl");
+  });
+});
+
+describe("describePendingWork", () => {
+  test("mentions tasks (preferring task ids) and the wakeup", () => {
+    const s = describePendingWork({
+      pendingTasks: [
+        { toolUseId: "toolu_a", source: "run_in_background" },
+        { toolUseId: "toolu_b", taskId: "bas5ws1zh", source: "timeout_backgrounded" },
+      ],
+      pendingWakeup: true,
+      skippedLines: 0,
+    });
+    expect(s).toContain("2 件");
+    expect(s).toContain("toolu_a");
+    expect(s).toContain("bas5ws1zh");
+    expect(s).toContain("ScheduleWakeup");
+  });
+
+  test("empty when nothing is pending", () => {
+    expect(
+      describePendingWork({ pendingTasks: [], pendingWakeup: false, skippedLines: 0 }),
+    ).toBe("");
+  });
+});

--- a/supervisor/tests/session/pending-work.test.ts
+++ b/supervisor/tests/session/pending-work.test.ts
@@ -188,6 +188,31 @@ describe("parsePendingWork", () => {
     expect(work.skippedLines).toBe(1);
     expect(work.pendingTasks).toHaveLength(1);
   });
+
+  test("notification XML echoed inside a tool_result does NOT fake-complete (PR #368 review)", () => {
+    // e.g. the worker Read a file quoting the notification of a STILL-RUNNING
+    // task — only real notification containers may complete it.
+    const jsonl = [
+      assistantToolUse("toolu_bg1", "Bash", { run_in_background: true }),
+      userToolResult(
+        "toolu_read1",
+        "<task-notification>\n<tool-use-id>toolu_bg1</tool-use-id>\n</task-notification>",
+      ),
+    ].join("\n");
+
+    expect(parsePendingWork(jsonl).pendingTasks).toHaveLength(1);
+  });
+
+  test("an injected user-message notification (plain text) DOES complete", () => {
+    const jsonl = [
+      assistantToolUse("toolu_bg1", "Bash", { run_in_background: true }),
+      plainUserPrompt(
+        "<task-notification>\n<tool-use-id>toolu_bg1</tool-use-id>\n<status>completed</status>\n</task-notification>",
+      ),
+    ].join("\n");
+
+    expect(parsePendingWork(jsonl).pendingTasks).toHaveLength(0);
+  });
 });
 
 describe("probePendingWork (fail-loud file wrapper)", () => {
@@ -201,6 +226,16 @@ describe("probePendingWork (fail-loud file wrapper)", () => {
     const p = join(dir, "empty.jsonl");
     writeFileSync(p, "   \n", "utf8");
     expect(probePendingWork(p).ok).toBe(false);
+  });
+
+  test("corrupt lines make the probe fail-loud (ok:false), never clean (PR #368 review)", () => {
+    const dir = mkdtempSync(join(tmpdir(), "pending-work-"));
+    const p = join(dir, "corrupt.jsonl");
+    // The corrupt line could have held the only background start.
+    writeFileSync(p, '{"type":"assistant","message"…truncated\n', "utf8");
+    const probe = probePendingWork(p);
+    expect(probe.ok).toBe(false);
+    if (!probe.ok) expect(probe.error).toContain("unparsable");
   });
 
   test("readable transcript parses through to a value", () => {


### PR DESCRIPTION
Closes #342

## 目的

headless dispatch（`claude -p`）ワーカーが背景タスク / timeout 自動 background 化 / ScheduleWakeup 予約を残したまま turn 終了 → **exit 0・成果ゼロのサイレント失敗**になる問題（実測 2 例: #338、agent-base#456）を機械的に塞ぐ。プロンプト規約（案C）だけでは 2 例目で回避が実証されたため、規約ではなく機構で防ぐ。

## 方式の選定（AgentTeams 協議 + 実機検証）

architect / devils-advocate の 2 名で 案A（tmux 既定化に巻き戻し）vs 案B（resume ラッパー）を協議した結果、**第3案「Stop hook で turn 終了自体をブロック」を採用**。

- 案A 不採用: RW-019/025/047（tmux send-keys silent drop / TUI 文字列マッチ）の既知手戻りクラスを復活させる。tmux の本質的利点は「プロセスが生存する」ことだけで、それは Stop hook で代替できる
- resume ループ不要: Stop hook で同一プロセス内継続できるため（背景タスク・シェル状態が生きたまま）
- **実機検証 3 点 PASS**（2026-08-06, v2.x）: ① `claude -p` で Stop hook が発火する ② `decision:block` が継続を強制する（1回目 block → モデル継続 → 2回目 stop_hook_active=true で終了を確認）③ `--settings` インライン JSON 経由の hook 注入が機能する
- マシンスペック考慮（会長指示）: 最悪占有時間は headless timeout 2h のまま**不変**。M1 Max 10core/32GB / MAX_SESSIONS=10 の並列容量に影響しない（増えるのは「早期に silent 死していた run が完走まで動く」平均占有のみ）

## 実装（二層防御）

### Layer 1: 予防（Stop hook）— `hooks/headless-pending-guard.ts`

- `manager.runHeadless` が `--settings` で **headless 子にのみ**注入（対話 / tmux セッションには無影響）
- Stop 時に transcript を決定的に解析し、pending が残る間は `decision:block` + 同期完遂の是正指示（TaskOutput で待つ / wakeup は stop:true で解除）
- 上限付き（既定 20 回、`HEADLESS_PENDING_GUARD_MAX_BLOCKS`）・kill switch（`HEADLESS_PENDING_GUARD=off`）・内部エラーは fail-open（Layer 2 が拾う）

### Layer 2: 検知・非 silent 化 — `manager.probeHeadlessCompletion`

exit 後に 2 つの決定的信号で completion を判定:

1. **process-group 生存**（`kill(-pid, 0)`）: detached 起動のため pid = pgid。孤児プロセス残存 = 作業放棄の証拠（CLI バージョン非依存）
2. **transcript 解析**（`src/session/pending-work.ts`、Layer 1 と共有の純粋ロジック）: `run_in_background` tool_use / timeout 自動 background 化の tool_result リテラル / `<task-notification>` の tool-use-id 対応付け / 未発火 ScheduleWakeup

判定結果:

- `pending` / `unknown` → dispatch レポートに `- completion:` 行を追加（**additive**。corp reconcile が読む heading・既存行は不変）+ Discord スレッドに ⚠️ 警告 + **worktree を復旧用に保全**（#456 は worktree 削除で復旧不能だった。`worktree.ensure` は再利用するので同ブランチ再 dispatch で作業を引き継げる）
- transcript 検証不能は `unknown`（**fail-loud**）。「確認できなかった」を「確認して OK だった」に折り畳まない
- モデル発話の自然文マッチ（「完了したら続けます」等）は**不採用**（RW-027/047 同型の anti-pattern のため）

## テスト

| 対象 | 内容 |
|---|---|
| `tests/session/pending-work.test.ts`（新規 18 件） | 実測 2 例の transcript 形状を fixture 化した検知契約 |
| `tests/hooks/headless-pending-guard.test.ts`（新規 6 件） | hook を実 subprocess で起動: block / 上限 / kill switch / fail-open |
| `manager-headless.test.ts`（+6 件） | clean=worktree 削除 / pending=保全（#456 回帰）/ unknown=fail-loud / 孤児 pg 検知 / --settings 注入 |
| `dispatch-report.test.ts`（+4 件） | completion 行の additive 契約（省略時は従来とバイト同一） |
| `dispatch-headless.test.ts`（+3 件） | スレッド ⚠️ 警告の有無 |

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | 実測 2 例の形（bg 起動 / timeout 化 / wakeup）を決定的に検知 | `bun test tests/session/pending-work.test.ts` | 全 pass | 18 pass / 0 fail | PASS |
| AC-2 | `claude -p` で Stop hook block が継続を強制 | 実機: guard 付き `claude -p`（haiku） | 2 回発火 + 継続出力 | guard.log 2 行 + `CONTINUED` 出力 | PASS |
| AC-3 | exit 0 + pending で report 警告 + worktree 保全 | `bun test tests/session/manager-headless.test.ts` | 全 pass | 20 pass / 0 fail | PASS |
| AC-4 | 非破壊: completion 省略時の report は従来とバイト同一 | `bun test tests/session/dispatch-report.test.ts` | 全 pass | 13 pass / 0 fail | PASS |
| AC-5 | CI gating / lint | `bun scripts/lint-gating-coverage.ts` 他 2 本 | ✓ | 3 本とも ✓（0 ungated） | PASS |
| AC-6 | 型 | `bunx tsc --noEmit` | エラーなし | エラーなし | PASS |

全体: 6/6 PASS

補足: Issue の統合ジャーニー AC-1（長時間待機を含む実 dispatch の完遂）は本番 headless dispatch でしか最終確認できないため、merge 後の次回 dispatch で観測する（Layer 2 により失敗しても silent にはならない）。

## thin-scaffolding self-check

- [x] 6 か月先の model でも gain が残るか: Y（「turn 終了 = プロセス終了」は headless 実行の構造であり model 賢化と独立。model が背景待機を作らなくなれば hook は単に発火しなくなる = 無害）
- [x] model への指示で代替できないか: N を実証済み（#456 は明示指示下で回避された）
- [x] 責務は 1 つか: Y（Layer 1 = turn 終了ゲート、Layer 2 = 完了検証。検知ロジックは共有）
- [x] 失敗観測性: Y（hook は stderr、Layer 2 は report の completion 行 + console.warn）
- [x] 対象外経路の明記: Y（対話 / tmux セッションには注入されない。`HEADLESS_PENDING_GUARD=off` で全停止）
- [x] 撤退基準: Claude Code 本体が headless での背景タスク待機をネイティブサポートしたら Layer 1 を撤去（Layer 2 の completion 行は観測として残す）
- [x] BLOCKING なら WARN-first: block はワーカーの turn 終了のみ対象（ユーザー操作を止めない）かつ上限付き自己解除のため、bounded block で導入。FP コストは余分な turn 数回

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HFcni4My1k5cu4R3qrUGPf


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ヘッドレス実行時に未完了のバックグラウンド作業や予約処理を検出し、必要に応じて継続を促すようになりました。
  * 実行完了状態を「完了・保留・不明」に分類し、レポートや通知に詳細を表示します。
  * 保留または確認不能な場合、関連する作業環境を保持します。
  * 安全な停止、無効化設定、停止回数の制限に対応しました。

* **テスト**
  * 保留作業の検出、通知、エラー時の動作を追加検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->