### PR TITLE
test(ci): 未 gate だった colocated テスト 6 本を CI 編入し、gating を機械可読な単一の真実源へ寄せる（#385）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,17 @@ jobs:
       # in a temp dir. git is always present on the runner (actions/checkout
       # needs it) and the suite touches neither tmux nor gh, so it needs no extra
       # setup and stays deterministic in this job.
+      #
+      # The trailing `src/session/*.test.ts` entries are COLOCATED suites (#385).
+      # They were never run in CI — the whitelist only ever listed `tests/...`
+      # paths and scripts/lint-gating-coverage.ts only scanned `tests/`, so
+      # nothing could flag the gap. That silently ungated 67 cases across six
+      # files, including src/session/iterm2.test.ts, the AppleScript-injection
+      # guard from #183. None of them use mock.module, so they share this
+      # process safely; all are hermetic (verified against a throwaway $HOME).
+      # tests/session/iterm2.test.ts joins them: it is no longer local-only now
+      # that it writes its own project-colors fixture and points
+      # SUPERVISOR_PROJECT_COLORS_PATH at it instead of reading ~/.claude (#385).
       - name: Run tests
         env:
           SUPERVISOR_DB_PATH: ":memory:"
@@ -197,7 +208,14 @@ jobs:
                    tests/session/relay-server-channel-post.test.ts \
                    tests/session/relay-port-isolation.test.ts \
                    tests/tools/session-ctl.test.ts \
-                   tests/tools/e2e-isolated.test.ts
+                   tests/tools/e2e-isolated.test.ts \
+                   tests/session/iterm2.test.ts \
+                   src/session/dispatch-child-probe.test.ts \
+                   src/session/dispatch-health-reaper.test.ts \
+                   src/session/file-attacher.test.ts \
+                   src/session/goal-watcher.test.ts \
+                   src/session/iterm2.test.ts \
+                   src/session/orphan-dispatch-reaper.test.ts
 
       # #238 regression: realTmuxAdapter.hasSession must treat a tmux
       # control-channel ETIMEDOUT as "alive" (assume the session survives),
@@ -330,6 +348,14 @@ jobs:
         run: bun test tests/e2e/session-lifecycle.test.ts
         working-directory: supervisor
 
-  # Local-only tests (require tmux/Claude CLI or local config):
-  #   manager.test.ts  — tmux + Claude Code CLI
-  #   iterm2.test.ts   — ~/.claude/scripts/project-colors.json
+  # Not-gated tests: see the EXCLUSIONS list in
+  # supervisor/scripts/lint-gating-coverage.ts — the single source of truth.
+  # Every *.test.ts under tests/ and src/ must be either gated in a `bun test`
+  # step above or carry a justified entry there; the lint fails the build
+  # otherwise, so that list cannot drift the way this comment did.
+  #
+  # This footer used to name manager.test.ts and iterm2.test.ts as local-only.
+  # Both were wrong — manager.test.ts had been gated in the Unit Tests job since
+  # #185 — yet codecov.yml and Issue #385 both cited it as fact. Deliberately no
+  # list or count here now: a hand-kept copy of a machine-checked fact only rots
+  # again (#385).

--- a/codecov.yml
+++ b/codecov.yml
@@ -85,9 +85,18 @@ ignore:
   # 不当に FAIL することはない。blocking 昇格時の再評価は #300 で追跡する。
   # （src/bot.ts の除外エントリは意図的に存在しない）
   #
-  # iterm2 タブ着色。~/.claude/scripts/project-colors.json とローカル iTerm2 を
-  # 要するローカル専用（ci.yml 末尾「Local-only tests」参照）。
-  - "supervisor/src/session/iterm2.ts"
+  # NOTE: src/session/iterm2.ts は除外しない（Issue #385 で除外を撤回）。
+  # 旧除外理由は「~/.claude/scripts/project-colors.json とローカル iTerm2 を
+  # 要するローカル専用」で、根拠として ci.yml 末尾の「Local-only tests」注記を
+  # 引いていた。その注記自体が stale（manager.test.ts は #185 以降 gate 済み）
+  # だったうえ、現在は純ロジック（resolveColor / hlsToRgb / dimColor /
+  # escapeAppleScriptString / build*AppleScript）を tests/session/iterm2.test.ts
+  # と src/session/iterm2.test.ts が CI で常時検証する（実測 funcs 84.62% /
+  # lines 48.32%）。未カバーは openTab / markTabStopped の実 iTerm2 + osascript
+  # 実行経路のみで、これは relay.ts の tmux error 分岐と同型の「ファイル単位
+  # 除外では切り出せない部分的未カバー」。実ロジックを含むファイルの blanket
+  # 除外は coverage-policy.md §5 の anti-gaming に反する（上の bot.ts の判断と
+  # 同じ）ため、informational（WARN-first）のままスコープ内に残す。
   # launchd 定義（宣言的 XML）。実行コードでなくカバレッジ対象外。
   - "**/*.plist"
   - "**/*.plist.template"

--- a/supervisor/scripts/lint-gating-coverage.ts
+++ b/supervisor/scripts/lint-gating-coverage.ts
@@ -11,16 +11,24 @@
  * security guard (#159 / RW-045) sits red-but-ungated today. Same failure class
  * as RW-029: a silently-green CI is worse than a red one.
  *
- * This lint scans every test file under `tests/` and requires each to be either:
+ * This lint scans every test file under `tests/` AND `src/` and requires each to
+ * be either:
  *   1. gated   — passed as an argument to some `bun test` step in ci.yml, or
  *   2. excluded — listed in EXCLUSIONS below WITH a non-empty reason.
  * Any other test file fails the build (a new gate omission). To stop the
  * exclusion list from rotting into a silent dumping ground, an entry with an
  * empty reason, or one that points at a file that no longer exists, also fails.
  *
+ * Issue #385 widened the scope to colocated `src/**\/*.test.ts`, which the
+ * original version explicitly deferred. That blind spot had already cost us:
+ * all SIX colocated suites (67 cases) — including
+ * `src/session/iterm2.test.ts`, the AppleScript-injection guard from #183 —
+ * were never run in CI and no lint could see it, because the whitelist only
+ * ever listed `tests/...` paths. Same RW-029 failure class the tests/-side
+ * scan was written to prevent, just one directory over.
+ *
  * Run: `bun scripts/lint-gating-coverage.ts` (from supervisor/). Exits 1 on any
- * violation. Scope is intentionally the `tests/` tree only — colocated tests
- * living under `src/` are out of scope for this issue (tracked separately).
+ * violation.
  */
 import { existsSync, readFileSync } from "fs";
 import { resolve } from "path";
@@ -38,14 +46,9 @@ export interface Exclusion {
  */
 export const EXCLUSIONS: Exclusion[] = [
   {
-    file: "tests/session/iterm2.test.ts",
-    reason:
-      "local-only: needs ~/.claude/scripts/project-colors.json (macOS iTerm2 tab colours), absent on CI ubuntu — see ci.yml 'Local-only tests' note.",
-  },
-  {
     file: "tests/session/iterm2-async.test.ts",
     reason:
-      "macOS-only timing: markTabStopped shells out to real `osascript`, which blocks >100ms on a Mac and fails the non-blocking assertion. Not deterministic across runners.",
+      "wall-clock flake, and the invariant is already gated deterministically elsewhere. Its '<100ms' assertion times a window containing two process spawns (tmux + pgrep); spawn latency is load-dependent on ANY OS, so it failed 2 of 3 consecutive local runs (#385). The property it targets — markTabStopped must not block the event loop — is enforced in CI without a clock by scripts/lint-no-sync-exec.ts (#227 PR-4). Gating it would add flake, not coverage. Full measurements and the correction to the pre-#385 reason (which blamed osascript, outside the measured window) are in the test file's header.",
   },
   {
     file: "tests/guards/shell-exec-safety.test.ts",
@@ -55,17 +58,22 @@ export const EXCLUSIONS: Exclusion[] = [
 ];
 
 /**
- * Pull every `tests/...*.test.ts` token out of the *command* lines of ci.yml.
+ * Pull every `tests/...*.test.ts` or `src/...*.test.ts` token out of the
+ * *command* lines of ci.yml.
  *
  * Comment lines (YAML `#`) are dropped first so that a file merely *mentioned*
- * in a comment (e.g. the "Local-only tests" note) is never mistaken for gated —
- * only paths inside an actual `run:` shell body count.
+ * in a comment (e.g. a "local-only" note) is never mistaken for gated — only
+ * paths inside an actual `run:` shell body count. That rule is what kept the
+ * stale "Local-only tests: manager.test.ts" footer from ever masking a real
+ * gap, and it is why widening the prefix to `src/` is safe.
  */
 export function extractGatedFiles(ciYaml: string): Set<string> {
   const gated = new Set<string>();
   for (const rawLine of ciYaml.split("\n")) {
     if (rawLine.trimStart().startsWith("#")) continue; // skip comments
-    for (const m of rawLine.matchAll(/tests\/[A-Za-z0-9_./-]+\.test\.ts/g)) {
+    for (const m of rawLine.matchAll(
+      /(?:tests|src)\/[A-Za-z0-9_./-]+\.test\.ts/g,
+    )) {
       gated.add(m[0]);
     }
   }
@@ -123,10 +131,16 @@ if (import.meta.main) {
   const gated = extractGatedFiles(ciYaml);
 
   const { Glob } = await import("bun");
-  const testFiles = [...new Glob("tests/**/*.test.ts").scanSync(root)].sort();
+  // Both trees are scanned (#385). `tests/` is the primary suite; `src/` picks
+  // up colocated *.test.ts files, which were invisible to this lint until #385
+  // and consequently never gated in ci.yml.
+  const testFiles = [
+    ...new Glob("tests/**/*.test.ts").scanSync(root),
+    ...new Glob("src/**/*.test.ts").scanSync(root),
+  ].sort();
   if (testFiles.length === 0) {
     console.error(
-      `✖ lint-gating-coverage: no test files found under ${root}/tests — refusing to report clean.`,
+      `✖ lint-gating-coverage: no test files found under ${root}/tests or ${root}/src — refusing to report clean.`,
     );
     process.exit(1);
   }

--- a/supervisor/src/session/iterm2.ts
+++ b/supervisor/src/session/iterm2.ts
@@ -8,12 +8,25 @@ import { TMUX_PATH, TMUX_ARGS, TMUX_CMD } from "./tmux";
 
 const execFileAsync = promisify(execFile);
 
-const PROJECT_COLORS_PATH = resolve(
-  homedir(),
-  ".claude",
-  "scripts",
-  "project-colors.json"
-);
+/**
+ * Location of the iTerm2 tab-colour config.
+ *
+ * Resolved per call (not frozen at module load) so a test can point it at a
+ * fixture via `SUPERVISOR_PROJECT_COLORS_PATH` regardless of import order. This
+ * is the same env-override seam the rest of the Supervisor already uses
+ * (`SUPERVISOR_DB_PATH`, `TMUX_PATH`, `SUPERVISOR_TMUX_SOCKET`,
+ * `SUPERVISOR_CLAUDE_PATH`). Without it `resolveColor`'s lookup table could only
+ * be exercised on a Mac that happens to have the real file, which is why its
+ * tests sat local-only and ungated (Issue #385).
+ *
+ * An empty value counts as unset so `SUPERVISOR_PROJECT_COLORS_PATH=` cannot
+ * silently redirect the read to the process CWD.
+ */
+export function projectColorsPath(): string {
+  const override = process.env.SUPERVISOR_PROJECT_COLORS_PATH;
+  if (override && override.length > 0) return override;
+  return resolve(homedir(), ".claude", "scripts", "project-colors.json");
+}
 
 interface ProjectColorsConfig {
   projects: Record<string, string>;
@@ -23,7 +36,7 @@ interface ProjectColorsConfig {
 
 function loadProjectColors(): ProjectColorsConfig {
   try {
-    const text = readFileSync(PROJECT_COLORS_PATH, "utf8");
+    const text = readFileSync(projectColorsPath(), "utf8");
     return JSON.parse(text);
   } catch {
     return { projects: {}, default_saturation: 0.3, default_brightness: 0.12 };

--- a/supervisor/tests/scripts/lint-gating-coverage.test.ts
+++ b/supervisor/tests/scripts/lint-gating-coverage.test.ts
@@ -12,9 +12,15 @@ import {
 /**
  * Issue #248: the gating-coverage lint must (AC-1) fail when a test file is
  * neither gated in ci.yml nor excluded, (AC-2) pass when every existing test
- * file under tests/ is gated or excluded, and (AC-3) fail when an exclusion
- * entry has no reason. The final "real repo" test makes AC-2 a live regression
- * guard against future gate omissions.
+ * file is gated or excluded, and (AC-3) fail when an exclusion entry has no
+ * reason. The final "real repo" test makes AC-2 a live regression guard against
+ * future gate omissions.
+ *
+ * Issue #385 widened the scanned scope from `tests/` to `tests/` + `src/`. The
+ * cases below pin that widening: colocated `src/**\/*.test.ts` files must be
+ * recognised as gated when passed to `bun test`, and the real-repo scan must
+ * include them so the six previously-invisible suites cannot silently drop out
+ * of CI again.
  */
 
 describe("extractGatedFiles", () => {
@@ -33,20 +39,35 @@ describe("extractGatedFiles", () => {
     expect(gated.size).toBe(3);
   });
 
+  test("collects colocated src/*.test.ts passed to a bun test step (#385)", () => {
+    const yaml = `      - name: Run tests
+        run: |
+          bun test --coverage \\
+                   tests/session/relay.test.ts \\
+                   src/session/iterm2.test.ts \\
+                   src/session/goal-watcher.test.ts`;
+    const gated = extractGatedFiles(yaml);
+    expect(gated.has("src/session/iterm2.test.ts")).toBe(true);
+    expect(gated.has("src/session/goal-watcher.test.ts")).toBe(true);
+    expect(gated.size).toBe(3);
+  });
+
   test("ignores a test file mentioned only in a comment (not a real run arg)", () => {
-    // The "Local-only tests" note must NOT be read as gating.
-    const yaml = `      # Local-only: tests/session/iterm2.test.ts needs project-colors.json
+    // A "local-only" note must NOT be read as gating — for either tree.
+    const yaml = `      # Local-only: tests/session/iterm2-async.test.ts is a wall-clock flake
+      # and src/session/iterm2.test.ts is merely referenced here
       - name: Run tests
         run: bun test tests/session/relay.test.ts`;
     const gated = extractGatedFiles(yaml);
     expect(gated.has("tests/session/relay.test.ts")).toBe(true);
-    expect(gated.has("tests/session/iterm2.test.ts")).toBe(false);
+    expect(gated.has("tests/session/iterm2-async.test.ts")).toBe(false);
+    expect(gated.has("src/session/iterm2.test.ts")).toBe(false);
   });
 });
 
 describe("analyzeCoverage", () => {
   const exclusions: Exclusion[] = [
-    { file: "tests/session/iterm2.test.ts", reason: "local-only config" },
+    { file: "tests/session/iterm2-async.test.ts", reason: "wall-clock flake" },
   ];
 
   test("AC-1: a file neither gated nor excluded is reported as ungated", () => {
@@ -61,12 +82,27 @@ describe("analyzeCoverage", () => {
 
   test("AC-2: every file gated or excluded → no violation", () => {
     const r = analyzeCoverage({
-      testFiles: ["tests/session/relay.test.ts", "tests/session/iterm2.test.ts"],
+      testFiles: [
+        "tests/session/relay.test.ts",
+        "tests/session/iterm2-async.test.ts",
+      ],
       gated: new Set(["tests/session/relay.test.ts"]),
       exclusions,
     });
     expect(r.ungated).toEqual([]);
     expect(hasFailure(r)).toBe(false);
+  });
+
+  test("#385: an ungated colocated src test is reported, not silently passed", () => {
+    // The exact hole #385 closed: before the scope widening this file was never
+    // even scanned, so it could not appear in `ungated` at all.
+    const r = analyzeCoverage({
+      testFiles: ["src/session/iterm2.test.ts", "tests/session/relay.test.ts"],
+      gated: new Set(["tests/session/relay.test.ts"]),
+      exclusions,
+    });
+    expect(r.ungated).toEqual(["src/session/iterm2.test.ts"]);
+    expect(hasFailure(r)).toBe(true);
   });
 
   test("AC-3: an exclusion with a blank reason fails", () => {
@@ -102,13 +138,18 @@ describe("analyzeCoverage", () => {
 });
 
 describe("real repository (AC-2 regression guard)", () => {
-  test("every tests/**/*.test.ts is gated in ci.yml or justifiably excluded", async () => {
+  test("every tests/ and src/ *.test.ts is gated in ci.yml or justifiably excluded", async () => {
     const root = resolve(import.meta.dir, "../.."); // supervisor/
     const ciYaml = await Bun.file(resolve(root, "../.github/workflows/ci.yml")).text();
     const gated = extractGatedFiles(ciYaml);
 
     const { Glob } = await import("bun");
-    const testFiles = [...new Glob("tests/**/*.test.ts").scanSync(root)].sort();
+    // Must mirror the script's own scan (#385) — if this only globbed tests/,
+    // a colocated src suite could rot out of CI with this guard still green.
+    const testFiles = [
+      ...new Glob("tests/**/*.test.ts").scanSync(root),
+      ...new Glob("src/**/*.test.ts").scanSync(root),
+    ].sort();
     expect(testFiles.length).toBeGreaterThan(0);
 
     const report = analyzeCoverage({
@@ -124,6 +165,22 @@ describe("real repository (AC-2 regression guard)", () => {
       emptyReason: report.emptyReason,
       staleExclusions: report.staleExclusions,
     }).toEqual({ ungated: [], emptyReason: [], staleExclusions: [] });
+  });
+
+  test("#385: the colocated src suites are actually gated, not merely scanned", async () => {
+    // Pins the outcome, not just the mechanism: these six files were silently
+    // never run in CI before #385. If one is dropped from ci.yml this fails
+    // even if someone also removes it from the glob above.
+    const root = resolve(import.meta.dir, "../..");
+    const ciYaml = await Bun.file(resolve(root, "../.github/workflows/ci.yml")).text();
+    const gated = extractGatedFiles(ciYaml);
+
+    const { Glob } = await import("bun");
+    const colocated = [...new Glob("src/**/*.test.ts").scanSync(root)].sort();
+    expect(colocated.length).toBeGreaterThan(0);
+
+    const excluded = new Set(EXCLUSIONS.map((e) => e.file));
+    expect(colocated.filter((f) => !gated.has(f) && !excluded.has(f))).toEqual([]);
   });
 
   test("this lint's own test file is gated (no self-exemption)", async () => {

--- a/supervisor/tests/session/iterm2-async.test.ts
+++ b/supervisor/tests/session/iterm2-async.test.ts
@@ -11,6 +11,23 @@ import { test, expect, describe } from "bun:test";
  * the non-blocking guarantee is unchanged: the synchronous portion (scheduling
  * the rename `spawn`) runs before the first `await`, so calling it never blocks
  * the event loop. realItermAdapter still calls it fire-and-forget (`void`).
+ *
+ * LOCAL-ONLY — deliberately NOT gated in ci.yml (Issue #385; the justification
+ * lives in scripts/lint-gating-coverage.ts EXCLUSIONS).
+ *
+ * The <100ms assertion below is a wall-clock threshold over a window that
+ * contains two process spawns (tmux rename-window + pgrep), and process-creation
+ * latency is load-dependent on any OS: five local probe runs measured
+ * 11/18/33/140/193ms, and this suite failed 2 of 3 consecutive runs on an idle
+ * Mac. It is a flake detector, not a regression detector.
+ *
+ * The invariant it is reaching for — markTabStopped must never block the event
+ * loop — IS enforced in CI, deterministically and without a clock, by
+ * scripts/lint-no-sync-exec.ts, which bans execSync/execFileSync/spawnSync
+ * anywhere under src/session/**. Prefer fixing that lint over this timing check.
+ *
+ * (For the record: `osascript` is NOT what makes this slow. It is only spawned
+ * after `await isItermRunning()` resolves — i.e. outside the measured window.)
  */
 
 describe("markTabStopped non-blocking (#27)", () => {

--- a/supervisor/tests/session/iterm2.test.ts
+++ b/supervisor/tests/session/iterm2.test.ts
@@ -1,5 +1,51 @@
-import { test, expect, describe } from "bun:test";
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
 import { resolveColor, dimColor, isItermRunning } from "../../src/session/iterm2";
+
+/**
+ * Issue #385: this file used to be local-only — `resolveColor`'s lookup-table
+ * cases asserted colours that only exist in the developer's real
+ * `~/.claude/scripts/project-colors.json`, so on CI (which has no such file)
+ * they fell through to the hash fallback and failed. It was therefore excluded
+ * from CI gating and the whole lookup path — including the "longest prefix
+ * wins" rule — went unguarded.
+ *
+ * It is now hermetic: the suite writes its OWN fixture to a temp dir and points
+ * `SUPERVISOR_PROJECT_COLORS_PATH` at it (see `projectColorsPath()`), so the
+ * expected colours are defined here rather than inherited from the machine.
+ * Verified by running with a throwaway `$HOME`: 0 failures.
+ */
+
+const FIXTURE_COLORS = {
+  projects: {
+    team_salary: "#1e1028",
+    team_salary_blog: "#102525",
+  },
+  default_saturation: 0.3,
+  default_brightness: 0.12,
+};
+
+let fixtureDir: string;
+let previousOverride: string | undefined;
+
+beforeAll(() => {
+  previousOverride = process.env.SUPERVISOR_PROJECT_COLORS_PATH;
+  fixtureDir = mkdtempSync(join(tmpdir(), "iterm2-colors-"));
+  const fixturePath = join(fixtureDir, "project-colors.json");
+  writeFileSync(fixturePath, JSON.stringify(FIXTURE_COLORS), "utf8");
+  process.env.SUPERVISOR_PROJECT_COLORS_PATH = fixturePath;
+});
+
+afterAll(() => {
+  if (previousOverride === undefined) {
+    delete process.env.SUPERVISOR_PROJECT_COLORS_PATH;
+  } else {
+    process.env.SUPERVISOR_PROJECT_COLORS_PATH = previousOverride;
+  }
+  rmSync(fixtureDir, { recursive: true, force: true });
+});
 
 describe("resolveColor", () => {
   test("returns exact match from project-colors.json", () => {
@@ -8,6 +54,8 @@ describe("resolveColor", () => {
   });
 
   test("returns prefix match (longest wins)", () => {
+    // Both "team_salary" and "team_salary_blog" are prefixes of the input; the
+    // longer key must win. This rule was previously unguarded in CI (#385).
     const color = resolveColor("team_salary_blog");
     expect(color).toBe("#102525");
   });
@@ -21,6 +69,21 @@ describe("resolveColor", () => {
     const color1 = resolveColor("some-project");
     const color2 = resolveColor("some-project");
     expect(color1).toBe(color2);
+  });
+
+  test("falls back to a hash color when the config file is missing", () => {
+    // The CI/no-config path: loadProjectColors swallows the read error and
+    // returns empty defaults, so every project resolves via the hash. Guards
+    // that a missing config degrades instead of throwing.
+    const missing = join(fixtureDir, "does-not-exist.json");
+    const restore = process.env.SUPERVISOR_PROJECT_COLORS_PATH;
+    process.env.SUPERVISOR_PROJECT_COLORS_PATH = missing;
+    try {
+      expect(resolveColor("team_salary")).toMatch(/^#[0-9a-f]{6}$/);
+      expect(resolveColor("team_salary")).not.toBe("#1e1028");
+    } finally {
+      process.env.SUPERVISOR_PROJECT_COLORS_PATH = restore;
+    }
   });
 });
 
@@ -50,6 +113,8 @@ describe("dimColor", () => {
 describe("isItermRunning", () => {
   // Issue #227 (PR-4): isItermRunning is async now (pgrep moved to the async
   // `execFile`), so it returns Promise<boolean> — await it before asserting.
+  // Safe on CI: if `pgrep` is absent or matches nothing, execFile rejects and
+  // the catch returns false, so the result is a boolean on every platform.
   test("resolves to a boolean", async () => {
     const result = await isItermRunning();
     expect(typeof result).toBe("boolean");


### PR DESCRIPTION
## 概要

Issue #385（Epic #381）の実装。「local-only とされていたテスト群を CI 編入するか、除外理由を明文化する」を、
**ci.yml のコメントではなく機械可読な単一の真実源**へ寄せる形で解決する。

## 調査で判明したこと（Issue の前提が stale だった）

- `manager.test.ts` は **#185 以降すでに CI で実行されている**。ci.yml 末尾の「Local-only tests」注記が
  古いまま残っており、`codecov.yml` もそれを事実として引用していた
- 本当の穴は別にあった: **colocated な `src/**/*.test.ts` 6 本（67 ケース）が一度も CI で実行されていなかった**。
  ci.yml の whitelist は `tests/...` しか列挙せず、`lint-gating-coverage.ts` も `tests/` しか走査していなかったため、
  **ギャップを検知する手段自体が無かった**（#183 の AppleScript インジェクションガードもこの中に含まれる）

## 主な変更点

| ファイル | 内容 |
|---|---|
| `.github/workflows/ci.yml` | colocated 6 本 + `tests/session/iterm2.test.ts` を gate 対象へ追加。末尾の stale な「Local-only tests」注記を撤去し、EXCLUSIONS への参照に置換 |
| `supervisor/scripts/lint-gating-coverage.ts` | 走査範囲を `src/` へ拡張。**未 gate かつ EXCLUSIONS 未記載のテストがあればビルドを落とす**（コメントのように drift しない） |
| `supervisor/src/session/iterm2.ts` / `tests/session/iterm2.test.ts` | `~/.claude/scripts/project-colors.json` 依存を解消（fixture を自前で書き `SUPERVISOR_PROJECT_COLORS_PATH` を向ける）。これで local-only ではなくなった |
| `codecov.yml` | `supervisor/src/session/iterm2.ts` の除外を撤回（実ロジックを含むファイルの blanket 除外は `coverage-policy.md` §5 の anti-gaming に反する）。未カバーは実 iTerm2 + osascript 経路のみで、patch は informational のため PR を不当に落とさない |
| `tests/scripts/lint-gating-coverage.test.ts` | 上記 lint の回帰テスト |

## AC 検証結果（オーケストレーターが独立に再実行）

| 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|
| 新規 gate 分がすべて通る | `bun test <新規 7 ファイル>` | 全 PASS | **76 pass / 0 fail**（159 expect） | PASS |
| iterm2 テストが hermetic（`~/.claude` 非依存） | `HOME=$(mktemp -d) bun test tests/session/iterm2.test.ts src/session/iterm2.test.ts` | 全 PASS | **18 pass / 0 fail** | PASS |
| gating lint が全件を把握 | `bun run scripts/lint-gating-coverage.ts` | exit 0 | `102 test file(s) — 100 gated, 2 excluded, 0 ungated`（exit 0） | PASS |
| **未 gate を実際に落とせるか（負例）** | 未 gate の `src/session/zz-verifier-probe.test.ts` を追加して lint 実行 | 非 0 で FAIL | 当該ファイルを名指しで指摘し **exit 1**。削除後は再び exit 0 | PASS |

負例まで確認したのは、この PR の価値が「テストを 7 本足したこと」ではなく
**「同じ drift が二度と起きないよう機械的に止められること」**にあるため。

## オーケストレーターによる代行事項（透明性のため明記）

ワーカーは実装をコミット（`382ca03`）した直後の turn 終了時に落ち、**push と PR 作成に到達しなかった**
（known failure mode `headless-turn-end-death`。worktree は削除されたがブランチ参照は残っていたため成果は無傷）。
残作業が「rebase → push → PR」のみで再 dispatch は重複作業・二重 PR を招くため、オーケストレーターが
代行した（`orchestration-escalation-policy.md` B-1e）。

代行時に **PR #399（#383）と衝突した `codecov.yml` を手で解決**している。#383 の bot.ts NOTE ブロックと
#385 の iterm2 除外撤回の**両方を残す**方向で解決した（どちらか一方を落としていない）。

## 関連

- Issue: #385 / Epic: #381
- 直列依存: #382（merged）→ #383（merged）→ **本 PR** → #300（カバレッジ blocking 昇格）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **品質改善**
  * iTerm2連携やセッション処理のテストをCIのカバレッジ対象に追加しました。
  * `src/` と `tests/` 配下のテストを網羅的に検証できるようになりました。
  * iTerm2のプロジェクトカラー設定で、環境変数による設定ファイル指定に対応しました。
  * 設定ファイルが見つからない場合のフォールバック動作をテストしました。
  * 非同期処理や外部コマンド実行時の挙動に関する検証を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->