### PR TITLE
feat(#384): トレーサビリティ週次メトリクスの自動計測（Epic #381）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -135,6 +135,7 @@ jobs:
                    tests/hijoguchi-routing/p0.test.ts \
                    tests/e2e/ac-verification.test.ts \
                    tests/scripts/lint-gating-coverage.test.ts \
+                   tests/scripts/traceability-metrics.test.ts \
                    tests/commands/session-compact.test.ts \
                    tests/commands/compact-button.test.ts \
                    tests/session/manager-compact-concurrency.test.ts \

--- a/.github/workflows/traceability-metrics.yml
+++ b/.github/workflows/traceability-metrics.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           # Full history: the script reads `git log --since` on main.
           fetch-depth: 0
+          # Read-only job: git is only read locally, gh uses GH_TOKEN.
+          persist-credentials: false
 
       - uses: oven-sh/setup-bun@v2
         with:

--- a/.github/workflows/traceability-metrics.yml
+++ b/.github/workflows/traceability-metrics.yml
@@ -1,0 +1,42 @@
+# Issue #384 (Epic #381): weekly traceability metrics.
+#
+# Recomputes the #381 baseline numbers (main fix ratio / revert count /
+# main-push CI failures / bug-issue repro-section rate) and publishes them to
+# the run's Step Summary. This is the consumer that keeps the metric alive
+# (rules/general/observability.md: no writer without a consumer).
+#
+# Read-only: git log + read-scoped `gh api` / `gh issue list` only. No
+# Pushover, no issue writes, no real-service side effects.
+name: Traceability Metrics
+
+on:
+  schedule:
+    # Mondays 21:00 UTC = Tuesday 06:00 JST, before the workday starts.
+    - cron: "0 21 * * 1"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  issues: read
+  actions: read
+
+jobs:
+  metrics:
+    name: Weekly metrics report
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Full history: the script reads `git log --since` on main.
+          fetch-depth: 0
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Compute metrics
+        working-directory: supervisor
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: bun scripts/traceability-metrics.ts --days 90 | tee "$GITHUB_STEP_SUMMARY"

--- a/supervisor/scripts/traceability-metrics.ts
+++ b/supervisor/scripts/traceability-metrics.ts
@@ -130,7 +130,7 @@ export function renderReport(r: ReportInput): string {
     // through merge commits; this script uses --first-parent (one entry per
     // landing on main), so its numbers are lower. Trends must only be compared
     // against this script's own history, anchored to the first scripted run:
-    "ベースライン（2026-08-08 初回スクリプト実測, 90日窓）: fix 22/94=23.4% / main 赤 4/92 / 再現手順 28/61=45.9%（#381 手動解析の 42/145 とは分母定義が異なる）",
+    "ベースライン（2026-08-08 初回スクリプト実測, 90日窓）: fix 22/94=23.4% / main 赤 4/92 / 再現手順 21/40=52.5%（#381 手動解析の 42/145 とは分母定義が異なる）",
   ].join("\n");
 }
 
@@ -155,19 +155,25 @@ if (import.meta.main) {
   const logText = await $`git log --first-parent --since=${days + " days ago"} --pretty=%s ${ref}`.text();
   const subjects = logText.split("\n").filter((l) => l.trim() !== "");
 
-  // Actions runs are paginated newest-first; 3 pages ≅ 300 runs covers >90 days
-  // at the current merge cadence. Older windows just clip (trend still valid).
+  const sinceDate = new Date(Date.now() - days * 86400_000).toISOString().slice(0, 10);
+
+  // Server-side `created` filter keeps the window exact; pages are followed
+  // until exhausted (cap 20 = 2000 runs, far above the weekly cadence — if the
+  // cap ever clips, say so instead of silently under-reporting failures).
   const runs: CiRunLite[] = [];
-  for (let page = 1; page <= 3; page++) {
+  for (let page = 1; page <= 20; page++) {
     const chunk = JSON.parse(
-      await $`gh api ${"repos/" + repo + "/actions/runs?per_page=100&page=" + page}`.text(),
-    ).workflow_runs as (CiRunLite & { created_at: string })[];
-    runs.push(...chunk.filter((r) => Date.now() - Date.parse(r.created_at) < days * 86400_000));
+      await $`gh api ${"repos/" + repo + "/actions/runs?per_page=100&page=" + page + "&created=>=" + sinceDate}`.text(),
+    ).workflow_runs as CiRunLite[];
+    runs.push(...chunk);
     if (chunk.length < 100) break;
+    if (page === 20) console.error(`⚠ CI run pagination capped at 2000 within ${days}d — mainRuns may undercount.`);
   }
 
+  // Same window as the commit metric. Closed bugs stay in the denominator on
+  // purpose: a fixed-and-closed bug still either had repro steps or didn't.
   const issues: IssueLite[] = JSON.parse(
-    await $`gh issue list -R ${repo} --state all --limit 200 --json number,title,labels,body`.text(),
+    await $`gh issue list -R ${repo} --state all --limit 500 --search ${"created:>=" + sinceDate} --json number,title,labels,body`.text(),
   );
 
   const report = renderReport({

--- a/supervisor/scripts/traceability-metrics.ts
+++ b/supervisor/scripts/traceability-metrics.ts
@@ -1,0 +1,181 @@
+#!/usr/bin/env bun
+/**
+ * Issue #384 (Epic #381): traceability weekly metrics.
+ *
+ * The #381 analysis quantified why bugs recur: main's fix-commit ratio was 29%
+ * (42/145), only 13% of PRs were caught by CI pre-merge, and just 55% of bug
+ * issues carried an evidence-backed `## 再現手順`. Those were one-off manual
+ * numbers — this script recomputes the observable subset on a schedule so the
+ * Epic's improvements (regression gates, real-env E2E) show up as trend lines
+ * instead of anecdotes.
+ *
+ * Metrics (window = --days, default 90):
+ *   1. fix-commit ratio on main   (git log --first-parent origin/main)
+ *   2. revert count on main       (same source)
+ *   3. CI failures on main pushes (gh api actions/runs — merge escapes that
+ *      turned main red)
+ *   4. repro-section rate on bug-type issues (gh issue list)
+ *
+ * Read-only: only `git log` and read-scoped `gh` calls. No Pushover, no writes.
+ * Run: `bun scripts/traceability-metrics.ts --days 90` (from supervisor/).
+ * The weekly GitHub Actions workflow pipes the output into the Step Summary
+ * (consumer, per rules/general/observability.md) — see
+ * .github/workflows/traceability-metrics.yml.
+ */
+
+export interface CommitStats {
+  total: number;
+  fix: number;
+  revert: number;
+}
+
+/**
+ * Classify git subject lines. `fix` counts conventional-commit fix prefixes
+ * only (`fix:` / `fix(scope):` / `fix(#370):`), not arbitrary words starting
+ * with "fix" — the ratio must not drift when someone adds a `fixture:` type.
+ */
+export function parseGitSubjects(subjects: string[]): CommitStats {
+  let fix = 0;
+  let revert = 0;
+  for (const s of subjects) {
+    if (/^fix[:(]/.test(s)) fix++;
+    // `git revert` writes `Revert "..."`; count manual `revert:` too.
+    if (/^revert[:( "]/i.test(s)) revert++;
+  }
+  return { total: subjects.length, fix, revert };
+}
+
+export interface CiRunLite {
+  head_branch: string | null;
+  event: string;
+  conclusion: string | null;
+}
+
+export interface CiStats {
+  mainRuns: number;
+  mainFailures: number;
+}
+
+/**
+ * Merge-escape signal: completed CI runs triggered by a push to main. A
+ * failure here means a bug got past the PR gate and turned main red.
+ * PR-branch runs, manual dispatches, and still-running runs are excluded.
+ */
+export function summarizeCiRuns(runs: CiRunLite[]): CiStats {
+  const mainPush = runs.filter(
+    (r) => r.head_branch === "main" && r.event === "push" && r.conclusion !== null,
+  );
+  return {
+    mainRuns: mainPush.length,
+    mainFailures: mainPush.filter((r) => r.conclusion === "failure").length,
+  };
+}
+
+export interface IssueLite {
+  number: number;
+  title: string;
+  labels: { name: string }[];
+  body: string | null;
+}
+
+export interface IssueStats {
+  bugTotal: number;
+  bugWithRepro: number;
+}
+
+/**
+ * Bug-type proxy: labelled bug/P0, or a title carrying a defect keyword. This
+ * is intentionally a stable heuristic (same one used for the #381 baseline),
+ * not a perfect classifier — the trend matters, so the rule must stay fixed.
+ */
+const BUG_TITLE = /(bug|fix\b|不具合|エラー|壊れ|落ち|直らない|crash|stall|silent)/i;
+
+export function analyzeIssues(issues: IssueLite[]): IssueStats {
+  const bugs = issues.filter(
+    (i) =>
+      i.labels.some((l) => l.name === "bug" || l.name === "P0") || BUG_TITLE.test(i.title),
+  );
+  return {
+    bugTotal: bugs.length,
+    bugWithRepro: bugs.filter((i) => (i.body ?? "").includes("## 再現手順")).length,
+  };
+}
+
+export interface ReportInput {
+  days: number;
+  commits: CommitStats;
+  ci: CiStats;
+  issues: IssueStats;
+  generatedAt: string;
+}
+
+function pct(num: number, den: number): string {
+  if (den === 0) return "n/a";
+  return `${((num / den) * 100).toFixed(1)}%`;
+}
+
+export function renderReport(r: ReportInput): string {
+  const { commits, ci, issues } = r;
+  return [
+    `## トレーサビリティ週次メトリクス（直近 ${r.days} 日, ${r.generatedAt}）`,
+    "",
+    "| 指標 | 実測 | 比率 |",
+    "|---|---|---|",
+    `| main の fix コミット比率 | ${commits.fix}/${commits.total} | ${pct(commits.fix, commits.total)} |`,
+    `| main の revert コミット数 | ${commits.revert} | — |`,
+    `| main push CI の failure（merge エスケープ） | ${ci.mainFailures}/${ci.mainRuns} | ${pct(ci.mainFailures, ci.mainRuns)} |`,
+    `| バグ型 Issue の \`## 再現手順\` 保有率 | ${issues.bugWithRepro}/${issues.bugTotal} | ${pct(issues.bugWithRepro, issues.bugTotal)} |`,
+    "",
+    // The #381 manual analysis (fix 42/145=29.0%) walked *all* commits reachable
+    // through merge commits; this script uses --first-parent (one entry per
+    // landing on main), so its numbers are lower. Trends must only be compared
+    // against this script's own history, anchored to the first scripted run:
+    "ベースライン（2026-08-08 初回スクリプト実測, 90日窓）: fix 22/94=23.4% / main 赤 4/92 / 再現手順 28/61=45.9%（#381 手動解析の 42/145 とは分母定義が異なる）",
+  ].join("\n");
+}
+
+if (import.meta.main) {
+  const { $ } = await import("bun");
+  const daysArg = process.argv.indexOf("--days");
+  const days = daysArg !== -1 ? Number(process.argv[daysArg + 1]) : 90;
+  if (!Number.isInteger(days) || days <= 0) {
+    console.error(`✖ --days must be a positive integer, got: ${process.argv[daysArg + 1]}`);
+    process.exit(1);
+  }
+
+  const repo =
+    process.env.GH_REPO ??
+    (await $`gh repo view --json nameWithOwner -q .nameWithOwner`.text()).trim();
+
+  // Prefer origin/main (fresh after fetch); fall back to local main.
+  const ref =
+    (await $`git rev-parse --verify -q origin/main`.nothrow().quiet()).exitCode === 0
+      ? "origin/main"
+      : "main";
+  const logText = await $`git log --first-parent --since=${days + " days ago"} --pretty=%s ${ref}`.text();
+  const subjects = logText.split("\n").filter((l) => l.trim() !== "");
+
+  // Actions runs are paginated newest-first; 3 pages ≅ 300 runs covers >90 days
+  // at the current merge cadence. Older windows just clip (trend still valid).
+  const runs: CiRunLite[] = [];
+  for (let page = 1; page <= 3; page++) {
+    const chunk = JSON.parse(
+      await $`gh api ${"repos/" + repo + "/actions/runs?per_page=100&page=" + page}`.text(),
+    ).workflow_runs as (CiRunLite & { created_at: string })[];
+    runs.push(...chunk.filter((r) => Date.now() - Date.parse(r.created_at) < days * 86400_000));
+    if (chunk.length < 100) break;
+  }
+
+  const issues: IssueLite[] = JSON.parse(
+    await $`gh issue list -R ${repo} --state all --limit 200 --json number,title,labels,body`.text(),
+  );
+
+  const report = renderReport({
+    days,
+    commits: parseGitSubjects(subjects),
+    ci: summarizeCiRuns(runs),
+    issues: analyzeIssues(issues),
+    generatedAt: new Date().toISOString(),
+  });
+  console.log(report);
+}

--- a/supervisor/tests/scripts/traceability-metrics.test.ts
+++ b/supervisor/tests/scripts/traceability-metrics.test.ts
@@ -1,0 +1,138 @@
+/**
+ * Issue #384 (Epic #381): traceability weekly metrics.
+ *
+ * The #381 analysis produced one-off numbers (main fix ratio 29%, pre-merge CI
+ * catch rate 13%, repro-section rate 55%). These tests pin the pure aggregation
+ * logic so the recurring report keeps producing the same numbers for the same
+ * inputs — the metric itself must not silently drift (that would defeat a
+ * traceability metric).
+ */
+import { describe, expect, test } from "bun:test";
+
+import {
+  analyzeIssues,
+  parseGitSubjects,
+  renderReport,
+  summarizeCiRuns,
+  type IssueLite,
+} from "../../scripts/traceability-metrics";
+
+describe("parseGitSubjects", () => {
+  test("counts fix (both `fix:` and `fix(scope):`), revert, and total", () => {
+    const subjects = [
+      "fix: supervisor shutdown の worktree 破壊を修正 (#378)",
+      "fix(#370): AskUserQuestion を Discord に中継 (#373)",
+      "feat: headless dispatch に成果物ゼロ検知を追加 (#371)",
+      'Revert "feat: broken thing"',
+      "chore: bump deps",
+      "docs: update bot-operations",
+    ];
+    expect(parseGitSubjects(subjects)).toEqual({
+      total: 6,
+      fix: 2,
+      revert: 1,
+    });
+  });
+
+  test("does not count fixture/prefix look-alikes as fix", () => {
+    const subjects = ["fixture: add test data", "prefix: something", "refactor: fix-adjacent rename"];
+    expect(parseGitSubjects(subjects).fix).toBe(0);
+  });
+
+  test("empty input yields zeros", () => {
+    expect(parseGitSubjects([])).toEqual({ total: 0, fix: 0, revert: 0 });
+  });
+});
+
+describe("summarizeCiRuns", () => {
+  const run = (over: Partial<Parameters<typeof summarizeCiRuns>[0][number]>) => ({
+    head_branch: "main",
+    event: "push",
+    conclusion: "success" as string | null,
+    ...over,
+  });
+
+  test("counts only completed main-push runs; failures separately", () => {
+    const runs = [
+      run({}),
+      run({ conclusion: "failure" }),
+      run({ head_branch: "feat/x", event: "pull_request", conclusion: "failure" }), // PR branch: excluded
+      run({ conclusion: null }), // still running: excluded
+      run({ event: "workflow_dispatch" }), // manual: excluded
+    ];
+    expect(summarizeCiRuns(runs)).toEqual({ mainRuns: 2, mainFailures: 1 });
+  });
+});
+
+describe("analyzeIssues", () => {
+  const issue = (over: Partial<IssueLite>): IssueLite => ({
+    number: 1,
+    title: "feat: something",
+    labels: [],
+    body: "",
+    ...over,
+  });
+
+  test("classifies bug by label (bug / P0) and by title keyword", () => {
+    const issues = [
+      issue({ number: 1, labels: [{ name: "bug" }] }),
+      issue({ number: 2, labels: [{ name: "P0" }] }),
+      issue({ number: 3, title: "○○が壊れている" }),
+      issue({ number: 4, title: "fix: relay が落ちる" }),
+      issue({ number: 5, title: "feat: 新機能", labels: [{ name: "enhancement" }] }),
+    ];
+    const r = analyzeIssues(issues);
+    expect(r.bugTotal).toBe(4);
+  });
+
+  test("counts repro sections only among bug-type issues", () => {
+    const issues = [
+      issue({ number: 1, labels: [{ name: "bug" }], body: "## 再現手順\n\n```bash\nbun test\n```" }),
+      issue({ number: 2, labels: [{ name: "bug" }], body: "なんか動かない" }),
+      // non-bug with a repro section must not inflate the numerator
+      issue({ number: 3, title: "feat: x", body: "## 再現手順\nn/a" }),
+    ];
+    const r = analyzeIssues(issues);
+    expect(r.bugTotal).toBe(2);
+    expect(r.bugWithRepro).toBe(1);
+  });
+
+  test("empty issue list yields zeros (no NaN ratios downstream)", () => {
+    const r = analyzeIssues([]);
+    expect(r.bugTotal).toBe(0);
+    expect(r.bugWithRepro).toBe(0);
+  });
+});
+
+describe("renderReport", () => {
+  test("renders all four metric rows with computed ratios", () => {
+    const md = renderReport({
+      days: 90,
+      commits: { total: 145, fix: 42, revert: 0 },
+      ci: { mainRuns: 158, mainFailures: 7 },
+      issues: { bugTotal: 40, bugWithRepro: 22 },
+      generatedAt: "2026-08-08T12:00:00Z",
+    });
+    expect(md).toContain("fix コミット比率");
+    expect(md).toContain("42/145");
+    expect(md).toContain("29.0%");
+    expect(md).toContain("revert");
+    expect(md).toContain("7/158");
+    expect(md).toContain("再現手順");
+    expect(md).toContain("22/40");
+    expect(md).toContain("55.0%");
+    expect(md).toContain("90"); // window
+  });
+
+  test("zero denominators render as n/a, not NaN", () => {
+    const md = renderReport({
+      days: 7,
+      commits: { total: 0, fix: 0, revert: 0 },
+      ci: { mainRuns: 0, mainFailures: 0 },
+      issues: { bugTotal: 0, bugWithRepro: 0 },
+      generatedAt: "2026-08-08T12:00:00Z",
+    });
+    expect(md).not.toContain("NaN");
+    expect(md).toContain("n/a");
+  });
+});


### PR DESCRIPTION
## 目的

Epic #381（トレーサビリティ向上）の最初のサブイシュー #384 を実装する。#381 の解析レポートで手動算出した数値（fix 比率 / merge エスケープ / 再現手順保有率）を週次で自動計測し、改善をトレンドとして観測できるようにする。

Closes #384

## 主な変更

- `supervisor/scripts/traceability-metrics.ts`（新規）: 4 指標を集計して markdown レポートを出力
  - main の fix コミット比率（`git log --first-parent`、`fix:`/`fix(` プレフィックスのみ）
  - main の revert コミット数
  - main push CI の failure 数（= merge エスケープ、`gh api actions/runs` read-only）
  - バグ型 Issue の `## 再現手順` セクション保有率（`gh issue list` read-only）
- `.github/workflows/traceability-metrics.yml`（新規）: 週次 schedule + workflow_dispatch で実行し Step Summary に出力（observability ルールの「writer には consumer 必須」を充足）
- `supervisor/tests/scripts/traceability-metrics.test.ts`（新規）: 純関数 4 つを 9 ケースでピン留め（メトリクス定義のドリフト防止）
- `.github/workflows/ci.yml`: 新テストを unit-test job にゲート登録（#248 gating lint 準拠）

## 設計メモ

- **--first-parent 基準**: #381 手動解析（42/145=29.0%）は merge commit 経由のブランチ内コミットも数えていた。スクリプトは main への着地単位（--first-parent）で数えるため値が小さく出る。トレンド比較はスクリプト実測同士で行う旨をレポート脚注に明記し、初回実測（fix 22/94=23.4% / main 赤 4/92 / 再現手順 28/61=45.9%）を新ベースラインとした
- 実 API は GitHub read-only のみ。Pushover / Discord / 実課金の発火なし（オーケストレーター指示準拠）

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | ローカル実行で 4 指標の markdown が出る | `bun scripts/traceability-metrics.ts --days 90` | exit 0 + 4 指標行 | 4 行すべて出力（fix 22/94 等） | PASS |
| AC-2 | 既知値との突合 | `--days 100` vs `git log --first-parent --since='100 days ago'` + grep 集計 | 一致 | script `24/109` = direct git `fix 24 / total 109` 完全一致 | PASS |
| AC-3 | workflow_dispatch で Step Summary 出力 | Actions 手動実行 | Summary にレポート表示 | **merge 後検証**（workflow は default branch 上でのみ dispatch 可能） | PENDING |
| 追加 | 新テストが CI にゲートされる | `bun scripts/lint-gating-coverage.ts` | exit 0 | `93 test file(s) — 90 gated, 3 excluded, 0 ungated` | PASS |
| 追加 | typecheck | `bunx tsc --noEmit` | exit 0 | exit 0 | PASS |
| 追加 | 新テスト | `bun test tests/scripts/traceability-metrics.test.ts` | 全 pass | 9 pass / 0 fail | PASS |

AC-3 は merge 後に workflow_dispatch を実行して確認する（結果は #384 にコメントする）。

## テスト方法

```bash
cd supervisor
bun test tests/scripts/traceability-metrics.test.ts
bun scripts/traceability-metrics.ts --days 90
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - トレーサビリティ指標を自動集計し、Markdownレポートとして出力できるようになりました。
  - 過去90日間の修正・リバート、CI失敗、バグ報告の再現手順記載率を確認できます。
  - 指標レポートを毎週自動生成できるようになり、手動実行にも対応しました。

- **テスト**
  - 指標の集計、分類、レポート出力に関するテストを追加しました。
  - データがない場合も適切に表示されることを確認しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->