### PR TITLE
feat(#388): headless の wall-clock 上限を 2h から 5h へ延長する

### DIFF
--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -108,7 +108,7 @@ dispatch は「Issue 番号とコマンドを与えて完走させる」バッ�
 |---|---|---|
 | `DISPATCH_EXECUTOR_MODE` | 未設定（既定） / `tmux` | 現行の tmux 対話 TUI 経路（変更なし） |
 | `DISPATCH_EXECUTOR_MODE` | `headless` | dispatch を `claude -p` の子プロセスで実行し stdout をスレッド返却 |
-| `DISPATCH_HEADLESS_TIMEOUT_MS` | 正の整数（既定 `7200000` = 2h） | headless 子プロセスの wall-clock 上限。超過で SIGTERM → スレッドにタイムアウト明示 |
+| `DISPATCH_HEADLESS_TIMEOUT_MS` | 正の整数（既定 `18000000` = 5h、#388 で 2h から延長） | headless 子プロセスの wall-clock 上限。超過で SIGTERM → スレッドにタイムアウト明示。不正値（0 / 負 / 非数値）は既定へフォールバック |
 | `DISPATCH_CLAUDE_MODEL` | 未設定（既定） | 設定時のみ headless argv に `--model <値>` を追加（例 `claude-opus-4-8`）。未設定・空白のみ = 環境既定モデル（現行不変）。corp #81 Phase 6 / #298 |
 
 - 完全に **opt-in**: `headless` 以外の値（未設定・空・大文字 `HEADLESS` 等）はすべて `tmux` にフォールバックする（`resolveExecutorMode`、fail-safe）。
@@ -123,7 +123,7 @@ headless の argv は `buildHeadlessClaudeFlags()`（`supervisor/src/session/man
 ### ライフサイクル / 誤回収防止
 
 - 子プロセス spawn 時に session を登録（MAX_SESSIONS 枠・`/session list` に反映）、exit で close（DB を `stopped` 化、reason は `headless_exited` / タイムアウトは `headless_timeout`、worktree は best-effort 削除）。
-- headless セッションは自己終了（子プロセス exit が権威的な liveness）で relay 進捗を出さないため、tmux idle 前提の **OrphanDispatchReaper / GoalWatcher は `executor:"headless"` を skip** する（idle 誤回収・done ラベル起因の stop() レースを回避）。wedge した子は上記 `DISPATCH_HEADLESS_TIMEOUT_MS` で回収する。
+- headless セッションは自己終了（子プロセス exit が権威的な liveness）で relay 進捗を出さないため、tmux idle 前提の **OrphanDispatchReaper / GoalWatcher は `executor:"headless"` を skip** する（idle 誤回収・done ラベル起因の stop() レースを回避）。wedge した子は上記 `DISPATCH_HEADLESS_TIMEOUT_MS` で回収する。既定を 5h に延ばした結果（#388）、wedge した子が MAX_SESSIONS 枠を占有し得る最大時間も 5h になる。枠飽和が起きる運用では `DISPATCH_HEADLESS_TIMEOUT_MS` を短く戻すか `DISPATCH_MAX_CONCURRENT` を下げて同時実行数側で調整する。
 
 ### 観測ログ
 

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -252,8 +252,14 @@ export function buildClaudeFlags(
  * with its own timeout is the authoritative liveness bound, not tmux idle time —
  * so this ceiling is that bound. Env-overridable for ops tuning (mirrors
  * DISPATCH_ORPHAN_IDLE_MS) without a redeploy.
+ *
+ * Raised 2h → 5h (#388): long `/pdca` runs (Epic children processed serially)
+ * were being SIGTERM'd mid-implementation by the wall-clock ceiling rather than
+ * by any real wedge. The cost is that a genuinely wedged child now squats its
+ * MAX_SESSIONS slot for up to 5h instead of 2h; operators who need the tighter
+ * bound back set DISPATCH_HEADLESS_TIMEOUT_MS.
  */
-export const HEADLESS_TIMEOUT_MS = 2 * 60 * 60 * 1000; // 2 hours
+export const HEADLESS_TIMEOUT_MS = 5 * 60 * 60 * 1000; // 5 hours (18000000 ms)
 
 function headlessTimeoutMs(): number {
   const raw = process.env.DISPATCH_HEADLESS_TIMEOUT_MS;

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -264,8 +264,11 @@ export const HEADLESS_TIMEOUT_MS = 5 * 60 * 60 * 1000; // 5 hours (18000000 ms)
 function headlessTimeoutMs(): number {
   const raw = process.env.DISPATCH_HEADLESS_TIMEOUT_MS;
   if (!raw) return HEADLESS_TIMEOUT_MS;
-  const n = Number(raw);
-  return Number.isFinite(n) && n > 0 ? Math.floor(n) : HEADLESS_TIMEOUT_MS;
+  // Floor BEFORE the positivity check: a fractional value like "0.5" is > 0 but
+  // floors to 0, and a 0 ms ceiling SIGTERMs the child on the next tick — the
+  // opposite of a ceiling. Fail safe to the default instead (PR #391 review).
+  const n = Math.floor(Number(raw));
+  return Number.isFinite(n) && n > 0 ? n : HEADLESS_TIMEOUT_MS;
 }
 
 /**

--- a/supervisor/tests/session/manager-headless.test.ts
+++ b/supervisor/tests/session/manager-headless.test.ts
@@ -3,6 +3,7 @@ import { mkdirSync } from "fs";
 import { tmpdir } from "os";
 import { resolve } from "path";
 import {
+  HEADLESS_TIMEOUT_MS,
   SessionManager,
   buildHeadlessClaudeFlags,
   buildPendingGuardFlags,
@@ -280,6 +281,58 @@ describe("SessionManager.runHeadless", () => {
     expect(mgr.count()).toBe(0);
     expect(mgr.has("thread-fail")).toBe(false);
     await mgr.shutdownAll();
+  });
+
+  // Issue #388: the headless wall-clock ceiling. Pins the default so it cannot
+  // drift away from docs/bot-operations.md, and asserts the env override still
+  // reaches the executor.
+  describe("headless wall-clock ceiling (#388)", () => {
+    /** Run runHeadless with DISPATCH_HEADLESS_TIMEOUT_MS forced to `value`. */
+    async function timeoutForEnv(
+      value: string | undefined,
+      threadId: string,
+    ): Promise<number | undefined> {
+      const prev = process.env.DISPATCH_HEADLESS_TIMEOUT_MS;
+      if (value === undefined) delete process.env.DISPATCH_HEADLESS_TIMEOUT_MS;
+      else process.env.DISPATCH_HEADLESS_TIMEOUT_MS = value;
+      try {
+        const fx = createFakeEffects();
+        const mgr = new SessionManager({
+          effects: fx,
+          gracefulKillTimeoutMs: 0,
+          probeArtifactsFn: foundArtifactsFn,
+        });
+        await mgr.runHeadless(config, threadId, "/pdca 388", `corp-dispatch-${threadId}`);
+        await mgr.shutdownAll();
+        return fx.executor.runHeadlessCalls[0]!.timeoutMs;
+      } finally {
+        if (prev === undefined) delete process.env.DISPATCH_HEADLESS_TIMEOUT_MS;
+        else process.env.DISPATCH_HEADLESS_TIMEOUT_MS = prev;
+      }
+    }
+
+    test("HEADLESS_TIMEOUT_MS default is 5h (18000000 ms) and matches docs (AC-1)", () => {
+      // Literal, not `5 * 60 * 60 * 1000`: this pins the exact number quoted in
+      // docs/bot-operations.md so the two cannot drift apart silently.
+      expect(HEADLESS_TIMEOUT_MS).toBe(18_000_000);
+    });
+
+    test("runHeadless hands the 5h default to the executor when the env is unset", async () => {
+      expect(await timeoutForEnv(undefined, "thread-to-default")).toBe(18_000_000);
+    });
+
+    test("DISPATCH_HEADLESS_TIMEOUT_MS overrides the default (AC-2)", async () => {
+      expect(await timeoutForEnv("60000", "thread-to-env")).toBe(60_000);
+    });
+
+    test("invalid DISPATCH_HEADLESS_TIMEOUT_MS values fall back to the default", async () => {
+      // 0 / negative / non-numeric / blank are not usable ceilings: fail safe to
+      // the compiled-in default rather than spawning with an absurd timeout.
+      expect(await timeoutForEnv("0", "thread-to-zero")).toBe(HEADLESS_TIMEOUT_MS);
+      expect(await timeoutForEnv("-1", "thread-to-neg")).toBe(HEADLESS_TIMEOUT_MS);
+      expect(await timeoutForEnv("abc", "thread-to-nan")).toBe(HEADLESS_TIMEOUT_MS);
+      expect(await timeoutForEnv("", "thread-to-blank")).toBe(HEADLESS_TIMEOUT_MS);
+    });
   });
 
   // corp #81 Phase 6 / #298: DISPATCH_CLAUDE_MODEL → headless --model.

--- a/supervisor/tests/session/manager-headless.test.ts
+++ b/supervisor/tests/session/manager-headless.test.ts
@@ -332,6 +332,12 @@ describe("SessionManager.runHeadless", () => {
       expect(await timeoutForEnv("-1", "thread-to-neg")).toBe(HEADLESS_TIMEOUT_MS);
       expect(await timeoutForEnv("abc", "thread-to-nan")).toBe(HEADLESS_TIMEOUT_MS);
       expect(await timeoutForEnv("", "thread-to-blank")).toBe(HEADLESS_TIMEOUT_MS);
+      // Sub-1ms fractions are the subtle case: 0.5 is > 0 but floors to 0, and a
+      // 0 ms ceiling would SIGTERM the child on the next tick (PR #391 review).
+      expect(await timeoutForEnv("0.5", "thread-to-frac")).toBe(HEADLESS_TIMEOUT_MS);
+      expect(await timeoutForEnv("0.999", "thread-to-frac2")).toBe(HEADLESS_TIMEOUT_MS);
+      // A fraction that still floors to a positive ms is honored as given.
+      expect(await timeoutForEnv("1500.7", "thread-to-frac3")).toBe(1500);
     });
   });
 


### PR DESCRIPTION
Closes #388

## 概要

headless dispatch の wall-clock 上限（`headless_timeout`）の既定を **2h → 5h**（`18000000` ms）へ延長する。

長時間の dispatch ワーカー（`/pdca` の一気通貫、Epic の直列実行）が、実装完了前に上限で SIGTERM され打ち切られるケースを避けるのが目的。会長要望（corp `/orchestrate` 2026-08-09、同日の訂正指示で 5h 確定）。

## 変更点

| ファイル | 変更 |
|---|---|
| `supervisor/src/session/manager.ts` | `HEADLESS_TIMEOUT_MS` を `2 * 60 * 60 * 1000` → `5 * 60 * 60 * 1000`（18000000）。JSDoc に延長理由と枠占有トレードオフを追記 |
| `docs/bot-operations.md` | 既定値記述を `18000000` = 5h に更新（L111）。枠占有の最大時間が 5h に延びる旨と調整手段を lifecycle 節に追記 |
| `supervisor/tests/session/manager-headless.test.ts` | 回帰テスト 4 件を追加（`describe("headless wall-clock ceiling (#388)")`） |

## 影響の検討: 枠飽和リスク

5h へ延ばすと、**wedge した headless 子プロセスが MAX_SESSIONS（= 10）枠を占有し得る最大時間も 2h → 5h（2.5 倍）に延びる**。

現状 headless セッションは OrphanDispatchReaper / GoalWatcher の対象外（`executor:"headless"` を skip、`docs/bot-operations.md` の lifecycle 節）であり、**wedge 検知は事実上この wall-clock 上限だけに委ねられている**。completion probe（#342 Layer 2）は「成果物ゼロ」を run 終了後に検知する仕組みで、実行中の wedge を回収する経路ではない。したがって今回の変更は、回収の遅さと打ち切りの早さのトレードオフを後者寄りに倒す判断そのものになる。

飽和が現実に問題化した場合の逃げ道は 2 つあり、いずれもコード変更なしで運用調整できる:

- `DISPATCH_HEADLESS_TIMEOUT_MS` を短く戻す（env 上書き。本 PR のテストで上書きが効くことを担保）
- `DISPATCH_MAX_CONCURRENT` を下げて、そもそも同時に走る headless 数を絞る

実運用では正常な `/pdca` 完走が 2h を超えるケースの方が観測されており（本 Issue の起点）、「正常な仕事を殺す」コストの方が「wedge の回収が 3h 遅れる」コストより高いと判断した。将来 wedge 検知を時間切れ以外の手段（実行中の進捗プローブ等）に移せれば、この上限はさらに緩められる。

## 統合ジャーニーAC の検証結果

| AC | 検証内容 | 実測 | 判定 |
|---|---|---|---|
| AC-1 | 既定タイムアウトが `18000000`（5h）であることをアサート | `bun test tests/session/manager-headless.test.ts` → 31 pass / 0 fail（exit 0） | PASS |
| AC-2 | `DISPATCH_HEADLESS_TIMEOUT_MS=60000` が既定を上書き | executor が受け取った `timeoutMs` = `60000` を実測アサート | PASS |
| AC-3 | docs の既定値が 5h に更新済み | `grep -n 18000000 docs/bot-operations.md` → L111 ヒット / `grep -c 7200000` → **0** | PASS |
| AC-4 | CI 全 green | Type Check / Unit Tests / E2E / Routing / codecov/patch / CodeRabbit すべて pass | PASS |

## テスト

追加した 4 ケース（いずれも fake executor が受領する `timeoutMs` を実測）:

1. `HEADLESS_TIMEOUT_MS` が `18000000` であること（**リテラルで固定**し、docs の数値と乖離したら落ちるようにした）
2. env 未設定時に 5h の既定が executor へ渡ること（定数だけでなく配線も検証）
3. `DISPATCH_HEADLESS_TIMEOUT_MS=60000` が既定を上書きすること
4. 不正値（`0` / `-1` / `abc` / 空文字）が既定へフォールバックすること

ローカル実測:

- `bun test tests/session/manager-headless.test.ts` → **31 pass / 0 fail**
- headless 関連 4 ファイル（manager-headless / dispatch-headless / headless-liveness / adapters-executor）→ **55 pass / 0 fail**
- `bunx tsc --noEmit` → exit 0
- CI lint 4 種（check-access-policy / lint-blocking-in-timers / lint-no-sync-exec / lint-gating-coverage）→ すべて pass

なお CI curated list をローカル一括実行すると `tests/scripts/cleanup-idle-claude.test.ts` / `list-claude-processes.sh` が 5s タイムアウトで落ちるが、**変更前の HEAD でも同じく落ちる**（baseline: 18 fail / 変更後: 19 fail、いずれも失敗ケースは同じシェルスクリプト系のみ）。実マシンのプロセス一覧を走査するテストで本変更とは無関係。

## 範囲外

- OrphanDispatchReaper / GoalWatcher の閾値変更（headless は元から skip 対象）
- idle Reaper（30 日）の変更
- MAX_SESSIONS / DISPATCH_MAX_CONCURRENT の既定変更

## レビュー対応

CodeRabbit から 1 件（Functional Correctness / Minor）。**実在するバグだったため修正**（2a70b55）:

`DISPATCH_HEADLESS_TIMEOUT_MS="0.5"` のような小数は `Number.isFinite && > 0` を通過した後に `Math.floor` で `0` になり、**0ms の上限＝次の tick で子プロセスを即 SIGTERM** させていた（上限として機能せず fail-safe の逆）。`Math.floor` を正数チェックの前に移し、既定へフォールバックするようにした。回帰テスト 3 件（`0.5` / `0.999` → 既定、`1500.7` → 1500）を追加。CodeRabbit 側も対応済みとして確認済み。
