### PR TITLE
fix(#370): AskUserQuestion を Discord に中継できるよう修理し配線検証を追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
                    tests/hooks/stop-relay.test.ts \
                    tests/infra/db.test.ts \
                    tests/infra/db-isolation.test.ts \
+                   tests/infra/hook-wiring-check.test.ts \
                    tests/session/dialog-detect.test.ts \
                    tests/session/dialog-watchdog.test.ts \
                    tests/session/relay-send-failure.test.ts \

--- a/supervisor/docs/architecture.md
+++ b/supervisor/docs/architecture.md
@@ -19,6 +19,7 @@ Issue #13 で評価した 20 通り（A-T）のうち、以下の **A + B + G** 
 | Claude Code → Discord 応答 | **Stop hook → HTTP POST → Supervisor relay-server** | `hooks/stop-relay.sh` + `src/session/relay-server.ts` |
 | 中間進捗表示 | **PostToolUse hook → HTTP POST → Supervisor `/progress`** | `hooks/progress-relay.sh` |
 | パーミッションデッドロック回避 | **PermissionRequest hook で自動承認** + Supervisor セッションは `--dangerously-skip-permissions` を常時付与（`manager.ts:130`） | `hooks/auto-approve-permission.sh` + `src/session/manager.ts` |
+| 選択式質問 (AskUserQuestion → Discord) | **PreToolUse hook → POST `/ask/{threadId}` → 質問+選択肢をスレッド投稿 → 次のスレッド返信を回答として hook に返却**（Issue #370。回答は PreToolUse deny reason で Claude に伝わり TUI ダイアログをスキップ。300s 無回答で TUI フォールバック）。**要配線**: `~/.claude/settings.json` の `PreToolUse` matcher `AskUserQuestion`・timeout 320s。未配線は起動時に `src/infra/hook-wiring-check.ts` が警告 | `hooks/ask-user-relay.sh` + `src/session/relay-server.ts` (`/ask`) + `src/bot.ts` (`onAskUser` / `hasPendingAsk`) |
 | 画像添付 (Discord → Claude) | Discord 画像を `~/claude-hub/tmp/attachments` に DL → メッセージ本文先頭に `Read the image at <path>` を連結して `tmux send-keys` で注入 | `src/session/relay.ts` (`downloadAttachment` + `relayMessage`) |
 | 添付ファイルのライフサイクル | `~/claude-hub/tmp/attachments` に DL したファイルは **30 日保持**（Issue #151, 案B）。以前は relay 完了の 5 分後に削除していたためセッションを跨ぐと素材が消えていた。現在は age ベースで日次 GC するのみ（削除ごとに warning ログ）。GC: `src/session/gc-attachments.ts`（`bun run` 可）/ 日次起動: `com.claude-hub.gc-attachments.plist` | `src/session/gc-attachments.ts` |
 | ファイル添付 (Claude → Discord) | Claude の応答からファイルパスを抽出し Discord にアップロード | `src/session/file-attacher.ts` |

--- a/supervisor/hooks/ask-user-relay.sh
+++ b/supervisor/hooks/ask-user-relay.sh
@@ -1,16 +1,24 @@
 #!/bin/bash
-# Claude Code PreToolUse hook (matcher: AskUserQuestion). Issue #12 Phase 1.
+# Claude Code PreToolUse hook (matcher: AskUserQuestion). Issue #12 Phase 1 / #370.
 #
-# Forwards an AskUserQuestion prompt from a headless supervisor session to the
-# Discord thread, waits for the user's reply, and injects the reply back into
-# the tool call via PreToolUse `updatedInput` so Claude continues without
-# blocking on a TUI dialog.
+# Forwards an AskUserQuestion prompt from a supervisor session to the Discord
+# thread, waits for the user's reply, and returns the reply to Claude via a
+# PreToolUse deny envelope so Claude continues without blocking on a TUI
+# dialog that a Discord-only user can never see (Issue #370).
+#
+# Why deny instead of `updatedInput`: AskUserQuestion has no documented way to
+# pre-supply an answer through its input — rewriting the input still opens the
+# TUI dialog. A deny reason IS delivered to Claude as the tool result, so the
+# reason text mirrors the native answered-dialog wording ("Your questions have
+# been answered: ...") and Claude treats it as the user's answer, not a
+# refusal.
 #
 # Skipping behaviour
 # ------------------
 # Out of a supervisor session (no relay-url file for the cwd), the hook exits
 # 0 silently with no stdout — Claude sees the original tool input unchanged
 # and the regular TUI dialog flow runs (Issue #12 AC-3 / Journey-AC #3).
+# Unknown input shapes (no `questions[]`) fall through the same way.
 #
 # Relay URL discovery mirrors `progress-relay.sh`: the runtime-dir layout is
 # written by SessionManager.start (`relayUrlFilePath()` in manager.ts).
@@ -53,14 +61,36 @@ fi
 # gemini-code-assist on PR #142, comment 3179491537).
 ASK_URL=$(printf '%s' "$SUPERVISOR_RELAY_URL" | sed 's|/relay/|/ask/|')
 
-# Extract the question Claude wants to ask. AskUserQuestion's input shape is
-# `{ "question": "..." }`. Some flavours nest it under `prompt`, so accept
-# either; on the way out we always send `question` to the relay-server.
-QUESTION=$(echo "$INPUT" | jq -r '.tool_input.question // .tool_input.prompt // ""')
-if [ -z "$QUESTION" ]; then
-  # Nothing useful to forward — let Claude proceed with its original input.
+# AskUserQuestion's real input shape (Issue #370 D2, captured from a live
+# transcript) is:
+#   { "questions": [ { "question", "header", "multiSelect",
+#                      "options": [ { "label", "description" } ] } ] }
+# Single question: forward its text + options flattened to "label — description"
+# strings so Discord can list the choices. Multiple questions: forward all
+# question texts joined by newlines; per-question option mapping over one
+# free-text reply is ambiguous, so options are omitted.
+QUESTION_COUNT=$(echo "$INPUT" | jq -r '(.tool_input.questions // []) | length' 2>/dev/null)
+if [ -z "$QUESTION_COUNT" ] || [ "$QUESTION_COUNT" -eq 0 ] 2>/dev/null; then
+  # Unknown / legacy shape — let the regular TUI dialog handle it.
   exit 0
 fi
+
+QUESTION_TEXT=$(echo "$INPUT" | jq -r '(.tool_input.questions // []) | map(.question // "") | join("\n")')
+if [ -z "$QUESTION_TEXT" ]; then
+  exit 0
+fi
+
+PAYLOAD=$(echo "$INPUT" | jq -c '
+  (.tool_input.questions // []) as $qs
+  | if ($qs | length) == 1 then
+      { question: ($qs[0].question // ""),
+        options: [ $qs[0].options[]?
+          | (.label // "")
+            + (if (.description // "") != "" then " — " + .description else "" end) ] }
+      | if (.options | length) == 0 then del(.options) else . end
+    else
+      { question: ($qs | map(.question // "") | join("\n")) }
+    end')
 
 # Forward to the supervisor and wait for the user's reply. --max-time matches
 # the relay-server's DEFAULT_ASK_TIMEOUT_MS (300s since Issue #255) plus a small
@@ -68,7 +98,7 @@ fi
 # INVARIANT: this MUST stay >= DEFAULT_ASK_TIMEOUT_MS/1000, or curl gives up
 # before the server and the user's late reply is wasted. relay-server.test.ts
 # locks `--max-time*1000 >= DEFAULT_ASK_TIMEOUT_MS`.
-RESPONSE=$(jq -n --arg q "$QUESTION" '{question: $q}' | \
+RESPONSE=$(printf '%s' "$PAYLOAD" | \
   curl -s -X POST "$ASK_URL" \
     -H "Content-Type: application/json" \
     -d @- \
@@ -87,14 +117,13 @@ if [ -z "$ANSWER" ]; then
   exit 0
 fi
 
-# Inject the reply via PreToolUse `updatedInput`. Claude consumes this as the
-# new tool_input, so AskUserQuestion completes synchronously with the user's
-# reply and Claude continues on the next turn.
-jq -n --arg answer "$ANSWER" '{
+# Deliver the reply via PreToolUse deny. The reason mirrors the wording the
+# harness itself uses for an answered dialog, so Claude reads it as "the user
+# answered" and continues the turn with the answer in mind.
+jq -n --arg q "$QUESTION_TEXT" --arg a "$ANSWER" '{
   hookSpecificOutput: {
     hookEventName: "PreToolUse",
-    updatedInput: {
-      question: $answer
-    }
+    permissionDecision: "deny",
+    permissionDecisionReason: ("Your questions have been answered: \"" + $q + "\"=\"" + $a + "\". You can now continue with these answers in mind. (answered by the user via Discord relay)")
   }
 }'

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -43,8 +43,12 @@ import {
   onSessionsQuery,
   onHubWork,
   onChannelPost,
+  onAskUser,
+  hasPendingAsk,
+  resolveAskUser,
 } from "./session/relay-server";
 import { runHubWork, HUB_WORK_PARENT_CHANNEL } from "./session/hub-work";
+import { checkHookWiring } from "./infra/hook-wiring-check";
 import {
   extractFilePaths,
   collectAttachableFiles,
@@ -417,6 +421,13 @@ export async function startBot(token: string): Promise<void> {
     activityWatchdog.start();
     resourceMonitor.start();
 
+    // Issue #370 A-2: warn (never fail) about supervisor relay hooks that
+    // exist on disk but are not wired into ~/.claude/settings.json.
+    // ask-user-relay.sh sat unwired for months because nothing checked this.
+    for (const warning of checkHookWiring()) {
+      console.error(warning);
+    }
+
     // Register progress callback to send tool progress to Discord threads.
     // Events are buffered (Issue #119) and flushed every 2s as a single
     // message per thread to stay under Discord's 5-msg/5-sec rate limit.
@@ -440,6 +451,39 @@ export async function startBot(token: string): Promise<void> {
     // live snapshot of the manager's in-memory sessions so an E2E harness can
     // verify the thread → tmux session mapping without host access.
     onSessionsQuery(() => sessionManager.sessionsHealth());
+
+    // Issue #370: forward AskUserQuestion prompts (POSTed by
+    // hooks/ask-user-relay.sh to /ask/:threadId) to the Discord thread. Without
+    // this subscriber the endpoint fast-fails 503 and the question never leaves
+    // the TUI — the user saw a silent 19-minute block. The next user message in
+    // the thread resolves the ask (see the messageCreate handler).
+    onAskUser((event) => {
+      void (async () => {
+        try {
+          const channel = await client.channels.fetch(event.threadId);
+          if (!channel?.isThread()) return;
+          const lines = [`❓ **Claude からの質問**`, event.question];
+          if (event.options?.length) {
+            lines.push("", ...event.options.map((o, i) => `${i + 1}. ${o}`));
+          }
+          lines.push(
+            "",
+            "このスレッドへの次の返信がそのまま回答として送られます（約 5 分でタイムアウトし、TUI ダイアログに戻ります）。"
+          );
+          // Discord caps a message at 2000 chars; a long option list must not
+          // kill the whole question post.
+          const body = lines.join("\n");
+          await channel.send(
+            body.length > 1900 ? `${body.slice(0, 1900)}…` : body
+          );
+        } catch (err) {
+          console.error(
+            `[Bot] Failed to post AskUserQuestion to thread ${event.threadId}:`,
+            err
+          );
+        }
+      })();
+    });
 
     // Register late-response callback: when a Stop hook POST arrives after
     // the initial relay already resolved (e.g. Monitor/background-task split
@@ -1190,6 +1234,20 @@ export async function startBot(token: string): Promise<void> {
       messageText = "添付ファイルを確認してください。";
     }
     if (!messageText) return;
+
+    // Issue #370: a pending AskUserQuestion consumes the next user message in
+    // this thread as its answer. The session is blocked inside the PreToolUse
+    // hook waiting on POST /ask — relaying the reply into tmux would type it
+    // into a TUI that is not accepting input, so resolve the ask and stop.
+    if (hasPendingAsk(threadId)) {
+      resolveAskUser(threadId, messageText);
+      try {
+        await message.react("✅");
+      } catch {
+        // Best-effort ack; delivering the answer is what matters.
+      }
+      return;
+    }
 
     // Slash-prefix stripping: `/hanle-review XXX` → `hanle-review XXX`. Without
     // this, Claude Code's Ink TUI enters its slash-command picker on `/`, and

--- a/supervisor/src/infra/hook-wiring-check.ts
+++ b/supervisor/src/infra/hook-wiring-check.ts
@@ -1,0 +1,102 @@
+// supervisor/src/infra/hook-wiring-check.ts (Issue #370 A-2)
+//
+// Machine check for "the hook file exists but nobody wired it into settings".
+// ask-user-relay.sh sat unwired for ~5 months because nothing verified the
+// wiring: `scripts/check-stale-assets.sh` looks for assets with zero
+// references, but this hook HAD references (tests, docs) — it was referenced
+// yet unreachable. This module closes that gap: bot startup reads the user's
+// ~/.claude/settings.json and warns about every supervisor relay hook that is
+// not registered under its required event.
+//
+// Deliberately WARN-only (console + return value), never fatal: a missing
+// hook degrades UX but the supervisor itself is healthy, and a config-parse
+// hiccup must not take the bot down (defensive-programming: fail soft on the
+// observability path).
+
+import { readFileSync } from "fs";
+import { homedir } from "os";
+import { join } from "path";
+
+export interface RequiredHook {
+  /** Hook event name as it appears in settings.json (e.g. "PreToolUse"). */
+  event: string;
+  /** Path suffix of the hook script, matched against each command string. */
+  scriptSuffix: string;
+}
+
+/**
+ * Relay hooks the supervisor cannot work without. Each must appear as a
+ * command under its event in ~/.claude/settings.json (any matcher).
+ */
+export const REQUIRED_SUPERVISOR_HOOKS: RequiredHook[] = [
+  { event: "PostToolUse", scriptSuffix: "supervisor/hooks/progress-relay.sh" },
+  { event: "Stop", scriptSuffix: "supervisor/hooks/stop-relay.sh" },
+  {
+    event: "PermissionRequest",
+    scriptSuffix: "supervisor/hooks/auto-approve-permission.sh",
+  },
+  { event: "PreToolUse", scriptSuffix: "supervisor/hooks/ask-user-relay.sh" },
+];
+
+interface HookEntry {
+  command?: unknown;
+}
+
+interface MatcherGroup {
+  hooks?: unknown;
+}
+
+/**
+ * Pure check: which required hooks are missing from a parsed settings object?
+ * Exported separately from the file-reading wrapper so tests can exercise the
+ * matching logic against fixtures without touching the real home directory.
+ */
+export function findMissingHookWiring(
+  settings: unknown,
+  required: RequiredHook[] = REQUIRED_SUPERVISOR_HOOKS
+): RequiredHook[] {
+  const hooks =
+    settings && typeof settings === "object"
+      ? (settings as { hooks?: unknown }).hooks
+      : undefined;
+  const events =
+    hooks && typeof hooks === "object"
+      ? (hooks as Record<string, unknown>)
+      : {};
+
+  return required.filter((req) => {
+    const groups = events[req.event];
+    if (!Array.isArray(groups)) return true;
+    const commands = groups.flatMap((group: MatcherGroup) =>
+      Array.isArray(group?.hooks)
+        ? group.hooks.map((h: HookEntry) =>
+            typeof h?.command === "string" ? h.command : ""
+          )
+        : []
+    );
+    return !commands.some((cmd) => cmd.includes(req.scriptSuffix));
+  });
+}
+
+/**
+ * Read the user's settings file and return human-readable warnings for every
+ * missing wiring (empty array = all wired). Never throws.
+ */
+export function checkHookWiring(
+  settingsPath: string = join(homedir(), ".claude", "settings.json")
+): string[] {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(readFileSync(settingsPath, "utf8"));
+  } catch (err) {
+    return [
+      `[HookWiring] ${settingsPath} を読めないため配線検証をスキップしました: ${String(err)}`,
+    ];
+  }
+
+  return findMissingHookWiring(parsed).map(
+    (req) =>
+      `[HookWiring] ${req.scriptSuffix} が ${req.event} に未配線です。` +
+      `Discord 中継が欠けます — ${settingsPath} の hooks.${req.event} に登録してください（Issue #370 D1 の再発）。`
+  );
+}

--- a/supervisor/src/session/relay-server.ts
+++ b/supervisor/src/session/relay-server.ts
@@ -226,6 +226,17 @@ export function resolveAskUser(threadId: string, answer: string): void {
 }
 
 /**
+ * Issue #370: whether a /ask/:threadId request is currently awaiting a user
+ * reply for this thread. bot.ts consults this in messageCreate so the next
+ * thread message resolves the pending ask instead of being relayed into tmux
+ * (the session is blocked inside the PreToolUse hook and the TUI is not
+ * accepting input).
+ */
+export function hasPendingAsk(threadId: string): boolean {
+  return pendingAsks.has(threadId);
+}
+
+/**
  * Cancel a pending /ask/:threadId request. The waiting POST handler responds
  * with 499 (Client Closed Request, Nginx convention) so the hook script can
  * fall back to the original tool input rather than blocking the session.

--- a/supervisor/tests/hooks/ask-user-relay.test.ts
+++ b/supervisor/tests/hooks/ask-user-relay.test.ts
@@ -1,9 +1,16 @@
-// supervisor/tests/hooks/ask-user-relay.test.ts (Issue #12 Phase 1)
+// supervisor/tests/hooks/ask-user-relay.test.ts (Issue #12 Phase 1 / #370)
 //
 // Black-box test for hooks/ask-user-relay.sh. Uses a mock curl to capture the
 // outbound POST and feed back a synthetic supervisor reply, then asserts the
-// hook's stdout produces the PreToolUse `updatedInput` envelope so Claude
-// resumes with the user's answer instead of blocking on the TUI dialog.
+// hook's stdout produces the PreToolUse deny envelope that carries the user's
+// answer back to Claude so it resumes without blocking on the TUI dialog.
+//
+// Issue #370 (D2): AskUserQuestion's real input shape is `questions[]` — an
+// array of { question, header, multiSelect, options[{label, description}] }.
+// The old tests fixed a flat `{ question: "..." }` shape that the tool never
+// sends, which let the schema mismatch pass CI. All fixtures here use the
+// real shape captured from a live transcript
+// (~/.claude/projects/.../6639c00f-....jsonl, 2026-08-06T07:13:18Z).
 import { test, expect, describe, beforeEach, afterEach } from "bun:test";
 import { $ } from "bun";
 import { resolve } from "path";
@@ -81,6 +88,29 @@ function makeInput(toolInput: Record<string, unknown>, cwd: string): string {
   });
 }
 
+/** Real single-question input shape (captured from a live transcript). */
+function singleQuestionInput(): Record<string, unknown> {
+  return {
+    questions: [
+      {
+        question: "claude-hub#342 の対策方式はどれで確定しますか？",
+        header: "342方式",
+        multiSelect: false,
+        options: [
+          {
+            label: "案B-lite（推奨）",
+            description: "完了判定を git 成果物ベースに変更",
+          },
+          {
+            label: "案A: tmux 既定化",
+            description: "dispatch セッションを tmux 常駐にして予防",
+          },
+        ],
+      },
+    ],
+  };
+}
+
 async function runHook(
   env: TestEnv,
   input: string,
@@ -101,17 +131,14 @@ describe("ask-user-relay.sh — supervisor session active", () => {
   beforeEach(() => {
     env = setupTestEnv({
       relayUrl: "http://localhost:12345/relay/thread-abc",
-      curlOutput: '{"answer":"use PR #42"}',
+      curlOutput: '{"answer":"案B-lite（推奨）"}',
     });
   });
 
   afterEach(() => cleanup(env));
 
-  test("forwards question to /ask/ and emits updatedInput with the user's reply", async () => {
-    const input = makeInput(
-      { question: "Which PR did you mean?" },
-      env.dir,
-    );
+  test("forwards question + options to /ask/ and emits deny envelope carrying the user's reply", async () => {
+    const input = makeInput(singleQuestionInput(), env.dir);
 
     const { stdout, exitCode } = await runHook(env, input);
     expect(exitCode).toBe(0);
@@ -121,21 +148,51 @@ describe("ask-user-relay.sh — supervisor session active", () => {
     expect(curlArgs).toContain("http://localhost:12345/ask/thread-abc");
     expect(curlArgs).not.toContain("\\/");
 
-    // Outbound JSON sent to relay-server.
+    // Outbound JSON sent to relay-server: question text + flattened options.
     const sent = JSON.parse(readFileSync(env.curlStdinFile, "utf8"));
-    expect(sent.question).toBe("Which PR did you mean?");
+    expect(sent.question).toBe(
+      "claude-hub#342 の対策方式はどれで確定しますか？",
+    );
+    expect(sent.options).toEqual([
+      "案B-lite（推奨） — 完了判定を git 成果物ベースに変更",
+      "案A: tmux 既定化 — dispatch セッションを tmux 常駐にして予防",
+    ]);
 
-    // Hook stdout: PreToolUse hookSpecificOutput with updatedInput.
+    // Hook stdout: PreToolUse deny whose reason carries the answer. The
+    // wording mirrors the native answered-dialog tool_result ("Your questions
+    // have been answered: ...") so Claude treats it as an answer, not a
+    // refusal, and continues the turn.
     const out = JSON.parse(stdout);
     expect(out.hookSpecificOutput.hookEventName).toBe("PreToolUse");
-    expect(out.hookSpecificOutput.updatedInput.question).toBe("use PR #42");
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain(
+      'Your questions have been answered:',
+    );
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain(
+      '"claude-hub#342 の対策方式はどれで確定しますか？"="案B-lite（推奨）"',
+    );
   });
 
-  test("accepts `prompt` field as fallback for the question text", async () => {
-    const input = makeInput({ prompt: "Pick a path" }, env.dir);
-    await runHook(env, input);
+  test("multiple questions: all question texts are forwarded, options omitted", async () => {
+    const input = makeInput(
+      {
+        questions: [
+          { question: "Q1 はどうしますか？", header: "Q1", multiSelect: false, options: [{ label: "a", description: "d1" }] },
+          { question: "Q2 はどうしますか？", header: "Q2", multiSelect: false, options: [{ label: "b", description: "d2" }] },
+        ],
+      },
+      env.dir,
+    );
+
+    const { exitCode } = await runHook(env, input);
+    expect(exitCode).toBe(0);
+
     const sent = JSON.parse(readFileSync(env.curlStdinFile, "utf8"));
-    expect(sent.question).toBe("Pick a path");
+    // Both questions must reach Discord in one message; per-question option
+    // mapping is ambiguous over a free-text reply, so options are omitted.
+    expect(sent.question).toContain("Q1 はどうしますか？");
+    expect(sent.question).toContain("Q2 はどうしますか？");
+    expect(sent.options).toBeUndefined();
   });
 });
 
@@ -150,7 +207,7 @@ describe("ask-user-relay.sh — URL derivation safety", () => {
       curlOutput: '{"answer":"ok"}',
     });
     try {
-      const input = makeInput({ question: "ping" }, env.dir);
+      const input = makeInput(singleQuestionInput(), env.dir);
       await runHook(env, input);
       const curlArgs = readFileSync(env.curlArgsFile, "utf8");
       expect(curlArgs).toContain(
@@ -168,7 +225,7 @@ describe("ask-user-relay.sh — URL derivation safety", () => {
       curlOutput: '{"answer":"ok"}',
     });
     try {
-      const input = makeInput({ question: "ping" }, env.dir);
+      const input = makeInput(singleQuestionInput(), env.dir);
       await runHook(env, input);
       const curlArgs = readFileSync(env.curlArgsFile, "utf8");
       expect(curlArgs).toContain(
@@ -184,7 +241,7 @@ describe("ask-user-relay.sh — fallback / safety", () => {
   test("no relay-url file: hook is a no-op (empty stdout, exit 0)", async () => {
     const env = setupTestEnv({}); // no relayUrl written
     try {
-      const input = makeInput({ question: "hi" }, env.dir);
+      const input = makeInput(singleQuestionInput(), env.dir);
       const { stdout, exitCode } = await runHook(env, input);
       // AC-3 / Journey-AC #3: hook must produce no stdout when not in a
       // supervisor session — Claude proceeds with original tool_input.
@@ -195,7 +252,7 @@ describe("ask-user-relay.sh — fallback / safety", () => {
     }
   });
 
-  test("missing question/prompt: hook exits 0 with no stdout", async () => {
+  test("empty tool_input: hook exits 0 with no stdout", async () => {
     const env = setupTestEnv({
       relayUrl: "http://localhost:12345/relay/t",
       curlOutput: '{"answer":"x"}',
@@ -210,13 +267,30 @@ describe("ask-user-relay.sh — fallback / safety", () => {
     }
   });
 
+  test("legacy flat shape (question at top level, no questions[]): TUI fallback", async () => {
+    // Issue #370 (D2): the tool never sends this shape. An unknown shape must
+    // fall through to the TUI dialog, never emit a half-built deny envelope.
+    const env = setupTestEnv({
+      relayUrl: "http://localhost:12345/relay/t",
+      curlOutput: '{"answer":"x"}',
+    });
+    try {
+      const input = makeInput({ question: "hi" }, env.dir);
+      const { stdout, exitCode } = await runHook(env, input);
+      expect(stdout.trim()).toBe("");
+      expect(exitCode).toBe(0);
+    } finally {
+      cleanup(env);
+    }
+  });
+
   test("supervisor returns 504-style empty answer: hook is a no-op (TUI fallback)", async () => {
     const env = setupTestEnv({
       relayUrl: "http://localhost:12345/relay/t",
       curlOutput: '{"error":"ask timeout"}',
     });
     try {
-      const input = makeInput({ question: "hi" }, env.dir);
+      const input = makeInput(singleQuestionInput(), env.dir);
       const { stdout, exitCode } = await runHook(env, input);
       expect(stdout.trim()).toBe("");
       expect(exitCode).toBe(0);
@@ -232,7 +306,7 @@ describe("ask-user-relay.sh — fallback / safety", () => {
       curlExit: 7, // CURLE_COULDNT_CONNECT
     });
     try {
-      const input = makeInput({ question: "hi" }, env.dir);
+      const input = makeInput(singleQuestionInput(), env.dir);
       const { stdout, exitCode } = await runHook(env, input);
       expect(stdout.trim()).toBe("");
       expect(exitCode).toBe(0);
@@ -249,7 +323,7 @@ describe("ask-user-relay.sh — fallback / safety", () => {
     try {
       const input = JSON.stringify({
         tool_name: "AskUserQuestion",
-        tool_input: { question: "hi" },
+        tool_input: singleQuestionInput(),
         // no `cwd`
       });
       const { stdout, exitCode } = await runHook(env, input);

--- a/supervisor/tests/infra/hook-wiring-check.test.ts
+++ b/supervisor/tests/infra/hook-wiring-check.test.ts
@@ -1,0 +1,166 @@
+// supervisor/tests/infra/hook-wiring-check.test.ts (Issue #370 A-2)
+//
+// Journey-AC #5: removing ask-user-relay.sh from settings must surface a
+// warning at supervisor startup instead of silently regressing to the
+// "hook exists but is unreachable" state that hid Issue #370 for months.
+import { test, expect, describe } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { resolve } from "path";
+import { tmpdir } from "os";
+import {
+  findMissingHookWiring,
+  checkHookWiring,
+  REQUIRED_SUPERVISOR_HOOKS,
+} from "../../src/infra/hook-wiring-check";
+
+/** Settings fixture with every required supervisor hook wired. */
+function fullyWiredSettings(): unknown {
+  return {
+    hooks: {
+      PostToolUse: [
+        {
+          matcher: "",
+          hooks: [
+            {
+              type: "command",
+              command:
+                "bash /Users/x/claude-hub/supervisor/hooks/progress-relay.sh",
+            },
+          ],
+        },
+      ],
+      Stop: [
+        {
+          matcher: "",
+          hooks: [
+            {
+              type: "command",
+              command:
+                "bash /Users/x/claude-hub/supervisor/hooks/stop-relay.sh",
+            },
+            { type: "command", command: "bash ~/.claude/hooks/other.sh" },
+          ],
+        },
+      ],
+      PermissionRequest: [
+        {
+          matcher: "",
+          hooks: [
+            {
+              type: "command",
+              command:
+                "bash /Users/x/claude-hub/supervisor/hooks/auto-approve-permission.sh",
+            },
+          ],
+        },
+      ],
+      PreToolUse: [
+        {
+          matcher: "Bash",
+          hooks: [
+            { type: "command", command: "bash ~/.claude/hooks/block-dangerous.sh" },
+          ],
+        },
+        {
+          matcher: "AskUserQuestion",
+          hooks: [
+            {
+              type: "command",
+              command:
+                "bash /Users/x/claude-hub/supervisor/hooks/ask-user-relay.sh",
+              timeout: 320,
+            },
+          ],
+        },
+      ],
+    },
+  };
+}
+
+describe("findMissingHookWiring", () => {
+  test("fully wired settings: no missing hooks", () => {
+    expect(findMissingHookWiring(fullyWiredSettings())).toEqual([]);
+  });
+
+  test("ask-user-relay missing from PreToolUse is reported (Issue #370 D1)", () => {
+    const settings = fullyWiredSettings() as {
+      hooks: { PreToolUse: { matcher: string }[] };
+    };
+    settings.hooks.PreToolUse = settings.hooks.PreToolUse.filter(
+      (g) => g.matcher !== "AskUserQuestion"
+    );
+
+    const missing = findMissingHookWiring(settings);
+    expect(missing.map((m) => m.scriptSuffix)).toEqual([
+      "supervisor/hooks/ask-user-relay.sh",
+    ]);
+  });
+
+  test("hook registered under the WRONG event still counts as missing", () => {
+    const settings = fullyWiredSettings() as {
+      hooks: Record<string, unknown[]>;
+    };
+    // Move ask-user-relay from PreToolUse to PostToolUse.
+    settings.hooks.PostToolUse.push({
+      matcher: "AskUserQuestion",
+      hooks: [
+        {
+          type: "command",
+          command: "bash /Users/x/claude-hub/supervisor/hooks/ask-user-relay.sh",
+        },
+      ],
+    });
+    settings.hooks.PreToolUse = (
+      settings.hooks.PreToolUse as { matcher: string }[]
+    ).filter((g) => g.matcher !== "AskUserQuestion");
+
+    const missing = findMissingHookWiring(settings);
+    expect(missing.map((m) => m.scriptSuffix)).toEqual([
+      "supervisor/hooks/ask-user-relay.sh",
+    ]);
+  });
+
+  test("empty / malformed settings report every required hook", () => {
+    expect(findMissingHookWiring({}).length).toBe(
+      REQUIRED_SUPERVISOR_HOOKS.length
+    );
+    expect(findMissingHookWiring(null).length).toBe(
+      REQUIRED_SUPERVISOR_HOOKS.length
+    );
+    expect(
+      findMissingHookWiring({ hooks: { PreToolUse: "not-an-array" } }).length
+    ).toBe(REQUIRED_SUPERVISOR_HOOKS.length);
+  });
+});
+
+describe("checkHookWiring (file wrapper)", () => {
+  test("returns warnings for missing wiring and never throws on a real file", () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "hook-wiring-test-"));
+    try {
+      const path = resolve(dir, "settings.json");
+      writeFileSync(path, JSON.stringify({ hooks: {} }), "utf8");
+      const warnings = checkHookWiring(path);
+      expect(warnings.length).toBe(REQUIRED_SUPERVISOR_HOOKS.length);
+      expect(warnings[0]).toContain("未配線");
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  test("unreadable settings file degrades to a single skip warning (fail-soft)", () => {
+    const warnings = checkHookWiring("/nonexistent/settings.json");
+    expect(warnings.length).toBe(1);
+    expect(warnings[0]).toContain("スキップ");
+  });
+
+  test("fully wired file returns no warnings", () => {
+    const dir = mkdtempSync(resolve(tmpdir(), "hook-wiring-test-"));
+    try {
+      const path = resolve(dir, "settings.json");
+      writeFileSync(path, JSON.stringify(fullyWiredSettings()), "utf8");
+      expect(checkHookWiring(path)).toEqual([]);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+});

--- a/supervisor/tests/infra/hook-wiring-check.test.ts
+++ b/supervisor/tests/infra/hook-wiring-check.test.ts
@@ -101,7 +101,9 @@ describe("findMissingHookWiring", () => {
       hooks: Record<string, unknown[]>;
     };
     // Move ask-user-relay from PreToolUse to PostToolUse.
-    settings.hooks.PostToolUse.push({
+    const postToolUse = settings.hooks.PostToolUse ?? [];
+    settings.hooks.PostToolUse = postToolUse;
+    postToolUse.push({
       matcher: "AskUserQuestion",
       hooks: [
         {


### PR DESCRIPTION
## 概要

Fixes #370（A-1 + A-2 スコープ。A-3/A-4/A-5 は follow-up）

対話セッションで AskUserQuestion を含む turn が Discord に一切中継されず、ユーザーからは 19 分無応答に見える問題（#370）のうち、P0 の 2 件を修正する。

## 変更内容

### A-1: AskUserQuestion → Discord 中継の修理と結線

- **`supervisor/hooks/ask-user-relay.sh`（D2 修正）**: 実スキーマ `questions[]` 配列（transcript 実測: `{questions:[{question, header, multiSelect, options:[{label, description}]}]}`）から質問文と選択肢を抽出して `/ask/:threadId` へ POST するよう修正。旧実装が読んでいた `tool_input.question` はツールが送らない形状で、常に exit 0 → TUI フォールバックしていた
- **回答注入方式の変更**: 旧実装の `updatedInput: {question: answer}` は実スキーマと不一致な上、input を書き換えても TUI ダイアログ自体は開いてしまう。PreToolUse **deny**（`permissionDecision: "deny"` + `permissionDecisionReason`）に変更し、reason にネイティブの回答済みダイアログと同じ文言（`Your questions have been answered: "…"="…"`。実 transcript から採取）を載せて Claude に回答として伝える
- **`supervisor/src/bot.ts`（D1 の欠落部分）**: `/ask` エンドポイントの購読者が本番コードに存在しなかった（`onAskUser` はテストのみが使用、実運用では常に 503）。起動時に `onAskUser` を購読して質問+選択肢をスレッドへ投稿し、`messageCreate` で pending ask があるスレッドの次の返信を `resolveAskUser` に回す（tmux へは中継しない — セッションは hook 内でブロック中のため）
- **`supervisor/src/session/relay-server.ts`**: `hasPendingAsk(threadId)` を export（bot.ts の回答インターセプト用）

### A-2: 配線の機械検証（死蔵の再発防止）

- **`supervisor/src/infra/hook-wiring-check.ts`（新規）**: `~/.claude/settings.json` に必須 relay hook 4 本（progress-relay / stop-relay / auto-approve-permission / ask-user-relay）が正しい event に登録されているかを検査。bot 起動時に未配線を console.error で警告（WARN-only・fail-soft）
- ask-user-relay.sh は #12 で実装されてから約 5 か月間未配線だった。`check-stale-assets.sh` は「参照 0 件」を検知するが「参照はあるのに配線されていない」は検知できないため、専用チェックを追加

### テスト（RED → GREEN）

- `supervisor/tests/hooks/ask-user-relay.test.ts`: フィクスチャを誤形状 `{question: "hi"}` から実スキーマに全面差し替え（旧テストが誤形状を固定していたため CI で D2 を検出できなかった）。複数質問・legacy 形状フォールバック・タイムアウト時 TUI フォールバックを追加
- `supervisor/tests/infra/hook-wiring-check.test.ts`（新規）: 配線欠落・wrong-event 登録・malformed settings・fail-soft を検証

## デプロイ手順（merge 後に必要な作業）

1. `~/.claude/settings.json` の `PreToolUse` に matcher `AskUserQuestion` で `supervisor/hooks/ask-user-relay.sh` を **timeout 320** 付きで登録（relay-server の ask timeout 300s + バッファ。未登録のままでも起動時警告が出るのみで従来動作）
2. Supervisor 再起動（**注意**: #369 の shutdownAll がセッション stop + worktree 削除を行うため、稼働中セッションが無いタイミングで実施すること）

## テスト方法

```bash
cd supervisor
bun test tests/hooks/ask-user-relay.test.ts   # 10 pass
bun test tests/infra/hook-wiring-check.test.ts # 7 pass
bun test                                       # 全件
bunx tsc --noEmit                              # 型チェック
```

統合ジャーニーAC #1/#2（Discord 実機 E2E）は supervisor 再起動が前提のため、デプロイ後に実施する（#370 に結果を記録）。

## 関連

- Issue #370（本体）/ #369（同セッション群の別障害・相互リンク済み）/ #12（hook の追加元）
- follow-up: A-3（先行テキスト同送）/ A-4（stall 案内の実行可能化）/ A-5（dispatch・headless 経路の同一調査）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H8boX18irt85kLKogenb7u
