### PR TITLE
feat: headless dispatch に成果物ゼロ検知を追加（#342 Layer 2 拡張）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,6 +160,7 @@ jobs:
                    tests/session/dispatch-integration.test.ts \
                    tests/session/dispatch-headless.test.ts \
                    tests/session/dispatch-report.test.ts \
+                   tests/session/artifact-probe.test.ts \
                    tests/session/orchestrate.test.ts \
                    tests/session/adapters-executor.test.ts \
                    tests/session/manager-headless.test.ts \

--- a/supervisor/src/session/artifact-probe.ts
+++ b/supervisor/src/session/artifact-probe.ts
@@ -1,0 +1,255 @@
+/**
+ * Post-exit artifact probe for headless dispatch runs (Issue #342, Layer 2
+ * extension).
+ *
+ * #368 closed the "pending work left behind" hole: a run that leaves
+ * background tasks / a ScheduleWakeup reservation is flagged `pending`. This
+ * module closes the remaining one: a run that leaves NO pending signal but
+ * also produced NOTHING — no commit, no PR, no Issue, no comment — and exits 0
+ * would still be treated as a success. Both holes are the same disease
+ * ("exit 0 must not masquerade as delivery"); this probe checks the delivery
+ * side.
+ *
+ * Artifact definition (会長レビュー 2026-08-06): investigation dispatches
+ * (/inv etc.) legitimately produce no commits — their deliverable is an Issue
+ * or an Issue comment. So "artifact" is ANY of:
+ *
+ *   1. a commit on the dispatch branch dated after the run started,
+ *   2. a PR whose head is the dispatch branch,
+ *   3. an Issue created in the target repo after the run started,
+ *   4. a comment posted to the target Issue after the run started.
+ *
+ * One hit is enough (checked cheap-first, short-circuiting). All four empty →
+ * `none`. A check that errors while nothing was found → `unknown` (fail-LOUD,
+ * same principle as the completion probe: "could not verify" must never be
+ * folded into "verified OK").
+ *
+ * Known accepted limitations (documented, not bugs):
+ *   - The Issue-created check is time-window based; a concurrent session
+ *     creating an Issue in the same repo within the window counts as a hit.
+ *     All dispatches run as the same gh account, so an author filter would not
+ *     tighten this.
+ *   - A pre-existing PR on a re-dispatched branch counts as a hit: the branch
+ *     has a delivery vehicle, which is what "zero artifacts" must exclude.
+ */
+
+import { execFile } from "child_process";
+import { promisify } from "util";
+
+const execFileAsync = promisify(execFile);
+
+/** Bound each git/gh probe call so a wedged gh can never hang teardown. */
+const PROBE_CMD_TIMEOUT_MS = 15_000;
+
+export type ArtifactStatus = "found" | "none" | "unknown";
+
+export interface ArtifactProbe {
+  status: ArtifactStatus;
+  /**
+   * Evidence: the first artifact found (`commit <sha>` / `pr #N` /
+   * `issue #N` / `comments <n>件`), probe errors when `unknown`, "" when
+   * `none`.
+   */
+  detail: string;
+  /**
+   * True when the worktree has uncommitted changes. Not an artifact (nothing
+   * was delivered) but recovery-worthy: a `none`+dirty worktree is retained
+   * instead of removed, so abandoned edits survive (the #456 failure lost its
+   * work precisely because the worktree was reclaimed).
+   */
+  dirty: boolean;
+}
+
+export interface ArtifactProbeInput {
+  /** Branch worktree cwd — git state and gh repo resolution both come from here. */
+  cwd: string;
+  /** Dispatch branch (the PR head to look for). */
+  branch: string;
+  /** Target Issue number, or null when the dispatch had none (no comment check then). */
+  issueNumber: number | null;
+  /** Run start — lower bound of the artifact window. */
+  startedAt: Date;
+}
+
+/**
+ * Command runner seam. Production shells out via async execFile (same
+ * non-blocking discipline as the issueReporter adapter); tests inject a fake
+ * so no real git/gh runs.
+ */
+export type ArtifactCmdRunner = (
+  cmd: string,
+  args: string[],
+  cwd: string,
+) => Promise<{ ok: true; stdout: string } | { ok: false; error: string }>;
+
+const realRunner: ArtifactCmdRunner = async (cmd, args, cwd) => {
+  try {
+    const { stdout } = await execFileAsync(cmd, args, {
+      cwd,
+      encoding: "utf8",
+      timeout: PROBE_CMD_TIMEOUT_MS,
+    });
+    return { ok: true, stdout };
+  } catch (err) {
+    return {
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    };
+  }
+};
+
+/**
+ * GitHub search accepts full ISO-8601 timestamps (`created:>=…THH:MM:SSZ`)
+ * but not fractional seconds — strip the milliseconds the JS Date carries.
+ */
+export function artifactWindowStart(startedAt: Date): string {
+  return startedAt.toISOString().replace(/\.\d{3}Z$/, "Z");
+}
+
+/**
+ * Run the artifact checks, cheap-first with short-circuit:
+ * local git (commit / dirty) → PR → Issues created → Issue comments. The two
+ * git checks work offline, so a gh outage cannot mask a run that did commit.
+ */
+export async function probeArtifacts(
+  input: ArtifactProbeInput,
+  run: ArtifactCmdRunner = realRunner,
+): Promise<ArtifactProbe> {
+  const since = artifactWindowStart(input.startedAt);
+  const errors: string[] = [];
+
+  // Dirty state first: it feeds the retention decision regardless of which
+  // artifact check short-circuits. An error here degrades to "not dirty" but
+  // is carried into the unknown-detail if nothing is found.
+  let dirty = false;
+  const status = await run("git", ["status", "--porcelain"], input.cwd);
+  if (status.ok) {
+    dirty = status.stdout.trim().length > 0;
+  } else {
+    errors.push(`git status: ${status.error}`);
+  }
+
+  // 1. Commit on the branch inside the run window (offline-capable).
+  const commit = await run(
+    "git",
+    ["log", "-1", `--since=${since}`, "--format=%H"],
+    input.cwd,
+  );
+  if (commit.ok) {
+    const sha = commit.stdout.trim();
+    if (sha) {
+      return { status: "found", detail: `commit ${sha.slice(0, 8)}`, dirty };
+    }
+  } else {
+    errors.push(`git log: ${commit.error}`);
+  }
+
+  // 2. PR with this branch as head (any state — a delivery vehicle exists).
+  const pr = await run(
+    "gh",
+    [
+      "pr",
+      "list",
+      "--head",
+      input.branch,
+      "--state",
+      "all",
+      "--json",
+      "number",
+      "--limit",
+      "1",
+    ],
+    input.cwd,
+  );
+  if (pr.ok) {
+    const num = firstNumber(pr.stdout);
+    if (num !== null) {
+      return { status: "found", detail: `pr #${num}`, dirty };
+    }
+  } else {
+    errors.push(`gh pr list: ${pr.error}`);
+  }
+
+  // 3. Issue / Epic created in the target repo inside the run window.
+  const issues = await run(
+    "gh",
+    [
+      "issue",
+      "list",
+      "--search",
+      `created:>=${since}`,
+      "--json",
+      "number",
+      "--limit",
+      "10",
+    ],
+    input.cwd,
+  );
+  if (issues.ok) {
+    const num = firstNumber(issues.stdout, input.issueNumber);
+    if (num !== null) {
+      return { status: "found", detail: `issue #${num}`, dirty };
+    }
+  } else {
+    errors.push(`gh issue list: ${issues.error}`);
+  }
+
+  // 4. Comment on the target Issue inside the run window. Runs BEFORE the
+  //    dispatch report is posted, so the report itself never counts.
+  if (input.issueNumber !== null) {
+    const comments = await run(
+      "gh",
+      [
+        "api",
+        `repos/{owner}/{repo}/issues/${input.issueNumber}/comments?since=${since}&per_page=100`,
+        "--jq",
+        "length",
+      ],
+      input.cwd,
+    );
+    if (comments.ok) {
+      const n = Number.parseInt(comments.stdout.trim(), 10);
+      if (Number.isFinite(n) && n > 0) {
+        return { status: "found", detail: `comments ${n}件`, dirty };
+      }
+    } else {
+      errors.push(`gh api comments: ${comments.error}`);
+    }
+  }
+
+  if (errors.length > 0) {
+    // Nothing found AND at least one check could not run: fail-loud.
+    return { status: "unknown", detail: errors.join(" / "), dirty };
+  }
+  return { status: "none", detail: "", dirty };
+}
+
+/**
+ * Parse a gh `--json number` payload and return the first number, skipping
+ * `exclude` (the dispatch's own target Issue predates the run but would match
+ * a `created:>=` window race). Returns null on empty / unparsable output —
+ * an unparsable success is treated as "no hit", never as an artifact.
+ */
+function firstNumber(jsonText: string, exclude: number | null = null): number | null {
+  try {
+    const arr = JSON.parse(jsonText) as Array<{ number?: unknown }>;
+    if (!Array.isArray(arr)) return null;
+    for (const row of arr) {
+      if (typeof row.number === "number" && row.number !== exclude) {
+        return row.number;
+      }
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/** One-line human summary for report / thread-warning use. "" when found-clean. */
+export function describeArtifacts(probe: ArtifactProbe): string {
+  if (probe.status === "found") return probe.detail;
+  if (probe.status === "unknown") return `検証不能 (${probe.detail})`;
+  return probe.dirty
+    ? "成果物なし（未 commit の変更が worktree に残存）"
+    : "成果物なし";
+}

--- a/supervisor/src/session/dispatch-report.ts
+++ b/supervisor/src/session/dispatch-report.ts
@@ -40,6 +40,17 @@ export interface DispatchReportFields {
   completion?: "clean" | "pending" | "unknown";
   /** Human-readable pending/unknown evidence; omitted when empty. */
   completionDetail?: string;
+  /**
+   * Artifact verdict (Issue #342, Layer 2 extension). ADDITIVE like
+   * `completion`: `found` runs still emit the line so a reader can distinguish
+   * "verified delivery" from "predates the artifact probe". `none` means the
+   * run delivered no commit / PR / Issue / comment — a warning even when
+   * `completion` is clean. Optional so callers without a probe (non-branch
+   * runs) simply omit the lines.
+   */
+  artifacts?: "found" | "none" | "unknown";
+  /** First artifact found / probe errors; omitted when empty. */
+  artifactsDetail?: string;
 }
 
 /**
@@ -61,13 +72,26 @@ export function formatDispatchReport(fields: DispatchReportFields): string {
     if (fields.completionDetail) {
       lines.push(`- completion_detail: ${fields.completionDetail}`);
     }
-    if (fields.completion !== "clean") {
-      lines.push(
-        "",
-        "⚠️ この run は正常完了と確認できていません（Issue claude-hub#342）。" +
-          "worktree は復旧用に保全されています。同じブランチへの再 dispatch で作業状態を引き継げます。",
-      );
+  }
+  if (fields.artifacts) {
+    lines.push(`- artifacts: ${fields.artifacts}`);
+    if (fields.artifactsDetail) {
+      lines.push(`- artifacts_detail: ${fields.artifactsDetail}`);
     }
+  }
+  if (fields.completion && fields.completion !== "clean") {
+    lines.push(
+      "",
+      "⚠️ この run は正常完了と確認できていません（Issue claude-hub#342）。" +
+        "worktree は復旧用に保全されています。同じブランチへの再 dispatch で作業状態を引き継げます。",
+    );
+  }
+  if (fields.artifacts && fields.artifacts !== "found") {
+    lines.push(
+      "",
+      "⚠️ この run の成果物（commit / PR / Issue / コメント）を確認できませんでした" +
+        `（artifacts: ${fields.artifacts}、Issue claude-hub#342）。作業が実際に行われたか確認してください。`,
+    );
   }
   return lines.join("\n") + "\n";
 }

--- a/supervisor/src/session/dispatch.ts
+++ b/supervisor/src/session/dispatch.ts
@@ -208,6 +208,14 @@ export interface DispatchHeadlessOutcome {
    * "no probe ran" and no completion warning is posted.
    */
   completion?: { status: "clean" | "pending" | "unknown"; detail: string };
+  /**
+   * Artifact verdict from the manager's post-exit probe (Issue #342, Layer 2
+   * extension). `none`/`unknown` runs are surfaced as warnings even on exit 0
+   * + clean completion — a run that finished cleanly but delivered no commit /
+   * PR / Issue / comment is the remaining silent-failure shape. Optional for
+   * the same seam-compatibility reason as `completion`.
+   */
+  artifacts?: { status: "found" | "none" | "unknown"; detail: string; dirty: boolean };
 }
 
 /**
@@ -535,6 +543,19 @@ async function postHeadlessOutcome(
       `⚠️ この run は正常完了と確認できていません（completion: ${completion.status}）。` +
         `${completion.detail ? `\n検出内容: ${completion.detail}` : ""}\n` +
         `worktree は復旧用に保全されています。同じブランチへの再 dispatch で作業状態を引き継げます（Issue claude-hub#342）。`,
+    );
+  }
+
+  // Issue #342 Layer 2 extension: zero artifacts is a warning REGARDLESS of
+  // exit code or completion — "finished cleanly but delivered nothing" is the
+  // remaining silent-failure shape the pending probe cannot see.
+  const artifacts = outcome.artifacts;
+  if (artifacts && artifacts.status !== "found") {
+    chunks.push(
+      `⚠️ この run の成果物（commit / PR / Issue / コメント）を確認できませんでした（artifacts: ${artifacts.status}）。` +
+        `${artifacts.detail ? `\n検出内容: ${artifacts.detail}` : ""}` +
+        `${artifacts.dirty ? "\n未 commit の変更が worktree に残っているため、worktree を復旧用に保全しています。" : ""}` +
+        `\n作業が実際に行われたか確認してください（Issue claude-hub#342）。`,
     );
   }
 

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -48,6 +48,11 @@ import {
   probePendingWork,
   type PendingWorkProbe,
 } from "./pending-work";
+import {
+  probeArtifacts,
+  type ArtifactProbe,
+  type ArtifactProbeInput,
+} from "./artifact-probe";
 
 const DEFAULT_CLAUDE_PATH = resolve(homedir(), ".local", "bin", "claude");
 const TMUX_SESSION_PREFIX = "claude-";
@@ -446,6 +451,14 @@ export interface HeadlessSessionResult {
   claudeSessionId: string;
   /** Completion verdict (Issue #342): pending/unknown runs are not successes. */
   completion: HeadlessCompletion;
+  /**
+   * Artifact verdict (Issue #342, Layer 2 extension): did the run deliver
+   * ANYTHING (commit / PR / Issue / comment)? Present only for branch runs —
+   * without a branch there is no dispatch worktree to probe. `none`/`unknown`
+   * is a warning even on exit 0 + `clean` completion: a run that finished
+   * "cleanly" but produced nothing is the remaining silent-failure shape.
+   */
+  artifacts?: ArtifactProbe;
 }
 
 /**
@@ -547,6 +560,13 @@ export interface SessionManagerOptions {
    * Production leaves this undefined.
    */
   probePendingWorkFn?: (transcriptPath: string) => PendingWorkProbe;
+  /**
+   * Test seam for the post-exit artifact probe (Issue #342, Layer 2
+   * extension): overrides the git/gh-backed {@link probeArtifacts} so unit
+   * tests control the artifact verdict without shelling out. Production
+   * leaves this undefined.
+   */
+  probeArtifactsFn?: (input: ArtifactProbeInput) => Promise<ArtifactProbe>;
 }
 
 /**
@@ -626,6 +646,9 @@ export class SessionManager {
   private readonly probePendingWorkFn: (
     transcriptPath: string,
   ) => PendingWorkProbe;
+  private readonly probeArtifactsFn: (
+    input: ArtifactProbeInput,
+  ) => Promise<ArtifactProbe>;
 
   constructor(options: SessionManagerOptions = {}) {
     this.effects = {
@@ -651,6 +674,7 @@ export class SessionManager {
       options.inputReadyPollIntervalMs ?? 1000;
     this.watchIntervalMs = options.watchIntervalMs ?? 10_000;
     this.probePendingWorkFn = options.probePendingWorkFn ?? probePendingWork;
+    this.probeArtifactsFn = options.probeArtifactsFn ?? probeArtifacts;
 
     // Issue #227 (PR-4): ensureSocketConfigured is async now. The constructor
     // cannot await, so fire-and-forget it — it is idempotent and re-applied in
@@ -1160,6 +1184,36 @@ export class SessionManager {
         );
       }
 
+      // Issue #342 Layer 2 extension: verify the run DELIVERED something
+      // (commit / PR / Issue / comment). Runs before postDispatchReport so the
+      // report comment never counts as its own artifact. Branch runs only —
+      // without a branch there is no dispatch worktree to probe. Same
+      // observability-not-control-flow rule as the completion probe: a seam
+      // failure degrades to `unknown`, never rejects runHeadless.
+      let artifacts: ArtifactProbe | undefined;
+      if (trimmedBranch) {
+        try {
+          artifacts = await this.probeArtifactsFn({
+            cwd: projectDir,
+            branch: trimmedBranch,
+            issueNumber: issueNumber ?? null,
+            startedAt: now,
+          });
+        } catch (err) {
+          artifacts = {
+            status: "unknown",
+            detail: `artifact probe failed: ${err instanceof Error ? err.message : String(err)}`,
+            dirty: false,
+          };
+        }
+        if (artifacts.status !== "found") {
+          console.warn(
+            `[SessionManager] Headless run for thread ${threadId} produced ` +
+              `no verifiable artifact (${artifacts.status}${artifacts.detail ? `: ${artifacts.detail}` : ""})`,
+          );
+        }
+      }
+
       const outcome: HeadlessSessionResult = {
         exitCode: result.exitCode,
         stdout: parsed.text,
@@ -1170,6 +1224,7 @@ export class SessionManager {
         sessionId,
         claudeSessionId,
         completion,
+        artifacts,
       };
 
       // Post the Dispatch 実行レポート to the target Issue BEFORE finishHeadless
@@ -1182,7 +1237,14 @@ export class SessionManager {
       // Child exited → close the session (frees the slot). Even if onSpawn never
       // fired (should not happen unless the adapter misbehaves), finishHeadless
       // is a no-op safe cleanup.
-      await this.finishHeadless(threadId, sessionId, result, worktree, completion);
+      await this.finishHeadless(
+        threadId,
+        sessionId,
+        result,
+        worktree,
+        completion,
+        artifacts,
+      );
 
       return outcome;
     } finally {
@@ -1262,6 +1324,7 @@ export class SessionManager {
     result: HeadlessRunResult,
     worktree: SessionInfo["worktree"],
     completion: HeadlessCompletion,
+    artifacts?: ArtifactProbe,
   ): Promise<void> {
     this.sessions.delete(threadId);
     this.emitSessionEnd(threadId); // Phase 5c: free a dispatch queue slot (#294)
@@ -1274,6 +1337,10 @@ export class SessionManager {
     // SUPERVISOR_RELAY_URL and the headless child never writes one (stdout is
     // captured directly), so there is nothing the progress-relay hook could
     // have dropped for this cwd.
+    const abandonedEdits =
+      artifacts !== undefined &&
+      artifacts.status !== "found" &&
+      artifacts.dirty;
     if (worktree && completion.status !== "clean") {
       // Issue #342: a pending/unknown run is not a success — keep the worktree
       // (and its uncommitted work) recoverable instead of `--force`-removing it
@@ -1282,6 +1349,15 @@ export class SessionManager {
       // the state right back up.
       console.warn(
         `[SessionManager] Headless run ended ${completion.status} — retaining worktree ${worktree.path} for recovery (${completion.detail})`,
+      );
+    } else if (worktree && abandonedEdits) {
+      // Issue #342 Layer 2 extension: no artifact was delivered AND the
+      // worktree holds uncommitted edits — removing it would destroy the only
+      // copy of that work (the exact loss mode of agent-base#456). A
+      // none+clean-tree run has nothing to recover, so it is still reclaimed
+      // below (no worktree accumulation on genuinely-empty runs).
+      console.warn(
+        `[SessionManager] Headless run delivered no artifact but left uncommitted edits — retaining worktree ${worktree.path} for recovery`,
       );
     } else if (worktree && !this.isWorktreePathInUse(worktree.path)) {
       await this.removeWorktreeBestEffort(worktree);
@@ -1315,6 +1391,8 @@ export class SessionManager {
       exitCode: outcome.exitCode,
       completion: outcome.completion.status,
       completionDetail: outcome.completion.detail || undefined,
+      artifacts: outcome.artifacts?.status,
+      artifactsDetail: outcome.artifacts?.detail || undefined,
     });
     try {
       await this.effects.issueReporter.postComment({ cwd, issueNumber, body });

--- a/supervisor/tests/session/artifact-probe.test.ts
+++ b/supervisor/tests/session/artifact-probe.test.ts
@@ -1,0 +1,191 @@
+import { test, expect, describe } from "bun:test";
+import {
+  probeArtifacts,
+  artifactWindowStart,
+  describeArtifacts,
+  type ArtifactCmdRunner,
+  type ArtifactProbeInput,
+} from "../../src/session/artifact-probe";
+
+/**
+ * Issue #342 Layer 2 extension — zero-artifact detection contract. All runs
+ * use a scripted fake runner: no real git/gh is spawned, so the decision
+ * logic (cheap-first short-circuit / fail-loud unknown / dirty carry) is
+ * asserted deterministically.
+ */
+
+const START = new Date("2026-08-06T03:00:00.123Z");
+
+function input(overrides: Partial<ArtifactProbeInput> = {}): ArtifactProbeInput {
+  return {
+    cwd: "/tmp/wt",
+    branch: "corp-dispatch-42",
+    issueNumber: 42,
+    startedAt: START,
+    ...overrides,
+  };
+}
+
+/**
+ * Script the runner by command signature. Keys:
+ *   status  → `git status --porcelain`
+ *   log     → `git log …`
+ *   pr      → `gh pr list …`
+ *   issues  → `gh issue list …`
+ *   comments→ `gh api …/comments…`
+ * Unscripted keys resolve to ok+empty. `calls` records the order for
+ * short-circuit assertions.
+ */
+function fakeRunner(
+  script: Partial<Record<string, { ok: true; stdout: string } | { ok: false; error: string }>>,
+  calls: string[] = [],
+): ArtifactCmdRunner {
+  return async (cmd, args) => {
+    const key =
+      cmd === "git" && args[0] === "status"
+        ? "status"
+        : cmd === "git" && args[0] === "log"
+          ? "log"
+          : cmd === "gh" && args[0] === "pr"
+            ? "pr"
+            : cmd === "gh" && args[0] === "issue"
+              ? "issues"
+              : cmd === "gh" && args[0] === "api"
+                ? "comments"
+                : `${cmd} ${args[0]}`;
+    calls.push(key);
+    return script[key] ?? { ok: true, stdout: "" };
+  };
+}
+
+describe("artifactWindowStart", () => {
+  test("strips fractional seconds (GitHub search rejects them)", () => {
+    expect(artifactWindowStart(START)).toBe("2026-08-06T03:00:00Z");
+  });
+});
+
+describe("probeArtifacts", () => {
+  test("commit hit short-circuits before any gh call (offline-capable)", async () => {
+    const calls: string[] = [];
+    const res = await probeArtifacts(
+      input(),
+      fakeRunner(
+        {
+          log: { ok: true, stdout: "0123456789abcdef0123456789abcdef01234567\n" },
+        },
+        calls,
+      ),
+    );
+    expect(res.status).toBe("found");
+    expect(res.detail).toBe("commit 01234567");
+    expect(calls).toEqual(["status", "log"]);
+  });
+
+  test("PR on the head branch counts as an artifact", async () => {
+    const res = await probeArtifacts(
+      input(),
+      fakeRunner({ pr: { ok: true, stdout: '[{"number":12}]' } }),
+    );
+    expect(res.status).toBe("found");
+    expect(res.detail).toBe("pr #12");
+  });
+
+  test("Issue created in the window counts, but the dispatch's own target Issue is excluded", async () => {
+    const res = await probeArtifacts(
+      input({ issueNumber: 42 }),
+      fakeRunner({
+        issues: { ok: true, stdout: '[{"number":42},{"number":99}]' },
+      }),
+    );
+    expect(res.status).toBe("found");
+    expect(res.detail).toBe("issue #99");
+  });
+
+  test("only the target Issue in the created window is NOT an artifact", async () => {
+    const res = await probeArtifacts(
+      input({ issueNumber: 42 }),
+      fakeRunner({ issues: { ok: true, stdout: '[{"number":42}]' } }),
+    );
+    expect(res.status).toBe("none");
+  });
+
+  test("comments on the target Issue in the window count as an artifact", async () => {
+    const calls: string[] = [];
+    const res = await probeArtifacts(
+      input(),
+      fakeRunner({ comments: { ok: true, stdout: "3\n" } }, calls),
+    );
+    expect(res.status).toBe("found");
+    expect(res.detail).toBe("comments 3件");
+    // The comments endpoint carries the since-window and the issue number.
+    expect(calls).toEqual(["status", "log", "pr", "issues", "comments"]);
+  });
+
+  test("no target Issue → comment check is skipped entirely", async () => {
+    const calls: string[] = [];
+    const res = await probeArtifacts(
+      input({ issueNumber: null }),
+      fakeRunner({}, calls),
+    );
+    expect(res.status).toBe("none");
+    expect(calls).not.toContain("comments");
+  });
+
+  test("all checks empty → none, with dirty carried from git status", async () => {
+    const res = await probeArtifacts(
+      input(),
+      fakeRunner({ status: { ok: true, stdout: " M src/foo.ts\n" } }),
+    );
+    expect(res.status).toBe("none");
+    expect(res.dirty).toBe(true);
+    expect(describeArtifacts(res)).toContain("未 commit の変更");
+  });
+
+  test("a failing gh check with nothing found is fail-loud unknown, never none", async () => {
+    const res = await probeArtifacts(
+      input(),
+      fakeRunner({ pr: { ok: false, error: "gh: connection refused" } }),
+    );
+    expect(res.status).toBe("unknown");
+    expect(res.detail).toContain("gh pr list");
+    expect(describeArtifacts(res)).toContain("検証不能");
+  });
+
+  test("a commit hit still wins when gh is down (local git needs no network)", async () => {
+    const res = await probeArtifacts(
+      input(),
+      fakeRunner({
+        log: { ok: true, stdout: "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n" },
+        pr: { ok: false, error: "network down" },
+      }),
+    );
+    expect(res.status).toBe("found");
+  });
+
+  test("unparsable gh JSON is a no-hit, not an artifact", async () => {
+    const res = await probeArtifacts(
+      input(),
+      fakeRunner({
+        pr: { ok: true, stdout: "not json" },
+        issues: { ok: true, stdout: '{"oops":true}' },
+      }),
+    );
+    expect(res.status).toBe("none");
+  });
+
+  test("since-window and issue number are threaded into the gh arguments", async () => {
+    const seen: string[][] = [];
+    await probeArtifacts(input(), async (cmd, args) => {
+      seen.push([cmd, ...args]);
+      return { ok: true, stdout: "" };
+    });
+    const flat = seen.map((c) => c.join(" "));
+    expect(flat.some((c) => c.includes("--since=2026-08-06T03:00:00Z"))).toBe(true);
+    expect(flat.some((c) => c.includes("created:>=2026-08-06T03:00:00Z"))).toBe(true);
+    expect(
+      flat.some((c) =>
+        c.includes("issues/42/comments?since=2026-08-06T03:00:00Z"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/supervisor/tests/session/dispatch-headless.test.ts
+++ b/supervisor/tests/session/dispatch-headless.test.ts
@@ -384,3 +384,64 @@ describe("headless completion warning (#342)", () => {
     }
   });
 });
+
+// Issue #342 Layer 2 extension: zero artifacts is warned in the thread even on
+// exit 0 + clean completion ("finished cleanly but delivered nothing").
+describe("headless artifact warning (#342 Layer 2 extension)", () => {
+  async function run(artifacts: DispatchHeadlessOutcome["artifacts"]) {
+    const { manager } = harness({
+      exitCode: 0,
+      stdout: "done",
+      stderr: "",
+      timedOut: false,
+      completion: { status: "clean", detail: "" },
+      artifacts,
+    });
+    const posts: string[] = [];
+    await runDispatch({
+      config,
+      branch: "b",
+      issueNumber: 1,
+      command: "impl",
+      sessionManager: manager,
+      executorMode: "headless",
+      createThread: async () => ({ id: "t" }),
+      postToThread: async (_id, c) => {
+        posts.push(c);
+      },
+    });
+    return posts.join("\n");
+  }
+
+  test("artifacts none posts the ⚠️ zero-artifact warning even on clean completion", async () => {
+    const all = await run({ status: "none", detail: "", dirty: false });
+    expect(all).toContain("成果物（commit / PR / Issue / コメント）を確認できませんでした");
+    expect(all).toContain("artifacts: none");
+    expect(all).not.toContain("未 commit の変更");
+  });
+
+  test("artifacts none + dirty mentions the retained worktree", async () => {
+    const all = await run({ status: "none", detail: "", dirty: true });
+    expect(all).toContain("未 commit の変更が worktree に残っている");
+  });
+
+  test("artifacts unknown also warns (fail-loud)", async () => {
+    const all = await run({
+      status: "unknown",
+      detail: "gh pr list: connection refused",
+      dirty: false,
+    });
+    expect(all).toContain("artifacts: unknown");
+    expect(all).toContain("connection refused");
+  });
+
+  test("artifacts found / absent posts no artifact warning", async () => {
+    for (const artifacts of [
+      { status: "found" as const, detail: "pr #12", dirty: false },
+      undefined,
+    ]) {
+      const all = await run(artifacts);
+      expect(all).not.toContain("成果物（commit / PR / Issue / コメント）を確認できませんでした");
+    }
+  });
+});

--- a/supervisor/tests/session/dispatch-report.test.ts
+++ b/supervisor/tests/session/dispatch-report.test.ts
@@ -119,4 +119,66 @@ describe("formatDispatchReport", () => {
       );
     });
   });
+
+  // Issue #342 Layer 2 extension: artifact lines are ADDITIVE like completion.
+  describe("artifact lines (#342 Layer 2 extension)", () => {
+    test("found run emits the artifacts lines, no warning", () => {
+      const body = formatDispatchReport({
+        tokens: 1,
+        durationMs: 2,
+        exitCode: 0,
+        completion: "clean",
+        artifacts: "found",
+        artifactsDetail: "pr #12",
+      });
+      expect(body.split("\n")).toContain("- artifacts: found");
+      expect(body.split("\n")).toContain("- artifacts_detail: pr #12");
+      expect(body).not.toContain("⚠️");
+    });
+
+    test("none run warns even when completion is clean", () => {
+      const body = formatDispatchReport({
+        tokens: 1,
+        durationMs: 2,
+        exitCode: 0,
+        completion: "clean",
+        artifacts: "none",
+      });
+      expect(body.split("\n")).toContain("- artifacts: none");
+      expect(body).toContain("成果物（commit / PR / Issue / コメント）を確認できませんでした");
+      // clean completion adds no completion warning of its own.
+      expect(body).not.toContain("正常完了と確認できていません");
+    });
+
+    test("unknown run warns (fail-loud) with detail line", () => {
+      const body = formatDispatchReport({
+        tokens: null,
+        durationMs: 5,
+        exitCode: 0,
+        completion: "clean",
+        artifacts: "unknown",
+        artifactsDetail: "gh pr list: connection refused",
+      });
+      expect(body.split("\n")).toContain("- artifacts: unknown");
+      expect(body).toContain("- artifacts_detail: gh pr list: connection refused");
+      expect(body).toContain("成果物（commit / PR / Issue / コメント）を確認できませんでした");
+    });
+
+    test("omitting artifacts keeps the #368 shape byte-identical", () => {
+      const body = formatDispatchReport({
+        tokens: 1,
+        durationMs: 2,
+        exitCode: 0,
+        completion: "pending",
+        completionDetail: "未完了の背景タスク 1 件 (x)",
+      });
+      expect(body).not.toContain("artifacts");
+      expect(body).toBe(
+        "## Dispatch 実行レポート\n\n- tokens: 1\n- duration_ms: 2\n- exit_code: 0\n" +
+          "- completion: pending\n- completion_detail: 未完了の背景タスク 1 件 (x)\n\n" +
+          "⚠️ この run は正常完了と確認できていません（Issue claude-hub#342）。" +
+          "worktree は復旧用に保全されています。同じブランチへの再 dispatch で作業状態を引き継げます。\n",
+      );
+    });
+  });
 });

--- a/supervisor/tests/session/manager-headless.test.ts
+++ b/supervisor/tests/session/manager-headless.test.ts
@@ -31,6 +31,18 @@ import type { ChannelConfig } from "../../src/config/channels";
  *   - the start guards (dup) and spawn-failure surfacing hold.
  */
 
+/**
+ * Neutral artifact probe (Issue #342 Layer 2 extension) for tests that do NOT
+ * exercise the artifact path: `found` adds no warning and changes no
+ * retention, and injecting it keeps unit tests from shelling out to the real
+ * git/gh-backed default.
+ */
+const foundArtifactsFn = async () => ({
+  status: "found" as const,
+  detail: "commit deadbeef",
+  dirty: false,
+});
+
 function makeChannelConfig(overrides: Partial<ChannelConfig> = {}): ChannelConfig {
   const dir = resolve(tmpdir(), `headless-mgr-${process.pid}`);
   mkdirSync(dir, { recursive: true });
@@ -49,7 +61,11 @@ describe("SessionManager.runHeadless", () => {
 
   beforeEach(() => {
     effects = createFakeEffects();
-    manager = new SessionManager({ effects, gracefulKillTimeoutMs: 0 });
+    manager = new SessionManager({
+      effects,
+      gracefulKillTimeoutMs: 0,
+      probeArtifactsFn: foundArtifactsFn,
+    });
     config = makeChannelConfig({ channelName: "chan-hl" });
   });
 
@@ -112,6 +128,7 @@ describe("SessionManager.runHeadless", () => {
     const mgr = new SessionManager({
       effects: { ...createFakeEffects(), executor: exec },
       gracefulKillTimeoutMs: 0,
+      probeArtifactsFn: foundArtifactsFn,
     });
 
     const p = mgr.runHeadless(config, "thread-run", "/impl 1", "corp-dispatch-1");
@@ -255,6 +272,7 @@ describe("SessionManager.runHeadless", () => {
     const mgr = new SessionManager({
       effects: { ...createFakeEffects(), executor: failing },
       gracefulKillTimeoutMs: 0,
+      probeArtifactsFn: foundArtifactsFn,
     });
     await expect(
       mgr.runHeadless(config, "thread-fail", "/impl 1", "corp-dispatch-1"),
@@ -348,6 +366,7 @@ describe("SessionManager.runHeadless", () => {
         effects: fx,
         gracefulKillTimeoutMs: 0,
         probePendingWorkFn: probe,
+        probeArtifactsFn: foundArtifactsFn,
       });
       return { mgr, fx };
     }
@@ -445,6 +464,111 @@ describe("SessionManager.runHeadless", () => {
       const flags = buildPendingGuardFlags({});
       expect(flags[0]).toBe("--settings");
       expect(flags[1]).toContain("headless-pending-guard.ts");
+    });
+  });
+
+  // Issue #342 Layer 2 extension: zero-artifact detection. A run can leave no
+  // pending signal (completion: clean) and still have delivered nothing — no
+  // commit, no PR, no Issue, no comment. That is the remaining silent-failure
+  // shape after #368 and must be loud.
+  describe("artifact probe (Issue #342 Layer 2 extension)", () => {
+    const cleanProbe = () => ({
+      ok: true as const,
+      value: { pendingTasks: [], pendingWakeup: false, skippedLines: 0 },
+    });
+
+    function makeManager(
+      artifacts: () => Promise<{
+        status: "found" | "none" | "unknown";
+        detail: string;
+        dirty: boolean;
+      }>,
+    ): { mgr: SessionManager; fx: FakeSessionEffects } {
+      const fx = createFakeEffects();
+      const mgr = new SessionManager({
+        effects: fx,
+        gracefulKillTimeoutMs: 0,
+        probePendingWorkFn: cleanProbe,
+        probeArtifactsFn: artifacts,
+      });
+      return { mgr, fx };
+    }
+
+    test("found: reports artifacts: found, worktree removed as usual", async () => {
+      const { mgr, fx } = makeManager(async () => ({
+        status: "found" as const,
+        detail: "pr #12",
+        dirty: false,
+      }));
+      const res = await mgr.runHeadless(config, "t-art-found", "/impl 7", "corp-dispatch-7", 7);
+
+      expect(res.artifacts?.status).toBe("found");
+      expect(fx.worktree.removeCalls).toHaveLength(1);
+      const report = fx.issueReporter.postCommentCalls[0]!.body;
+      expect(report).toContain("- artifacts: found");
+      expect(report).toContain("- artifacts_detail: pr #12");
+      expect(report).not.toContain("成果物（commit / PR / Issue / コメント）を確認できませんでした");
+      await mgr.shutdownAll();
+    });
+
+    test("none + clean tree: loud in the report, worktree still reclaimed (nothing to recover)", async () => {
+      const { mgr, fx } = makeManager(async () => ({
+        status: "none" as const,
+        detail: "",
+        dirty: false,
+      }));
+      const res = await mgr.runHeadless(config, "t-art-none", "/impl 8", "corp-dispatch-8", 8);
+
+      expect(res.exitCode).toBe(0);
+      expect(res.completion.status).toBe("clean");
+      expect(res.artifacts?.status).toBe("none");
+      // Nothing uncommitted → reclaim (no worktree accumulation on empty runs).
+      expect(fx.worktree.removeCalls).toHaveLength(1);
+      const report = fx.issueReporter.postCommentCalls[0]!.body;
+      expect(report).toContain("- artifacts: none");
+      expect(report).toContain("成果物（commit / PR / Issue / コメント）を確認できませんでした");
+      await mgr.shutdownAll();
+    });
+
+    test("none + dirty tree RETAINS the worktree (abandoned edits, #456 loss mode)", async () => {
+      const { mgr, fx } = makeManager(async () => ({
+        status: "none" as const,
+        detail: "",
+        dirty: true,
+      }));
+      const res = await mgr.runHeadless(config, "t-art-dirty", "/impl 9", "corp-dispatch-9", 9);
+
+      expect(res.artifacts?.status).toBe("none");
+      expect(fx.worktree.removeCalls).toHaveLength(0);
+      expect(mgr.has("t-art-dirty")).toBe(false);
+      await mgr.shutdownAll();
+    });
+
+    test("a throwing artifact probe degrades to unknown and never leaks the slot", async () => {
+      const { mgr, fx } = makeManager(async () => {
+        throw new Error("gh exploded");
+      });
+      const res = await mgr.runHeadless(config, "t-art-throw", "/impl 10", "corp-dispatch-10", 10);
+
+      expect(res.artifacts?.status).toBe("unknown");
+      expect(res.artifacts?.detail).toContain("gh exploded");
+      expect(mgr.has("t-art-throw")).toBe(false);
+      expect(mgr.count()).toBe(0);
+      expect(fx.issueReporter.postCommentCalls[0]!.body).toContain("- artifacts: unknown");
+      await mgr.shutdownAll();
+    });
+
+    test("no branch → no artifact probe (nothing to measure without a dispatch worktree)", async () => {
+      let called = 0;
+      const { mgr } = makeManager(async () => {
+        called++;
+        return { status: "found" as const, detail: "", dirty: false };
+      });
+      const res = await mgr.runHeadless(config, "t-art-nobranch", "/impl 11");
+
+      expect(called).toBe(0);
+      expect(res.artifacts).toBeUndefined();
+      await mgr.shutdownAll();
     });
   });
 });


### PR DESCRIPTION
Refs #342（reopen 済み・本 PR で残スコープを対応）

## 目的

#368（二層防御）は「やり残し（pending）の検知」を塞いだが、**成果物ゼロの検知**は守備範囲外だった。pending 信号を一切残さず、commit / PR / Issue / コメントのいずれも作らずに exit 0 した run は `completion: clean` のまま silent に成功扱いされる。この残穴を Layer 2 の拡張として塞ぐ（会長指示 2026-08-06: follow-up を分けず同一 Issue で対応）。

## 成果物の定義（会長レビュー指摘を反映）

調査系 dispatch（/inv 等）は commit を作らない。成果物は以下のいずれか 1 つで成立:

| 種別 | 検知方法（決定的） |
|---|---|
| commit | dispatch ブランチの run 開始以降の commit（`git log --since`、オフライン可） |
| PR | head ブランチの PR 存在（`gh pr list --head`、全 state） |
| Issue / Epic 起票 | run 開始以降に対象 repo で作成された Issue（`gh issue list --search "created:>="`、対象 Issue 自身は除外） |
| 調査コメント | 対象 Issue への run 開始以降のコメント（`gh api .../comments?since=`。レポート投稿前に判定するため自分自身は数えない） |

- cheap-first・short-circuit（local git → gh）。gh 障害時も commit があれば `found`
- 全ゼロ → `none`。照会失敗で未確認 → `unknown`（fail-loud、#368 と同方針: 「確認できなかった」を「OK」に折り畳まない）

## 変更

- **`artifact-probe.ts` 新設**: 判定ロジック（runner 注入で純テスト可能）
- **manager.ts**: exit 後・レポート投稿前に probe 実行（branch run のみ）。`none` + 未 commit 変更ありは worktree を復旧用に保全（#456 の喪失モード）。`none` + clean tree は従来どおり回収（空 run で worktree を溜めない）
- **dispatch-report.ts**: `- artifacts:` / `- artifacts_detail:` 行を additive に追加（corp reconcile 契約は不変。省略時バイト同一をテストで担保）
- **dispatch.ts**: `none` / `unknown` を Discord スレッドに ⚠️ 警告
- **ci.yml**: 新テストファイルを gating に登録

## 既知の許容制限（ドキュメント化済み）

- Issue 起票チェックは時間窓ベース。同一 repo への並行セッションの起票はヒットになり得る（全 dispatch が同一 gh アカウントのため author 絞りは無効）
- 再 dispatch ブランチの既存 PR はヒット扱い（「配送手段が存在する」ため意図どおり）

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | probe 判定契約（short-circuit / fail-loud / 除外 / 窓形式） | `bun test tests/session/artifact-probe.test.ts` | 全 pass | 11 pass / 0 fail | PASS |
| AC-2 | none+dirty=保全 / none+clean=回収 / throw=unknown / 非 branch=probe なし | `bun test tests/session/manager-headless.test.ts` | 全 pass | 25 pass / 0 fail | PASS |
| AC-3 | report の additive 契約（省略時バイト同一） | `bun test tests/session/dispatch-report.test.ts` | 全 pass | 14 pass / 0 fail | PASS |
| AC-4 | スレッド ⚠️ 警告（none/unknown で出る・found/absent で出ない） | `bun test tests/session/dispatch-headless.test.ts` | 全 pass | 19 pass / 0 fail | PASS |
| AC-5 | gating / 型 | `bun scripts/lint-gating-coverage.ts` / `bunx tsc --noEmit` | 0 ungated / エラーなし | 0 ungated / エラーなし | PASS |

全体: 5/5 PASS

補足: フルスイートの fail は main（93f4212）でも再現する既存 flaky（tmux adapter 系・shell-exec guard の `db.ts`）で、本 PR 起因の新規 fail は gating 未登録の 1 件のみ → ci.yml 登録で解消済み（fail 名の diff で確認）。

## gh CLI フラグの出典

`gh pr list --head/--state/--json/--limit`・`gh issue list --search/--json/--limit`・`gh api {owner}/{repo} --jq` はローカル gh の `--help` 出力で実在確認済み。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcLCYT1DsQRmubooC9nQtt


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ヘッドレス実行後に、コミット・PR・Issue・コメントなどの成果物を自動確認できるようになりました。
  * 成果物の有無や確認結果を実行レポートへ表示します。
  * 成果物が未確認または確認不能な場合、警告と詳細を通知します。
  * 未コミット変更が残る場合は作業領域を保持します。

* **テスト**
  * 成果物検出、警告表示、作業領域の保持・削除に関するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->