### PR TITLE
chore(#389): DISPATCH_MAX_CONCURRENT の既定を 3 から 5 へ引き上げる

### DIFF
--- a/docs/adr/2026-07-05-corp-orchestration.md
+++ b/docs/adr/2026-07-05-corp-orchestration.md
@@ -85,7 +85,7 @@ compact / Mac 再起動後の再入手順:
 
 ### D4. 並列上限は既存 `DISPATCH_MAX_CONCURRENT` に従う
 
-オーケストレーターは独自の並列制御を持たず、既存の dispatch FIFO キューに従う。上限は `DISPATCH_MAX_CONCURRENT = 3`（`supervisor/src/config/channels.ts:205`、env `DISPATCH_MAX_CONCURRENT` で上書き可: `supervisor/src/session/dispatch-queue.ts:54-56`）。上限超過の dispatch は reject されず QUEUED になり、空き次第 FIFO で自動起動する（Phase 5c #294 の既存挙動）。オーケストレーターが 4 件以上を一括投入しても安全側に倒れる。
+オーケストレーターは独自の並列制御を持たず、既存の dispatch FIFO キューに従う。上限は `DISPATCH_MAX_CONCURRENT`（`supervisor/src/config/channels.ts`、env `DISPATCH_MAX_CONCURRENT` で上書き可: `supervisor/src/session/dispatch-queue.ts`）。本 ADR 起草時点の既定は `3`（**その後 #389 で `5` に引き上げ**。決定 D4 自体＝「独自制御を持たず既存キューに従う」は不変）。上限超過の dispatch は reject されず QUEUED になり、空き次第 FIFO で自動起動する（Phase 5c #294 の既存挙動）。オーケストレーターが 4 件以上を一括投入しても安全側に倒れる。
 
 ### D5. claude-hub work セッション経路（#208 案B）— corp チャンネル案を採用
 

--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -173,7 +173,7 @@ headless 実行の完了時、対象 Issue へ実行レポートを `gh issue co
 
 | env | 既定 | 意味 |
 |---|---|---|
-| `DISPATCH_MAX_CONCURRENT` | `3` | 同時に実行する dispatch セッションの上限。超過分は**拒否せずキュー**に積み、先行完了で FIFO 起動 |
+| `DISPATCH_MAX_CONCURRENT` | `5` | 同時に実行する dispatch セッションの上限。超過分は**拒否せずキュー**に積み、先行完了で FIFO 起動。既定は #389 で `3` → `5` に引き上げ（`MAX_SESSIONS = 10` の残り 5 枠は interactive 用）。負荷逼迫時はこの env で運用側から絞れる |
 
 - 対話 `/session start` は**このキューを通らない**（`MAX_SESSIONS` のみで制限）。人間の体験は不変。
 - キュー投入時・キューから起動時にスレッドへ状態を明示（サイレントに待たせない）。

--- a/supervisor/src/config/channels.ts
+++ b/supervisor/src/config/channels.ts
@@ -200,9 +200,12 @@ export const SESSION_IDLE_BACKSTOP_MS = IDLE_TIMEOUT_MS; // 30 days, hard cap
 // number of running dispatch sessions reaches this, a new /dispatch is QUEUED
 // (not rejected) and started FIFO as slots free. Interactive /session start does
 // NOT go through this queue (it is capped only by MAX_SESSIONS), so the human
-// experience is unchanged. Kept well under MAX_SESSIONS so interactive keeps
-// headroom. Env-overridable via `DISPATCH_MAX_CONCURRENT`.
-export const DISPATCH_MAX_CONCURRENT = 3;
+// experience is unchanged. Kept under MAX_SESSIONS so interactive keeps headroom:
+// at 5, half of the 10 MAX_SESSIONS slots stay reserved for interactive starts.
+// Raised 3 → 5 in #389 because independent tasks were serialising behind the
+// FIFO queue and stretching overall lead time. Under host pressure, ops can dial
+// it back down at runtime. Env-overridable via `DISPATCH_MAX_CONCURRENT`.
+export const DISPATCH_MAX_CONCURRENT = 5;
 
 // Phase 5d (#295 / Epic #292): dynamic admission is WARN-first — it defaults to
 // OBSERVE ONLY (log a WARN when load is high, but do NOT delay). Enforcement

--- a/supervisor/tests/session/dispatch-queue.test.ts
+++ b/supervisor/tests/session/dispatch-queue.test.ts
@@ -1,8 +1,12 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, afterEach } from "bun:test";
 import {
   DispatchQueue,
   type QueuedDispatch,
 } from "../../src/session/dispatch-queue";
+import {
+  DISPATCH_MAX_CONCURRENT,
+  MAX_SESSIONS,
+} from "../../src/config/channels";
 
 /**
  * Phase 5c / #294 (Epic #292 AC-2 / AC-3): dispatch concurrency limit + FIFO
@@ -119,6 +123,58 @@ describe("DispatchQueue (AC-2: concurrency limit + FIFO)", () => {
     await flush();
     // The throw must not leak the slot.
     expect(q.activeCount()).toBe(0);
+  });
+});
+
+describe("DispatchQueue (#389: default concurrency + env override)", () => {
+  const ENV_KEY = "DISPATCH_MAX_CONCURRENT";
+  const savedEnv = process.env[ENV_KEY];
+
+  afterEach(() => {
+    if (savedEnv === undefined) delete process.env[ENV_KEY];
+    else process.env[ENV_KEY] = savedEnv;
+  });
+
+  // AC-1: the shipped default is 5 (raised from 3 in #389).
+  test("the default concurrency constant is 5", () => {
+    expect(DISPATCH_MAX_CONCURRENT).toBe(5);
+  });
+
+  // The default must stay under MAX_SESSIONS so interactive starts (which bypass
+  // this queue) keep headroom — the invariant the constant's comment claims.
+  test("the default leaves interactive headroom under MAX_SESSIONS", () => {
+    expect(DISPATCH_MAX_CONCURRENT).toBeLessThan(MAX_SESSIONS);
+    expect(MAX_SESSIONS - DISPATCH_MAX_CONCURRENT).toBeGreaterThanOrEqual(5);
+  });
+
+  test("a queue built without an explicit limit adopts the default", () => {
+    delete process.env[ENV_KEY];
+    expect(new DispatchQueue({ log: quietLog }).limit()).toBe(
+      DISPATCH_MAX_CONCURRENT,
+    );
+  });
+
+  // AC-2: env still overrides the default, so ops can dial concurrency down when
+  // the host is under pressure.
+  test("DISPATCH_MAX_CONCURRENT=2 overrides the default", () => {
+    process.env[ENV_KEY] = "2";
+    expect(new DispatchQueue({ log: quietLog }).limit()).toBe(2);
+  });
+
+  test("an invalid env value falls back to the default", () => {
+    for (const bad of ["0", "-1", "abc", ""]) {
+      process.env[ENV_KEY] = bad;
+      expect(new DispatchQueue({ log: quietLog }).limit()).toBe(
+        DISPATCH_MAX_CONCURRENT,
+      );
+    }
+  });
+
+  test("an explicit maxConcurrent dep wins over the env value", () => {
+    process.env[ENV_KEY] = "2";
+    expect(new DispatchQueue({ maxConcurrent: 7, log: quietLog }).limit()).toBe(
+      7,
+    );
   });
 });
 


### PR DESCRIPTION
## 概要

Closes #389

dispatch の同時実行上限 `DISPATCH_MAX_CONCURRENT` の既定を **3 → 5** に引き上げる。

2026-08-09 の Wave 1 投入で 6 本中 3 本が FIFO 待機となり、独立タスクが直列化して全体のリードタイムが伸びていた。待機自体は安全側の設計（拒否ではなくキュー）だが、上限 3 は現行のワークロードに対して保守的すぎた。

## 変更点

| ファイル | 変更 |
|---|---|
| `supervisor/src/config/channels.ts` | 既定値 `3` → `5`。コメントを 5 でも成立する根拠へ更新（`MAX_SESSIONS = 10` の残り 5 枠が interactive 用に確保される旨） |
| `supervisor/tests/session/dispatch-queue.test.ts` | 回帰テスト 6 件を追加（既定値 / headroom 不変条件 / env 上書き / 不正値フォールバック / 明示 dep 優先） |
| `docs/bot-operations.md` | env 表の既定値を `5` に更新し、逼迫時は env で運用側から絞れる旨を追記 |
| `docs/adr/2026-07-05-corp-orchestration.md` | D4 が引用していた既定値 `3` が陳腐化しないよう注記（決定 D4 自体＝「独自制御を持たず既存キューに従う」は不変） |

interactive `/session start` はこのキューを通らない（`MAX_SESSIONS` のみで制限）ため、人間の体験は不変。

## 統合ジャーニーAC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | 既定値が 5 | `bun test tests/session/dispatch-queue.test.ts` | exit 0 + 該当テストが pass | exit 0 / `the default concurrency constant is 5` pass（10 pass 0 fail） | **PASS** |
| AC-2 | env 上書きが効く | 同上（`DISPATCH_MAX_CONCURRENT=2` を設定して `limit()` を実測） | 戻り値 2 | `DISPATCH_MAX_CONCURRENT=2 overrides the default` pass（実測 2） | **PASS** |
| AC-3 | ソース上の定数 | `grep -n "DISPATCH_MAX_CONCURRENT = " supervisor/src/config/channels.ts` / `grep -c "DISPATCH_MAX_CONCURRENT = 3" ...` | `= 5` / count 0 | `208:export const DISPATCH_MAX_CONCURRENT = 5;` / count `0` | **PASS** |
| AC-4 | CI green | `gh pr view <N> --json statusCheckRollup` | 全 SUCCESS | CI 実行待ち | 保留 |

**全体: 3/3 PASS（AC-4 は CI 実行待ち）**

ローカル追加検証:

- `bunx tsc --noEmit` → exit 0
- `bun scripts/check-access-policy.ts --ci` / `lint-blocking-in-timers` / `lint-no-sync-exec` / `lint-gating-coverage` → 全て exit 0
- ci.yml のゲート済みテスト一覧を実行 → 失敗は `cleanup-idle-claude.sh` / `list-claude-processes.sh` / `lint-blocking-in-timers` 回帰ガードの 5 件のみ。**同一コマンドを `origin/main` の別 worktree で実行したところ同じ 6 件が失敗**しており（本ブランチはその部分集合、branch-only failure は 0 件）、いずれもローカル macOS 環境依存の既存失敗。本 PR 起因の新規失敗なし
- 本テストファイルは `ci.yml:172` でゲート済み（`lint-gating-coverage` PASS で機械的にも確認）

## 運用上の注意

### 1. admission control は現状 observe-only（enforce 昇格の判断材料）

`DISPATCH_ADMISSION_ENFORCE=1` を設定して初めて遅延が効き、既定は **観測のみ（WARN ログのみ、遅延なし）**。判定は `load1 > cores * ADMISSION_LOAD_FACTOR`（`ADMISSION_LOAD_FACTOR = 1.0`）、超過時の動作は `ADMISSION_DELAY_MS = 5000` の一回きりの遅延で、**拒否は決してしない**（`supervisor/src/session/admission.ts`）。

本 PR では昇格しない。判断材料として所見を記す:

- 稼働機は **M1 Max 10 コア / 32GB**。本 PR 作成時点（2026-08-09 21:14 JST）の実測で `load1 = 19.57` / swap 4416MB 使用（6144MB 中）。Issue 記載の同日 `load1 = 24.6` と同傾向で、**逼迫は継続している**
- factor 1.0 では ceiling = 10 に対し load1 ≈ 19.6 なので、**既に常時「high load」判定**の状態。つまり observe モードの WARN は現状ほぼ常時発報しており、シグナルとしての弁別力を失っている
- この状態のまま enforce に昇格すると、ほぼ全ての dispatch 起動に一律 5s の遅延が乗るだけになる。5s は飽和のタイムスケール（数分〜数十分）に対して短すぎ、ホスト保護の実効はほとんど期待できない一方、WARN は減らない
- **所見（推奨）**: enforce 昇格の前に `ADMISSION_LOAD_FACTOR` の再チューニング（例 1.5〜2.0）で「本当に危険な水準」だけを弁別できるようにするのが先。factor 1.0 のままの昇格は thin-scaffolding の WARN-first dogfood（false positive ゼロを確認してから昇格）の前提を満たさない

### 2. 逼迫時は env で絞れる

並列 5 が重いと判断した場合、コード変更なしに `DISPATCH_MAX_CONCURRENT`（正の整数）で運用側から下げられる。本 PR の回帰テストでこの上書き経路を明示的に担保している。

## 反映タイミング（重要）

この定数は **Supervisor プロセス起動時に読まれる**ため、**merge しただけでは効かず Supervisor の再起動が必要**。

再起動時は `shutdownAll()` が全セッションを停止する（`supervisor/src/session/manager.ts:2172`）。停止理由は `supervisor_restart` で、#369 の修正により **この理由での停止は worktree を保持する**（未コミット作業は失われない）が、稼働中セッションは一旦落ちる。

→ **稼働セッションが無いタイミングで、会長またはオーケストレーターが再起動を実施すること。**

## 関連

- 起点: corp `/orchestrate` 2026-08-09（会長指示）
- 関連: #294 / Epic #292（dispatch 並列制限と FIFO キューの導入）、#295（admission control WARN-first）、#369（`supervisor_restart` での worktree 保持）
