### PR TITLE
test(#382): worktree 操作を実 git で検証する integration テストを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,11 @@ jobs:
       # timing-flaky but is now driven by an injected virtual clock (#190), so
       # it is deterministic and gated here too — this also gates the
       # feedback-survey "send 0, never 1" regression test it contains (#153).
+      # tests/integration/worktree-real-git.test.ts (#382) is gated here too: it
+      # drives REAL `git worktree add/remove/list/prune` against a throwaway repo
+      # in a temp dir. git is always present on the runner (actions/checkout
+      # needs it) and the suite touches neither tmux nor gh, so it needs no extra
+      # setup and stays deterministic in this job.
       - name: Run tests
         env:
           SUPERVISOR_DB_PATH: ":memory:"
@@ -178,6 +183,7 @@ jobs:
                    tests/session/slash-prefix.test.ts \
                    tests/session/thread-title.test.ts \
                    tests/session/worktree.test.ts \
+                   tests/integration/worktree-real-git.test.ts \
                    tests/session/keep-attachment.test.ts \
                    tests/commands/session-keep.test.ts \
                    tests/session/self-heal.test.ts \

--- a/supervisor/tests/integration/worktree-real-git.test.ts
+++ b/supervisor/tests/integration/worktree-real-git.test.ts
@@ -1,0 +1,574 @@
+import { test, expect, describe, afterAll, beforeEach, afterEach } from "bun:test";
+import { execFile } from "child_process";
+import { promisify } from "util";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+  ensureWorktree,
+  realGitGhRunner,
+  recreateWorktreeForExistingBranch,
+  removeWorktree,
+  resolveWorktreePath,
+  type GitGhRunner,
+} from "../../src/session/worktree";
+import { SessionManager } from "../../src/session/manager";
+import {
+  createFakeEffects,
+  type FakeSessionEffects,
+} from "../../src/session/adapters-fake";
+import { realWorktreeAdapter, type SessionEffects } from "../../src/session/adapters";
+import type { ChannelConfig } from "../../src/config/channels";
+
+/**
+ * Issue #382 (Epic #381): worktree management verified against REAL git.
+ *
+ * Every pre-existing worktree test drives a fake {@link GitGhRunner}, so the
+ * layer that actually destroyed uncommitted work — `git worktree add/remove/
+ * list` and the on-disk state they produce — had never been executed by a test.
+ * That gap lines up exactly with where the bugs kept coming back: #342 →
+ * #368/#371/#372 → #369/#378. These tests close it by running the production
+ * runner and the production {@link realWorktreeAdapter} against a throwaway git
+ * repo in a temp dir, asserting on the real filesystem and on real
+ * `git worktree list --porcelain` output.
+ *
+ * Scope (issue body): git is REAL, gh stays FAKE. The only gh call in the
+ * production runner is `defaultBranch` (`gh api repos/:owner/:repo`); it is
+ * stubbed in {@link gitRunner}, and the SessionManager cases use a pre-existing
+ * branch so that path is never reached at all.
+ *
+ * Regressions pinned here:
+ *   - #277        a new-branch worktree is cut from the FRESHLY FETCHED origin tip
+ *   - #158        a residue dir / wrong-branch worktree is rejected, never reused
+ *   - #369/#378   a supervisor shutdown preserves the worktree + uncommitted work
+ *   - #378        a dead tmux session (hasSession false) does not tear it down
+ *   - #342/#372   an `unknown` artifact probe retains the worktree
+ *   - #217/#281   stop → resume re-creates the worktree at the same path
+ */
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Identity for the fixture's own commits, supplied as env instead of three
+ * `git config` calls per repo (each git spawn costs ~100ms on macOS, and the
+ * whole fixture has to fit inside bun's hook timeout). The production runner
+ * never commits, so it does not need this.
+ */
+const GIT_ENV = {
+  ...process.env,
+  GIT_AUTHOR_NAME: "Worktree Test",
+  GIT_AUTHOR_EMAIL: "worktree-test@example.invalid",
+  GIT_COMMITTER_NAME: "Worktree Test",
+  GIT_COMMITTER_EMAIL: "worktree-test@example.invalid",
+};
+
+/** Run git in `cwd` and return trimmed stdout. Rejects (loudly) on failure. */
+async function git(cwd: string, ...args: string[]): Promise<string> {
+  const { stdout } = await execFileAsync(
+    "git",
+    ["-C", cwd, "-c", "commit.gpgsign=false", ...args],
+    { encoding: "utf8", env: GIT_ENV },
+  );
+  return stdout.trim();
+}
+
+/**
+ * The production runner with ONLY its single gh call stubbed. `defaultBranch`
+ * shells out to `gh api repos/:owner/:repo`, which needs a real GitHub remote
+ * and an authenticated gh — neither exists for a temp repo, and the issue
+ * explicitly keeps gh fake. Every other method is the real git one.
+ */
+const gitRunner: GitGhRunner = {
+  ...realGitGhRunner,
+  async defaultBranch() {
+    return "main";
+  },
+};
+
+/** Branch that exists in every fixture repo, carrying its own commit. */
+const EXISTING_BRANCH = "feat-existing";
+const EXISTING_BRANCH_FILE = "branch-content.txt";
+const EXISTING_BRANCH_CONTENT = "committed on the branch\n";
+
+interface WorktreeEntry {
+  path: string;
+  /** Checked-out branch, or null for a detached HEAD. */
+  branch: string | null;
+  /** git flagged the registration as stale (its directory is gone). */
+  prunable: boolean;
+}
+
+/** Parse real `git worktree list --porcelain` output. */
+async function listWorktrees(repo: string): Promise<WorktreeEntry[]> {
+  const out = await git(repo, "worktree", "list", "--porcelain");
+  const entries: WorktreeEntry[] = [];
+  for (const block of out.split(/\n\s*\n/)) {
+    const lines = block.split("\n");
+    const wtLine = lines.find((l) => l.startsWith("worktree "));
+    if (!wtLine) continue;
+    const branchLine = lines.find((l) => l.startsWith("branch "));
+    entries.push({
+      path: wtLine.slice("worktree ".length).trim(),
+      branch: branchLine
+        ? branchLine.slice("branch ".length).trim().replace(/^refs\/heads\//, "")
+        : null,
+      prunable: lines.some((l) => l.startsWith("prunable")),
+    });
+  }
+  return entries;
+}
+
+/** The registration for `path`, or undefined when git does not know it. */
+async function worktreeEntry(
+  repo: string,
+  path: string,
+): Promise<WorktreeEntry | undefined> {
+  return (await listWorktrees(repo)).find((e) => e.path === path);
+}
+
+/** True when `branch` still resolves locally (Q3 preserves the branch). */
+async function branchExists(repo: string, branch: string): Promise<boolean> {
+  try {
+    await git(repo, "show-ref", "--verify", "--quiet", `refs/heads/${branch}`);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// --- fixture -------------------------------------------------------------
+//
+// A real git repo per test, without paying for one per test: the template repo
+// and its bare `origin` are built ONCE, and each test copies the template
+// directory (~30ms) instead of re-running ~16 git commands (~2s on macOS).
+//
+// The template deliberately ships a STALE `refs/remotes/origin/main`: origin's
+// main carries one commit the copy has never fetched. Only a real `git fetch`
+// before `git worktree add` can land a new worktree on that tip, which is what
+// makes the #277 assertion meaningful.
+
+interface Template {
+  /** Shared temp root: bare origin + template repo + per-test copies. */
+  root: string;
+  templateDir: string;
+  /** Commit the template's local main points at (the stale base). */
+  baseSha: string;
+  /** Commit origin/main points at — reachable only after a fetch. */
+  originTipSha: string;
+}
+
+async function buildTemplate(): Promise<Template> {
+  // realpath because `git worktree list` prints canonical paths (on macOS
+  // /var/folders → /private/var/folders) and the assertions compare those
+  // against paths derived from repoDir.
+  const root = realpathSync(mkdtempSync(join(tmpdir(), "wt-real-git-")));
+  const originDir = join(root, "origin.git");
+  const templateDir = join(root, "template");
+
+  await execFileAsync("git", ["init", "-q", "--bare", originDir], { env: GIT_ENV });
+  await execFileAsync("git", ["init", "-q", templateDir], { env: GIT_ENV });
+  await git(templateDir, "symbolic-ref", "HEAD", "refs/heads/main");
+
+  writeFileSync(join(templateDir, "README.md"), "base\n");
+  await git(templateDir, "add", "README.md");
+  await git(templateDir, "commit", "-qm", "base");
+  await git(templateDir, "remote", "add", "origin", originDir);
+
+  writeFileSync(join(templateDir, "advance.txt"), "merged elsewhere\n");
+  await git(templateDir, "add", "advance.txt");
+  await git(templateDir, "commit", "-qm", "advance");
+  const [originTipSha, baseSha] = (
+    await git(templateDir, "rev-parse", "HEAD", "HEAD~1")
+  ).split("\n");
+
+  await git(templateDir, "push", "-q", "-u", "origin", "main");
+
+  // Rewind the local side only: main goes back to base and the remote-tracking
+  // ref is pinned there too, so origin/main is stale until something fetches.
+  await git(templateDir, "reset", "--hard", "-q", baseSha!);
+  await git(templateDir, "update-ref", "refs/remotes/origin/main", baseSha!);
+
+  // A branch that already exists in every copy (the Q1 / SessionManager path,
+  // which never consults the gh-backed defaultBranch).
+  await git(templateDir, "checkout", "-q", "-b", EXISTING_BRANCH);
+  writeFileSync(join(templateDir, EXISTING_BRANCH_FILE), EXISTING_BRANCH_CONTENT);
+  await git(templateDir, "add", EXISTING_BRANCH_FILE);
+  await git(templateDir, "commit", "-qm", "branch commit");
+  await git(templateDir, "checkout", "-q", "main");
+
+  return { root, templateDir, baseSha: baseSha!, originTipSha: originTipSha! };
+}
+
+/**
+ * Built at module scope, NOT in `beforeAll`: ~16 git spawns cost several
+ * seconds on macOS, which exceeds bun:test's 5s hook timeout. Module evaluation
+ * carries no such deadline, and the build still happens exactly once per file.
+ */
+const { root, templateDir, baseSha, originTipSha } = await buildTemplate();
+
+/** Per-test: a fresh copy of the template, used as the "main repo dir". */
+let repoDir: string;
+let caseDir: string;
+/** Managers created by a test, shut down in afterEach so no watcher leaks. */
+let managers: SessionManager[];
+
+afterAll(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  caseDir = mkdtempSync(join(root, "case-"));
+  repoDir = join(caseDir, "repo");
+  cpSync(templateDir, repoDir, { recursive: true });
+  managers = [];
+});
+
+afterEach(async () => {
+  for (const m of managers) {
+    await m.shutdownAll();
+  }
+  rmSync(caseDir, { recursive: true, force: true });
+});
+
+describe("#382 real git: ensureWorktree", () => {
+  test("AC-1 / #277: an unknown branch is cut from the FRESHLY FETCHED origin tip", async () => {
+    const result = await ensureWorktree(repoDir, "corp-dispatch-382", gitRunner);
+
+    expect(result.reused).toBe(false);
+    expect(result.baseBranch).toBe("origin/main");
+    expect(existsSync(result.path)).toBe(true);
+
+    // Real registration, not a fake's bookkeeping.
+    const entry = await worktreeEntry(repoDir, result.path);
+    expect(entry).toBeDefined();
+    expect(entry!.branch).toBe("corp-dispatch-382");
+    expect(entry!.prunable).toBe(false);
+
+    // behind origin/main = 0: the fetch really ran before the add, so the
+    // worktree sees work merged after this clone last fetched (#277).
+    const head = await git(result.path, "rev-parse", "HEAD");
+    expect(head).toBe(originTipSha);
+    expect(head).not.toBe(baseSha);
+    expect(existsSync(join(result.path, "advance.txt"))).toBe(true);
+  });
+
+  test("Q1: an existing branch is checked out with its own content", async () => {
+    const result = await ensureWorktree(repoDir, EXISTING_BRANCH, gitRunner);
+
+    expect(result.reused).toBe(false);
+    expect(result.baseBranch).toBeUndefined();
+    expect(readFileSync(join(result.path, EXISTING_BRANCH_FILE), "utf8")).toBe(
+      EXISTING_BRANCH_CONTENT,
+    );
+    // The primary worktree (on main) is untouched by the branch's commit.
+    expect(existsSync(join(repoDir, EXISTING_BRANCH_FILE))).toBe(false);
+    expect((await worktreeEntry(repoDir, result.path))?.branch).toBe(EXISTING_BRANCH);
+  });
+
+  test("Q4: a second ensure reuses the worktree without registering a duplicate", async () => {
+    const first = await ensureWorktree(repoDir, EXISTING_BRANCH, gitRunner);
+    const before = await listWorktrees(repoDir);
+
+    const second = await ensureWorktree(repoDir, EXISTING_BRANCH, gitRunner);
+
+    expect(second.reused).toBe(true);
+    expect(second.path).toBe(first.path);
+    expect(await listWorktrees(repoDir)).toEqual(before);
+  });
+
+  test("#158: a plain directory at the path is rejected, not silently reused", async () => {
+    const path = resolveWorktreePath(repoDir, "feat-residue");
+    mkdirSync(path, { recursive: true });
+    writeFileSync(join(path, "left-behind.txt"), "residue\n");
+
+    await expect(ensureWorktree(repoDir, "feat-residue", gitRunner)).rejects.toThrow(
+      /git worktree ではありません|残骸/,
+    );
+    // The rejection must not touch the directory or register anything.
+    expect(readFileSync(join(path, "left-behind.txt"), "utf8")).toBe("residue\n");
+    expect(await worktreeEntry(repoDir, path)).toBeUndefined();
+  });
+
+  test("#158: a real worktree checked out on a DIFFERENT branch is rejected", async () => {
+    const path = resolveWorktreePath(repoDir, "feat-expected");
+    // Genuinely register `path` on the wrong branch, via real git.
+    await git(repoDir, "worktree", "add", "-q", path, EXISTING_BRANCH);
+
+    await expect(ensureWorktree(repoDir, "feat-expected", gitRunner)).rejects.toThrow(
+      /期待 branch/,
+    );
+    expect((await worktreeEntry(repoDir, path))?.branch).toBe(EXISTING_BRANCH);
+  });
+
+  test("a stale registration (directory deleted behind git's back) fails until prune clears it", async () => {
+    // Real-git-only failure mode: once the directory is gone `pathExists` is
+    // false, so ensureWorktree takes the Q1 add path — and git refuses, because
+    // the path is "a missing but already registered worktree". A fake runner
+    // cannot surface this at all, which is why #382 exists.
+    const created = await ensureWorktree(repoDir, EXISTING_BRANCH, gitRunner);
+    rmSync(created.path, { recursive: true, force: true });
+
+    expect((await worktreeEntry(repoDir, created.path))?.prunable).toBe(true);
+    await expect(ensureWorktree(repoDir, EXISTING_BRANCH, gitRunner)).rejects.toThrow();
+
+    await git(repoDir, "worktree", "prune");
+
+    const recreated = await ensureWorktree(repoDir, EXISTING_BRANCH, gitRunner);
+    expect(recreated.path).toBe(created.path);
+    expect(existsSync(recreated.path)).toBe(true);
+    const entry = await worktreeEntry(repoDir, created.path);
+    expect(entry?.branch).toBe(EXISTING_BRANCH);
+    expect(entry?.prunable).toBe(false);
+  });
+});
+
+describe("#382 real git: removeWorktree (Q3) and resume recovery (#217/#281)", () => {
+  test("Q3: remove deletes the directory and deregisters it, keeping the branch", async () => {
+    const created = await ensureWorktree(repoDir, EXISTING_BRANCH, gitRunner);
+
+    await removeWorktree(repoDir, created.path, gitRunner);
+
+    expect(existsSync(created.path)).toBe(false);
+    expect(await worktreeEntry(repoDir, created.path)).toBeUndefined();
+    // Q3's whole point: the branch survives, so the work stays recoverable.
+    expect(await branchExists(repoDir, EXISTING_BRANCH)).toBe(true);
+  });
+
+  test("#217/#281: stop → resume re-creates the worktree at the SAME path with its content", async () => {
+    const created = await ensureWorktree(repoDir, EXISTING_BRANCH, gitRunner);
+    await removeWorktree(repoDir, created.path, gitRunner);
+    expect(existsSync(created.path)).toBe(false);
+
+    const recovered = await recreateWorktreeForExistingBranch(
+      repoDir,
+      EXISTING_BRANCH,
+      gitRunner,
+    );
+
+    expect(recovered).toBe(true);
+    // Same cwd as before — that is what `claude --resume` (keyed by cwd) needs.
+    expect(existsSync(created.path)).toBe(true);
+    expect(readFileSync(join(created.path, EXISTING_BRANCH_FILE), "utf8")).toBe(
+      EXISTING_BRANCH_CONTENT,
+    );
+    expect((await worktreeEntry(repoDir, created.path))?.branch).toBe(EXISTING_BRANCH);
+  });
+
+  test("#217: a deleted branch is NOT fabricated from default — returns false, creates nothing", async () => {
+    const path = resolveWorktreePath(repoDir, "feat-gone");
+
+    const recovered = await recreateWorktreeForExistingBranch(
+      repoDir,
+      "feat-gone",
+      gitRunner,
+    );
+
+    expect(recovered).toBe(false);
+    expect(existsSync(path)).toBe(false);
+    expect(await worktreeEntry(repoDir, path)).toBeUndefined();
+  });
+});
+
+/**
+ * SessionManager teardown decisions, executed against the real worktree
+ * adapter. tmux / iTerm2 / process signals / the executor stay faked — only the
+ * worktree effect is real, so a wrong retention decision shows up as an actually
+ * deleted directory instead of a missing entry in a fake's call log (note that
+ * `removeWorktreeBestEffort` swallows removal errors, so a call log cannot even
+ * prove removal happened).
+ *
+ * All cases use {@link EXISTING_BRANCH}, so ensureWorktree takes the Q1 path and
+ * the gh-backed `defaultBranch` is never called.
+ */
+describe("#382 real git: SessionManager teardown", () => {
+  let fake: FakeSessionEffects;
+
+  function makeManager(opts: { watchIntervalMs?: number } = {}): SessionManager {
+    fake = createFakeEffects();
+    const effects: SessionEffects = { ...fake, worktree: realWorktreeAdapter };
+    const manager = new SessionManager({
+      effects,
+      gracefulKillTimeoutMs: 0,
+      ...opts,
+    });
+    managers.push(manager);
+    return manager;
+  }
+
+  function makeConfig(): ChannelConfig {
+    return {
+      channelName: "wt-real-git",
+      dir: repoDir,
+      displayName: "Worktree Real Git",
+    };
+  }
+
+  /** Poll until `pred` holds, so a watcher tick is awaited without a fixed sleep. */
+  async function waitUntil(pred: () => boolean, timeoutMs = 3_000): Promise<void> {
+    const deadline = Date.now() + timeoutMs;
+    while (!pred()) {
+      if (Date.now() > deadline) throw new Error("waitUntil timed out");
+      await new Promise((r) => setTimeout(r, 5));
+    }
+  }
+
+  test("AC-2 / #369: shutdownAll preserves the worktree AND its uncommitted changes", async () => {
+    const manager = makeManager();
+    const session = await manager.start(makeConfig(), "thread-shutdown", EXISTING_BRANCH);
+    const wt = session.worktree!.path;
+    // The exact loss shape of the handoff-96-2 incident: work that exists only
+    // in the worktree when a SIGTERM / launchctl kickstart arrives.
+    writeFileSync(join(wt, "WIP.txt"), "uncommitted work\n");
+
+    await manager.shutdownAll();
+
+    expect(existsSync(wt)).toBe(true);
+    expect(readFileSync(join(wt, "WIP.txt"), "utf8")).toBe("uncommitted work\n");
+    // Still a live worktree, not an orphaned directory.
+    expect(await git(wt, "status", "--porcelain")).toContain("WIP.txt");
+    const entry = await worktreeEntry(repoDir, wt);
+    expect(entry?.branch).toBe(EXISTING_BRANCH);
+    expect(entry?.prunable).toBe(false);
+  });
+
+  test("#369: an explicit stop('supervisor_restart') preserves the worktree too", async () => {
+    const manager = makeManager();
+    const session = await manager.start(makeConfig(), "thread-sr", EXISTING_BRANCH);
+    const wt = session.worktree!.path;
+    writeFileSync(join(wt, "WIP.txt"), "uncommitted\n");
+
+    await manager.stop("thread-sr", "supervisor_restart");
+
+    expect(existsSync(wt)).toBe(true);
+    expect(readFileSync(join(wt, "WIP.txt"), "utf8")).toBe("uncommitted\n");
+  });
+
+  test("Q3 control: an explicit stop('manual') DOES remove the real worktree", async () => {
+    // Without this the preservation cases above could pass vacuously (e.g. if
+    // removal silently no-op'd against a real repo). Here removal must happen.
+    const manager = makeManager();
+    const session = await manager.start(makeConfig(), "thread-manual", EXISTING_BRANCH);
+    const wt = session.worktree!.path;
+    expect(existsSync(wt)).toBe(true);
+
+    await manager.stop("thread-manual", "manual");
+
+    expect(existsSync(wt)).toBe(false);
+    expect(await worktreeEntry(repoDir, wt)).toBeUndefined();
+    expect(await branchExists(repoDir, EXISTING_BRANCH)).toBe(true);
+  });
+
+  test("#378: a dead tmux session (hasSession false) must NOT tear the worktree down", async () => {
+    const manager = makeManager({ watchIntervalMs: 5 });
+    const session = await manager.start(makeConfig(), "thread-tmux-exit", EXISTING_BRANCH);
+    const wt = session.worktree!.path;
+    writeFileSync(join(wt, "WIP.txt"), "uncommitted\n");
+
+    // hasSession now reports false — the #378 false-teardown trigger. The
+    // session name comes from the sanctioned mapping, never re-derived here.
+    await fake.tmux.killSession(
+      SessionManager.tmuxSessionNameFor("thread-tmux-exit"),
+    );
+    await waitUntil(() => !manager.has("thread-tmux-exit"));
+
+    expect(existsSync(wt)).toBe(true);
+    expect(readFileSync(join(wt, "WIP.txt"), "utf8")).toBe("uncommitted\n");
+    expect((await worktreeEntry(repoDir, wt))?.branch).toBe(EXISTING_BRANCH);
+  });
+});
+
+/**
+ * Headless dispatch teardown (#342 / #371 / #372) against the real worktree.
+ * The completion and artifact probes are injected (in production they shell out
+ * to git/gh), the worktree effect is real — so "retained" / "reclaimed" is
+ * asserted as an actual directory on disk.
+ */
+describe("#382 real git: headless dispatch retention (#342/#372)", () => {
+  const cleanCompletion = () => ({
+    ok: true as const,
+    value: { pendingTasks: [], pendingWakeup: false, skippedLines: 0 },
+  });
+
+  function makeHeadlessManager(
+    artifacts: () => Promise<{
+      status: "found" | "none" | "unknown";
+      detail: string;
+      dirty: boolean;
+    }>,
+  ): SessionManager {
+    const fake = createFakeEffects();
+    const effects: SessionEffects = { ...fake, worktree: realWorktreeAdapter };
+    const manager = new SessionManager({
+      effects,
+      gracefulKillTimeoutMs: 0,
+      probePendingWorkFn: cleanCompletion,
+      probeArtifactsFn: artifacts,
+    });
+    managers.push(manager);
+    return manager;
+  }
+
+  function makeConfig(): ChannelConfig {
+    return {
+      channelName: "wt-real-git-hl",
+      dir: repoDir,
+      displayName: "Worktree Real Git Headless",
+    };
+  }
+
+  test("#372: an `unknown` artifact probe retains the real worktree and its edits", async () => {
+    // Pre-create the worktree (runHeadless then reuses it, Q4) so abandoned
+    // edits are already present when the run finishes — the agent-base#456
+    // loss shape.
+    const pre = await ensureWorktree(repoDir, EXISTING_BRANCH, gitRunner);
+    writeFileSync(join(pre.path, "WIP.txt"), "abandoned edits\n");
+
+    const manager = makeHeadlessManager(async () => ({
+      status: "unknown" as const,
+      detail: "gh pr list: connection refused",
+      dirty: false,
+    }));
+    const res = await manager.runHeadless(
+      makeConfig(),
+      "thread-hl-unknown",
+      "/impl 382",
+      EXISTING_BRANCH,
+    );
+
+    expect(res.artifacts?.status).toBe("unknown");
+    // "Could not verify" must never destroy possibly-live work (PR #371 review).
+    expect(existsSync(pre.path)).toBe(true);
+    expect(readFileSync(join(pre.path, "WIP.txt"), "utf8")).toBe("abandoned edits\n");
+    expect(await worktreeEntry(repoDir, pre.path)).toBeDefined();
+  });
+
+  test("control: a clean run with a found artifact reclaims the real worktree", async () => {
+    const manager = makeHeadlessManager(async () => ({
+      status: "found" as const,
+      detail: "pr #999",
+      dirty: false,
+    }));
+    const res = await manager.runHeadless(
+      makeConfig(),
+      "thread-hl-found",
+      "/impl 382",
+      EXISTING_BRANCH,
+    );
+
+    expect(res.completion.status).toBe("clean");
+    expect(res.artifacts?.status).toBe("found");
+    const wt = resolveWorktreePath(repoDir, EXISTING_BRANCH);
+    expect(existsSync(wt)).toBe(false);
+    expect(await worktreeEntry(repoDir, wt)).toBeUndefined();
+    expect(await branchExists(repoDir, EXISTING_BRANCH)).toBe(true);
+  });
+});


### PR DESCRIPTION
Closes #382 （親 Epic: #381）

## 背景

worktree 管理のテスト（`supervisor/tests/session/worktree.test.ts` 等）は fake `GitGhRunner` のみで、**実 git を一度も実行していなかった**。一方で worktree 破壊・保全のバグは #342 → #368/#371/#372 → #369/#378 と複数ラウンド再発しており、再発層と非検証層が一致していた（#381 解析レポート）。

## 変更点

`supervisor/tests/integration/worktree-real-git.test.ts` を新規追加（15 ケース）。一時ディレクトリに実 git リポジトリ（bare `origin` つき）を作り、production の `realGitGhRunner` / `realWorktreeAdapter` をそのまま実行して、**実ファイルシステムと実 `git worktree list --porcelain` 出力**にアサートする。

**git は実物 / gh は fake**（Issue 本文の指定どおり）:

- production runner で gh を叩くのは `defaultBranch`（`gh api repos/:owner/:repo`）だけなので、そこだけ stub
- SessionManager 経路のケースは **既存 branch** を使うので Q1 に入り、gh 経路には到達しない

### 固定した回帰

| 対象 | 内容 |
|---|---|
| #277 | 新規 branch worktree が **fetch 済み** `origin/main` から切られる（HEAD == origin tip、stale local main ではない） |
| #158 | 残骸ディレクトリ / 別 branch の worktree は再利用せず明示エラー |
| （実 git 固有） | ディレクトリだけ消えた stale 登録は `worktree add` が失敗し、`git worktree prune` 後に復旧する。**fake では原理的に再現できない失敗モード** |
| #369/#378 | `shutdownAll()` / `stop("supervisor_restart")` で worktree と未コミット変更が残存 |
| #378 | `hasSession` false（tmux 消滅）で teardown しない |
| #342/#372 | artifacts `unknown` で worktree を保全（`found` + clean の**対照ケース**で実削除も検証） |
| #217/#281 | stop → resume で同一 path に worktree を再生成でき、branch の内容が戻る |
| Q3 | `stop("manual")` は実際に worktree を削除し、branch は残す（保全ケースが vacuous でないことの対照） |

対照ケースを入れたのは、`removeWorktreeBestEffort` が削除エラーを握りつぶすため、**fake の call log では「本当に消えたか」を証明できない**から。実 git なら `existsSync` で決定的に判定できる。

### テスト実行時間への配慮

git spawn が macOS で 1 回 100ms 超かかるため、リポジトリは template を 1 度だけ構築し、各ケースは `cpSync` でコピーする（約 30ms）。template 構築（16 git コマンド）は bun:test の 5s hook timeout を超えるので `beforeAll` ではなく module scope の top-level await で行う（理由をコード内コメントに明記）。

### CI

#248 の gating lint（`scripts/lint-gating-coverage.ts`）に従い、unit-test job の curated list に編入。git は runner に常在（actions/checkout が必要とする）で、tmux も gh も使わないため追加セットアップ不要。

## 統合ジャーニーAC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | 実 git worktree に対する全ケースが PASS（fake 不使用） | `bun test tests/integration/worktree-real-git.test.ts` | exit 0、`git worktree list` の実出力をアサート | `15 pass / 0 fail`、exit 0（2 回連続で同一結果） | PASS |
| AC-2 | shutdown 相当の経路（uncommitted 変更あり）で worktree とその変更が残存 | 同上（`AC-2 / #369: shutdownAll preserves the worktree AND its uncommitted changes`） | path 存在 + dirty ファイル内容一致 | `existsSync` true / 内容一致 / `git status --porcelain` に WIP.txt / 登録が prunable=false | PASS |
| AC-3 | 新テストが ci.yml のいずれかの job でゲートされる | `bun scripts/lint-gating-coverage.ts` | gating lint PASS、新ファイルが gated | `✓ 94 test file(s) — 91 gated, 3 excluded, 0 ungated.` exit 0 | PASS |

## その他の検証

- `bunx tsc --noEmit` → exit 0
- `bun scripts/lint-blocking-in-timers.ts` / `lint-no-sync-exec.ts` / `check-access-policy.ts --ci` → 全て exit 0
- CI curated list 全体（85 files / 1057 tests）を新ファイル込みで実行 → `1054 pass / 3 skip / 0 fail`
  - 別実行で `cleanup-idle-claude.sh` 等が 5s timeout する事象を観測したが、**新ファイルを外した baseline でも同じ 4 件が落ちる**ため、ローカル macOS の負荷依存 flake（本 PR とは無関係）と判断

🤖 Generated with [Claude Code](https://claude.com/claude-code)
