### PR TITLE
refactor(bot): bot.ts 起動配線の分離リファクタと配線テスト追加（#383）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,6 +149,7 @@ jobs:
                    tests/config/check-access-policy.test.ts \
                    tests/discord/in-memory-client.test.ts \
                    tests/discord/real-client.test.ts \
+                   tests/bot/startup-wiring.test.ts \
                    tests/guards/access-enforcement-wired.test.ts \
                    tests/hooks/ask-user-relay.test.ts \
                    tests/hooks/auto-approve-permission.test.ts \

--- a/codecov.yml
+++ b/codecov.yml
@@ -63,6 +63,8 @@ ignore:
   # エントリ（~38 行、ビジネスロジックなし）。トークン無しでは実行不能な境界
   # コードのため除外（AC-1/2/3 は PR 本文で手動検証扱い。ci.yml e2e-tests
   # ジョブのコメント参照）。
+  - "supervisor/index.ts"
+  #
   # NOTE: src/bot.ts はコアロジック（アクセス制御 / self-heal / キュー / 中継）を
   # 含むため除外しない。#383（Epic #381）で startBot() の**起動時配線**を
   # src/bot-wiring.ts へ分離し、tests/bot/startup-wiring.test.ts で計測・検証
@@ -81,7 +83,8 @@ ignore:
   #     除外すると、今後 bot.ts へ**戻る**方向の変更が検知されなくなる。
   # patch は WARN-first（informational）なので、未カバーの残部に触れた PR が
   # 不当に FAIL することはない。blocking 昇格時の再評価は #300 で追跡する。
-  - "supervisor/index.ts"
+  # （src/bot.ts の除外エントリは意図的に存在しない）
+  #
   # iterm2 タブ着色。~/.claude/scripts/project-colors.json とローカル iTerm2 を
   # 要するローカル専用（ci.yml 末尾「Local-only tests」参照）。
   - "supervisor/src/session/iterm2.ts"

--- a/codecov.yml
+++ b/codecov.yml
@@ -63,11 +63,24 @@ ignore:
   # エントリ（~38 行、ビジネスロジックなし）。トークン無しでは実行不能な境界
   # コードのため除外（AC-1/2/3 は PR 本文で手動検証扱い。ci.yml e2e-tests
   # ジョブのコメント参照）。
-  # NOTE: src/bot.ts（~1065 行）はコアロジック（アクセス制御 / self-heal /
-  # キュー / 中継）を含むため除外しない。現状は startBot(token) 内に密結合で
-  # 未カバーだが、blanket 除外は coverage-policy.md §5 の anti-gaming に反する
-  # （PR #301 の gemini review 指摘）。トークン起動部とロジックの分離リファクタ
-  # + テスト補充は follow-up #300 で追跡する。
+  # NOTE: src/bot.ts はコアロジック（アクセス制御 / self-heal / キュー / 中継）を
+  # 含むため除外しない。#383（Epic #381）で startBot() の**起動時配線**を
+  # src/bot-wiring.ts へ分離し、tests/bot/startup-wiring.test.ts で計測・検証
+  # 対象にした。
+  #
+  # 残部（bot.ts のイベントハンドラ本体）の扱いは「カバー対象化」で確定する
+  # （除外しない）。理由:
+  #   - blanket 除外は coverage-policy.md §5 の anti-gaming に反する
+  #     （PR #301 の gemini review 指摘）。
+  #   - 残部は index.ts のような「トークンが無いと実行不能な境界コード」では
+  #     なく、分岐を持つロジック（アクセスゲート / dispatch・orchestrate 傍受 /
+  #     slash strip / 中継キュー）である。coverage-policy.md §4 の除外事由
+  #     （外部 API 直叩き・E2E 担保・単純委譲）のいずれにも該当しない。
+  #   - 実際、これらの分岐の多くは既に純関数側（access-policy / slash-prefix /
+  #     dispatch / orchestrate / salvage-reply）へ切り出され計測されている。
+  #     除外すると、今後 bot.ts へ**戻る**方向の変更が検知されなくなる。
+  # patch は WARN-first（informational）なので、未カバーの残部に触れた PR が
+  # 不当に FAIL することはない。blocking 昇格時の再評価は #300 で追跡する。
   - "supervisor/index.ts"
   # iterm2 タブ着色。~/.claude/scripts/project-colors.json とローカル iTerm2 を
   # 要するローカル専用（ci.yml 末尾「Local-only tests」参照）。

--- a/supervisor/src/bot-wiring.ts
+++ b/supervisor/src/bot-wiring.ts
@@ -1,0 +1,323 @@
+// supervisor/src/bot-wiring.ts (Issue #383, Epic #381)
+//
+// The startup *wiring* of bot.ts — "which event gets which handler" — extracted
+// out of startBot() as a declarative id list plus two pure application
+// functions. Same shape as `infra/hook-wiring-check.ts` (#370): a required-
+// wiring constant + a pure checker, so the contract is data a test can assert
+// against instead of prose nobody verifies.
+//
+// Why this exists: a dropped or mis-targeted registration in startBot() only
+// shows up on a live Discord Gateway, so CI waves it through (#381's analysis:
+// 13% of these are caught before merge). #370 was exactly that failure —
+// ask-user-relay.sh POSTed to an endpoint whose subscriber was never wired, and
+// the question silently never left the TUI for ~5 months. Routing every
+// registration through a surface makes the wiring observable in-process:
+// `RecordingWiringSurface` captures what a real startup would register, and
+// `createDiscordWiringSurface` is the single place that maps an id onto its
+// real target (client event / relay subscriber / signal).
+//
+// Deliberately NOT moved here: the handler bodies. They stay in bot.ts closing
+// over startBot's collaborators. This module owns the *map*, not the behaviour.
+
+import { Events, type Client, type Interaction, type Message } from "discord.js";
+import type * as RelayServer from "./session/relay-server";
+
+// ---------------------------------------------------------------------------
+// Wiring identifiers
+// ---------------------------------------------------------------------------
+
+/**
+ * Registrations made once, before `client.login()`. Order within this list is
+ * the order they are applied; it is not behaviourally significant (each id is a
+ * distinct event with a single handler) but keeping it stable makes the test
+ * snapshot readable.
+ */
+export const BOOT_WIRING_IDS = [
+  "sessionManager:sessionEnd",
+  "client:ClientReady",
+  "client:InteractionCreate",
+  "client:MessageCreate",
+  "process:SIGTERM",
+  "process:SIGINT",
+] as const;
+
+/**
+ * Relay-server subscribers registered *after* the Gateway is ready. They must
+ * not be hoisted to boot time: their handlers resolve Discord channels (and
+ * `relay:hubWork` enumerates `readyClient.guilds.cache`), so a request arriving
+ * before login would fail. The relay endpoints answer 503 / empty until wired,
+ * which is the intended fail-closed window.
+ */
+export const READY_WIRING_IDS = [
+  "relay:progress",
+  "relay:sessionsQuery",
+  "relay:askUser",
+  "relay:lateResponse",
+  "relay:hubWork",
+  "relay:channelPost",
+] as const;
+
+export type BootWiringId = (typeof BOOT_WIRING_IDS)[number];
+export type ReadyWiringId = (typeof READY_WIRING_IDS)[number];
+export type WiringId = BootWiringId | ReadyWiringId;
+
+// ---------------------------------------------------------------------------
+// Handler contracts
+// ---------------------------------------------------------------------------
+
+/**
+ * Handlers bot.ts supplies for the boot-time wiring. Keyed by wiring id so the
+ * call site reads as the wiring map itself, and a forgotten handler is a
+ * compile error rather than a runtime hole.
+ */
+export interface BootWiringHandlers {
+  "sessionManager:sessionEnd": (threadId: string) => void;
+  "client:ClientReady": (readyClient: Client<true>) => void | Promise<void>;
+  "client:InteractionCreate": (interaction: Interaction) => void;
+  "client:MessageCreate": (message: Message) => void | Promise<void>;
+  "process:SIGTERM": () => void | Promise<void>;
+  "process:SIGINT": () => void | Promise<void>;
+}
+
+/**
+ * Handlers for the ready-time relay subscribers. Types are derived from the
+ * real `relay-server` registration functions, so a signature change there
+ * surfaces here as a type error instead of a silently-mismatched callback.
+ */
+export interface ReadyWiringHandlers {
+  "relay:progress": Parameters<typeof RelayServer.onProgress>[0];
+  "relay:sessionsQuery": Parameters<typeof RelayServer.onSessionsQuery>[0];
+  "relay:askUser": Parameters<typeof RelayServer.onAskUser>[0];
+  "relay:lateResponse": Parameters<typeof RelayServer.onLateResponse>[0];
+  "relay:hubWork": Parameters<typeof RelayServer.onHubWork>[0];
+  "relay:channelPost": Parameters<typeof RelayServer.onChannelPost>[0];
+}
+
+// ---------------------------------------------------------------------------
+// Surface
+// ---------------------------------------------------------------------------
+
+/**
+ * Sink every startup registration flows through. Handlers are `unknown` here on
+ * purpose: the type-safe contract lives in {@link BootWiringHandlers} /
+ * {@link ReadyWiringHandlers} at the call site, and narrowing again per id
+ * would force this interface to enumerate them a second time.
+ */
+export interface BotWiringSurface {
+  register(id: WiringId, handler: unknown): void;
+}
+
+/**
+ * Applies the boot-time wiring. Callers own the handler bodies; this owns the
+ * mapping of body → id.
+ */
+export function wireBoot(
+  surface: BotWiringSurface,
+  handlers: BootWiringHandlers,
+): void {
+  for (const id of BOOT_WIRING_IDS) surface.register(id, handlers[id]);
+}
+
+/** Applies the ready-time relay wiring. Call from inside the ClientReady handler. */
+export function wireReady(
+  surface: BotWiringSurface,
+  handlers: ReadyWiringHandlers,
+): void {
+  for (const id of READY_WIRING_IDS) surface.register(id, handlers[id]);
+}
+
+// ---------------------------------------------------------------------------
+// Real surface (id → live target)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minimal shape of the discord.js `Client` used for event registration.
+ *
+ * `any[]` on the listener is required, not laziness: discord.js types `on` /
+ * `once` as generic overloads keyed on `keyof ClientEvents`, and a stricter
+ * listener parameter (`never[]`) makes the real `Client` non-assignable to this
+ * interface. The narrow types are recovered by the casts in
+ * {@link createDiscordWiringSurface}, which the wiring test verifies by
+ * asserting each id lands on the right event with the right handler.
+ */
+export interface WiringClient {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  once(event: string, listener: (...args: any[]) => void): unknown;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  on(event: string, listener: (...args: any[]) => void): unknown;
+}
+
+/** The live objects a wiring id can be registered against. */
+export interface WiringTargets {
+  client: WiringClient;
+  relay: {
+    onProgress: typeof RelayServer.onProgress;
+    onSessionsQuery: typeof RelayServer.onSessionsQuery;
+    onAskUser: typeof RelayServer.onAskUser;
+    onLateResponse: typeof RelayServer.onLateResponse;
+    onHubWork: typeof RelayServer.onHubWork;
+    onChannelPost: typeof RelayServer.onChannelPost;
+  };
+  sessionManager: { onSessionEnd(listener: (threadId: string) => void): void };
+  signals: { on(signal: NodeJS.Signals, listener: () => void): unknown };
+}
+
+/**
+ * The one place a wiring id becomes a real registration. The switch is
+ * exhaustive over {@link WiringId} (see the `never` default), so adding an id
+ * without giving it a target is a compile error.
+ */
+export function createDiscordWiringSurface(
+  targets: WiringTargets,
+): BotWiringSurface {
+  return {
+    register(id, handler) {
+      switch (id) {
+        case "sessionManager:sessionEnd":
+          targets.sessionManager.onSessionEnd(
+            handler as BootWiringHandlers["sessionManager:sessionEnd"],
+          );
+          return;
+        case "client:ClientReady":
+          targets.client.once(
+            Events.ClientReady,
+            handler as BootWiringHandlers["client:ClientReady"],
+          );
+          return;
+        case "client:InteractionCreate":
+          targets.client.on(
+            Events.InteractionCreate,
+            handler as BootWiringHandlers["client:InteractionCreate"],
+          );
+          return;
+        case "client:MessageCreate":
+          targets.client.on(
+            Events.MessageCreate,
+            handler as BootWiringHandlers["client:MessageCreate"],
+          );
+          return;
+        case "process:SIGTERM":
+          targets.signals.on(
+            "SIGTERM",
+            handler as BootWiringHandlers["process:SIGTERM"],
+          );
+          return;
+        case "process:SIGINT":
+          targets.signals.on(
+            "SIGINT",
+            handler as BootWiringHandlers["process:SIGINT"],
+          );
+          return;
+        case "relay:progress":
+          targets.relay.onProgress(
+            handler as ReadyWiringHandlers["relay:progress"],
+          );
+          return;
+        case "relay:sessionsQuery":
+          targets.relay.onSessionsQuery(
+            handler as ReadyWiringHandlers["relay:sessionsQuery"],
+          );
+          return;
+        case "relay:askUser":
+          targets.relay.onAskUser(
+            handler as ReadyWiringHandlers["relay:askUser"],
+          );
+          return;
+        case "relay:lateResponse":
+          targets.relay.onLateResponse(
+            handler as ReadyWiringHandlers["relay:lateResponse"],
+          );
+          return;
+        case "relay:hubWork":
+          targets.relay.onHubWork(
+            handler as ReadyWiringHandlers["relay:hubWork"],
+          );
+          return;
+        case "relay:channelPost":
+          targets.relay.onChannelPost(
+            handler as ReadyWiringHandlers["relay:channelPost"],
+          );
+          return;
+        default: {
+          const unreachable: never = id;
+          throw new Error(`[BotWiring] unmapped wiring id: ${String(unreachable)}`);
+        }
+      }
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Recording surface + diff (test / introspection)
+// ---------------------------------------------------------------------------
+
+export interface RecordedWiring {
+  id: WiringId;
+  handler: unknown;
+}
+
+/**
+ * Captures registrations instead of performing them. Lets a test run the real
+ * `wireBoot` / `wireReady` and assert the resulting wiring set exactly, so both
+ * a missing and a duplicated registration fail.
+ */
+export class RecordingWiringSurface implements BotWiringSurface {
+  private readonly recorded: RecordedWiring[] = [];
+
+  register(id: WiringId, handler: unknown): void {
+    this.recorded.push({ id, handler });
+  }
+
+  /** Registered ids in registration order (duplicates preserved). */
+  ids(): WiringId[] {
+    return this.recorded.map((r) => r.id);
+  }
+
+  /** Handlers registered for an id. Length > 1 means a duplicate registration. */
+  handlersFor(id: WiringId): unknown[] {
+    return this.recorded.filter((r) => r.id === id).map((r) => r.handler);
+  }
+
+  entries(): readonly RecordedWiring[] {
+    return this.recorded;
+  }
+}
+
+export interface WiringDiff {
+  /** Expected but never registered — the #370 failure mode. */
+  missing: WiringId[];
+  /** Registered but not part of the expected contract. */
+  unexpected: WiringId[];
+  /** Registered more than once (a second handler silently replaces the first). */
+  duplicated: WiringId[];
+}
+
+/**
+ * Pure comparison of an actual registration list against the expected contract.
+ * Exported separately from the surface so the matching logic is testable on
+ * fixtures, mirroring `findMissingHookWiring` (#370).
+ */
+export function diffWiring(
+  actual: readonly WiringId[],
+  expected: readonly WiringId[],
+): WiringDiff {
+  const counts = new Map<WiringId, number>();
+  for (const id of actual) counts.set(id, (counts.get(id) ?? 0) + 1);
+
+  return {
+    missing: expected.filter((id) => !counts.has(id)),
+    unexpected: [...counts.keys()].filter((id) => !expected.includes(id)),
+    duplicated: [...counts.entries()]
+      .filter(([, n]) => n > 1)
+      .map(([id]) => id),
+  };
+}
+
+/** True when the wiring matches the contract exactly. */
+export function isWiringComplete(diff: WiringDiff): boolean {
+  return (
+    diff.missing.length === 0 &&
+    diff.unexpected.length === 0 &&
+    diff.duplicated.length === 0
+  );
+}

--- a/supervisor/src/bot-wiring.ts
+++ b/supervisor/src/bot-wiring.ts
@@ -251,7 +251,7 @@ export function createDiscordWiringSurface(
 // Recording surface + diff (test / introspection)
 // ---------------------------------------------------------------------------
 
-export interface RecordedWiring {
+interface RecordedWiring {
   id: WiringId;
   handler: unknown;
 }
@@ -276,10 +276,6 @@ export class RecordingWiringSurface implements BotWiringSurface {
   /** Handlers registered for an id. Length > 1 means a duplicate registration. */
   handlersFor(id: WiringId): unknown[] {
     return this.recorded.filter((r) => r.id === id).map((r) => r.handler);
-  }
-
-  entries(): readonly RecordedWiring[] {
-    return this.recorded;
   }
 }
 

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -3,7 +3,6 @@ import {
   GatewayIntentBits,
   REST,
   Routes,
-  Events,
   type Interaction,
   type Message,
   type Channel,
@@ -83,6 +82,12 @@ import {
 } from "./session/orchestrate";
 import { AdmissionController } from "./session/admission";
 import { buildThreadTitle } from "./session/thread-title";
+import {
+  createDiscordWiringSurface,
+  wireBoot,
+  wireReady,
+  type ReadyWiringHandlers,
+} from "./bot-wiring";
 
 /** Shared context for delivering a self-heal outcome to a thread (Issue #206/#244). */
 interface SelfHealCtx {
@@ -260,6 +265,25 @@ export async function startBot(token: string): Promise<void> {
 
   const sessionManager = new SessionManager();
 
+  // Issue #383: every startup registration goes through this surface instead of
+  // calling client.on / relay-server on* / process.on directly. src/bot-wiring.ts
+  // owns the id → target map, so tests can replay the same wiring against
+  // in-memory targets and assert nothing was dropped or mis-targeted (#370 was
+  // a subscriber that existed but was never wired, undetectable in CI).
+  const wiringSurface = createDiscordWiringSurface({
+    client,
+    relay: {
+      onProgress,
+      onSessionsQuery,
+      onAskUser,
+      onLateResponse,
+      onHubWork,
+      onChannelPost,
+    },
+    sessionManager,
+    signals: process,
+  });
+
   // Per-thread message queue: ensures only one message is relayed at a time per thread.
   // Without this, concurrent messages overwrite the pending relay request and responses are lost.
   const threadQueues = new Map<string, Promise<void>>();
@@ -351,7 +375,8 @@ export async function startBot(token: string): Promise<void> {
   // handleDispatchMessage submits here; interactive /session start bypasses it
   // (AC-3). The SessionManager frees a slot when a dispatch session ends.
   const dispatchQueue = new DispatchQueue();
-  sessionManager.onSessionEnd((threadId) => dispatchQueue.notifyEnded(threadId));
+  const handleSessionEnd = (threadId: string): void =>
+    dispatchQueue.notifyEnded(threadId);
   // Phase 5d (#295): dynamic admission (WARN-first). Default observe-only — logs a
   // WARN under high load but does not delay; enforcement is opt-in via
   // DISPATCH_ADMISSION_ENFORCE=1.
@@ -392,7 +417,7 @@ export async function startBot(token: string): Promise<void> {
   });
 
   // Register slash commands
-  client.once(Events.ClientReady, async (readyClient) => {
+  const handleClientReady = async (readyClient: Client<true>) => {
     console.log(`[Bot] Logged in as ${readyClient.user.tag}`);
     console.log(
       `[Bot] Registered channels: ${Array.from(CHANNEL_MAP.keys()).join(", ")}`
@@ -431,7 +456,7 @@ export async function startBot(token: string): Promise<void> {
     // Register progress callback to send tool progress to Discord threads.
     // Events are buffered (Issue #119) and flushed every 2s as a single
     // message per thread to stay under Discord's 5-msg/5-sec rate limit.
-    onProgress((event) => {
+    const handleProgress: ReadyWiringHandlers["relay:progress"] = (event) => {
       // Issue #209: a session streaming PostToolUse progress is *not* silent.
       // Refresh lastActivityAt here so the activity watchdog's "quiet" signal
       // (AC1) doesn't false-positive on a session that is actively reporting
@@ -445,19 +470,20 @@ export async function startBot(token: string): Promise<void> {
         tool: event.tool,
         message: event.message,
       });
-    });
+    };
 
     // Issue #78 (AC-4): back the read-only GET /health/sessions endpoint with a
     // live snapshot of the manager's in-memory sessions so an E2E harness can
     // verify the thread → tmux session mapping without host access.
-    onSessionsQuery(() => sessionManager.sessionsHealth());
+    const handleSessionsQuery: ReadyWiringHandlers["relay:sessionsQuery"] = () =>
+      sessionManager.sessionsHealth();
 
     // Issue #370: forward AskUserQuestion prompts (POSTed by
     // hooks/ask-user-relay.sh to /ask/:threadId) to the Discord thread. Without
     // this subscriber the endpoint fast-fails 503 and the question never leaves
     // the TUI — the user saw a silent 19-minute block. The next user message in
     // the thread resolves the ask (see the messageCreate handler).
-    onAskUser((event) => {
+    const handleAskUser: ReadyWiringHandlers["relay:askUser"] = (event) => {
       void (async () => {
         try {
           const channel = await client.channels.fetch(event.threadId);
@@ -483,13 +509,15 @@ export async function startBot(token: string): Promise<void> {
           );
         }
       })();
-    });
+    };
 
     // Register late-response callback: when a Stop hook POST arrives after
     // the initial relay already resolved (e.g. Monitor/background-task split
     // a single user turn into multiple assistant turns), forward the follow-up
     // text directly to the Discord thread so it isn't dropped.
-    onLateResponse(async (event) => {
+    const handleLateResponse: ReadyWiringHandlers["relay:lateResponse"] = async (
+      event,
+    ) => {
       try {
         const channel = await client.channels.fetch(event.threadId);
         if (!channel?.isThread()) return;
@@ -531,7 +559,7 @@ export async function startBot(token: string): Promise<void> {
       } catch (err) {
         console.error(`[Bot] Late response send error for thread ${event.threadId}:`, err);
       }
-    });
+    };
 
     // Epic #316 Phase 3 (#320, ADR-002 D5): claude-hub work セッション経路。
     // relay サーバの `POST /hub-work`（loopback-only、session-ctl
@@ -539,7 +567,7 @@ export async function startBot(token: string): Promise<void> {
     // CHANNEL_MAP.get() を通らない ephemeral なもの（runHubWork 内で組み立て、
     // CHANNEL_MAP へは登録しない）。ワーカースレッドは corp チャンネル配下
     // （D5-3）。キュー / admission / executor は既存 /dispatch と同一機構。
-    onHubWork(async (body) =>
+    const handleHubWork: ReadyWiringHandlers["relay:hubWork"] = async (body) =>
       runHubWork({
         body,
         sessionManager,
@@ -588,14 +616,16 @@ export async function startBot(token: string): Promise<void> {
             await thread.send(content);
           }
         },
-      }),
-    );
+      });
 
     // Issue #339: オーケストレーターの進捗・最終レポートをスレッドの**親
     // チャンネル直下**へ投稿する経路（POST /channel-post/:threadId →
     // session-ctl post-channel が叩く）。投稿先は threadId から解決した親
     // チャンネルに構造的に限定される（任意チャンネル ID を受け取らない）。
-    onChannelPost(async (threadId, text) => {
+    const handleChannelPost: ReadyWiringHandlers["relay:channelPost"] = async (
+      threadId,
+      text,
+    ) => {
       let thread;
       try {
         thread = await client.channels.fetch(threadId);
@@ -656,8 +686,19 @@ export async function startBot(token: string): Promise<void> {
         `[Bot] channel-post: thread ${threadId} → #${parent.name} (${chunks.length} chunks, ${text.length} chars)`,
       );
       return { ok: true, channelId: parent.id, chunks: chunks.length };
+    };
+
+    // Issue #383: apply the ready-time relay wiring in one place. Registering
+    // here (not at boot) is deliberate — see READY_WIRING_IDS in bot-wiring.ts.
+    wireReady(wiringSurface, {
+      "relay:progress": handleProgress,
+      "relay:sessionsQuery": handleSessionsQuery,
+      "relay:askUser": handleAskUser,
+      "relay:lateResponse": handleLateResponse,
+      "relay:hubWork": handleHubWork,
+      "relay:channelPost": handleChannelPost,
     });
-  });
+  };
 
   // Safe reply helper: never throws. Used in error paths where the interaction may
   // already be stale (Mac sleep/wake can expire the 3-second initial-response token).
@@ -683,7 +724,7 @@ export async function startBot(token: string): Promise<void> {
   }
 
   // Handle slash commands + message components
-  client.on(Events.InteractionCreate, (interaction: Interaction) => {
+  const handleInteractionCreate = (interaction: Interaction): void => {
     // #364: the one-click compact button. Component interactions are routed by
     // customId to the app that sent the message, so unlike a top-level
     // `/compact` slash command this can never be captured by another bot.
@@ -703,7 +744,7 @@ export async function startBot(token: string): Promise<void> {
       console.error("[Bot] Command error:", err);
       await safeReplyError(interaction, err);
     });
-  });
+  };
 
   // Issue #32 / S7 (dispatch transport): handle a `/dispatch <branch> <issue>`
   // message from an allowed external source (webhook / bot). Returns true when
@@ -1094,7 +1135,7 @@ export async function startBot(token: string): Promise<void> {
   }
 
   // Message relay: thread messages → Claude Code → thread reply
-  client.on(Events.MessageCreate, async (message: Message) => {
+  const handleMessageCreate = async (message: Message): Promise<void> => {
     // Issue #32 / S7 (dispatch transport): intercept `/dispatch` from an allowed
     // external source BEFORE the blanket bot/webhook drop below. Only an
     // authorized source on a known, policy-configured channel can start a
@@ -1474,7 +1515,7 @@ export async function startBot(token: string): Promise<void> {
         }
       }
     });
-  });
+  };
 
   // Graceful shutdown
   const shutdown = async () => {
@@ -1499,8 +1540,18 @@ export async function startBot(token: string): Promise<void> {
     process.exit(0);
   };
 
-  process.on("SIGTERM", shutdown);
-  process.on("SIGINT", shutdown);
+  // Issue #383: the single boot-time wiring application. Every handler above is
+  // defined by now, and nothing can fire before client.login() below, so
+  // applying the whole map here is equivalent to the previous scattered
+  // client.on / process.on calls — with the map itself now assertable in tests.
+  wireBoot(wiringSurface, {
+    "sessionManager:sessionEnd": handleSessionEnd,
+    "client:ClientReady": handleClientReady,
+    "client:InteractionCreate": handleInteractionCreate,
+    "client:MessageCreate": handleMessageCreate,
+    "process:SIGTERM": shutdown,
+    "process:SIGINT": shutdown,
+  });
 
   await client.login(token);
 }

--- a/supervisor/tests/bot/startup-wiring.test.ts
+++ b/supervisor/tests/bot/startup-wiring.test.ts
@@ -1,0 +1,385 @@
+// Issue #383 (Epic #381): startup wiring verification for bot.ts.
+//
+// The bug class: a registration in startBot() that is dropped, duplicated, or
+// pointed at the wrong event only fails against a live Discord Gateway, so CI
+// waves it through. #370 is the reference incident — a relay subscriber that
+// existed but was never wired, silent for ~5 months.
+//
+// These tests replay the *real* wiring functions (wireBoot / wireReady) against
+// in-memory targets and assert the resulting registration set exactly, so both
+// a missing and an extra/duplicate wiring fail. The id → target mapping in
+// createDiscordWiringSurface is exercised too: a handler landing on the wrong
+// client event or relay subscriber fails here rather than in production.
+//
+// Note on the client double: bot.ts drives the raw discord.js Client (on/once),
+// not the IDiscordClient relay abstraction that src/discord/in-memory-client.ts
+// fakes. So this file uses its own in-memory client covering the surface bot.ts
+// actually registers against; conflating the two abstractions would make
+// InMemoryDiscordClient serve two unrelated roles.
+
+import { test, expect, describe } from "bun:test";
+import { Events } from "discord.js";
+import {
+  BOOT_WIRING_IDS,
+  READY_WIRING_IDS,
+  RecordingWiringSurface,
+  createDiscordWiringSurface,
+  diffWiring,
+  isWiringComplete,
+  wireBoot,
+  wireReady,
+  type BootWiringHandlers,
+  type BootWiringId,
+  type ReadyWiringHandlers,
+  type ReadyWiringId,
+  type WiringId,
+} from "../../src/bot-wiring";
+
+// --- in-memory doubles -----------------------------------------------------
+
+interface Registration {
+  event: string;
+  once: boolean;
+  handler: unknown;
+}
+
+/** In-memory stand-in for the discord.js Client's event registration surface. */
+class InMemoryWiringClient {
+  readonly registrations: Registration[] = [];
+
+  once(event: string, handler: (...args: never[]) => void): unknown {
+    this.registrations.push({ event, once: true, handler });
+    return this;
+  }
+
+  on(event: string, handler: (...args: never[]) => void): unknown {
+    this.registrations.push({ event, once: false, handler });
+    return this;
+  }
+
+  find(event: string): Registration | undefined {
+    return this.registrations.find((r) => r.event === event);
+  }
+}
+
+/**
+ * Records which relay subscriber received which handler. Signatures are
+ * intentionally loose (the surface casts); identity is what these tests assert.
+ */
+function makeRelayTargets() {
+  const seen = new Map<string, unknown[]>();
+  const capture =
+    (name: string) =>
+    (handler: unknown): void => {
+      seen.set(name, [...(seen.get(name) ?? []), handler]);
+    };
+  return {
+    seen,
+    targets: {
+      onProgress: capture("onProgress"),
+      onSessionsQuery: capture("onSessionsQuery"),
+      onAskUser: capture("onAskUser"),
+      onLateResponse: capture("onLateResponse"),
+      onHubWork: capture("onHubWork"),
+      onChannelPost: capture("onChannelPost"),
+    } as unknown as Parameters<typeof createDiscordWiringSurface>[0]["relay"],
+  };
+}
+
+/** Sentinel handlers: distinct objects so cross-wiring is detectable by identity. */
+function makeBootHandlers(): BootWiringHandlers {
+  return {
+    "sessionManager:sessionEnd": () => {},
+    "client:ClientReady": async () => {},
+    "client:InteractionCreate": () => {},
+    "client:MessageCreate": async () => {},
+    "process:SIGTERM": async () => {},
+    // A *distinct* function from SIGTERM here even though bot.ts shares one
+    // `shutdown` — sharing is fine in production, but distinct sentinels are
+    // what let this test detect one signal being wired to the other's handler.
+    "process:SIGINT": async () => {},
+  };
+}
+
+function makeReadyHandlers(): ReadyWiringHandlers {
+  return {
+    "relay:progress": () => {},
+    "relay:sessionsQuery": () => [],
+    "relay:askUser": () => {},
+    "relay:lateResponse": () => {},
+    "relay:hubWork": async () => ({
+      ok: true as const,
+      threadId: "t",
+      queued: false,
+      injected: "",
+    }),
+    "relay:channelPost": async () => ({
+      ok: true as const,
+      channelId: "c",
+      chunks: 1,
+    }),
+  };
+}
+
+function makeSurfaceUnderTest() {
+  const client = new InMemoryWiringClient();
+  const relay = makeRelayTargets();
+  const sessionEndHandlers: unknown[] = [];
+  const signalHandlers: Array<{ signal: string; handler: unknown }> = [];
+  const surface = createDiscordWiringSurface({
+    client,
+    relay: relay.targets,
+    sessionManager: {
+      onSessionEnd: (h) => {
+        sessionEndHandlers.push(h);
+      },
+    },
+    signals: {
+      on: (signal, handler) => {
+        signalHandlers.push({ signal, handler });
+        return undefined;
+      },
+    },
+  });
+  return { surface, client, relay, sessionEndHandlers, signalHandlers };
+}
+
+// --- the reviewed contract -------------------------------------------------
+
+/**
+ * Hand-written expectation, deliberately NOT derived from BOOT_WIRING_IDS /
+ * READY_WIRING_IDS. Asserting the constants against themselves would pass even
+ * if an id were deleted from the constant (the applied list shrinks with it) —
+ * exactly the mutation this suite has to catch. Changing the supervisor's
+ * startup wiring must therefore be a two-sided, reviewed edit.
+ */
+const EXPECTED_BOOT_WIRING: BootWiringId[] = [
+  "sessionManager:sessionEnd",
+  "client:ClientReady",
+  "client:InteractionCreate",
+  "client:MessageCreate",
+  "process:SIGTERM",
+  "process:SIGINT",
+];
+
+const EXPECTED_READY_WIRING: ReadyWiringId[] = [
+  "relay:progress",
+  "relay:sessionsQuery",
+  "relay:askUser",
+  "relay:lateResponse",
+  "relay:hubWork",
+  "relay:channelPost",
+];
+
+// --- wiring completeness ---------------------------------------------------
+
+describe("startup wiring is complete (#383)", () => {
+  test("the exported contracts match the reviewed wiring list", () => {
+    expect([...BOOT_WIRING_IDS]).toEqual(EXPECTED_BOOT_WIRING);
+    expect([...READY_WIRING_IDS]).toEqual(EXPECTED_READY_WIRING);
+  });
+
+  test("wireBoot registers exactly the boot-time contract", () => {
+    const recorder = new RecordingWiringSurface();
+    wireBoot(recorder, makeBootHandlers());
+
+    // Exact array equality: a dropped id, an extra id, and a re-ordered list
+    // all fail. Registration order is asserted so the snapshot stays readable.
+    expect(recorder.ids()).toEqual(EXPECTED_BOOT_WIRING);
+
+    const diff = diffWiring(recorder.ids(), EXPECTED_BOOT_WIRING);
+    expect(diff).toEqual({ missing: [], unexpected: [], duplicated: [] });
+    expect(isWiringComplete(diff)).toBe(true);
+  });
+
+  test("wireReady registers exactly the ready-time contract", () => {
+    const recorder = new RecordingWiringSurface();
+    wireReady(recorder, makeReadyHandlers());
+
+    expect(recorder.ids()).toEqual(EXPECTED_READY_WIRING);
+    expect(diffWiring(recorder.ids(), EXPECTED_READY_WIRING)).toEqual({
+      missing: [],
+      unexpected: [],
+      duplicated: [],
+    });
+  });
+
+  test("each id receives its own handler (no cross-wiring, no duplicates)", () => {
+    const recorder = new RecordingWiringSurface();
+    const boot = makeBootHandlers();
+    const ready = makeReadyHandlers();
+    wireBoot(recorder, boot);
+    wireReady(recorder, ready);
+
+    for (const id of BOOT_WIRING_IDS) {
+      expect(recorder.handlersFor(id)).toEqual([boot[id]]);
+    }
+    for (const id of READY_WIRING_IDS) {
+      expect(recorder.handlersFor(id)).toEqual([ready[id]]);
+    }
+  });
+
+  test("boot and ready contracts are disjoint", () => {
+    const overlap = (BOOT_WIRING_IDS as readonly string[]).filter((id) =>
+      (READY_WIRING_IDS as readonly string[]).includes(id),
+    );
+    expect(overlap).toEqual([]);
+  });
+});
+
+// --- id → real target mapping ---------------------------------------------
+
+describe("wiring surface targets the right sink (#383)", () => {
+  test("client events land on the right discord.js event with the right mode", () => {
+    const { surface, client } = makeSurfaceUnderTest();
+    const boot = makeBootHandlers();
+    wireBoot(surface, boot);
+
+    // ClientReady must be `once` (re-running boot setup on every reconnect
+    // would re-register slash commands and restart the reapers).
+    expect(client.find(Events.ClientReady)).toEqual({
+      event: Events.ClientReady,
+      once: true,
+      handler: boot["client:ClientReady"],
+    });
+    expect(client.find(Events.InteractionCreate)).toEqual({
+      event: Events.InteractionCreate,
+      once: false,
+      handler: boot["client:InteractionCreate"],
+    });
+    expect(client.find(Events.MessageCreate)).toEqual({
+      event: Events.MessageCreate,
+      once: false,
+      handler: boot["client:MessageCreate"],
+    });
+    // Nothing else was registered on the client.
+    expect(client.registrations).toHaveLength(3);
+  });
+
+  test("session-end and both termination signals are wired", () => {
+    const { surface, sessionEndHandlers, signalHandlers } = makeSurfaceUnderTest();
+    const boot = makeBootHandlers();
+    wireBoot(surface, boot);
+
+    expect(sessionEndHandlers).toEqual([boot["sessionManager:sessionEnd"]]);
+    // SIGTERM (launchd stop) and SIGINT (Ctrl-C) both need the graceful path —
+    // losing either leaks tmux sessions on shutdown.
+    expect(signalHandlers).toEqual([
+      { signal: "SIGTERM", handler: boot["process:SIGTERM"] },
+      { signal: "SIGINT", handler: boot["process:SIGINT"] },
+    ]);
+  });
+
+  test("every relay subscriber receives exactly its own handler", () => {
+    const { surface, relay } = makeSurfaceUnderTest();
+    const ready = makeReadyHandlers();
+    wireReady(surface, ready);
+
+    expect(Object.fromEntries(relay.seen)).toEqual({
+      onProgress: [ready["relay:progress"]],
+      onSessionsQuery: [ready["relay:sessionsQuery"]],
+      onAskUser: [ready["relay:askUser"]],
+      onLateResponse: [ready["relay:lateResponse"]],
+      // #370's regression: this subscriber going missing left AskUserQuestion
+      // stranded in the TUI. onHubWork / onChannelPost fail-close to 503, which
+      // is quieter still.
+      onHubWork: [ready["relay:hubWork"]],
+      onChannelPost: [ready["relay:channelPost"]],
+    });
+  });
+
+  test("boot wiring touches no relay subscriber (and vice versa)", () => {
+    const boot = makeSurfaceUnderTest();
+    wireBoot(boot.surface, makeBootHandlers());
+    expect(boot.relay.seen.size).toBe(0);
+
+    const ready = makeSurfaceUnderTest();
+    wireReady(ready.surface, makeReadyHandlers());
+    expect(ready.client.registrations).toHaveLength(0);
+    expect(ready.signalHandlers).toHaveLength(0);
+    expect(ready.sessionEndHandlers).toHaveLength(0);
+  });
+
+  test("an unmapped id throws instead of silently no-op-ing", () => {
+    const { surface } = makeSurfaceUnderTest();
+    expect(() =>
+      surface.register("relay:doesNotExist" as WiringId, () => {}),
+    ).toThrow(/unmapped wiring id/);
+  });
+});
+
+// --- bot.ts routes every registration through the surface ------------------
+
+describe("bot.ts does not bypass the wiring surface (#383)", () => {
+  // The contract above only covers registrations that go through the surface.
+  // A `client.on(...)` added straight into startBot() would be invisible to it,
+  // which puts us back at the #370 failure mode. Source-level guard, same shape
+  // as tests/guards/access-enforcement-wired.test.ts.
+  const BYPASS_PATTERNS: Array<{ pattern: RegExp; why: string }> = [
+    { pattern: /\bclient\.(on|once)\s*\(/, why: "use wireBoot() with a client:* id" },
+    { pattern: /\bprocess\.on\s*\(/, why: "use wireBoot() with a process:* id" },
+    {
+      pattern: /\bsessionManager\.onSessionEnd\s*\(/,
+      why: "use wireBoot() with sessionManager:sessionEnd",
+    },
+    {
+      pattern: /\bon(Progress|SessionsQuery|AskUser|LateResponse|HubWork|ChannelPost)\s*\(/,
+      why: "use wireReady() with the matching relay:* id",
+    },
+  ];
+
+  test("startBot registers only via wireBoot / wireReady", async () => {
+    const src = await Bun.file("src/bot.ts").text();
+
+    for (const { pattern, why } of BYPASS_PATTERNS) {
+      const offenders = src
+        .split("\n")
+        .map((line, i) => ({ line: line.trim(), no: i + 1 }))
+        .filter(({ line }) => pattern.test(line) && !line.startsWith("//"));
+      expect({ pattern: String(pattern), offenders, why }).toEqual({
+        pattern: String(pattern),
+        offenders: [],
+        why,
+      });
+    }
+
+    // ...and it does apply both halves of the contract.
+    expect(src).toContain("wireBoot(wiringSurface");
+    expect(src).toContain("wireReady(wiringSurface");
+  });
+});
+
+// --- diff logic ------------------------------------------------------------
+
+describe("diffWiring (#383)", () => {
+  test("reports a dropped registration", () => {
+    const actual = BOOT_WIRING_IDS.filter((id) => id !== "client:MessageCreate");
+    const diff = diffWiring(actual, BOOT_WIRING_IDS);
+    expect(diff.missing).toEqual(["client:MessageCreate"]);
+    expect(isWiringComplete(diff)).toBe(false);
+  });
+
+  test("reports a duplicated registration", () => {
+    const actual: WiringId[] = [...BOOT_WIRING_IDS, "client:MessageCreate"];
+    const diff = diffWiring(actual, BOOT_WIRING_IDS);
+    // A second registration on the same relay slot silently replaces the first,
+    // so duplicates are a defect even though nothing is "missing".
+    expect(diff.duplicated).toEqual(["client:MessageCreate"]);
+    expect(diff.missing).toEqual([]);
+    expect(isWiringComplete(diff)).toBe(false);
+  });
+
+  test("reports an unexpected registration", () => {
+    const diff = diffWiring(
+      [...BOOT_WIRING_IDS, "relay:progress"],
+      BOOT_WIRING_IDS,
+    );
+    expect(diff.unexpected).toEqual(["relay:progress"]);
+    expect(isWiringComplete(diff)).toBe(false);
+  });
+
+  test("empty actual reports every expected id as missing", () => {
+    const diff = diffWiring([], READY_WIRING_IDS);
+    expect(diff.missing).toEqual([...READY_WIRING_IDS]);
+  });
+});

--- a/supervisor/tests/bot/startup-wiring.test.ts
+++ b/supervisor/tests/bot/startup-wiring.test.ts
@@ -315,27 +315,53 @@ describe("bot.ts does not bypass the wiring surface (#383)", () => {
   // A `client.on(...)` added straight into startBot() would be invisible to it,
   // which puts us back at the #370 failure mode. Source-level guard, same shape
   // as tests/guards/access-enforcement-wired.test.ts.
+  // `\s*` around the dot, applied to comment-stripped and whitespace-collapsed
+  // source, so a call split across lines (`client\n  .on(`) cannot slip past.
   const BYPASS_PATTERNS: Array<{ pattern: RegExp; why: string }> = [
-    { pattern: /\bclient\.(on|once)\s*\(/, why: "use wireBoot() with a client:* id" },
-    { pattern: /\bprocess\.on\s*\(/, why: "use wireBoot() with a process:* id" },
     {
-      pattern: /\bsessionManager\.onSessionEnd\s*\(/,
+      pattern: /\bclient\s*\.\s*(on|once)\s*\(/g,
+      why: "use wireBoot() with a client:* id",
+    },
+    {
+      pattern: /\bprocess\s*\.\s*on\s*\(/g,
+      why: "use wireBoot() with a process:* id",
+    },
+    {
+      pattern: /\bsessionManager\s*\.\s*onSessionEnd\s*\(/g,
       why: "use wireBoot() with sessionManager:sessionEnd",
     },
     {
-      pattern: /\bon(Progress|SessionsQuery|AskUser|LateResponse|HubWork|ChannelPost)\s*\(/,
+      pattern:
+        /\bon(Progress|SessionsQuery|AskUser|LateResponse|HubWork|ChannelPost)\s*\(/g,
       why: "use wireReady() with the matching relay:* id",
     },
   ];
 
+  /**
+   * Drop block and line comments before matching. Without this a trailing
+   * comment (`foo(); // client.on(...) は使わない`) or a commented-out example
+   * reads as a bypass. Truncating a `//` inside a string literal is harmless
+   * here — the result is only searched for registration calls.
+   */
+  function stripComments(src: string): string {
+    return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/\/\/.*$/gm, "");
+  }
+
+  /** Comment-free, whitespace-collapsed source ready for pattern matching. */
+  function scannable(src: string): string {
+    return stripComments(src).replace(/\s+/g, " ");
+  }
+
   test("startBot registers only via wireBoot / wireReady", async () => {
     const src = await Bun.file("src/bot.ts").text();
+    const haystack = scannable(src);
 
     for (const { pattern, why } of BYPASS_PATTERNS) {
-      const offenders = src
-        .split("\n")
-        .map((line, i) => ({ line: line.trim(), no: i + 1 }))
-        .filter(({ line }) => pattern.test(line) && !line.startsWith("//"));
+      // Report the surrounding snippet: line numbers are gone after collapsing,
+      // and the snippet is what actually tells you where to look.
+      const offenders = [...haystack.matchAll(pattern)].map((m) =>
+        haystack.slice(Math.max(0, m.index - 60), m.index + 60),
+      );
       expect({ pattern: String(pattern), offenders, why }).toEqual({
         pattern: String(pattern),
         offenders: [],
@@ -346,6 +372,18 @@ describe("bot.ts does not bypass the wiring surface (#383)", () => {
     // ...and it does apply both halves of the contract.
     expect(src).toContain("wireBoot(wiringSurface");
     expect(src).toContain("wireReady(wiringSurface");
+  });
+
+  test("the guard ignores comments and catches a split-line bypass", () => {
+    // Guard-the-guard: without stripComments the first two samples false-positive,
+    // and without whitespace collapsing the third one escapes detection.
+    const clientPattern = BYPASS_PATTERNS[0]!.pattern;
+    const hits = (src: string): number =>
+      [...scannable(src).matchAll(clientPattern)].length;
+
+    expect(hits("wireBoot(s, {}); // client.on(...) は使わない\n")).toBe(0);
+    expect(hits("/* client.once(Events.ClientReady, h) */\nwireBoot(s, {});")).toBe(0);
+    expect(hits("client\n  .on(Events.MessageCreate, h);")).toBe(1);
   });
 });
 


### PR DESCRIPTION
Closes #383 / 親 Epic #381

## 目的

`supervisor/src/bot.ts` の `startBot()` は起動時配線（どのイベントにどのハンドラを結ぶか）を一枚で抱えており、配線ミスが**実 Discord でしか発現せず CI を素通り**していた。#370 はまさにこれで、relay subscriber が約 5 か月未配線のまま silent だった。

## 変更内容

### 1. 配線定義の分離（`supervisor/src/bot-wiring.ts` 新規）

`startBot()` に散らばっていた **12 箇所**の登録を、宣言的な配線 ID + 純関数へ分離した。`infra/hook-wiring-check.ts`（#370）と同型の「必要配線を定数化 + 純粋チェッカー」構造。

| export | 役割 |
|---|---|
| `BOOT_WIRING_IDS` / `READY_WIRING_IDS` | 配線契約（boot 時 6 件 / ready 時 6 件） |
| `wireBoot` / `wireReady` | 契約をサーフェスへ適用する純関数 |
| `createDiscordWiringSurface` | **ID → 実ターゲットの唯一の写像**。`never` で網羅性をコンパイル時に担保 |
| `RecordingWiringSurface` | 登録を実行せず記録する in-memory サーフェス |
| `diffWiring` / `isWiringComplete` | 欠落 / 余剰 / 重複の純粋比較 |

ハンドラ**本体は bot.ts に据え置き**（`startBot` のコラボレータをクロージャで掴んでいるため）。本モジュールが持つのは写像だけで、挙動は持たない。

boot / ready の 2 段構成は意図的です。relay subscriber は Gateway ready 後に登録する必要があり（`relay:hubWork` は `readyClient.guilds.cache` を引く）、boot 時へ巻き上げると login 前の到達で壊れます。

### 2. 配線テスト（`supervisor/tests/bot/startup-wiring.test.ts` 新規、15 テスト）

**実際の** `wireBoot` / `wireReady` を in-memory ターゲットへ再生し、登録集合を厳密に検証する。

- 配線集合の完全一致（欠落・余剰・重複・順序いずれも FAIL）
- ID → 実ターゲットの写像（`Events.ClientReady` は `once`、`InteractionCreate` / `MessageCreate` は `on`、SIGTERM/SIGINT 両方、relay 6 本がそれぞれ自分のハンドラを受け取る）
- `bot.ts` がサーフェスを迂回して直接 `client.on(...)` していないことのソースガード（`tests/guards/access-enforcement-wired.test.ts` と同型）

> 期待リストは `BOOT_WIRING_IDS` から**導出せずハンドコード**しています。定数と定数を突き合わせると、定数側から ID を削除したとき適用リストも一緒に縮んで PASS してしまい、AC-2 のミューテーションを検知できないためです。

in-memory クライアントは本テスト内に置きました。`bot.ts` が使うのは生の discord.js `Client`（`on`/`once`）で、既存 `src/discord/in-memory-client.ts` が fake しているのは別抽象の `IDiscordClient` です。両者を混ぜると `InMemoryDiscordClient` が無関係な 2 役を負うため分けています。

### 3. codecov 方針の確定（#383 の 3 つ目のタスク）

`bot.ts` 残部は**カバー対象化（除外しない）**で確定。理由を `codecov.yml` に明記した。

- blanket 除外は `coverage-policy.md` §5 の anti-gaming に反する（PR #301 の gemini 指摘）
- 残部は `index.ts` のような「トークンが無いと実行不能な境界コード」ではなく分岐を持つロジックで、§4 の除外事由に該当しない
- 分岐の多くは既に純関数側へ切り出し済みで、除外すると **bot.ts へ戻る方向の変更**が検知できなくなる

patch は WARN-first（informational）なので、未カバー箇所に触れた PR が不当に FAIL することはありません。blocking 昇格時の再評価は #300 で追跡。

## 統合ジャーニーAC 検証結果

| AC | 内容 | 実測 | 判定 |
|---|---|---|---|
| AC-1 | 主要イベントの結線が期待リストと完全一致（欠落・重複とも FAIL） | `bun test tests/bot/startup-wiring.test.ts` → **15 pass / 0 fail**（46 expect） | PASS |
| AC-2 | 結線を 1 本外すとテストが FAIL する | ミューテーション 4 種すべて FAIL、revert 後 15 pass 復帰（下表） | PASS |
| AC-3 | 実環境で挙動不変 | 後述（未実施・要ローカル E2E） | 保留 |

### AC-2 ミューテーション実測

| # | 注入した欠陥 | 結果 |
|---|---|---|
| M1 | `READY_WIRING_IDS` から `relay:askUser` を削除 | **3 fail**（契約一致 / ready 配線 / relay ターゲット） |
| M2 | `ClientReady` を `once` でなく `on` で登録 | **1 fail**（client イベント写像） |
| M3 | `relay:askUser` を `onLateResponse` へ誤配線 | **1 fail**（relay ターゲット） |
| M4 | `bot.ts` に直接 `client.on(...)` を追加（サーフェス迂回） | **1 fail**（迂回ガード） |
| — | 全 revert 後 | **15 pass / 0 fail**、`tsc --noEmit` exit 0 |

### AC-3 について（未実施・申し送り）

本 PR では**実施できません**。理由は環境要因で、根拠は以下のとおり実測済みです。

1. **稼働中の Supervisor は本ブランチのコードを読んでいない**。live プロセスは main チェックアウト側から起動しています:

    ```
    10845 caffeinate -dimsu bun run /Users/harieshokunin/claude-hub/supervisor/index.ts
    ```

   worktree（`.claude/worktrees/hub-work-383`）ではないため、再起動しても検証されるのは旧コードです。AC-3 は **merge 後のデプロイが前提**になります。

2. **再起動は進行中の作業を巻き込みます**。実測時点で `tmux -L claude-hub` に 6 セッション、うち 2 件は headless の `/impl`（#511 / #501）が実行中でした。

したがって AC-3 は merge 後に `/local-e2e-discord` 手順で実施する申し送りとします。挙動不変であることの根拠（コード側）:

- ハンドラ本体は**再インデントを含め一切変更していない**（差分は登録の開始行・終了行のみ）
- `sessionManager.onSessionEnd` の登録位置が早期 → `wireBoot`（`client.login()` 直前）へ移るが、その間にセッションは開始され得ない（`SessionManager` 構築直後で、セッション開始は login 後の Discord イベント起点）
- `bunx tsc --noEmit` exit 0 / 全 CI green

## その他の検証

| 項目 | 結果 |
|---|---|
| Type Check（`bunx tsc --noEmit`） | exit 0 |
| Unit Tests（ci.yml curated 45 ファイル） | 510 pass / 13 skip / 0 fail |
| E2E（ac-verification / relay / dialog-stall） | 21 pass / 18 skip / 0 fail |
| `lint-gating-coverage` | 94 files — 91 gated / 3 excluded / **0 ungated** |
| `lint-blocking-in-timers` / `lint-no-sync-exec` | いずれも OK |

## 既知の無関係な CI flake（本 PR 起因ではない・別 Issue へ分離）

実装中に既存の flaky テストを 2 系統発見しました。いずれも `git stash` で本 PR の変更を外した base（c2d9005）でも再現するため**本 PR 起因ではありません**。スコープを膨らませないため修正は別 Issue に分離しています。

### #398 — lint 回帰ガード 2 本が 5s タイムアウト境界で flaky（ローカル Mac のみ）

`tests/scripts/lint-blocking-in-timers.test.ts` と `lint-no-sync-exec.test.ts` の回帰ガードが Bun のデフォルト 5000ms 境界（実測 5004〜5643ms）に張り付いています。

| 条件 | FAIL 率 |
|---|---|
| base（c2d9005、本 PR の変更なし） | 5 回中 4 回 |
| 本ブランチ | 5 回中 3 回 |

CI（ubuntu ランナー）では再現していません。

### #401 — action/token の改竄検知テストが約 6.25% で FAIL（CI で顕在化）

本 PR の CI で 1 度 FAIL しました（`tampered signature fails verification`）。根本原因を実測で特定済みです: HMAC-SHA256 の base64url 表現は 43 文字目が有効ビットを 2 bit しか持たないため、末尾 `A` → `B` の書き換えは**デコード後のバイト列が変わらず**改竄になっていません。

```
bytes equal: true
P(sig ends with A) = 6.20%   (理論値 1/16 = 6.25%)
```

セキュリティ上の影響はありません（署名の malleability であって forgery ではない）。詳細と修正案は #401 に記載。再実行で green になっています。
