### PR TITLE
fix: supervisor shutdown の worktree 破壊と hasSession false-teardown を修正 (#369)

### DIFF
--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -52,6 +52,15 @@ claude-hub プロジェクトで運用している Discord Bot の役割分担�
 2. 必要なら `claudeHubExit` 経由で修正
 3. ローカルで `launchctl kickstart -k gui/$(id -u)/com.claude-hub.supervisor`
 
+> **警告（Issue #369）**: supervisor の再起動（`launchctl kickstart -k ... com.claude-hub.supervisor`）を
+> **supervisor 管理下のセッション内から実行してはならない**。SIGTERM → `shutdownAll()` が実行中の
+> 全セッション（自分自身を含む）を stop するため、実行したセッションはコマンドの途中で kill され、
+> handoff に「supervisor 再起動」が残っていると resume のたびに同じ地点で自死するループになる。
+> 再起動は必ずセッション外（ローカルターミナル / claudeHubExit 経由）から実行すること。
+> なお shutdown で停止したセッションは `stopped_reason=supervisor_restart` で記録され、
+> worktree は保持される（`/session resume` で再開可能）。ユーザーの明示的な `/session stop`
+> （`stopped_reason=manual`）のみが worktree を削除する。
+
 ## 関連ファイル
 
 - `supervisor/src/config/channels.ts` — CHANNEL_MAP 定義 + claude-hub ガード

--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -268,6 +268,26 @@ export const realTmuxAdapter: TmuxAdapter = {
       if (warnIfTmuxTimeout("has-session", name, err)) {
         return true;
       }
+      const e = err as NodeJS.ErrnoException | undefined;
+      // Issue #369 (cause B): under memory/load pressure the fork+exec of tmux
+      // itself can fail (EAGAIN/ENOMEM/EMFILE, ...) before tmux ever runs.
+      // Those errors carry a *string* errno code, unlike a real tmux
+      // "no such session" exit (numeric exit code on err.code). A spawn
+      // failure says nothing about the session, so — like a timeout — treat
+      // liveness as unknown and assume alive rather than tearing down live
+      // work.
+      if (typeof e?.code === "string") {
+        console.warn(
+          `[tmux] has-session spawn failed for ${name} (code=${e.code}); liveness unknown → assuming alive (#369)`
+        );
+        return true;
+      }
+      // tmux ran and exited non-zero → the session really is gone. Log the
+      // exit detail so a suspected false teardown can be diagnosed post-hoc
+      // (#369 B-1: this path used to be silent, making incidents unanalyzable).
+      console.warn(
+        `[tmux] has-session: no session ${name} (exit=${e?.code ?? "?"})`
+      );
       return false;
     }
   },

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -2065,6 +2065,21 @@ export class SessionManager {
     updateSessionStatus(session.id, "stopped", reason);
     this.cleanupRelayUrlFile(session.projectDir);
 
+    // Issue #369 (cause A): a supervisor shutdown (SIGTERM / launchctl
+    // kickstart) is NOT an explicit teardown — the user never chose to drop
+    // this work. `git worktree remove --force` here destroyed uncommitted work
+    // three times in the handoff-96-2 incident. Preserve the worktree so
+    // `/session resume` can pick the branch back up (matches the
+    // tmux_exited/recoverFromDb paths, and docs/e2e-orchestrate.md).
+    if (reason === "supervisor_restart") {
+      if (session.worktree) {
+        console.log(
+          `[SessionManager] Preserving worktree ${session.worktree.path} (supervisor restart; resume with /session resume)`
+        );
+      }
+      return;
+    }
+
     // Issue #154 (Q3): remove the per-branch worktree on stop; the branch is
     // preserved. But Q4 allows multiple sessions to share one worktree (同
     // branch 多重 session). `this.sessions` no longer contains the current
@@ -2156,8 +2171,12 @@ export class SessionManager {
 
   async shutdownAll(): Promise<void> {
     console.log("[SessionManager] Shutting down all sessions...");
+    // Issue #369 (cause A): record `supervisor_restart`, not `manual`. This is
+    // a SIGTERM-driven shutdown, not a user's /session stop — stop() preserves
+    // the worktree for this reason so uncommitted work survives the restart,
+    // and the DB reason matches what docs/e2e-orchestrate.md documents.
     const promises = Array.from(this.sessions.keys()).map((threadId) =>
-      this.stop(threadId, "manual").catch((err) =>
+      this.stop(threadId, "supervisor_restart").catch((err) =>
         console.error(`[SessionManager] Error stopping ${threadId}:`, err)
       )
     );
@@ -2167,7 +2186,7 @@ export class SessionManager {
       clearInterval(handle);
     }
     this.watchers.clear();
-    // Defensive — stop("manual") already drops each, but clear any orphan left
+    // Defensive — stop() above already drops each, but clear any orphan left
     // by a failed-then-unresumed self_heal_restart (Issue #244).
     this.selfHealers.clear();
     this.effects.relayServer.stop();

--- a/supervisor/tests/session/adapters-hassession.test.ts
+++ b/supervisor/tests/session/adapters-hassession.test.ts
@@ -130,6 +130,7 @@ describe("realTmuxAdapter.hasSession timeout handling (#238 / #227)", () => {
     // so a false teardown can be diagnosed post-hoc (previously silent).
     expect(warnSpy).toHaveBeenCalledTimes(1);
     expect(String(warnSpy.mock.calls[0]?.[0])).toContain("claude-dead");
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("exit=1");
   });
 
   test("#369 B-1: returns true (assume alive) when the tmux spawn itself fails (EAGAIN)", async () => {

--- a/supervisor/tests/session/adapters-hassession.test.ts
+++ b/supervisor/tests/session/adapters-hassession.test.ts
@@ -117,11 +117,44 @@ describe("realTmuxAdapter.hasSession timeout handling (#238 / #227)", () => {
   });
 
   test("returns false when the session genuinely does not exist (non-timeout error)", async () => {
-    mockExecFileError = new Error("can't find session: claude-dead");
+    // Real shape: tmux ran and exited 1 → promisify(execFile) sets the numeric
+    // exit code on err.code.
+    const err = new Error(
+      "Command failed: tmux has-session -t claude-dead\ncan't find session: claude-dead"
+    ) as Error & { code: number };
+    err.code = 1;
+    mockExecFileError = err;
 
     expect(await realTmuxAdapter.hasSession("claude-dead")).toBe(false);
-    // A real "no session" is not a timeout, so no timeout warning.
-    expect(warnSpy).not.toHaveBeenCalled();
+    // Issue #369 B-1: the "no session" outcome is logged with its exit detail
+    // so a false teardown can be diagnosed post-hoc (previously silent).
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("claude-dead");
+  });
+
+  test("#369 B-1: returns true (assume alive) when the tmux spawn itself fails (EAGAIN)", async () => {
+    // Under freeMem≈0% / load1≈50 the fork+exec of tmux can fail with
+    // EAGAIN/ENOMEM before tmux ever runs. That is NOT evidence the session
+    // exited — treating it as "exited" tears down a live session (the
+    // handoff-96 false-teardown, Issue #369 cause B). errno-style spawn
+    // failures carry a *string* code, unlike a tmux exit (numeric code).
+    const err = new Error("spawn EAGAIN") as NodeJS.ErrnoException;
+    err.code = "EAGAIN";
+    err.errno = -35;
+    mockExecFileError = err;
+
+    expect(await realTmuxAdapter.hasSession("claude-loaded")).toBe(true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
+    expect(String(warnSpy.mock.calls[0]?.[0])).toContain("EAGAIN");
+  });
+
+  test("#369 B-1: returns true (assume alive) on ENOMEM spawn failure", async () => {
+    const err = new Error("spawn ENOMEM") as NodeJS.ErrnoException;
+    err.code = "ENOMEM";
+    mockExecFileError = err;
+
+    expect(await realTmuxAdapter.hasSession("claude-oom")).toBe(true);
+    expect(warnSpy).toHaveBeenCalledTimes(1);
   });
 
   test("returns true when has-session succeeds (session present)", async () => {

--- a/supervisor/tests/session/manager.test.ts
+++ b/supervisor/tests/session/manager.test.ts
@@ -20,6 +20,7 @@ import {
   type FakeSessionEffects,
 } from "../../src/session/adapters-fake";
 import type { ChannelConfig } from "../../src/config/channels";
+import { getSessionByClaudeSessionId } from "../../src/infra/db";
 
 /**
  * These tests inject fake adapters via {@link SessionManager}'s DI hooks so
@@ -682,6 +683,26 @@ describe("SessionManager worktree integration (#154)", () => {
   test("stop of a branchless session does not call worktree.remove", async () => {
     await manager.start(config, "thread-plain-stop");
     await manager.stop("thread-plain-stop", "manual");
+    expect(effects.worktree.removeCalls).toHaveLength(0);
+  });
+
+  test("#369 A-1: shutdownAll preserves worktrees and records supervisor_restart", async () => {
+    // A SIGTERM-driven shutdown (launchctl kickstart) is NOT an explicit
+    // /session stop — force-removing the worktree here destroyed uncommitted
+    // work three times in the handoff-96-2 incident (Issue #369, cause A).
+    const session = await manager.start(config, "thread-restart-wt", "feature-foo");
+
+    await manager.shutdownAll();
+
+    expect(effects.worktree.removeCalls).toHaveLength(0);
+    const row = getSessionByClaudeSessionId(session.claudeSessionId!);
+    expect(row?.status).toBe("stopped");
+    expect(row?.stopped_reason).toBe("supervisor_restart");
+  });
+
+  test("#369 A-1: explicit stop('supervisor_restart') also preserves the worktree", async () => {
+    await manager.start(config, "thread-sr-stop", "feature-foo");
+    await manager.stop("thread-sr-stop", "supervisor_restart");
     expect(effects.worktree.removeCalls).toHaveLength(0);
   });
 


### PR DESCRIPTION
## 目的

Issue #369 の調査で確定した「supervisor 管理下セッションの自死ループ」（原因 A）と「hasSession の false-teardown 残存経路」（原因 B）の P0 修正 + docs 是正（A-2）。

Closes #369

## 主な変更点

### A-1 (P0): shutdownAll が worktree を破壊しない
- `shutdownAll()` の stop reason を `manual` → `supervisor_restart` に変更（`supervisor/src/session/manager.ts`）
- `stop()` は `reason === "supervisor_restart"` のとき worktree 削除をスキップし、保持ログを出す
- これで SIGTERM 経由の shutdown が未コミット作業を `git worktree remove --force` で消さなくなり、`docs/e2e-orchestrate.md:22` の記載（`supervisor_restart` + worktree 保持 + `/session resume` 可）と実挙動が一致する
- ユーザー明示の `/session stop`（`manual`）の worktree 削除挙動は不変（Issue #154 Q3 維持）

### B-1 (P0): hasSession の spawn 失敗を「生存不明 = alive」扱いに + 観測性
- `hasSession()` の catch で、string errno（`EAGAIN` / `ENOMEM` / `EMFILE` 等 = fork/exec 自体の失敗）を timeout と同様「生存不明 → alive」として扱う（#238 の残存経路を閉塞）
- 真の no-session（tmux が非ゼロ exit = numeric code）も exit code 付きで warn 出力し、事後調査を可能にした（従来は完全に silent）

### A-2 (P1): docs 是正
- `docs/bot-operations.md` の復旧手順に「supervisor 管理下のセッション内から kickstart を実行してはならない」警告と、実際に記録される `stopped_reason` / worktree 挙動を明記

## テスト

TDD（RED → GREEN）で以下を追加・更新:

- `tests/session/manager.test.ts`: shutdownAll が worktree を保持し `supervisor_restart` を記録する / `stop("supervisor_restart")` も保持（新規 2 件）
- `tests/session/adapters-hassession.test.ts`: EAGAIN / ENOMEM spawn 失敗で alive 扱い + warn（新規 2 件）、no-session 判定の実 shape（numeric exit code）化 + warn 検証（更新 1 件）

検証結果:
- `bunx tsc --noEmit` PASS
- CI curated list（82 ファイル）: 1017 pass / 5 fail — fail は全て `cleanup-idle-claude.sh` / `list-claude-processes.sh` / `lint-blocking-in-timers` の 5 秒タイムアウトで、ローカル Mac の実プロセス走査（claude 31 プロセス稼働・高負荷）由来。本 diff（supervisor/src/session + docs のみ）と無関係
- mock 隔離ファイル（adapters-hassession / adapters / tmux / relay-nonblocking）: 全 PASS
- lint 3 種（blocking-in-timers / no-sync-exec / gating-coverage）: 全 PASS

## スコープ外（申し送り）

- B-2: false-teardown 後の orphan 回収は既存 #246（OPEN）で追跡。B-1 の warn ログが #246 の入力になる
- C-1 (P2): リソース逼迫の常態化（ResourceMonitor が observe のみ）は別 Issue で検討
- `self_heal_restart` 経由の stop も worktree を削除してから resume 時に再作成しており、理論上は未コミット作業を失いうるが、挙動変更のリスクを避け本 PR では触れていない（必要なら follow-up）

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * tmux の一時的な起動失敗時に、セッションを誤って消失扱いしないよう改善しました。
  * セッション終了時の状態と警告表示を正確に記録するようにしました。

* **改善**
  * Supervisor 再起動時もセッションの worktree を保持し、後から再開できるようにしました。
  * 明示的なセッション停止時のみ worktree が削除されます。

* **ドキュメント**
  * セッション内から Supervisor を再起動しないための注意事項と復旧手順を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->