### PR TITLE
test(e2e): e2e-live の S2-4 error loop / S2-5 resume 再入の SKIP を解除（#386）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,7 +189,8 @@ jobs:
                    tests/session/relay-server-hub-work.test.ts \
                    tests/session/relay-server-channel-post.test.ts \
                    tests/session/relay-port-isolation.test.ts \
-                   tests/tools/session-ctl.test.ts
+                   tests/tools/session-ctl.test.ts \
+                   tests/tools/e2e-isolated.test.ts
 
       # #238 regression: realTmuxAdapter.hasSession must treat a tmux
       # control-channel ETIMEDOUT as "alive" (assume the session survives),

--- a/codecov.yml
+++ b/codecov.yml
@@ -85,3 +85,10 @@ ignore:
   # に該当。CI では実行不能な境界コード（index.ts と同型の正当化）。
   # 注: supervisor/tools/session-ctl.ts は計測対象のまま（除外しない）。
   - "supervisor/tools/e2e-live.ts"
+  # 同上（Issue #386）。隔離スタックで実 tmux セッションを起動・kill する
+  # シナリオ本体で、CI では実行できない（実 tmux + 実 git worktree + 使い捨て
+  # Supervisor スタックを要する）。**判定規則の側**（署名の正規化 / error loop の
+  # 閾値 / 誤検知防止 / 隔離ガード）は純関数として切り出し、
+  # tests/tools/e2e-isolated.test.ts が CI で常時検証する = 除外しても
+  # ロジックが無検証にはならない（coverage-policy.md §4 / §5）。
+  - "supervisor/tools/e2e-isolated.ts"

--- a/docs/e2e-orchestrate.md
+++ b/docs/e2e-orchestrate.md
@@ -13,7 +13,25 @@ bash scripts/e2e-orchestrate.sh --keep           # 残骸を残す（デバッ�
 bash scripts/e2e-orchestrate.sh --full           # S1 の最終レポート到達まで待つ（Phase 5 向け）
 ```
 
+シナリオを 1 つだけ回す（デバッグ・部分検証。ライブドライバ直叩き）:
+
+```bash
+bun --env-file=supervisor/.env supervisor/tools/e2e-live.ts --scenario s2-4
+bun --env-file=supervisor/.env supervisor/tools/e2e-live.ts --scenario s2-5
+```
+
+`--scenario` に指定できるのは `s1 / s1b / s2-1 / s2-2 / s2-3 / s2-4 / s2-5 / s3`。
+未知の値は fail-closed（typo で「全部スキップして 0 終了」にならない）。
+
 終了時に PASS/FAIL/SKIP のサマリ表を出力し、FAIL が 1 件でもあれば exit 1。
+
+### dispatch 同時実行枠に注意（S1b / S2-5 live）
+
+`start-hub-worker` を使うシナリオ（S1b / S2-5 の live レグ）は、dispatch 同時実行枠
+（`DISPATCH_MAX_CONCURRENT`、既定 3）が埋まっていると **SKIP** する。枠が埋まった状態で
+投入すると `POST /hub-work` は拒否ではなく **FIFO キューに載り**（exit 0 のまま戻る）、
+キューにはキャンセル API が無いため、cleanup 後に勝手に走り出す取り消せないジョブが残るため。
+枠の空きは `bun run supervisor/tools/session-ctl.ts list` で確認できる。
 
 ## 前提（手動準備・初回のみ）
 
@@ -41,15 +59,35 @@ bash scripts/e2e-orchestrate.sh --full           # S1 の最終レポート到�
 | S1-c | Mermaid 進捗ダッシュボード（P2 AC-5） | スキル | スレッドに ```` ```mermaid ```` ブロック |
 | S1-d | ワーカー起動（hub work 経路） | スキル + Supervisor | sessions.db に `channel_name='claude-hub-work'` 行 |
 | S1-e | 完了 → 最終レポート | スキル | `--full` 時のみ（Phase 5 受け入れ実走で使用） |
-| S1b | hub work 経路の直接 smoke（start-hub-worker → send → stop） | session-ctl（決定的） | DB 行 / thread / stop 反映 / hijoguchi 投稿ゼロ |
+| S1b | hub work 経路の直接 smoke（start-hub-worker → send → stop） | session-ctl（決定的） | DB 行 / thread / stop 反映 / hijoguchi 投稿ゼロ。dispatch 枠が埋まっていれば SKIP |
+| S2-4 | ワーカー故意失敗 3 回 → error loop 検知 → stop → 報告（P2 AC-3） | 隔離スタック（決定的）+ live 配達 | mock claude が同一エラーを 3 回返す → 同一署名 3 回で検知 → 実 `session-ctl stop` で tmux 消滅 + sessions.db 反映 → 報告を `post-channel` で corp へ配達し着弾確認（Issue #386） |
+| S2-5 | kill → 再入で worktree 再利用（P2 AC-4 smoke） | 隔離スタック（決定的）+ live | iso: 一時 git リポで kill → 同 branch 再入 → **worktree path 同一 + 未コミット作業の生存 + 応答復帰**。live: 実 `start-hub-worker` で同じ流れ（dispatch 枠が空いているときのみ、Issue #386） |
 | S3 | 既存機能回帰 | hermetic + live | CI と同一の e2e スイート + dispatch/orchestrate/hub-work ユニット + hijoguchi pid 不変 + session-ctl list |
+
+### S2-4 / S2-5 の隔離スタック（Issue #386）
+
+S2-4 / S2-5 の決定的部分は `supervisor/tools/e2e-isolated.ts` が**子プロセス**として実行する。
+稼働中 Supervisor の claude を差し替えられない（`SUPERVISOR_CLAUDE_PATH` はプロセス起動時に固定）
+ため、mock claude・専用 tmux socket・専用 sessions.db・専用 runtime dir を与えた使い捨てスタックを
+別プロセスで立てる。`assertIsolatedEnv` が本番 socket / 本番 DB / 本番 relay-port を指したままの
+実行を fail-closed で止める。単体デバッグは:
+
+```bash
+SUPERVISOR_TMUX_SOCKET=claude-hub-e2e-dbg \
+SUPERVISOR_DB_PATH=/tmp/e2e-dbg/sessions.db \
+XDG_RUNTIME_DIR=/tmp/e2e-dbg/runtime \
+SUPERVISOR_CLAUDE_PATH=supervisor/tests/e2e/fixtures/claude-error-loop-mock.sh \
+bun supervisor/tools/e2e-isolated.ts --scenario s2-4
+```
+
+判定規則そのもの（同一署名の正規化・閾値・誤検知防止・隔離ガード）は
+`supervisor/tests/tools/e2e-isolated.test.ts` が CI で常時検証する。
 
 ### Phase 5 送り（本 E2E では SKIP として明示レポート）
 
 | 項目 | 理由 |
 |---|---|
-| S2-4 error loop（故意失敗 3 回 → 停止、P2 AC-3） | error loop 検知はオーケストレーター（モデル）の意味判断で、決定的な PASS/FAIL アサートが書けず 30 分超かかる。実走（#322）で観測する |
-| S2-5 kill → resume 再入（P2 AC-4 smoke） | resume は Epic 番号前提（SKILL Phase E）。テスト用 Epic の常設はテスト残骸になるため実走で検証。corp 台帳の冪等性（重複投入なしの土台）は agent-base `tests/test_orchestrate_runner.sh` で担保済み |
+| error loop の**意味判断**（このエラーは同じ失敗か） | オーケストレーター（モデル）の判断であり決定的アサートが書けない。機構（検知規則 → stop → 報告）は S2-4 が自動検証するので、残るのはモデル判断のみ。実走（#322）で観測する |
 | /session start\|list\|stop\|resume の実 Discord slash 駆動 | **Bot は他 Bot の slash command を実行できない**（Discord 制約）。hermetic 回帰（session lifecycle / commands テスト）+ `.claude/commands/local-e2e-discord.md`（Chrome 手動）でカバー |
 | hijoguchi メンション応答 | `allowFrom=[owner]` のため owner アカウントからのみ発火できる（driver Bot では原理的に不可）。実走時に目視 |
 

--- a/supervisor/tests/e2e/fixtures/claude-error-loop-mock.sh
+++ b/supervisor/tests/e2e/fixtures/claude-error-loop-mock.sh
@@ -1,0 +1,66 @@
+#!/bin/bash
+# claude-error-loop-mock.sh — 常に同じエラーで失敗する fake `claude` CLI
+# (Issue #386 / e2e-live S2-4)。
+#
+# 目的: orchestrate の error loop 判定（agent-base
+# rules/general/orchestration-escalation-policy.md B-3「error loop = エラー署名が
+# 3 回一致」）に、**実課金ゼロ・決定的**なワーカーを与える。実モデルは同じ失敗を
+# 3 回踏むまで数十分かかり、出力も揺れるため、その層は本モックで置き換える。
+#
+# 応答は「エラー中核は毎回同一・可変部（ISO タイムスタンプ / 試行回数）だけ変化」に
+# する。毎回バイト完全一致にしないのは意図的で、署名の正規化（可変部を落として
+# 同一と判定できるか）まで検証するため。実 CLI のエラーも毎回タイムスタンプが違う。
+#
+# stdin/stdout と Stop hook POST の契約（{text, session_id}）は claude-mock.sh と
+# 同一。違いは応答内容だけなので、Supervisor 側から見た経路は変わらない。
+#
+# Env:
+#   SUPERVISOR_RELAY_URL        Stop hook 相当の POST 先。未設定なら stdout echo のみ。
+#   CLAUDE_MOCK_SESSION_ID      既定 "mock-error-loop-$$"
+#   CLAUDE_MOCK_ERROR_TEXT      毎回返すエラー中核（署名として一致すべき部分）
+#   CLAUDE_MOCK_CURL_TIMEOUT    curl --max-time 秒。既定 5
+#
+# EOF (Ctrl-D / pipe close) で exit 0。
+
+set -u
+
+SESSION_ID="${CLAUDE_MOCK_SESSION_ID:-mock-error-loop-$$}"
+ERROR_TEXT="${CLAUDE_MOCK_ERROR_TEXT:-Error: EACCES: permission denied, open '/tmp/e2e-error-loop.lock'}"
+CURL_TIMEOUT="${CLAUDE_MOCK_CURL_TIMEOUT:-5}"
+
+# jq は必須（claude-mock.sh と同じ理由: 任意の制御文字を含みうるテキストを安全に
+# JSON 化する。壊れた payload を黙って送るより loud に落とす）。
+if ! command -v jq >/dev/null 2>&1; then
+  echo "claude-error-loop-mock.sh: jq is required for safe JSON encoding (install jq)" >&2
+  exit 127
+fi
+
+json_escape() {
+  printf '%s' "$1" | jq -Rs .
+}
+
+attempt=0
+while IFS= read -r line; do
+  # 空行はスキップ（ループは維持）。claude-mock.sh と同じ扱い。
+  [ -z "$line" ] && continue
+
+  attempt=$((attempt + 1))
+  # 可変部（タイムスタンプ・試行回数）+ 不変のエラー中核。入力 $line は応答に
+  # 含めない: 入力ごとに応答が変わると「同一エラーの反復」にならないため。
+  reply="[$(date -u +%Y-%m-%dT%H:%M:%SZ)] attempt ${attempt}: ${ERROR_TEXT}"
+  printf '%s\n' "$reply"
+
+  # Stop hook 相当（best-effort）。ネットワーク不可の環境でも stdout echo は残る。
+  if [ -n "${SUPERVISOR_RELAY_URL:-}" ]; then
+    text_json=$(json_escape "$reply")
+    sid_json=$(json_escape "$SESSION_ID")
+    payload="{\"text\":${text_json},\"session_id\":${sid_json}}"
+    curl -s -X POST "$SUPERVISOR_RELAY_URL" \
+      -H "Content-Type: application/json" \
+      -d "$payload" \
+      --max-time "$CURL_TIMEOUT" \
+      >/dev/null 2>&1 || true
+  fi
+done
+
+exit 0

--- a/supervisor/tests/tools/e2e-isolated.test.ts
+++ b/supervisor/tests/tools/e2e-isolated.test.ts
@@ -1,0 +1,238 @@
+import { test, expect, describe } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+import {
+  ERROR_LOOP_THRESHOLD,
+  assertIsolatedEnv,
+  detectErrorLoop,
+  errorSignature,
+  formatErrorLoopReport,
+  looksLikeError,
+} from "../../tools/e2e-isolated";
+
+/**
+ * e2e-live S2-4（error loop 検知）の純関数テスト（Issue #386 / Epic #381）。
+ *
+ * ライブ側（実 tmux + mock claude + 実 session-ctl stop）は e2e-live.ts の
+ * `--scenario s2-4` が回す。ここで固定するのは、そのライブ実行が依存する
+ * 判定規則そのもの:
+ *
+ *   - 可変部（タイムスタンプ / 試行回数）が違っても同じ失敗を同一視できるか
+ *   - 別の失敗まで同一視していないか（過剰正規化の検出）
+ *   - 成功応答の反復を error loop と誤判定しないか（誤 kill 防止）
+ *   - 隔離 env の fail-closed ガードが本番資産を守るか
+ *
+ * 本ファイルは tmux も DB も触らないため CI で常時実行できる（#144 の CI 編入で
+ * ライブ側が入るまでの間、規則部分だけは機械的に守られる）。
+ */
+
+/** claude-error-loop-mock.sh が実際に吐く形（可変部だけが違う 3 応答）。 */
+const MOCK_REPLIES = [
+  "[2026-08-09T10:00:01Z] attempt 1: Error: EACCES: permission denied, open '/tmp/e2e-error-loop.lock'",
+  "[2026-08-09T10:00:09Z] attempt 2: Error: EACCES: permission denied, open '/tmp/e2e-error-loop.lock'",
+  "[2026-08-09T10:00:17Z] attempt 3: Error: EACCES: permission denied, open '/tmp/e2e-error-loop.lock'",
+];
+
+describe("errorSignature", () => {
+  test("可変部（タイムスタンプ・試行回数）が違っても同一署名になる", () => {
+    const signatures = new Set(MOCK_REPLIES.map(errorSignature));
+    expect(signatures.size).toBe(1);
+  });
+
+  test("エラー中核が違えば別署名になる（過剰正規化の検出）", () => {
+    const a = errorSignature(
+      "[2026-08-09T10:00:01Z] attempt 1: Error: EACCES: permission denied",
+    );
+    const b = errorSignature(
+      "[2026-08-09T10:00:01Z] attempt 1: Error: ENOENT: no such file or directory",
+    );
+    expect(a).not.toBe(b);
+  });
+
+  test("ANSI エスケープと 16 進 ID を落とす", () => {
+    const withAnsi = "\u001B[31mError: task 9f8e7d6c5b4a3210 failed\u001B[0m";
+    const plain = "Error: task 0123456789abcdef failed";
+    expect(errorSignature(withAnsi)).toBe(errorSignature(plain));
+  });
+
+  test("空白の揺れを吸収する", () => {
+    expect(errorSignature("Error:   foo \n  bar ")).toBe(
+      errorSignature("Error: foo bar"),
+    );
+  });
+});
+
+describe("looksLikeError", () => {
+  test("エラー表現を検出する（日英）", () => {
+    expect(looksLikeError("Error: boom")).toBe(true);
+    expect(looksLikeError("処理に失敗しました")).toBe(true);
+    expect(looksLikeError("Traceback (most recent call last)")).toBe(true);
+  });
+
+  test("通常の応答はエラー扱いしない", () => {
+    expect(looksLikeError("[mock-claude] received: ping")).toBe(false);
+  });
+});
+
+describe("detectErrorLoop", () => {
+  test("同一エラー 3 回で検知する（policy B-3）", () => {
+    const verdict = detectErrorLoop(MOCK_REPLIES);
+    expect(verdict.detected).toBe(true);
+    expect(verdict.count).toBe(ERROR_LOOP_THRESHOLD);
+    expect(verdict.considered).toBe(3);
+    expect(verdict.signature).toContain("EACCES");
+  });
+
+  test("2 回では検知しない（閾値の下側境界）", () => {
+    const verdict = detectErrorLoop(MOCK_REPLIES.slice(0, 2));
+    expect(verdict.detected).toBe(false);
+    expect(verdict.count).toBe(2);
+  });
+
+  test("別々のエラー 3 種では検知しない", () => {
+    const verdict = detectErrorLoop([
+      "Error: EACCES: permission denied",
+      "Error: ENOENT: no such file",
+      "Error: ETIMEDOUT: timed out",
+    ]);
+    expect(verdict.detected).toBe(false);
+    expect(verdict.count).toBe(1);
+  });
+
+  test("同一の成功応答 3 回は error loop にしない（誤 kill 防止）", () => {
+    const verdict = detectErrorLoop([
+      "[mock-claude] received: ping",
+      "[mock-claude] received: ping",
+      "[mock-claude] received: ping",
+    ]);
+    expect(verdict.detected).toBe(false);
+    expect(verdict.considered).toBe(0);
+    expect(verdict.signature).toBeNull();
+  });
+
+  test("エラーに混在する成功応答は判定対象から外れる", () => {
+    const verdict = detectErrorLoop([
+      MOCK_REPLIES[0]!,
+      "[mock-claude] received: ok",
+      MOCK_REPLIES[1]!,
+      MOCK_REPLIES[2]!,
+    ]);
+    expect(verdict.detected).toBe(true);
+    expect(verdict.considered).toBe(3);
+  });
+});
+
+describe("formatErrorLoopReport", () => {
+  test("停止理由・回数・自動再投入しない旨を含む", () => {
+    const verdict = detectErrorLoop(MOCK_REPLIES);
+    const report = formatErrorLoopReport({
+      worker: "sess-abc (tmux claude-thread)",
+      verdict,
+      lastError: MOCK_REPLIES[2]!,
+      stopOutcome: "session-ctl stop exit=0 / sessions.db status=stopped",
+    });
+    expect(report).toContain("error loop");
+    expect(report).toContain("sess-abc");
+    expect(report).toContain(`${ERROR_LOOP_THRESHOLD} 回`);
+    expect(report).toContain("EACCES");
+    expect(report).toContain("session-ctl stop exit=0");
+    // policy B-3: 別アプローチでの自動再投入はしない（L2 申し送り）。
+    expect(report).toContain("自動再投入はしません");
+  });
+});
+
+describe("assertIsolatedEnv", () => {
+  const FIXTURE = resolve(
+    import.meta.dir,
+    "../e2e/fixtures/claude-error-loop-mock.sh",
+  );
+
+  function isolatedEnv(overrides: Record<string, string | undefined> = {}) {
+    const dir = mkdtempSync(join(tmpdir(), "e2e-el-guard-"));
+    return {
+      env: {
+        SUPERVISOR_TMUX_SOCKET: "claude-hub-e2e-test",
+        SUPERVISOR_DB_PATH: join(dir, "sessions.db"),
+        XDG_RUNTIME_DIR: join(dir, "runtime"),
+        SUPERVISOR_CLAUDE_PATH: FIXTURE,
+        ...overrides,
+      } as Record<string, string | undefined>,
+      cleanup: () => rmSync(dir, { recursive: true, force: true }),
+    };
+  }
+
+  test("隔離済み env では通る", () => {
+    const { env, cleanup } = isolatedEnv();
+    try {
+      expect(() => assertIsolatedEnv(env)).not.toThrow();
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("本番 tmux socket を拒否する（RW-019）", () => {
+    const { env, cleanup } = isolatedEnv({ SUPERVISOR_TMUX_SOCKET: "claude-hub" });
+    try {
+      expect(() => assertIsolatedEnv(env)).toThrow(/claude-hub/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("SUPERVISOR_DB_PATH 未設定を拒否する（本番 sessions.db 保護）", () => {
+    const { env, cleanup } = isolatedEnv({ SUPERVISOR_DB_PATH: undefined });
+    try {
+      expect(() => assertIsolatedEnv(env)).toThrow(/SUPERVISOR_DB_PATH/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test(":memory: を拒否する（書き手と読み手で別 DB になるため）", () => {
+    const { env, cleanup } = isolatedEnv({ SUPERVISOR_DB_PATH: ":memory:" });
+    try {
+      expect(() => assertIsolatedEnv(env)).toThrow(/memory/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("XDG_RUNTIME_DIR 未設定を拒否する（relay-port 上書き防止）", () => {
+    const { env, cleanup } = isolatedEnv({ XDG_RUNTIME_DIR: undefined });
+    try {
+      expect(() => assertIsolatedEnv(env)).toThrow(/XDG_RUNTIME_DIR/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("SUPERVISOR_CLAUDE_PATH 未設定を拒否する（実 claude の課金防止）", () => {
+    const { env, cleanup } = isolatedEnv({ SUPERVISOR_CLAUDE_PATH: undefined });
+    try {
+      expect(() => assertIsolatedEnv(env)).toThrow(/SUPERVISOR_CLAUDE_PATH/);
+    } finally {
+      cleanup();
+    }
+  });
+
+  test("複数欠落はすべて列挙する（1 個直して再実行の往復を避ける）", () => {
+    const { env, cleanup } = isolatedEnv({
+      SUPERVISOR_TMUX_SOCKET: "claude-hub",
+      SUPERVISOR_CLAUDE_PATH: undefined,
+    });
+    try {
+      expect(() => assertIsolatedEnv(env)).toThrow(/RW-019|claude-hub/);
+      let message = "";
+      try {
+        assertIsolatedEnv(env);
+      } catch (err) {
+        message = err instanceof Error ? err.message : String(err);
+      }
+      expect(message).toContain("SUPERVISOR_TMUX_SOCKET");
+      expect(message).toContain("SUPERVISOR_CLAUDE_PATH");
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/supervisor/tools/e2e-isolated.ts
+++ b/supervisor/tools/e2e-isolated.ts
@@ -1,0 +1,737 @@
+#!/usr/bin/env bun
+/**
+ * e2e-isolated — 隔離スタックで走らせる決定的 E2E シナリオ群
+ * (Issue #386 / Epic #381)。
+ *
+ * 実 Supervisor（稼働中の本番プロセス）では実行できない検証を、
+ * **mock claude + 専用 tmux socket + 専用 sessions.db + 専用 runtime dir** の
+ * 使い捨てスタックで再現する。e2e-live.ts が子プロセスとして起動する。
+ *
+ *   - **s2-4** error loop: ワーカーが同じエラーを 3 回返す →
+ *     検知 → `session-ctl stop` → 報告文生成（{@link runErrorLoopScenario}）
+ *   - **s2-5** worktree 再利用: ワーカーを kill → 同じ branch で再入 →
+ *     **同一 worktree が再利用され未コミットの作業が残る**
+ *     （{@link runWorktreeReuseScenario}）
+ *
+ * ## 何を検証し、何を検証しないか
+ *
+ * agent-base `rules/general/orchestration-escalation-policy.md` B-3 は
+ * 「error loop（エラー署名が 3 回一致）→ 当該ワーカーを `session-ctl stop`
+ * → スレッド報告 → 別アプローチでの自動再投入はしない（L2 申し送り）」、および
+ * 「dead-session 再入（hub）は `start-hub-worker` 再実行で自動再起動（同 branch は
+ * worktree 再利用で冪等）」と定める。
+ *
+ *   - **検証する**: 実ワーカーの実出力に対する「同一署名 3 回」判定、
+ *     `session-ctl stop` が実際にループ中のワーカーを落とすこと、
+ *     停止が sessions.db と tmux の双方に反映されること、報告文の生成、
+ *     kill 後の再入で実 git worktree が再利用され作業が残ること。
+ *   - **検証しない**: 「このエラーは同じ失敗か」というオーケストレーター
+ *     （モデル）の意味判断。ここは実走（#322）の観測範囲のまま残す。
+ *     `POST /hub-work` 経由の投入そのものは e2e-live の S1b / S2-5 live レグが見る。
+ *
+ * この切り分けにより、実モデル・実課金なしで S2-4 / S2-5 の**機構**を回帰にできる。
+ * ワーカーの claude は {@link ../tests/e2e/fixtures/claude-error-loop-mock.sh}
+ * （毎回同一のエラー中核 + 可変タイムスタンプ）や既存の `claude-mock.sh`
+ * （エコー応答）に差し替える。
+ *
+ * ## なぜ e2e-live.ts の中で直接動かさず、別プロセスなのか
+ *
+ * Supervisor の 3 つのグローバルが **モジュールロード時に固定**されるため:
+ *
+ *   - `TMUX_SOCKET`（tmux.ts）— 既定 `claude-hub` = 本番 socket（RW-019）
+ *   - `DB_PATH`（infra/db.ts）— 既定 `~/claude-hub/supervisor/sessions.db`
+ *   - relay ポートファイル（relay-server.ts）— `XDG_RUNTIME_DIR` 由来。
+ *     SessionManager のコンストラクタが relay サーバを start するので、
+ *     隔離しないと**稼働中 Supervisor のポートファイルを上書き**し、
+ *     session-ctl の discovery を壊す
+ *
+ * よって呼び出し側（e2e-live.ts）が隔離 env を与えて子プロセスとして起動する。
+ * 隔離が欠けたまま起動された場合は {@link assertIsolatedEnv} が fail-closed で
+ * 落とす（本番資産を壊すくらいならシナリオを落とす）。
+ *
+ * ## 使い方（通常は e2e-live.ts が spawn する。単体デバッグ用）
+ *
+ *   SUPERVISOR_TMUX_SOCKET=claude-hub-e2e-el \
+ *   SUPERVISOR_DB_PATH=/tmp/e2e-el/sessions.db \
+ *   XDG_RUNTIME_DIR=/tmp/e2e-el/runtime \
+ *   SUPERVISOR_CLAUDE_PATH=supervisor/tests/e2e/fixtures/claude-error-loop-mock.sh \
+ *   bun supervisor/tools/e2e-isolated.ts --scenario s2-4
+ *
+ * 結果は最終行に `E2E_ISOLATED_RESULT: <json>` として出す（親が parse する）。
+ *
+ * 本モジュールの **静的 import は純関数のみ**に限る。SessionManager 等の
+ * 重い import は {@link runErrorLoopScenario} 内の動的 import に置く:
+ * そうしないと隔離チェックより先に db.ts / tmux.ts が評価され、ガードが
+ * 用をなさない（ESM の import は巻き上げられる）。単体テストが純関数だけを
+ * 安全に import できる、という副次効果もある。
+ */
+
+import { existsSync } from "fs";
+import { homedir } from "os";
+import { join, resolve } from "path";
+
+// ---------------------------------------------------------------------------
+// 純関数（隔離不要 = 単体テスト可能）
+// ---------------------------------------------------------------------------
+
+/** error loop と判定するまでの同一署名の反復回数（policy B-3「3 回一致」）。 */
+export const ERROR_LOOP_THRESHOLD = 3;
+
+const ANSI_ESCAPE = /\u001B\[[0-?]*[ -/]*[@-~]/g;
+const ISO_TIMESTAMP =
+  /\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?/g;
+/** 8 桁以上の 16 進列（UUID 断片 / オブジェクト ID / ハッシュ）。 */
+const HEX_ID = /\b[0-9a-f]{8,}\b/gi;
+const DIGIT_RUN = /\d+/g;
+
+/**
+ * エラーテキストを「同じ失敗かどうか」の比較キーへ正規化する。
+ *
+ * 実 CLI のエラーは毎回タイムスタンプ・PID・試行回数・一時ファイル名が変わる。
+ * それらを落とさずに文字列一致を取ると、同じ失敗を 3 回踏んでも永遠に
+ * error loop と判定できない（＝ policy B-3 が発火しない）。落としすぎると
+ * 別の失敗まで同一視するので、可変部として**時刻・16 進 ID・数値**のみを潰す。
+ */
+export function errorSignature(text: string): string {
+  return text
+    .replace(ANSI_ESCAPE, "")
+    .replace(ISO_TIMESTAMP, "<ts>")
+    .replace(HEX_ID, "<id>")
+    .replace(DIGIT_RUN, "<n>")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
+ * テキストがエラー報告に見えるか。
+ *
+ * 「同一署名 3 回」を無条件に適用すると、同じ成功応答を 3 回返しただけの
+ * ワーカーまで error loop として停止してしまう（誤 kill）。停止は不可逆に
+ * 近い介入なので、エラーらしさを前段の条件に置く（デフォルトの安全性）。
+ */
+export function looksLikeError(text: string): boolean {
+  return /error|エラー|failed|failure|失敗|exception|traceback|panic|fatal/i.test(
+    text,
+  );
+}
+
+export interface ErrorLoopVerdict {
+  detected: boolean;
+  /** 最多で反復した署名（エラー候補が 0 件なら null）。 */
+  signature: string | null;
+  /** その署名の反復回数。 */
+  count: number;
+  threshold: number;
+  /** 判定対象になった（= エラーに見えた）テキスト数。 */
+  considered: number;
+}
+
+/**
+ * policy B-3 の error loop 判定: エラーに見えるテキストのうち、同一署名が
+ * `threshold` 回以上現れたら detected。
+ */
+export function detectErrorLoop(
+  texts: readonly string[],
+  threshold: number = ERROR_LOOP_THRESHOLD,
+): ErrorLoopVerdict {
+  const errors = texts.filter(looksLikeError);
+  const counts = new Map<string, number>();
+  for (const text of errors) {
+    const sig = errorSignature(text);
+    if (!sig) continue;
+    counts.set(sig, (counts.get(sig) ?? 0) + 1);
+  }
+  let signature: string | null = null;
+  let count = 0;
+  for (const [sig, n] of counts) {
+    if (n > count) {
+      signature = sig;
+      count = n;
+    }
+  }
+  return {
+    detected: count >= threshold,
+    signature,
+    count,
+    threshold,
+    considered: errors.length,
+  };
+}
+
+export interface ErrorLoopReportInput {
+  /** ワーカーの識別子（session id / branch / thread など、読み手が辿れるもの）。 */
+  worker: string;
+  verdict: ErrorLoopVerdict;
+  /** 最後に観測した生のエラーテキスト（署名ではなく現物）。 */
+  lastError: string;
+  /** `session-ctl stop` の結果（exit code や理由）。 */
+  stopOutcome: string;
+}
+
+/**
+ * スレッドへ投稿する error loop 報告を組み立てる。
+ *
+ * policy B-3 は「当該ワーカーを stop → スレッド報告 → **他ワーカーは継続** /
+ * 別アプローチでの自動再投入はしない（L2 申し送り）」と定める。報告文には
+ * 「なぜ止めたか（署名と回数）」と「自動再投入しない」ことを必ず含める:
+ * これが無いと読み手は放置（silent）と区別できない。
+ */
+export function formatErrorLoopReport(input: ErrorLoopReportInput): string {
+  const { worker, verdict, lastError, stopOutcome } = input;
+  return [
+    "🛑 error loop 検知のためワーカーを停止しました（S2-4 / policy B-3）",
+    `- worker: ${worker}`,
+    `- 同一エラー: ${verdict.count} 回（閾値 ${verdict.threshold}）`,
+    `- 署名: ${verdict.signature ?? "(なし)"}`,
+    `- 直近のエラー: ${lastError.trim()}`,
+    `- 停止結果: ${stopOutcome}`,
+    "- 別アプローチでの自動再投入はしません（L2 申し送り）",
+  ].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// 隔離ガード
+// ---------------------------------------------------------------------------
+
+/** 本番 Supervisor が使う tmux socket（RW-019）。ここへ相乗りしてはならない。 */
+export const PRODUCTION_TMUX_SOCKET = "claude-hub";
+
+/**
+ * relay ポートファイルのパス（relay-server.ts `relayPortFilePath` と同一規則）。
+ *
+ * 規則をここに複製しているのは、ガードが **relay-server.ts を import する前**に
+ * 走る必要があるため（import した時点で本番 socket / DB の解決が起きる）。
+ * relay-server.ts 側を変更したら本関数も追随すること。
+ */
+function relayPortFileFor(env: Record<string, string | undefined>): string {
+  const runtimeDir = env.XDG_RUNTIME_DIR
+    ? join(env.XDG_RUNTIME_DIR, "claude-hub-supervisor")
+    : `/tmp/claude-hub-supervisor-${env.USER || "default"}`;
+  return join(runtimeDir, "relay-port");
+}
+
+/**
+ * 隔離 env が揃っているかを検査し、欠けていれば throw する（fail-closed）。
+ *
+ * 稼働中 Supervisor の tmux セッション・sessions.db・relay ポートファイルを
+ * 壊しうる状態では、シナリオを走らせるより落とす方が安全。
+ */
+export function assertIsolatedEnv(
+  env: Record<string, string | undefined> = process.env,
+): void {
+  const problems: string[] = [];
+
+  const socket = env.SUPERVISOR_TMUX_SOCKET ?? "";
+  if (!socket) {
+    problems.push("SUPERVISOR_TMUX_SOCKET が未設定（本番 socket に相乗りします）");
+  } else if (socket === PRODUCTION_TMUX_SOCKET) {
+    problems.push(
+      `SUPERVISOR_TMUX_SOCKET=${socket} は本番 socket（RW-019）。別名を指定してください`,
+    );
+  }
+
+  const dbPath = env.SUPERVISOR_DB_PATH ?? "";
+  const prodDbPath = resolve(homedir(), "claude-hub", "supervisor", "sessions.db");
+  if (!dbPath) {
+    problems.push("SUPERVISOR_DB_PATH が未設定（本番 sessions.db に書き込みます）");
+  } else if (resolve(dbPath) === prodDbPath) {
+    problems.push(`SUPERVISOR_DB_PATH=${dbPath} は本番 DB。別パスを指定してください`);
+  } else if (dbPath === ":memory:") {
+    // SessionManager（書き込み）と session-ctl（読み取り）は別コネクションで開くため、
+    // :memory: では行が共有されず stop の検証が成立しない。
+    problems.push(
+      "SUPERVISOR_DB_PATH=:memory: は不可（書き手と読み手で別 DB になるため）。一時ファイルを指定してください",
+    );
+  }
+
+  if (!env.XDG_RUNTIME_DIR) {
+    problems.push(
+      "XDG_RUNTIME_DIR が未設定（稼働中 Supervisor の relay-port ファイルを上書きします）",
+    );
+  } else {
+    const portFile = relayPortFileFor(env);
+    if (existsSync(portFile)) {
+      problems.push(
+        `既存の relay-port ファイルを上書きします: ${portFile}（未使用の一時ディレクトリを指定してください）`,
+      );
+    }
+  }
+
+  const claudePath = env.SUPERVISOR_CLAUDE_PATH ?? "";
+  if (!claudePath) {
+    problems.push(
+      "SUPERVISOR_CLAUDE_PATH が未設定（実 claude が起動し課金されます）",
+    );
+  } else if (!existsSync(claudePath)) {
+    problems.push(`SUPERVISOR_CLAUDE_PATH が存在しません: ${claudePath}`);
+  }
+
+  if (problems.length > 0) {
+    throw new Error(
+      "e2e-error-loop: 隔離 env が不十分なため中断しました。\n" +
+        problems.map((p) => `  - ${p}`).join("\n"),
+    );
+  }
+}
+
+// ---------------------------------------------------------------------------
+// シナリオ本体（隔離 env 前提）
+// ---------------------------------------------------------------------------
+
+export interface ErrorLoopScenarioResult {
+  /** 全レグ（検知 / 停止）が期待どおりだったか。 */
+  ok: boolean;
+  /** ワーカーから観測した応答（3 回分）。 */
+  replies: string[];
+  verdict: ErrorLoopVerdict;
+  /** `session-ctl stop` の exit code（未実行なら null）。 */
+  stopExit: number | null;
+  /** stop 後の sessions.db の status（未取得なら null）。 */
+  dbStatus: string | null;
+  /** stop 後に tmux セッションが消えたか。 */
+  tmuxGone: boolean;
+  tmuxName: string;
+  /** スレッドへ投稿すべき報告文。 */
+  report: string;
+  /** 満たせなかった条件（空なら ok=true）。silent に落とさないための記録。 */
+  failures: string[];
+}
+
+const PROMPT_COUNT = ERROR_LOOP_THRESHOLD;
+
+/**
+ * error loop シナリオを一通り走らせる。
+ *
+ * 1. 隔離スタック（mock claude + 専用 tmux socket + 専用 sessions.db）で
+ *    ワーカーを 1 本起動する
+ * 2. 3 回プロンプトを送り、実 relay 経由で返る応答を集める
+ * 3. {@link detectErrorLoop} で policy B-3 の判定を行う
+ * 4. 検知したら **実 `session-ctl stop`** で停止し、tmux 消滅と DB 反映を確認する
+ * 5. 報告文を組み立てて返す（Discord への配達は呼び出し側の責務）
+ */
+export async function runErrorLoopScenario(): Promise<ErrorLoopScenarioResult> {
+  assertIsolatedEnv();
+
+  // 動的 import: 上のガードを通過してから db.ts / tmux.ts を評価する（冒頭の
+  // docblock 参照）。
+  const { SessionManager } = await import("../src/session/manager");
+  const { FakeItermAdapter } = await import("../src/session/adapters-fake");
+  const { TMUX_PATH, TMUX_ARGS } = await import("../src/session/tmux");
+  const { runSessionCtl, createRealEffects } = await import("./session-ctl");
+  const { Database } = await import("bun:sqlite");
+  const { execFile } = await import("child_process");
+  const { promisify } = await import("util");
+  const { mkdtempSync, mkdirSync, writeFileSync, rmSync } = await import("fs");
+  const { tmpdir } = await import("os");
+
+  const execFileAsync = promisify(execFile);
+  const failures: string[] = [];
+  const replies: string[] = [];
+
+  const workDir = mkdtempSync(join(tmpdir(), "e2e-error-loop-"));
+  const projectDir = join(workDir, "project");
+  mkdirSync(projectDir, { recursive: true });
+  writeFileSync(join(projectDir, "README.md"), "# e2e error loop fixture\n");
+
+  // FakeItermAdapter: 実 iTerm2 タブを開かせない（開発機で窓が増えるのを防ぐ）。
+  // tmux / relay / DB は実物を使う = 検証したい経路はそのまま。
+  const manager = new SessionManager({
+    effects: { iterm2: new FakeItermAdapter() },
+  });
+  const config = {
+    channelName: "e2e-error-loop",
+    dir: projectDir,
+    displayName: "E2E Error Loop",
+  };
+  const threadId = `e2e-error-loop-${process.pid}-${Date.now()}`;
+  const tmuxName = SessionManager.tmuxSessionNameFor(threadId);
+
+  const hasTmuxSession = async (name: string): Promise<boolean> => {
+    try {
+      await execFileAsync(TMUX_PATH, [...TMUX_ARGS, "has-session", "-t", name], {
+        timeout: 5000,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  };
+
+  let stopExit: number | null = null;
+  let dbStatus: string | null = null;
+  let tmuxGone = false;
+  let verdict: ErrorLoopVerdict = {
+    detected: false,
+    signature: null,
+    count: 0,
+    threshold: ERROR_LOOP_THRESHOLD,
+    considered: 0,
+  };
+  let report = "";
+
+  try {
+    await manager.start(config, threadId);
+
+    for (let i = 1; i <= PROMPT_COUNT; i++) {
+      const result = await manager.sendMessage(
+        threadId,
+        `e2e error loop probe #${i}`,
+      );
+      // relay が返す本文（text）を第一とし、無ければ chunks を連結する。
+      // 空応答は「エラーが返らなかった」という観測結果としてそのまま残す
+      // （空文字を捏造して埋めない）。
+      const text = result.text ?? result.chunks.join("\n");
+      if (result.error) {
+        failures.push(`プロンプト #${i} の relay がエラー: ${result.error}`);
+      }
+      replies.push(text);
+    }
+
+    verdict = detectErrorLoop(replies);
+    if (!verdict.detected) {
+      failures.push(
+        `error loop 未検知: 同一署名 ${verdict.count} 回 (閾値 ${verdict.threshold}, 判定対象 ${verdict.considered} 件)`,
+      );
+    }
+
+    // 停止は SessionManager.stop ではなく **実 session-ctl stop** を通す。
+    // policy B-3 が指定する介入経路そのものを検証したいため。
+    const db = new Database(process.env.SUPERVISOR_DB_PATH!, { readonly: true });
+    let rowId: string | null = null;
+    try {
+      const row = db
+        .prepare(`SELECT id FROM sessions WHERE thread_id = ? ORDER BY started_at DESC LIMIT 1`)
+        .get(threadId) as { id: string } | undefined;
+      rowId = row?.id ?? null;
+    } finally {
+      db.close();
+    }
+
+    if (!rowId) {
+      failures.push("sessions.db にワーカー行が見つからない（stop を検証できない）");
+    } else {
+      stopExit = await runSessionCtl(["stop", rowId], createRealEffects(), {
+        statusWaitMs: 45_000,
+      });
+      if (stopExit !== 0) failures.push(`session-ctl stop が exit ${stopExit}`);
+
+      const db2 = new Database(process.env.SUPERVISOR_DB_PATH!, { readonly: true });
+      try {
+        const row = db2
+          .prepare(`SELECT status FROM sessions WHERE id = ?`)
+          .get(rowId) as { status: string } | undefined;
+        dbStatus = row?.status ?? null;
+      } finally {
+        db2.close();
+      }
+      if (dbStatus === "running") {
+        failures.push("stop 後も sessions.db が status=running のまま");
+      }
+    }
+
+    tmuxGone = !(await hasTmuxSession(tmuxName));
+    if (!tmuxGone) failures.push(`stop 後も tmux セッション ${tmuxName} が生存`);
+
+    report = formatErrorLoopReport({
+      worker: `${rowId ?? threadId} (tmux ${tmuxName})`,
+      verdict,
+      lastError: replies[replies.length - 1] ?? "(応答なし)",
+      stopOutcome: `session-ctl stop exit=${stopExit ?? "-"} / sessions.db status=${dbStatus ?? "-"}`,
+    });
+  } catch (err) {
+    failures.push(
+      `シナリオが例外で中断: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
+    );
+  } finally {
+    // 後始末は best-effort だが黙って捨てない（agent-output-quality #1）。
+    try {
+      await manager.shutdownAll();
+    } catch (err) {
+      console.warn(`[e2e-isolated] shutdownAll failed: ${err}`);
+    }
+    try {
+      // 隔離 socket のみを kill する（本番 socket には触れない）。
+      await execFileAsync(TMUX_PATH, [...TMUX_ARGS, "kill-server"], {
+        timeout: 10_000,
+      });
+    } catch {
+      // サーバ未起動 / 既に停止済み。
+    }
+    try {
+      rmSync(workDir, { recursive: true, force: true });
+    } catch (err) {
+      console.warn(`[e2e-isolated] workDir cleanup failed: ${err}`);
+    }
+  }
+
+  return {
+    ok: failures.length === 0,
+    replies,
+    verdict,
+    stopExit,
+    dbStatus,
+    tmuxGone,
+    tmuxName,
+    report,
+    failures,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// S2-5: kill → 同 branch 再入で worktree 再利用
+// ---------------------------------------------------------------------------
+
+export interface WorktreeReuseScenarioResult {
+  ok: boolean;
+  /** 初回セッションの worktree（sessions.db の project_dir）。 */
+  worktreeBefore: string | null;
+  /** 再入セッションの worktree。 */
+  worktreeAfter: string | null;
+  sameWorktree: boolean;
+  /** kill が Supervisor 側（watcher）に検知され status が running から外れたか。 */
+  deadDetected: boolean;
+  /** kill を挟んでも worktree 内の未コミット作業（sentinel）が残っていたか。 */
+  workSurvived: boolean;
+  /** 再入セッションが応答を返したか（= 再び使える状態に戻ったか）。 */
+  responsive: boolean;
+  /** 再入セッションの応答（デバッグ用）。 */
+  reply: string;
+  failures: string[];
+}
+
+/**
+ * worktree 再利用シナリオを走らせる。
+ *
+ * 1. 一時 git リポジトリを作り、branch を切って worktree セッションを起動する
+ * 2. worktree に**未コミットの作業**（sentinel ファイル）を置く
+ * 3. tmux セッションを kill して「ワーカーの突然死」を作る
+ * 4. Supervisor 相当（SessionManager の watcher）が dead を検知し、
+ *    **worktree を壊さない**こと（RW-046）を確認する
+ * 5. 同じ branch で再入し、**同一 worktree が再利用され sentinel が残っている**
+ *    こと、セッションが応答可能に戻ることを確認する
+ *
+ * path の同一性だけでなく sentinel の生存を見るのは、worktree を作り直しても
+ * path は一致してしまい「作業が失われた」ことを検出できないため。
+ */
+export async function runWorktreeReuseScenario(): Promise<WorktreeReuseScenarioResult> {
+  assertIsolatedEnv();
+
+  const { SessionManager } = await import("../src/session/manager");
+  const { FakeItermAdapter } = await import("../src/session/adapters-fake");
+  const { TMUX_PATH, TMUX_ARGS } = await import("../src/session/tmux");
+  const { Database } = await import("bun:sqlite");
+  const { execFile } = await import("child_process");
+  const { promisify } = await import("util");
+  const { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } = await import("fs");
+  const { tmpdir } = await import("os");
+
+  const execFileAsync = promisify(execFile);
+  const failures: string[] = [];
+
+  const workDir = mkdtempSync(join(tmpdir(), "e2e-worktree-reuse-"));
+  const repoDir = join(workDir, "repo");
+  mkdirSync(repoDir, { recursive: true });
+
+  const git = (args: string[]) =>
+    execFileAsync("git", args, { cwd: repoDir, timeout: 20_000 });
+
+  const dbPath = process.env.SUPERVISOR_DB_PATH!;
+  const rowFor = (threadId: string): { id: string; status: string; project_dir: string } | null => {
+    const db = new Database(dbPath, { readonly: true });
+    try {
+      return (db
+        .prepare(
+          `SELECT id, status, project_dir FROM sessions WHERE thread_id = ? ORDER BY started_at DESC LIMIT 1`,
+        )
+        .get(threadId) as { id: string; status: string; project_dir: string } | undefined) ?? null;
+    } finally {
+      db.close();
+    }
+  };
+  const poll = async <T>(fn: () => T | null, timeoutMs: number, intervalMs = 2_000) => {
+    const t0 = Date.now();
+    for (;;) {
+      const v = fn();
+      if (v !== null) return v;
+      if (Date.now() - t0 > timeoutMs) return null;
+      await new Promise((r) => setTimeout(r, intervalMs));
+    }
+  };
+
+  const manager = new SessionManager({
+    effects: { iterm2: new FakeItermAdapter() },
+  });
+  const branch = `e2e-reuse-${process.pid}-${Date.now()}`;
+  const config = {
+    channelName: "e2e-worktree-reuse",
+    dir: repoDir,
+    displayName: "E2E Worktree Reuse",
+  };
+  const threadA = `e2e-reuse-a-${process.pid}-${Date.now()}`;
+  const threadB = `e2e-reuse-b-${process.pid}-${Date.now()}`;
+
+  let worktreeBefore: string | null = null;
+  let worktreeAfter: string | null = null;
+  let deadDetected = false;
+  let workSurvived = false;
+  let responsive = false;
+  let reply = "";
+
+  try {
+    // 一時 git リポジトリ + ローカル branch（worktree.ensure の Q1 経路に載せる。
+    // Q2 は origin へ fetch しに行くのでリモート無しの一時リポでは使えない）。
+    await git(["init", "-q", "-b", "main"]);
+    await git(["config", "user.email", "e2e@example.invalid"]);
+    await git(["config", "user.name", "e2e"]);
+    await git(["config", "commit.gpgsign", "false"]);
+    writeFileSync(join(repoDir, "README.md"), "# e2e worktree reuse fixture\n");
+    await git(["add", "README.md"]);
+    await git(["commit", "-q", "-m", "init"]);
+    await git(["branch", branch]);
+
+    // (1) 初回起動 → worktree が切られる
+    await manager.start(config, threadA, branch);
+    const rowA = await poll(() => {
+      const r = rowFor(threadA);
+      return r && r.status === "running" ? r : null;
+    }, 60_000);
+    if (!rowA) {
+      failures.push("初回セッションの running 行が sessions.db に現れない");
+      throw new Error("初回セッション起動に失敗");
+    }
+    worktreeBefore = rowA.project_dir;
+
+    // (2) 未コミットの作業を置く（再利用の証拠。path 一致だけでは作り直しを検出できない）
+    const sentinel = join(worktreeBefore, ".e2e-uncommitted-work");
+    writeFileSync(sentinel, `e2e worktree reuse sentinel ${branch}\n`);
+
+    // (3) kill（session-ctl stop の graceful ではなく突然死を模す）
+    const tmuxA = SessionManager.tmuxSessionNameFor(threadA);
+    try {
+      await execFileAsync(TMUX_PATH, [...TMUX_ARGS, "kill-session", "-t", tmuxA], {
+        timeout: 10_000,
+      });
+    } catch (err) {
+      failures.push(`tmux kill-session に失敗: ${err}`);
+    }
+
+    // (4) watcher が dead を検知（10s poll なので余裕を持って待つ）
+    const dead = await poll(() => {
+      const r = rowFor(threadA);
+      return r && r.status !== "running" ? r : null;
+    }, 90_000);
+    deadDetected = dead !== null;
+    if (!deadDetected) failures.push("kill 後 90 秒以内に status が running から外れない");
+
+    // (5) worktree と未コミット作業の保全（RW-046）
+    workSurvived = existsSync(worktreeBefore) && existsSync(sentinel);
+    if (!workSurvived) {
+      failures.push(
+        `kill で worktree / 未コミット作業が失われた（worktree=${existsSync(worktreeBefore)} sentinel=${existsSync(sentinel)}）`,
+      );
+    }
+
+    // (6) 同じ branch で再入
+    await manager.start(config, threadB, branch);
+    const rowB = await poll(() => {
+      const r = rowFor(threadB);
+      return r && r.status === "running" ? r : null;
+    }, 60_000);
+    if (!rowB) {
+      failures.push("再入セッションの running 行が sessions.db に現れない");
+    } else {
+      worktreeAfter = rowB.project_dir;
+      if (worktreeAfter !== worktreeBefore) {
+        failures.push(
+          `再入で worktree が変わった: before=${worktreeBefore} after=${worktreeAfter}`,
+        );
+      }
+      if (!existsSync(sentinel)) {
+        failures.push("再入後に未コミット作業（sentinel）が消えている = worktree 作り直し");
+        workSurvived = false;
+      }
+
+      // (7) 応答可能に戻ったか
+      const result = await manager.sendMessage(threadB, "e2e worktree reuse ping");
+      reply = result.text ?? result.chunks.join("\n");
+      responsive = !result.error && reply.trim().length > 0;
+      if (!responsive) {
+        failures.push(`再入セッションが応答しない: error=${result.error ?? "-"} reply=${JSON.stringify(reply)}`);
+      }
+      await manager.stop(threadB, "manual");
+    }
+  } catch (err) {
+    failures.push(
+      `シナリオが例外で中断: ${err instanceof Error ? (err.stack ?? err.message) : String(err)}`,
+    );
+  } finally {
+    try {
+      await manager.shutdownAll();
+    } catch (err) {
+      console.warn(`[e2e-isolated] shutdownAll failed: ${err}`);
+    }
+    try {
+      await execFileAsync(TMUX_PATH, [...TMUX_ARGS, "kill-server"], { timeout: 10_000 });
+    } catch {
+      // サーバ未起動 / 既に停止済み。
+    }
+    try {
+      rmSync(workDir, { recursive: true, force: true });
+    } catch (err) {
+      console.warn(`[e2e-isolated] workDir cleanup failed: ${err}`);
+    }
+  }
+
+  return {
+    ok: failures.length === 0,
+    worktreeBefore,
+    worktreeAfter,
+    sameWorktree: worktreeBefore !== null && worktreeBefore === worktreeAfter,
+    deadDetected,
+    workSurvived,
+    responsive,
+    reply,
+    failures,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+/** 親プロセスが結果を拾うための行頭マーカー。 */
+export const RESULT_MARKER = "E2E_ISOLATED_RESULT:";
+
+/** `--scenario` に指定できる id。 */
+export const ISOLATED_SCENARIOS = ["s2-4", "s2-5"] as const;
+
+if (import.meta.main) {
+  const argv = process.argv.slice(2);
+  const i = argv.indexOf("--scenario");
+  const scenario = i >= 0 && argv[i + 1] ? argv[i + 1]! : "";
+
+  const emit = (result: { ok: boolean; failures: string[] }): never => {
+    console.log(`${RESULT_MARKER} ${JSON.stringify(result)}`);
+    process.exit(result.ok ? 0 : 1);
+  };
+
+  const run = async (): Promise<{ ok: boolean; failures: string[] }> => {
+    if (scenario === "s2-4") return await runErrorLoopScenario();
+    if (scenario === "s2-5") return await runWorktreeReuseScenario();
+    // 未指定 / 未知は fail-closed（黙って何もせず 0 終了しない）。
+    return {
+      ok: false,
+      failures: [
+        `--scenario は ${ISOLATED_SCENARIOS.join(" / ")} のいずれかを指定してください（指定値: ${scenario || "(なし)"}）`,
+      ],
+    };
+  };
+
+  run()
+    .then(emit)
+    .catch((err) => {
+      const message = err instanceof Error ? (err.stack ?? err.message) : String(err);
+      console.error(message);
+      emit({ ok: false, failures: [message] });
+    });
+}

--- a/supervisor/tools/e2e-live.ts
+++ b/supervisor/tools/e2e-live.ts
@@ -36,18 +36,47 @@
  *   --keep             cleanup をスキップ（残骸をデバッグ用に残す）
  *   --full             S1 で最終レポート到達まで待つ（Phase 5 受け入れ実走向け）
  *   --brain-timeout-min <n>  S1 のオーケストレーター頭脳検証の上限（既定 20）
+ *   --scenario <id>    1 シナリオだけ実行する（id は {@link SCENARIO_IDS}）。
+ *                      省略時は全シナリオ。S2-4 / S2-5 の単体デバッグ用
  *
- * S2-4（error loop）/ S2-5（kill→resume 再入）はモデル挙動依存 + 長時間のため
- * 本ドライバでは SKIP として明示レポートし、Phase 5（#322）の受け入れ実走で検証する。
+ * S2-4（error loop）/ S2-5（kill→resume 再入）は Issue #386 で SKIP を解除した。
+ * モデルの意味判断に依存しない**機構**部分だけを決定的に検証する:
+ *
+ *   - S2-4: ワーカーの claude を mock（同一エラーを毎回返す）に差し替えた隔離
+ *     スタックで「同一署名 3 回 → session-ctl stop」を実行し、報告は実
+ *     `post-channel` で corp へ配達して着弾を確認する。「このエラーは同じ失敗か」
+ *     というオーケストレーター（モデル）の判断自体は引き続き実走（#322）の範囲
+ *   - S2-5: kill 後の再入で **同一 branch の worktree が再利用される**
+ *     （= 作業が失われない、RW-046）ことをアサートする。隔離スタック側は常時実行、
+ *     実 `start-hub-worker` 側は dispatch 枠が空いているときだけ実行する
+ *
+ * 隔離スタックの中身は {@link ./e2e-isolated.ts}（子プロセスとして起動する理由も
+ * そちらの docblock に書いてある）。
  */
 
 import { Database } from "bun:sqlite";
-import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from "fs";
-import { homedir } from "os";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+  unlinkSync,
+} from "fs";
+import { homedir, tmpdir } from "os";
 import { join } from "path";
-import { runSessionCtl, createRealEffects } from "./session-ctl";
+import { runSessionCtl, createRealEffects, tmuxNameForThread } from "./session-ctl";
 import { relayPortFilePath } from "../src/session/relay-server";
 import { resolveDbPath } from "../src/infra/db";
+// 純関数と定数のみ（e2e-isolated.ts は重い import を動的にしているので、
+// ここで import しても本番 socket / DB の解決は起きない）。
+import {
+  RESULT_MARKER as ISOLATED_RESULT_MARKER,
+  type ErrorLoopScenarioResult,
+  type WorktreeReuseScenarioResult,
+} from "./e2e-isolated";
+import { DISPATCH_MAX_CONCURRENT } from "../src/config/channels";
 
 const API = "https://discord.com/api/v10";
 
@@ -68,6 +97,22 @@ const SKIP_LIVE = has("--skip-live");
 const KEEP = has("--keep");
 const FULL = has("--full");
 const BRAIN_TIMEOUT_MS = Number(argVal("--brain-timeout-min", "20")) * 60_000;
+
+/** `--scenario` で個別実行できるシナリオ id（省略時は全部走る）。 */
+export const SCENARIO_IDS = [
+  "s1",
+  "s1b",
+  "s2-1",
+  "s2-2",
+  "s2-3",
+  "s2-4",
+  "s2-5",
+  "s3",
+] as const;
+type ScenarioId = (typeof SCENARIO_IDS)[number];
+const SCENARIO = argVal("--scenario", "").toLowerCase();
+/** 選択されたシナリオか（未指定なら全 true）。 */
+const wants = (id: ScenarioId): boolean => SCENARIO === "" || SCENARIO === id;
 
 // ---------- 結果集計 ----------
 type Verdict = "PASS" | "FAIL" | "SKIP";
@@ -158,6 +203,27 @@ const runningByBranchPrefix = (prefix: string) =>
 const rowsSince = (isoT0: string) =>
   dbRows(`SELECT * FROM sessions WHERE started_at > ? ORDER BY started_at`, isoT0);
 
+/**
+ * dispatch 同時実行枠の空きを調べる（`start-hub-worker` を投げてよいか）。
+ *
+ * 枠が埋まっていると `POST /hub-work` は**拒否ではなくキュー投入**になり、
+ * exit 0 のまま返る（bot.ts / hub-work.ts の DispatchQueue）。キューには
+ * キャンセル API が無いので、埋まっているのに投げると「後で勝手に走り出す
+ * 取り消せないジョブ」が残る（テスト Issue は cleanup で閉じられているのに）。
+ * よって投げる前にここで空きを確認する。
+ *
+ * Supervisor 内部のキュー状態は外から読めないため、sessions.db 上の running な
+ * dispatch 由来セッション（hub work / corp dispatch）で近似する。
+ */
+function dispatchSlots(): { busy: number; limit: number; free: boolean } {
+  const limit = Number(process.env.DISPATCH_MAX_CONCURRENT) || DISPATCH_MAX_CONCURRENT;
+  const busy = dbRows(
+    `SELECT id FROM sessions WHERE status='running' AND (channel_name = ? OR branch LIKE 'corp-dispatch-%')`,
+    "claude-hub-work",
+  ).length;
+  return { busy, limit, free: busy < limit };
+}
+
 // ---------- cleanup 対象の記録 ----------
 const createdIssues: number[] = [];
 const createdSessionKeys: string[] = []; // session row id
@@ -175,7 +241,15 @@ async function stopSessionQuiet(key: string): Promise<void> {
 
 // ============================================================
 async function main(): Promise<number> {
-  console.log(`== e2e-live (Issue #321) ${new Date().toISOString()} ==`);
+  console.log(`== e2e-live (Issue #321 / #386) ${new Date().toISOString()} ==`);
+
+  // 未知のシナリオ名は fail-closed（typo で「全部 SKIP されて 0 終了」を防ぐ）。
+  if (SCENARIO && !(SCENARIO_IDS as readonly string[]).includes(SCENARIO)) {
+    record("ARGS", "--scenario の値", "FAIL",
+      `未知のシナリオ: ${SCENARIO}（指定可能: ${SCENARIO_IDS.join(" / ")}）`);
+    return finish();
+  }
+  if (SCENARIO) console.log(`-- シナリオ絞り込み: ${SCENARIO} --`);
 
   if (SKIP_LIVE) {
     record("LIVE", "ライブ手順（プリフライト含む）", "SKIP", "--skip-live 指定（hermetic 回帰のみ）");
@@ -256,7 +330,10 @@ async function main(): Promise<number> {
     "corp allowFrom に driver Bot 未登録のため /orchestrate 駆動不可（手動準備 3 = docs/e2e-orchestrate.md。owner が access.json を編集後に再実行）";
 
   // ---------- S2-1: 空引数 → Supervisor 層 fail-closed（セッション未起動） ----------
-  if (!orchestrateDriveAuthorized) {
+  if (!wants("s2-1")) {
+    // --scenario で選ばれなかったシナリオは record しない（絞り込み実行の出力を
+    // 「本当に検証したもの」だけに保つ）。
+  } else if (!orchestrateDriveAuthorized) {
     record("S2-1", "空引数 fail-closed（セッション未起動）", "SKIP", AUTH_SKIP);
   } else {
     const before = runningByBranchPrefix("orchestrate-").length;
@@ -278,7 +355,9 @@ async function main(): Promise<number> {
   // ADR-002 D2 により Supervisor は引数を解釈しない = セッション自体は起動する（設計どおり）。
   // アサート: 起動後、スキルがエラーを報告し、ワーカー/Issue を作らないこと。
   let orchA: any = null;
-  if (!orchestrateDriveAuthorized) {
+  if (!wants("s2-3")) {
+    // 絞り込みで対象外。
+  } else if (!orchestrateDriveAuthorized) {
     record("S2-3", "存在しない .tmp（スキル層 fail-closed）", "SKIP", AUTH_SKIP);
   } else {
     const bogus = `~/.claude/sessions/e2e-nonexistent-${Date.now()}.tmp`;
@@ -315,7 +394,9 @@ async function main(): Promise<number> {
   }
 
   // ---------- S2-2: 多重 /orchestrate → 2 本目は起動せず案内 ----------
-  if (orchA) {
+  if (!wants("s2-2")) {
+    // 絞り込みで対象外。
+  } else if (orchA) {
     const before = runningByBranchPrefix("orchestrate-").length;
     const msgId = await postMessage(corpId, "/orchestrate 多重起動テスト（起動しないこと）");
     const notice = await pollUntil(async () => {
@@ -338,11 +419,17 @@ async function main(): Promise<number> {
       stopped ? `status=${stopped.status}` : "stop 後も running のまま");
   } else {
     record("S2-2", "多重 /orchestrate → 案内のみ", "SKIP",
-      orchestrateDriveAuthorized ? "S2-3 でオーケストレーター未起動のため" : AUTH_SKIP);
+      !wants("s2-3")
+        ? "S2-3（オーケストレーター起動）が --scenario の対象外のため"
+        : orchestrateDriveAuthorized
+          ? "S2-3 でオーケストレーター未起動のため"
+          : AUTH_SKIP);
   }
 
   // ---------- S1: 正常系（.tmp 1 + テスト Issue 1） ----------
-  if (!orchestrateDriveAuthorized) {
+  if (!wants("s1")) {
+    // 絞り込みで対象外。
+  } else if (!orchestrateDriveAuthorized) {
     for (const [id, name] of [
       ["S1-a", "起動（セッション + スレッド + welcome 引数エコー）"],
       ["S1-b", ".tmp → Issue 化（P2 AC-1）"],
@@ -469,7 +556,13 @@ async function main(): Promise<number> {
   }
 
   // ---------- S1b: hub work 経路の決定的検証（P3 実機残検証） ----------
-  {
+  const s1bSlots = wants("s1b") ? dispatchSlots() : null;
+  if (s1bSlots && !s1bSlots.free) {
+    // 枠が埋まっているときに投げるとキャンセル不能なキュー残留になる（#386）。
+    record("S1b", "hub work 直接起動（start-hub-worker）", "SKIP",
+      `dispatch 同時実行枠が空いていません（running ${s1bSlots.busy} / 上限 ${s1bSlots.limit}）。` +
+        "キューはキャンセルできないため投入しません。枠が空いてから再実行してください");
+  } else if (wants("s1b")) {
     const issueBody = "E2E テスト専用（Phase 4 #321 / S1b）。何もしないでください。\n\n## 統合ジャーニーAC（不要・理由: E2E テスト用の使い捨て Issue）";
     writeFileSync("/tmp/e2e-issue-body2.md", issueBody);
     const created = gh(["issue", "create", "--title", "[e2e-test] Phase4 S1b hub-work 直接起動 smoke", "--body-file", "/tmp/e2e-issue-body2.md"]);
@@ -513,14 +606,14 @@ async function main(): Promise<number> {
     }
   }
 
-  // ---------- S2-4 / S2-5（長時間・モデル依存 → Phase 5 送り） ----------
-  record("S2-4", "ワーカー故意失敗 3 回 → error loop 停止（P2 AC-3）", "SKIP",
-    "error loop 検知はオーケストレーター（モデル）挙動で、決定的アサート不能 + 30 分超。Phase 5 受け入れ実走で検証");
-  record("S2-5", "オーケストレーター kill → resume 再入で重複なし（P2 AC-4 smoke）", "SKIP",
-    "resume は Epic 番号前提（SKILL Phase E）でテスト Epic が必要。Phase 5 で検証（corp 台帳の冪等性は agent-base 側テストで担保済み）");
+  // ---------- S2-4: error loop 検知 → session-ctl stop → 報告（Issue #386） ----------
+  if (wants("s2-4")) await runErrorLoopScenarioLeg(corpId);
+
+  // ---------- S2-5: kill → 再入で worktree 再利用（Issue #386） ----------
+  if (wants("s2-5")) await runResumeReentryLeg();
 
   // ---------- S3: 既存機能の回帰（live 分） ----------
-  {
+  if (wants("s3")) {
     // hijoguchi プロセス非干渉（pid 不変）
     const hijoguchiPidAfter = Bun.spawnSync(["pgrep", "-f", "CLAUDE_HUB_HIJOGUCHI_SESSION=1"]).stdout.toString().trim();
     record("S3-hijo", "hijoguchi プロセス非干渉（pid 不変）",
@@ -547,6 +640,344 @@ async function main(): Promise<number> {
     await cleanup();
   }
   return finish();
+}
+
+// ============================================================
+// S2-4: error loop 検知 → session-ctl stop → 報告（Issue #386）
+// ============================================================
+
+/**
+ * 子プロセスを起動し、`timeoutMs` を超えたら kill して結果を返す。
+ *
+ * S2-4 の子は relay 応答待ちを含むため、ハングしたときにドライバごと固まらない
+ * よう上限を持たせる（タイムアウトは FAIL の evidence として残す = silent に
+ * しない）。
+ */
+async function spawnWithTimeout(
+  cmd: string[],
+  env: Record<string, string>,
+  timeoutMs: number,
+): Promise<{ code: number | null; stdout: string; stderr: string; timedOut: boolean }> {
+  const proc = Bun.spawn(cmd, { env, stdout: "pipe", stderr: "pipe" });
+  let timedOut = false;
+  const timer = setTimeout(() => {
+    timedOut = true;
+    proc.kill();
+  }, timeoutMs);
+  try {
+    const [stdout, stderr] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+    ]);
+    const code = await proc.exited;
+    return { code, stdout, stderr, timedOut };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/** 隔離シナリオ子プロセスの上限。mock 応答は数秒なので 10 分あればハング判定に足りる。 */
+const ISOLATED_TIMEOUT_MS = 10 * 60_000;
+
+/**
+ * 隔離スタックのシナリオ（supervisor/tools/e2e-isolated.ts）を子プロセスで実行し、
+ * 結果 JSON を返す。
+ *
+ * 隔離 env（tmux socket / sessions.db / runtime dir / claude パス）はここで組み立てる。
+ * 子側の `assertIsolatedEnv` が同じ観点で再検査するので二重ガードになる。
+ */
+async function runIsolatedScenario<T extends { ok: boolean; failures: string[] }>(
+  scenario: "s2-4" | "s2-5",
+  mockFixture: string,
+): Promise<{ result: T | null; detail: string }> {
+  const toolPath = join(import.meta.dir, "e2e-isolated.ts");
+  const fixture = join(import.meta.dir, "..", "tests", "e2e", "fixtures", mockFixture);
+  if (!existsSync(fixture)) {
+    return { result: null, detail: `mock claude が見つかりません: ${fixture}` };
+  }
+  const scratch = mkdtempSync(join(tmpdir(), `e2e-${scenario}-`));
+  try {
+    const child = await spawnWithTimeout(
+      [process.execPath, toolPath, "--scenario", scenario],
+      {
+        ...(process.env as Record<string, string>),
+        SUPERVISOR_TMUX_SOCKET: `claude-hub-e2e-${scenario}`,
+        SUPERVISOR_DB_PATH: join(scratch, "sessions.db"),
+        XDG_RUNTIME_DIR: join(scratch, "runtime"),
+        SUPERVISOR_CLAUDE_PATH: fixture,
+      },
+      ISOLATED_TIMEOUT_MS,
+    );
+    const line = child.stdout
+      .split("\n")
+      .find((l) => l.startsWith(ISOLATED_RESULT_MARKER));
+    if (!line) {
+      return {
+        result: null,
+        detail:
+          `子プロセスが結果行を出力しませんでした（timedOut=${child.timedOut} exit=${child.code}）: ` +
+          (child.stderr.trim().slice(-300) || child.stdout.trim().slice(-300) || "(出力なし)"),
+      };
+    }
+    return {
+      result: JSON.parse(line.slice(ISOLATED_RESULT_MARKER.length).trim()) as T,
+      detail: "",
+    };
+  } catch (err) {
+    return { result: null, detail: `子プロセスの実行に失敗: ${err}` };
+  } finally {
+    try {
+      rmSync(scratch, { recursive: true, force: true });
+    } catch (err) {
+      console.warn(`cleanup: scratch ${scratch} の削除に失敗: ${err}`);
+    }
+  }
+}
+
+/**
+ * S2-4 — ワーカーが同じエラーを 3 回返したときの
+ * 「検知 → `session-ctl stop` → スレッド報告」を決定的に検証する。
+ *
+ * 検知と停止は隔離スタック（mock claude + 専用 tmux socket / sessions.db /
+ * runtime dir）の子プロセスが担当する（理由は e2e-isolated.ts の docblock）。
+ * 報告の配達だけは**稼働中 Supervisor の実経路**（session-ctl post-channel →
+ * `POST /channel-post` → Discord）を通し、driver Bot で着弾を確認する。
+ */
+async function runErrorLoopScenarioLeg(corpId: string): Promise<void> {
+  const NAME = "ワーカー故意失敗 3 回 → error loop 停止（P2 AC-3）";
+  const legFailures: string[] = [];
+
+  const { result, detail } = await runIsolatedScenario<ErrorLoopScenarioResult>(
+    "s2-4", "claude-error-loop-mock.sh",
+  );
+  if (!result) {
+    record("S2-4", NAME, "FAIL", detail);
+    return;
+  }
+  const r = result;
+
+  // (a) 検知: 同一署名が閾値回反復したことを実出力から判定できたか
+  const detected = r.verdict.detected;
+  if (!detected) legFailures.push("検知");
+  record("S2-4a", "同一エラー 3 回 → error loop 判定", detected ? "PASS" : "FAIL",
+    `同一署名 ${r.verdict.count}/${r.verdict.threshold} 回（判定対象 ${r.verdict.considered} 件）` +
+      ` 署名=${(r.verdict.signature ?? "(なし)").slice(0, 80)}`);
+
+  // (b) 停止: session-ctl stop が実際にループ中のワーカーを落としたか
+  const stopped = r.stopExit === 0 && r.dbStatus !== "running" && r.tmuxGone;
+  if (!stopped) legFailures.push("停止");
+  record("S2-4b", "session-ctl stop → tmux 消滅 + sessions.db 反映",
+    stopped ? "PASS" : "FAIL",
+    `stop exit=${r.stopExit ?? "-"} status=${r.dbStatus ?? "-"} tmuxGone=${r.tmuxGone}` +
+      (r.failures.length > 0 ? ` / ${r.failures.join(" ; ").slice(0, 200)}` : ""));
+
+  // (c) 報告: 実 Supervisor 経路（post-channel）で corp へ届くか
+  const runTag = `e2e-s2-4-${Date.now()}`;
+  const thread = await rest("POST", `/channels/${corpId}/threads`, {
+    name: `[e2e-test] S2-4 error loop 報告 ${runTag}`,
+    type: 11, // PUBLIC_THREAD（メッセージ非依存スレッド）
+    auto_archive_duration: 60,
+  });
+  if (thread.status !== 200 && thread.status !== 201) {
+    // 権限不足は「未検証」であって PASS ではない。SKIP + 理由で残す。
+    record("S2-4c", "error loop 報告の Discord 配達（post-channel）", "SKIP",
+      `driver Bot がスレッドを作成できません (HTTP ${thread.status})。corp での ` +
+        "Create Public Threads 権限を付与すると検証されます");
+  } else {
+    const threadId = thread.json.id as string;
+    createdThreads.push(threadId);
+    const text = `${r.report}\n- e2e-run: ${runTag}`;
+    const exit = await runSessionCtl(["post-channel", threadId, text], createRealEffects());
+    const landed = exit !== 0 ? null : await pollUntil(async () => {
+      const msgs = await fetchAllMessages(corpId);
+      return msgs.find((m) => (m.content ?? "").includes(runTag)) ?? null;
+    }, 60_000, 5_000);
+    if (!landed) legFailures.push("報告");
+    record("S2-4c", "error loop 報告の Discord 配達（post-channel）",
+      landed ? "PASS" : "FAIL",
+      landed
+        ? `corp に報告が着弾（run=${runTag}）`
+        : `post-channel exit=${exit} / 60 秒以内に corp へ着弾せず`);
+  }
+
+  record("S2-4", NAME, legFailures.length === 0 ? "PASS" : "FAIL",
+    legFailures.length === 0
+      ? `検知 ${r.verdict.count} 回 → stop exit=${r.stopExit} → 報告配達まで確認（モデルの意味判断は実走 #322 の範囲）`
+      : `未達: ${legFailures.join(" / ")}`);
+}
+
+// ============================================================
+// S2-5: kill → start-hub-worker 再入で worktree 再利用（Issue #386）
+// ============================================================
+
+/**
+ * S2-5 — ワーカーが死んだあと同じ branch で再投入したとき、**worktree が再利用**
+ * され（＝ 途中まで書いた作業が失われず）、セッションが再び応答可能になることを
+ * 検証する。
+ *
+ * これは orchestration-escalation-policy B-3「dead-session 再入（hub）は
+ * `start-hub-worker` 再実行で自動再起動（同 branch は worktree 再利用で冪等）」の
+ * 機械検証であり、同時に RW-046（停止で worktree を壊さない）の回帰でもある。
+ * Epic 番号を要する corp resume ではなく hub work 経路で検証するため、テスト用
+ * Epic の常設が不要になる（旧 SKIP 理由の解消）。
+ *
+ * 2 レグ構成:
+ *
+ *   - **iso**（常時実行）: 隔離スタック（mock claude + 一時 git リポジトリ）で
+ *     kill → 再入 → worktree 再利用 + 未コミット作業の生存 + 応答復帰を検証する。
+ *     dispatch 同時実行枠にも実課金にも依存しないので、いつ回しても検証される。
+ *   - **live**（枠が空いているときのみ）: 実 Supervisor の `start-hub-worker` で
+ *     同じ流れを通す。dispatch 枠（DISPATCH_MAX_CONCURRENT）が埋まっていると
+ *     投入が**キューに載って戻らない**ため、事前に空きを確認し、無ければ理由付きで
+ *     SKIP する（キューはキャンセル API を持たないので、埋まっているときに投げて
+ *     しまうと取り消せない残留ジョブになる。投げない方が安全）。
+ */
+async function runResumeReentryLeg(): Promise<void> {
+  const NAME = "kill → start-hub-worker 再入で worktree 再利用（P2 AC-4 smoke）";
+
+  // ---- iso レグ（決定的・常時実行） ----
+  const { result: iso, detail } = await runIsolatedScenario<WorktreeReuseScenarioResult>(
+    "s2-5", "claude-mock.sh",
+  );
+  if (!iso) {
+    record("S2-5-iso", "隔離スタックで kill → 再入 → worktree 再利用", "FAIL", detail);
+  } else {
+    record("S2-5-iso", "隔離スタックで kill → 再入 → worktree 再利用",
+      iso.ok ? "PASS" : "FAIL",
+      `before=${iso.worktreeBefore ?? "-"} after=${iso.worktreeAfter ?? "-"} same=${iso.sameWorktree}` +
+        ` dead検知=${iso.deadDetected} 未コミット作業の生存=${iso.workSurvived} 応答復帰=${iso.responsive}` +
+        (iso.failures.length > 0 ? ` / ${iso.failures.join(" ; ").slice(0, 200)}` : ""));
+  }
+  const isoOk = iso?.ok === true;
+
+  // ---- live レグ（dispatch 枠が空いているときのみ） ----
+  // 枠を占有しているのは running の dispatch 由来セッション（hub work / corp
+  // dispatch）。Supervisor 内部のキュー状態は外から読めないので同じ規則で近似する。
+  const slots = dispatchSlots();
+  if (!slots.free) {
+    record("S2-5-live", "実 start-hub-worker で kill → 再入", "SKIP",
+      `dispatch 同時実行枠が空いていません（running ${slots.busy} / 上限 ${slots.limit}）。` +
+        "投入するとキャンセル不能なキュー残留になるため投げません。枠が空いてから再実行してください");
+    record("S2-5", NAME, isoOk ? "PASS" : "FAIL",
+      isoOk
+        ? `隔離スタックで worktree 再利用を確認（live レグは dispatch 枠 ${slots.busy}/${slots.limit} のため SKIP）`
+        : "iso レグが FAIL");
+    return;
+  }
+
+  const liveFailures = await runResumeReentryLiveLeg();
+  record("S2-5", NAME, isoOk && liveFailures.length === 0 ? "PASS" : "FAIL",
+    isoOk && liveFailures.length === 0
+      ? "隔離・実 start-hub-worker の双方で kill → 再入の worktree 再利用を確認"
+      : `未達: ${[...(isoOk ? [] : ["iso"]), ...liveFailures].join(" / ")}`);
+}
+
+/** S2-5 live レグ本体。未達項目のラベル一覧を返す（空なら全 PASS）。 */
+async function runResumeReentryLiveLeg(): Promise<string[]> {
+  const bodyPath = "/tmp/e2e-issue-body-s2-5.md";
+  writeFileSync(bodyPath, [
+    "E2E テスト専用（Issue #386 / S2-5）。何もしないでください。",
+    "",
+    "## 統合ジャーニーAC（不要・理由: E2E テスト用の使い捨て Issue）",
+  ].join("\n"));
+  const created = gh(["issue", "create", "--title",
+    "[e2e-test] S2-5 kill 後の再入で worktree 再利用", "--body-file", bodyPath]);
+  const issueNumber = Number(created.stdout.match(/\/issues\/(\d+)/)?.[1] ?? 0);
+  if (!created.ok || !issueNumber) {
+    record("S2-5-live", "実 start-hub-worker で kill → 再入", "FAIL",
+      `テスト Issue 作成失敗: ${created.stderr.slice(0, 200)}`);
+    return ["live: Issue 作成"];
+  }
+  createdIssues.push(issueNumber);
+
+  const branch = `hub-work-${issueNumber}`;
+  const fx = createRealEffects();
+  const legFailures: string[] = [];
+
+  // (1) 初回起動。start-hub-worker はキューに載っても exit 0 で戻るため、
+  //     出力の queued フラグを見て「起動した」のか「待たされた」のかを区別する
+  //     （区別しないと 3 分待って「行が現れない」という誤解を招く FAIL になる）。
+  const ctlOut: string[] = [];
+  const capturing = { ...fx, out: (line: string) => { ctlOut.push(line); console.log(line); } };
+  const t0 = new Date().toISOString();
+  const startExit = await runSessionCtl(
+    ["start-hub-worker", branch, String(issueNumber), "no-template"], capturing);
+  if (ctlOut.some((l) => l.includes("queued=true"))) {
+    record("S2-5-live", "実 start-hub-worker で kill → 再入", "SKIP",
+      "投入が dispatch キューに載りました（枠が埋まった）。キューはキャンセルできないため、" +
+        "枠が空いてから再実行してください");
+    return [];
+  }
+  const first = startExit !== 0 ? null : await pollUntil(async () => {
+    const rows = rowsSince(t0).filter((r) => r.branch === branch && r.status === "running");
+    return rows[0] ?? null;
+  }, 180_000, 5_000);
+  if (!first) {
+    record("S2-5-live", "実 start-hub-worker で kill → 再入", "FAIL",
+      `初回 start-hub-worker exit=${startExit}, running 行が現れない`);
+    return ["live: 初回起動"];
+  }
+  createdSessionKeys.push(first.id);
+  createdBranches.push({ repoDir: join(homedir(), "claude-hub"), branch });
+  if (first.thread_id) createdThreads.push(first.thread_id);
+  const worktreePath: string = first.project_dir;
+
+  if (!first.thread_id) {
+    record("S2-5-live", "実 start-hub-worker で kill → 再入", "FAIL",
+      "初回セッションに thread_id がなく kill 経路を駆動できない");
+    return ["live: thread_id 欠落"];
+  }
+
+  // (2) kill（tmux セッションを落として「ワーカーが死んだ」状態を作る）。
+  //     session-ctl stop の graceful 経路ではなく突然死を模す。
+  await fx.killTmuxSession(tmuxNameForThread(first.thread_id));
+  const dead = await pollUntil(async () => {
+    const row = dbRows(`SELECT status,stopped_reason FROM sessions WHERE id = ?`, first.id)[0];
+    return row && row.status !== "running" ? row : null;
+  }, 120_000, 5_000);
+  if (!dead) legFailures.push("live: kill 検知");
+  record("S2-5-live-a", "kill → Supervisor が dead を検知し status 反映", dead ? "PASS" : "FAIL",
+    dead ? `status=${dead.status} reason=${dead.stopped_reason ?? "-"}` : "120 秒以内に running が解除されない");
+
+  // (3) worktree 保全（RW-046: 停止は worktree を壊さない）
+  const retained = existsSync(worktreePath);
+  if (!retained) legFailures.push("live: worktree 保全");
+  record("S2-5-live-b", "kill 後も worktree を保全（RW-046）", retained ? "PASS" : "FAIL",
+    `${worktreePath} exists=${retained}`);
+
+  // (4) 再入 — 同じ branch / issue で start-hub-worker をもう一度
+  const t1 = new Date().toISOString();
+  const reExit = await runSessionCtl(
+    ["start-hub-worker", branch, String(issueNumber), "no-template"], fx);
+  const second = reExit !== 0 ? null : await pollUntil(async () => {
+    const rows = rowsSince(t1).filter(
+      (r) => r.branch === branch && r.status === "running" && r.id !== first.id);
+    return rows[0] ?? null;
+  }, 180_000, 5_000);
+  if (second) {
+    createdSessionKeys.push(second.id);
+    if (second.thread_id) createdThreads.push(second.thread_id);
+  }
+
+  // (5) worktree 同一性（本シナリオの中核アサート）
+  const sameWorktree = !!second && second.project_dir === worktreePath;
+  if (!sameWorktree) legFailures.push("live: worktree 再利用");
+  record("S2-5-live-c", "再入で同一 branch の worktree を再利用", sameWorktree ? "PASS" : "FAIL",
+    second
+      ? `before=${worktreePath} after=${second.project_dir} same=${sameWorktree}`
+      : `再入 start-hub-worker exit=${reExit}, running 行が現れない`);
+
+  // (6) 応答可能に戻ったか（tmux ペインが send を受理する）
+  const sendExit = second
+    ? await runSessionCtl(
+        ["send", second.id, "e2e ping: 応答不要です。何もしないでください。"], fx)
+    : 1;
+  if (sendExit !== 0) legFailures.push("live: 応答可能");
+  record("S2-5-live-d", "再入セッションが応答可能（send 受理）", sendExit === 0 ? "PASS" : "FAIL",
+    `exit=${sendExit}`);
+
+  if (second) await stopSessionQuiet(second.id);
+  return legFailures;
 }
 
 function countE2eIssues(): number {

--- a/supervisor/tools/e2e-live.ts
+++ b/supervisor/tools/e2e-live.ts
@@ -587,9 +587,22 @@ async function main(): Promise<number> {
         if (row.thread_id) createdThreads.push(row.thread_id);
         record("S1b-start", "hub work 直接起動（start-hub-worker）", "PASS",
           `branch=${branch} thread=${row.thread_id} channel_name=${row.channel_name}`);
-        // send → stop
-        const sendCode = await runSessionCtl(["send", row.id, "e2e ping: 応答不要です。何もしないでください。"], createRealEffects());
-        record("S1b-send", "hub work セッションへ send", sendCode === 0 ? "PASS" : "FAIL", `exit=${sendCode}`);
+        // send → stop。send は tmux ペインへの入力なので、Supervisor が
+        // `DISPATCH_EXECUTOR_MODE=headless` で動いている（`claude -p` の一発実行で
+        // ペインを持たない、Issue #358）ときは非適用。PASS と偽らず SKIP にする。
+        const s1bFx = createRealEffects();
+        const s1bHasPane = row.thread_id
+          ? await s1bFx.hasTmuxSession(tmuxNameForThread(row.thread_id))
+          : false;
+        if (!s1bHasPane) {
+          record("S1b-send", "hub work セッションへ send", "SKIP",
+            "headless ワーカー（tmux ペインなし）のため send は非適用。" +
+              "起動の成立は S1b-start、停止は S1b-stop で確認する");
+        } else {
+          const sendCode = await runSessionCtl(
+            ["send", row.id, "e2e ping: 応答不要です。何もしないでください。"], s1bFx);
+          record("S1b-send", "hub work セッションへ send", sendCode === 0 ? "PASS" : "FAIL", `exit=${sendCode}`);
+        }
         await stopSessionQuiet(row.id);
         const stopped = await pollUntil(async () => {
           const r = dbRows(`SELECT status,stopped_reason FROM sessions WHERE id = ?`, row.id)[0];
@@ -928,16 +941,37 @@ async function runResumeReentryLiveLeg(): Promise<string[]> {
     return ["live: thread_id 欠落"];
   }
 
-  // (2) kill（tmux セッションを落として「ワーカーが死んだ」状態を作る）。
-  //     session-ctl stop の graceful 経路ではなく突然死を模す。
-  await fx.killTmuxSession(tmuxNameForThread(first.thread_id));
+  // (2) kill（「ワーカーが突然死した」状態を作る。session-ctl stop の graceful
+  //     経路ではない）。ワーカーは tmux とは限らない: Supervisor が
+  //     `DISPATCH_EXECUTOR_MODE=headless` で動いていると `claude -p` の
+  //     子プロセスで tmux を持たない（Issue #358）。tmux があれば kill-session、
+  //     無ければ pid へ SIGKILL する。pid 側は session-ctl と同じ本人確認
+  //     （コマンドラインに claude_session_id が含まれるか）を通してから撃つ
+  //     ——PID 再利用で無関係プロセスを殺さないため。
+  const tmuxName = tmuxNameForThread(first.thread_id);
+  let killDetail: string;
+  if (await fx.hasTmuxSession(tmuxName)) {
+    await fx.killTmuxSession(tmuxName);
+    killDetail = `tmux kill-session ${tmuxName}`;
+  } else if (first.pid != null && fx.pidAlive(first.pid)) {
+    const cmd = await fx.readPidCommand(first.pid);
+    if (first.claude_session_id && cmd?.includes(first.claude_session_id)) {
+      fx.killPid(first.pid, "SIGKILL");
+      killDetail = `headless: SIGKILL pid ${first.pid}`;
+    } else {
+      killDetail = `pid ${first.pid} のコマンドラインが session id と一致せず kill を見送り（PID 再利用の疑い）`;
+    }
+  } else {
+    killDetail = "tmux セッションも生存 pid も見つからない（既に終了？）";
+  }
   const dead = await pollUntil(async () => {
     const row = dbRows(`SELECT status,stopped_reason FROM sessions WHERE id = ?`, first.id)[0];
     return row && row.status !== "running" ? row : null;
   }, 120_000, 5_000);
   if (!dead) legFailures.push("live: kill 検知");
   record("S2-5-live-a", "kill → Supervisor が dead を検知し status 反映", dead ? "PASS" : "FAIL",
-    dead ? `status=${dead.status} reason=${dead.stopped_reason ?? "-"}` : "120 秒以内に running が解除されない");
+    `${killDetail} → ` +
+      (dead ? `status=${dead.status} reason=${dead.stopped_reason ?? "-"}` : "120 秒以内に running が解除されない"));
 
   // (3) worktree 保全（RW-046: 停止は worktree を壊さない）
   const retained = existsSync(worktreePath);
@@ -967,14 +1001,26 @@ async function runResumeReentryLiveLeg(): Promise<string[]> {
       ? `before=${worktreePath} after=${second.project_dir} same=${sameWorktree}`
       : `再入 start-hub-worker exit=${reExit}, running 行が現れない`);
 
-  // (6) 応答可能に戻ったか（tmux ペインが send を受理する）
-  const sendExit = second
-    ? await runSessionCtl(
-        ["send", second.id, "e2e ping: 応答不要です。何もしないでください。"], fx)
-    : 1;
-  if (sendExit !== 0) legFailures.push("live: 応答可能");
-  record("S2-5-live-d", "再入セッションが応答可能（send 受理）", sendExit === 0 ? "PASS" : "FAIL",
-    `exit=${sendExit}`);
+  // (6) 応答可能に戻ったか（tmux ペインが send を受理する）。
+  //     headless ワーカーはペインを持たない（`claude -p` の一発実行）ので送信の
+  //     概念が無い。その場合は「running 行が再び現れた」ことをもって再入の成立と
+  //     し、送信検証は理由付き SKIP にする（PASS と偽らない）。
+  const secondTmux = second?.thread_id ? tmuxNameForThread(second.thread_id) : null;
+  const secondHasPane = secondTmux ? await fx.hasTmuxSession(secondTmux) : false;
+  if (!second) {
+    legFailures.push("live: 応答可能");
+    record("S2-5-live-d", "再入セッションが応答可能（send 受理）", "FAIL", "再入セッションなし");
+  } else if (!secondHasPane) {
+    record("S2-5-live-d", "再入セッションが応答可能（send 受理）", "SKIP",
+      "headless ワーカー（tmux ペインなし）のため send 検証は非適用。" +
+        "再入の成立は running 行の再出現で確認済み");
+  } else {
+    const sendExit = await runSessionCtl(
+      ["send", second.id, "e2e ping: 応答不要です。何もしないでください。"], fx);
+    if (sendExit !== 0) legFailures.push("live: 応答可能");
+    record("S2-5-live-d", "再入セッションが応答可能（send 受理）", sendExit === 0 ? "PASS" : "FAIL",
+      `exit=${sendExit}`);
+  }
 
   if (second) await stopSessionQuiet(second.id);
   return legFailures;


### PR DESCRIPTION
Closes #386（Epic #381 トレーサビリティ向上）

## 背景

実 Discord E2E ドライバ `supervisor/tools/e2e-live.ts` は S2-4（error loop）と
S2-5（kill→resume 再入）を SKIP しており、この 2 経路は自動検証ゼロだった。
旧 SKIP 理由は「モデル挙動依存で決定的アサートが書けない / 30 分超かかる」。

## 方針

**モデルの意味判断**と**機構**を切り分け、機構だけを決定的に検証する。

- 検証する: 同一署名 3 回の判定、`session-ctl stop` が実際にループ中のワーカーを
  落とすこと、停止の sessions.db / tmux 反映、報告の Discord 配達、kill 後の
  worktree 再利用と作業の生存、応答復帰
- 検証しない（実走 #322 のまま）: 「このエラーは同じ失敗か」というオーケストレーター
  （モデル）の意味判断

## 主な変更

### `supervisor/tools/e2e-isolated.ts`（新規）

隔離スタック（mock claude + 専用 tmux socket / sessions.db / runtime dir）で走る
決定的シナリオ本体。**子プロセス**として起動する理由は、Supervisor の 3 つの
グローバル（`TMUX_SOCKET` / `DB_PATH` / relay ポートファイル）がモジュールロード時に
固定され、隔離しないと稼働中 Supervisor の tmux・sessions.db・relay-port を壊すため。
`assertIsolatedEnv` が本番 socket / 本番 DB / 既存 relay-port を指したままの実行を
fail-closed で止める。

- `--scenario s2-4`: 同一エラー 3 回 → error loop 判定 → 実 `session-ctl stop` →
  tmux 消滅 + sessions.db 反映 → 報告文生成
- `--scenario s2-5`: 一時 git リポで kill → 同 branch 再入 → worktree 再利用 +
  **未コミット作業（sentinel）の生存** + 応答復帰

path 一致だけでなく sentinel の生存を見るのは、worktree を作り直しても path は
一致してしまい「作業が失われた」ことを検出できないため。

### `supervisor/tests/e2e/fixtures/claude-error-loop-mock.sh`（新規）

毎回同一のエラー中核 + 可変タイムスタンプ・試行回数を返す mock claude。
バイト完全一致にしないのは意図的で、署名の正規化（可変部を落とせているか）まで
検証するため。実課金なし。

### `supervisor/tests/tools/e2e-isolated.test.ts`（新規, 19 tests）

判定規則そのものを CI で常時検証する（tmux も DB も触らない）:
署名の正規化 / 過剰正規化の検出 / 閾値の境界 / 成功応答の反復を error loop と
誤判定しないこと（誤 kill 防止）/ 隔離ガードの fail-closed。

### `supervisor/tools/e2e-live.ts`

- S2-4 / S2-5 の SKIP を実装に置換（S2-4 の報告レグは実 `post-channel` →
  `POST /channel-post` → Discord を通し、driver Bot で着弾確認）
- `--scenario <id>` を追加（`s1 / s1b / s2-1 / s2-2 / s2-3 / s2-4 / s2-5 / s3`）。
  未知の値は fail-closed（typo で「全部 SKIP して 0 終了」にしない）
- **S1b / S2-5 live に dispatch 枠ガードを追加**: 枠が埋まった状態の
  `start-hub-worker` は拒否ではなく **FIFO キュー投入**（exit 0 のまま戻る）で、
  キューにキャンセル API が無い。投げると cleanup 後に勝手に走り出す取り消せない
  ジョブが残るため、投げずに理由付き SKIP にする（本 PR の実装中に実際に踏んだ）

### その他

- `.github/workflows/ci.yml`: 新規ユニットテストを CI の対象に追加
- `codecov.yml`: `e2e-isolated.ts` を除外（e2e-live.ts と同型の理由 + 判定規則は
  純関数として別途テスト済み。coverage-policy.md §4/§5）
- `docs/e2e-orchestrate.md`: S2-4/S2-5 の行を「Phase 5 送り」から本編へ移動、
  `--scenario` と dispatch 枠の注意を追記

## AC 検証結果（ローカル実走）

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | S2-4 が error loop 検知 → 停止 → 報告で PASS | `e2e-live.ts --scenario s2-4` | exit 0 + S2-4 PASS 行 | exit 0 / `S2-4 ... PASS 検知 3 回 → stop exit=0 → 報告配達まで確認` | PASS |
| AC-2 | S2-5 が worktree 再利用で PASS | `e2e-live.ts --scenario s2-5` | exit 0 + worktree path 同一性の出力 | exit 0 / `same=true dead検知=true 未コミット作業の生存=true 応答復帰=true` | PASS |
| AC-3 | 既存シナリオの非破壊 | `--scenario s2-1 / s3 / s1b` + hermetic 一式 + `bun test tests/tools/` + `tsc` | 全 PASS | s2-1 2 PASS / s3 3 PASS 2 SKIP / s1b SKIP(枠) / tools 55 pass / tsc exit 0 | 部分 PASS（下記） |

**AC-3 の未実施部分（明示）**: `--skip-live` なしのフル実走のうち、
オーケストレーター駆動シナリオ（S1 / S2-2 / S2-3）は本セッションから実行して
いない。理由は (a) 実オーケストレーターセッションを 2 本起動し 30〜60 分・実課金が
かかる、(b) 現在 dispatch 枠が 3/3 で埋まっており、S1 のオーケストレーターが
ワーカーを投入すると**キャンセル不能なキュー残留**を作る、ため。
枠が空いている状態で以下を実行して確認してください:

```bash
bash scripts/e2e-orchestrate.sh
```

なお hermetic 回帰（wrapper の [1/2]）は実行済みで、`tests/e2e/dialog-stall.test.ts`
AC-2 が 1 件 fail するが、**本変更前の clean tree でも同じ 1 件が fail** する
（実 tmux 負荷依存の既存 flaky）ことを `git stash` で確認済み。

## 既知の副作用（申し送り）

実装中の試行で、dispatch 枠が埋まった状態で `start-hub-worker` を 1 回投入して
しまい、Issue #392（cleanup で close 済み）に対する `/impl 392` が Supervisor の
FIFO キューに残っている。枠が空くと起動するが、対象 Issue は closed のため
`/impl` は着手できず終了する見込み。キューはキャンセル API を持たず、確実に
消すには Supervisor 再起動（= 全セッション stop）が必要なため本 PR では触れて
いない。本 PR のガードにより同じ事象は再発しない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
