### PR TITLE
fix: artifacts unknown 時も worktree を保全する（#342 レビュー対応）

### DIFF
--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -1337,10 +1337,15 @@ export class SessionManager {
     // SUPERVISOR_RELAY_URL and the headless child never writes one (stdout is
     // captured directly), so there is nothing the progress-relay hook could
     // have dropped for this cwd.
+    // `unknown` retains too (PR #371 review, CodeRabbit Major): it means the
+    // probe could not verify — including the throw / git-status-failure paths
+    // that pin `dirty: false` — so `dirty` cannot be trusted to prove the tree
+    // is safe to reclaim. "Could not check" must not destroy possibly-live
+    // uncommitted work (same fail-loud rule as the completion probe).
     const abandonedEdits =
       artifacts !== undefined &&
       artifacts.status !== "found" &&
-      artifacts.dirty;
+      (artifacts.dirty || artifacts.status === "unknown");
     if (worktree && completion.status !== "clean") {
       // Issue #342: a pending/unknown run is not a success — keep the worktree
       // (and its uncommitted work) recoverable instead of `--force`-removing it
@@ -1357,7 +1362,9 @@ export class SessionManager {
       // none+clean-tree run has nothing to recover, so it is still reclaimed
       // below (no worktree accumulation on genuinely-empty runs).
       console.warn(
-        `[SessionManager] Headless run delivered no artifact but left uncommitted edits — retaining worktree ${worktree.path} for recovery`,
+        `[SessionManager] Headless run delivered no verifiable artifact ` +
+          `(status: ${artifacts!.status}, dirty: ${artifacts!.dirty}) — ` +
+          `retaining worktree ${worktree.path} for recovery`,
       );
     } else if (worktree && !this.isWorktreePathInUse(worktree.path)) {
       await this.removeWorktreeBestEffort(worktree);

--- a/supervisor/tests/session/manager-headless.test.ts
+++ b/supervisor/tests/session/manager-headless.test.ts
@@ -555,6 +555,22 @@ describe("SessionManager.runHeadless", () => {
       expect(mgr.has("t-art-throw")).toBe(false);
       expect(mgr.count()).toBe(0);
       expect(fx.issueReporter.postCommentCalls[0]!.body).toContain("- artifacts: unknown");
+      // The throw path pins dirty:false, which is exactly why unknown must
+      // retain (PR #371 review): "could not check" ≠ "safe to reclaim".
+      expect(fx.worktree.removeCalls).toHaveLength(0);
+      await mgr.shutdownAll();
+    });
+
+    test("unknown RETAINS the worktree even with dirty=false (dirty is untrustworthy, PR #371 review)", async () => {
+      const { mgr, fx } = makeManager(async () => ({
+        status: "unknown" as const,
+        detail: "gh pr list: connection refused",
+        dirty: false,
+      }));
+      const res = await mgr.runHeadless(config, "t-art-unk", "/impl 12", "corp-dispatch-12", 12);
+
+      expect(res.artifacts?.status).toBe("unknown");
+      expect(fx.worktree.removeCalls).toHaveLength(0);
       await mgr.shutdownAll();
     });
 


### PR DESCRIPTION
Refs #342（PR #371 の CodeRabbit Major 指摘への follow-up）

## 問題

PR #371 の artifact probe は、probe が throw した経路と `git status` が失敗した経路で `dirty: false` を固定する。このため `artifacts: unknown`（検証不能）のとき、「dirty=false だから回収して安全」という判定が成立せず、未 commit 作業を `git worktree remove` で破壊し得る。

## 修正

- worktree 保全条件に `artifacts.status === "unknown"` を追加（「確認できなかった」を「安全」に折り畳まない — completion probe と同じ fail-loud 原則）
- 保全ログに `status` / `dirty` を出力
- `unknown` + `dirty:false` で worktree が保持されることを検証するテストを追加、throw 経路のテストにも保持アサーションを追加

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | unknown で worktree 保持 / found・none+clean は従来どおり回収 | `bun test tests/session/manager-headless.test.ts` | 全 pass | 27 pass / 0 fail | PASS |
| AC-2 | 型 | `bunx tsc --noEmit` | エラーなし | エラーなし | PASS |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CcLCYT1DsQRmubooC9nQtt
