### PR TITLE
ci: カバレッジ patch 70% を blocking へ昇格し、破棄されていた mock-isolated 計測を回収する (#300)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -290,11 +290,21 @@ jobs:
       # evidence that a line executed (adapters.ts 38.18% -> 61.82%,
       # tmux.ts 70.59% -> 91.18%, total 77.21% -> 78.15%, denominator identical).
       # Rationale in full: supervisor/scripts/lcov-hits-only.ts (#300).
+      #
+      # The raw file is deleted right after filtering, and every upload step
+      # below sets `disable_search: true`. Both are needed: codecov-action
+      # defaults to `disable_search: false`, which makes the CLI ALSO auto-scan
+      # the tree and upload every lcov.info it finds — on the first run of this
+      # change it reported "Found 5 coverage files" and shipped the very raw
+      # reports this step exists to filter out, silently reintroducing the
+      # inflated denominator. Deleting the raw file makes the invariant hold
+      # even if that default flips back.
       - name: Keep only executed lines from the mock-isolated reports (#300)
         run: |
           for name in hassession adapters tmux relay-nonblocking; do
             bun scripts/lcov-hits-only.ts \
               "coverage-$name/lcov.info" "coverage-$name/hits-only.info"
+            rm "coverage-$name/lcov.info"
           done
 
       # One upload step per report, each with a single `files` value — the same
@@ -309,6 +319,7 @@ jobs:
           files: supervisor/coverage/lcov.info
           flags: unit-tests
           fail_ci_if_error: false
+          disable_search: true
 
       - name: Upload mock-isolated hasSession coverage to Codecov
         if: always()
@@ -317,6 +328,7 @@ jobs:
           files: supervisor/coverage-hassession/hits-only.info
           flags: unit-tests
           fail_ci_if_error: false
+          disable_search: true
 
       - name: Upload mock-isolated adapters coverage to Codecov
         if: always()
@@ -325,6 +337,7 @@ jobs:
           files: supervisor/coverage-adapters/hits-only.info
           flags: unit-tests
           fail_ci_if_error: false
+          disable_search: true
 
       - name: Upload mock-isolated tmux coverage to Codecov
         if: always()
@@ -333,6 +346,7 @@ jobs:
           files: supervisor/coverage-tmux/hits-only.info
           flags: unit-tests
           fail_ci_if_error: false
+          disable_search: true
 
       - name: Upload mock-isolated relay coverage to Codecov
         if: always()
@@ -341,6 +355,7 @@ jobs:
           files: supervisor/coverage-relay-nonblocking/hits-only.info
           flags: unit-tests
           fail_ci_if_error: false
+          disable_search: true
 
   routing-tests:
     name: Routing Tests (S5 #51)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,6 +151,7 @@ jobs:
                    tests/hijoguchi-routing/p0.test.ts \
                    tests/e2e/ac-verification.test.ts \
                    tests/scripts/lint-gating-coverage.test.ts \
+                   tests/scripts/lcov-hits-only.test.ts \
                    tests/scripts/traceability-metrics.test.ts \
                    tests/commands/session-compact.test.ts \
                    tests/commands/compact-button.test.ts \
@@ -223,13 +224,25 @@ jobs:
       # (PR #239). It uses mock.module("child_process"), which is
       # process-global in Bun and would leak into the curated list above, so it
       # runs as its OWN `bun test` process. No `|| true` — it must gate the
-      # build (RW-029: a silently-green CI is worse than a red one). Not run
-      # with --coverage so it does not overwrite the lcov.info produced above.
+      # build (RW-029: a silently-green CI is worse than a red one).
+      #
+      # It DOES run with --coverage, into its own --coverage-dir (#300). It used
+      # to run without --coverage "so it does not overwrite the lcov.info
+      # produced above" — but that silently DISCARDED the coverage of every
+      # mock-isolated suite, so lines these tests do exercise were reported to
+      # Codecov as unhit. That is not cosmetic: PR #378 changed adapters.ts and
+      # added this very test file in the same PR, and still scored 27.58% of
+      # diff hit — a false FAIL that only stayed invisible because patch was
+      # informational. Separate --coverage-dir keeps lcov.info intact and each
+      # report is uploaded on its own below; Codecov merges same-commit reports.
       - name: Run mock-isolated session tests (#238 hasSession ETIMEDOUT)
         env:
           SUPERVISOR_DB_PATH: ":memory:"
           TMUX_PATH: /usr/bin/tmux
-        run: bun test tests/session/adapters-hassession.test.ts
+        run: |
+          bun test --coverage --coverage-reporter=lcov \
+                   --coverage-dir=coverage-hassession \
+                   tests/session/adapters-hassession.test.ts
 
       # adapters.test.ts and tmux.test.ts each call mock.module("child_process"),
       # which is process-global in Bun and pollutes any file sharing the process
@@ -240,13 +253,19 @@ jobs:
         env:
           SUPERVISOR_DB_PATH: ":memory:"
           TMUX_PATH: /usr/bin/tmux
-        run: bun test tests/session/adapters.test.ts
+        run: |
+          bun test --coverage --coverage-reporter=lcov \
+                   --coverage-dir=coverage-adapters \
+                   tests/session/adapters.test.ts
 
       - name: Run mock-isolated tmux tests (#248)
         env:
           SUPERVISOR_DB_PATH: ":memory:"
           TMUX_PATH: /usr/bin/tmux
-        run: bun test tests/session/tmux.test.ts
+        run: |
+          bun test --coverage --coverage-reporter=lcov \
+                   --coverage-dir=coverage-tmux \
+                   tests/session/tmux.test.ts
 
       # #227 (PR-1 / #249) AC-3: relay.ts's tmux send hot path must stay
       # non-blocking after the execFileSync→execFile migration. This file mocks
@@ -257,13 +276,69 @@ jobs:
         env:
           SUPERVISOR_DB_PATH: ":memory:"
           TMUX_PATH: /usr/bin/tmux
-        run: bun test tests/session/relay-nonblocking.test.ts
+        run: |
+          bun test --coverage --coverage-reporter=lcov \
+                   --coverage-dir=coverage-relay-nonblocking \
+                   tests/session/relay-nonblocking.test.ts
 
+      # The isolated reports are NOT uploaded raw. A suite that merely imports a
+      # module still emits DA records for it, and Bun instruments a larger line
+      # set in those runs, so a raw merge inflates the denominator: measured on
+      # this repo it moved relay.ts 57.53% -> 42.57% and the whole report
+      # 77.21% -> 73.61%. Stripping zero-hit records keeps the curated run as
+      # the sole source of the denominator and lets the isolated runs only ADD
+      # evidence that a line executed (adapters.ts 38.18% -> 61.82%,
+      # tmux.ts 70.59% -> 91.18%, total 77.21% -> 78.15%, denominator identical).
+      # Rationale in full: supervisor/scripts/lcov-hits-only.ts (#300).
+      - name: Keep only executed lines from the mock-isolated reports (#300)
+        run: |
+          for name in hassession adapters tmux relay-nonblocking; do
+            bun scripts/lcov-hits-only.ts \
+              "coverage-$name/lcov.info" "coverage-$name/hits-only.info"
+          done
+
+      # One upload step per report, each with a single `files` value — the same
+      # shape agent-base/.github/workflows/ci.yml already uses for its python +
+      # shell reports. All five carry the same `unit-tests` flag because they
+      # are all this job's unit tests; Codecov merges reports uploaded for the
+      # same commit, so the merged view is curated ∪ mock-isolated (#300).
       - name: Upload coverage to Codecov
         if: always()
         uses: codecov/codecov-action@v5
         with:
           files: supervisor/coverage/lcov.info
+          flags: unit-tests
+          fail_ci_if_error: false
+
+      - name: Upload mock-isolated hasSession coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: supervisor/coverage-hassession/hits-only.info
+          flags: unit-tests
+          fail_ci_if_error: false
+
+      - name: Upload mock-isolated adapters coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: supervisor/coverage-adapters/hits-only.info
+          flags: unit-tests
+          fail_ci_if_error: false
+
+      - name: Upload mock-isolated tmux coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: supervisor/coverage-tmux/hits-only.info
+          flags: unit-tests
+          fail_ci_if_error: false
+
+      - name: Upload mock-isolated relay coverage to Codecov
+        if: always()
+        uses: codecov/codecov-action@v5
+        with:
+          files: supervisor/coverage-relay-nonblocking/hits-only.info
           flags: unit-tests
           fail_ci_if_error: false
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,10 +1,19 @@
 # codecov 設定（Epic miyashita337/agent-base#420 Phase 2 / rules/general/coverage-policy.md 準拠）
 #
-# WARN-first 運用（coverage-policy.md §6）:
-#   patch / project とも informational: true（WARN-only、非 blocking）で導入し、
-#   数 PR dogfood して false positive がないことを確認してから blocking 昇格する。
-#   blocking 昇格の条件・期限・手順は follow-up issue #300 で追跡する
-#   （informational のまま放置しない）。
+# WARN-first 運用（coverage-policy.md §6）の現在地:
+#   patch   = blocking（informational: false）。#300 で昇格した。
+#   project = informational: true 据え置き。理由は下の project ブロックを参照。
+#
+# 昇格の根拠（#300, 2026-08-09 実測）:
+#   informational: true の status は conclusion が常に success になるため、
+#   「マージ済み PR が全部緑だった」は dogfood の証拠にならない。実判定は
+#   check-run の output.title 側にある。#296 マージ以降の 20 PR を実測すると
+#   3 件が target 70% 未満で、うち #378 は false positive だった（adapters.ts の
+#   変更と担保テストを同一 PR で入れているのに 27.58%）。原因は ci.yml の
+#   mock-isolated ステップが --coverage なしで走りカバレッジを捨てていたこと。
+#   これを --coverage-dir 分離 + 個別アップロードで解消した上で昇格している。
+#   残る 2 件（#387 54.32% / #403 57.14%）は CLI の main ブロックと実 iTerm2
+#   経路の真の未テストで、false positive ではない = ゲートの意図した動作。
 
 coverage:
   precision: 2
@@ -12,15 +21,24 @@ coverage:
   range: "60...90"
   status:
     # プロジェクト全体: regression 禁止の ratchet（coverage-policy.md §2）。
-    # ベースライン実測（2026-07-05, ci.yml の curated Unit Tests suite）:
-    #   line 78.60% / func 81.04%。
+    # 実測（curated Unit Tests suite）:
+    #   2026-07-05 ベースライン line 78.60% / func 81.04%
+    #   2026-08-09 現在        line 81.09% / func 83.34%
     # target: auto = ベースコミット比で低下禁止。実測値の向上に合わせて
     # 明示 target（"80%" 等）へ段階引き上げる。
+    #
+    # patch と違い informational: true のまま据え置く（#300）。codecov/project
+    # という check は **一度も投稿されたことがない** ためである。#296 マージ
+    # 以降の PR 20 件と main 直近 6 commit の check-runs を実測したが、出るのは
+    # codecov/patch だけだった（原因は未特定 / 確度:低）。投稿されない status は
+    # dogfood できず、required status check に足せば PR が永久に pending で
+    # 詰まる。原因調査と昇格可否は #404 で追跡する。required status check の
+    # 追加自体（branch protection がまだ 1 つも無い）は #406 で扱う。
     project:
       default:
         target: auto
         threshold: 1% # 計測ノイズ許容（Bun coverage の実行順依存分）
-        informational: true # WARN-first。blocking 昇格は follow-up #300
+        informational: true # 投稿実績ゼロのため昇格不可。follow-up で調査
 
     # patch coverage: PR の変更行のみに適用（coverage-policy.md §1）。
     #
@@ -31,16 +49,22 @@ coverage:
     # 制約: codecov の ignore も Bun coverage も「行 / 分岐単位の除外」を
     # サポートしない（Bun は c8 / istanbul の ignore コメントを無視する。
     # 2026-07-05 検証済み）。よって relay.ts の error 分岐だけを外すことは
-    # できず、relay.ts はスコープ内に残す。WARN-first（informational）にする
-    # ことで、error 分岐のみ変更した PR が patch check で不当に FAIL すること
-    # を防ぐ（統合ジャーニーAC-3）。blocking 昇格時に relay.ts の error 分岐を
-    # 実 tmux 統合テストで誘発するか個別対応するかを follow-up #300 で判断する。
+    # できず、relay.ts はスコープ内に残す。
+    #
+    # #300 で決着（選択肢 a を採用）: ETIMEDOUT 分岐は
+    # tests/session/adapters-hassession.test.ts が既に担保している。足りな
+    # かったのはテストではなく **計測** で、当該 suite は mock.module 汚染を
+    # 避けるため独立プロセスで走らせつつ --coverage を外していた。ci.yml で
+    # --coverage-dir を分けて個別アップロードするようにしたので、この分岐は
+    # 計測されるようになった。よって relay.ts 専用の低め target（選択肢 c）も
+    # file-level 除外（選択肢 b、coverage-policy.md §5 の anti-gaming 違反）も
+    # 不要。
     patch:
       default:
         target: 70%
         threshold: 0%
         only_pulls: true
-        informational: true # WARN-first。blocking 昇格は follow-up #300
+        informational: false # blocking（#300）。根拠はファイル冒頭を参照
 
 # 変更を PR にインラインで注記する。マージゲート（強制）はテスト系ジョブ:
 #   - Type Check (bunx tsc --noEmit)
@@ -81,8 +105,9 @@ ignore:
   #   - 実際、これらの分岐の多くは既に純関数側（access-policy / slash-prefix /
   #     dispatch / orchestrate / salvage-reply）へ切り出され計測されている。
   #     除外すると、今後 bot.ts へ**戻る**方向の変更が検知されなくなる。
-  # patch は WARN-first（informational）なので、未カバーの残部に触れた PR が
-  # 不当に FAIL することはない。blocking 昇格時の再評価は #300 で追跡する。
+  # patch は #300 で blocking になったため、未カバーの残部に触れる PR は
+  # 変更行の 70% を要求される。これは除外し直す理由にはならない（上の 3 点は
+  # blocking かどうかと独立）。残債の解消は #405 で追跡する。
   # （src/bot.ts の除外エントリは意図的に存在しない）
   #
   # NOTE: src/session/iterm2.ts は除外しない（Issue #385 で除外を撤回）。
@@ -96,7 +121,9 @@ ignore:
   # 実行経路のみで、これは relay.ts の tmux error 分岐と同型の「ファイル単位
   # 除外では切り出せない部分的未カバー」。実ロジックを含むファイルの blanket
   # 除外は coverage-policy.md §5 の anti-gaming に反する（上の bot.ts の判断と
-  # 同じ）ため、informational（WARN-first）のままスコープ内に残す。
+  # 同じ）ため、スコープ内に残す。patch が blocking になった今でも同じ判断で
+  # ある: 実 iTerm2 経路に触る PR にテストを要求するのは正しい挙動で、それを
+  # 避けるための file-level 除外こそが anti-gaming 違反にあたる。
   # launchd 定義（宣言的 XML）。実行コードでなくカバレッジ対象外。
   - "**/*.plist"
   - "**/*.plist.template"

--- a/supervisor/.gitignore
+++ b/supervisor/.gitignore
@@ -8,6 +8,9 @@ dist
 
 # code coverage
 coverage
+# per-suite --coverage-dir outputs for the mock-isolated `bun test` runs (#300).
+# `coverage` above matches that exact name only, so these need their own entry.
+coverage-*
 *.lcov
 
 # logs

--- a/supervisor/scripts/lcov-hits-only.ts
+++ b/supervisor/scripts/lcov-hits-only.ts
@@ -1,0 +1,115 @@
+#!/usr/bin/env bun
+/**
+ * Strip every zero-hit record from an lcov report, keeping only positive hits.
+ *
+ * Why this exists (#300)
+ * ---------------------
+ * The Unit Tests job runs one big curated `bun test` plus four mock-isolated
+ * ones. The isolated suites call `mock.module("child_process")`, which is
+ * process-global in Bun, so they cannot share a process with the curated list.
+ * They used to run without `--coverage` entirely, which silently discarded
+ * their coverage: PR #378 changed `adapters.ts` and added
+ * `adapters-hassession.test.ts` in the same PR, yet Codecov scored it 27.58% of
+ * diff hit. That false FAIL only stayed invisible because patch was
+ * informational.
+ *
+ * Uploading the isolated reports raw does not work either. A suite that merely
+ * *imports* a module still emits DA records for it, and Bun instruments a
+ * different (larger) line set in those runs. Measured on this repo:
+ * relay-nonblocking contributes 0 newly-hit lines to `relay.ts` but 77
+ * instrumented-and-unhit ones, dragging it 57.53% -> 42.57% and the whole
+ * report 77.21% -> 73.61%. Merging raw reports makes coverage look *worse*.
+ *
+ * So the rule is: the curated run is the sole source of the denominator, and
+ * the isolated runs may only ever *add* evidence that a line was executed.
+ * Dropping zero-hit records enforces exactly that — a line Codecov already
+ * knows about can flip unhit -> hit, and nothing new enters the denominator.
+ * Nothing is hidden relative to today's baseline: any line the curated run
+ * instruments stays in its report untouched.
+ *
+ * Measured effect of the filtered merge: adapters.ts 38.18% -> 61.82%,
+ * tmux.ts 70.59% -> 91.18%, relay.ts unchanged, total 77.21% -> 78.15%, with
+ * an identical line denominator (7679).
+ */
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+
+/**
+ * Keep only `DA:`/`FNDA:` records with a non-zero hit count, and drop files
+ * left with no executed line at all. `LF`/`LH`/`FNF`/`FNH` are recomputed so
+ * the emitted report stays internally consistent (every retained line is hit,
+ * so found == hit by construction).
+ */
+export function hitsOnly(source: string): string {
+  const out: string[] = [];
+  let body: string[] = [];
+  let sourceFile = "";
+  let lines = 0;
+  let functions = 0;
+
+  const flush = (): void => {
+    if (sourceFile && lines > 0) {
+      out.push(
+        `SF:${sourceFile}`,
+        ...body,
+        `FNF:${functions}`,
+        `FNH:${functions}`,
+        `LF:${lines}`,
+        `LH:${lines}`,
+        "end_of_record",
+      );
+    }
+    body = [];
+    sourceFile = "";
+    lines = 0;
+    functions = 0;
+  };
+
+  for (const raw of source.split("\n")) {
+    const line = raw.trim();
+    if (line.startsWith("SF:")) {
+      flush();
+      sourceFile = line.slice(3);
+    } else if (line.startsWith("DA:")) {
+      const [lineNo, hits] = line.slice(3).split(",");
+      if (Number(hits) > 0) {
+        body.push(`DA:${lineNo},${hits}`);
+        lines++;
+      }
+    } else if (line.startsWith("FNDA:")) {
+      const comma = line.indexOf(",");
+      if (Number(line.slice(5, comma)) > 0) {
+        body.push(line);
+        functions++;
+      }
+    } else if (line === "end_of_record") {
+      flush();
+    }
+    // FN:/BRDA:/LF:/LH:/FNF:/FNH: are intentionally dropped — they either name
+    // records we did not keep or are counts we recompute above. (Bun emits no
+    // BRDA at all: its lcov reporter has no branch data, see #300 / #296.)
+  }
+  flush();
+
+  return out.length > 0 ? `${out.join("\n")}\n` : "";
+}
+
+if (import.meta.main) {
+  const [input, output] = process.argv.slice(2);
+  if (!input || !output) {
+    console.error("usage: bun scripts/lcov-hits-only.ts <input.info> <output.info>");
+    process.exit(2);
+  }
+  // Fail loudly rather than emitting an empty report: a silently-missing
+  // upload would drop coverage on every PR once patch is blocking (RW-029).
+  if (!existsSync(input)) {
+    console.error(`lcov-hits-only: input not found: ${input}`);
+    process.exit(1);
+  }
+  const filtered = hitsOnly(readFileSync(input, "utf8"));
+  if (filtered === "") {
+    console.error(`lcov-hits-only: ${input} contains no executed line`);
+    process.exit(1);
+  }
+  writeFileSync(output, filtered);
+  console.log(`lcov-hits-only: ${input} -> ${output}`);
+}

--- a/supervisor/scripts/lcov-hits-only.ts
+++ b/supervisor/scripts/lcov-hits-only.ts
@@ -93,23 +93,34 @@ export function hitsOnly(source: string): string {
   return out.length > 0 ? `${out.join("\n")}\n` : "";
 }
 
-if (import.meta.main) {
-  const [input, output] = process.argv.slice(2);
+/**
+ * Returns the process exit code instead of calling `process.exit`, so the
+ * guards below are exercised in-process by the tests. CI runs this between the
+ * test steps and the Codecov uploads, and those uploads set
+ * `fail_ci_if_error: false` — so a script that shrugged at a missing input or
+ * wrote an empty report would silently drop the isolated coverage from every
+ * PR. That is the RW-029 "silently-green CI" shape, hence the loud exits.
+ */
+export function runCli(args: string[]): number {
+  const [input, output] = args;
   if (!input || !output) {
     console.error("usage: bun scripts/lcov-hits-only.ts <input.info> <output.info>");
-    process.exit(2);
+    return 2;
   }
-  // Fail loudly rather than emitting an empty report: a silently-missing
-  // upload would drop coverage on every PR once patch is blocking (RW-029).
   if (!existsSync(input)) {
     console.error(`lcov-hits-only: input not found: ${input}`);
-    process.exit(1);
+    return 1;
   }
   const filtered = hitsOnly(readFileSync(input, "utf8"));
   if (filtered === "") {
     console.error(`lcov-hits-only: ${input} contains no executed line`);
-    process.exit(1);
+    return 1;
   }
   writeFileSync(output, filtered);
   console.log(`lcov-hits-only: ${input} -> ${output}`);
+  return 0;
+}
+
+if (import.meta.main) {
+  process.exit(runCli(process.argv.slice(2)));
 }

--- a/supervisor/tests/scripts/lcov-hits-only.test.ts
+++ b/supervisor/tests/scripts/lcov-hits-only.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, test } from "bun:test";
-import { hitsOnly } from "../../scripts/lcov-hits-only";
+import { afterAll, describe, expect, test } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { hitsOnly, runCli } from "../../scripts/lcov-hits-only";
 
 /**
  * Issue #300. The filter's whole job is to make the mock-isolated `bun test`
@@ -115,5 +118,48 @@ describe("hitsOnly", () => {
 
   test("tolerates a report with no trailing end_of_record", () => {
     expect(hitsOnly(["SF:src/a.ts", "DA:1,1"].join("\n"))).toContain("SF:src/a.ts");
+  });
+});
+
+/**
+ * The CLI must fail LOUDLY. CI runs it between the test steps and the Codecov
+ * uploads, and the uploads use `fail_ci_if_error: false` — so if this script
+ * ever emitted an empty file or shrugged at a missing input, the isolated
+ * coverage would vanish and every PR would silently lose it. That is the exact
+ * RW-029 "silently-green CI" shape the surrounding job comments warn about.
+ */
+describe("runCli", () => {
+  const dir = mkdtempSync(join(tmpdir(), "lcov-hits-only-"));
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+  test("writes the filtered report and returns 0", () => {
+    const input = join(dir, "in.info");
+    const output = join(dir, "out.info");
+    writeFileSync(input, ["SF:src/a.ts", "DA:1,4", "DA:2,0", "end_of_record"].join("\n"));
+
+    expect(runCli([input, output])).toBe(0);
+
+    const written = readFileSync(output, "utf8");
+    expect(written).toContain("DA:1,4");
+    expect(written).not.toContain("DA:2,0");
+  });
+
+  test("returns 1 when the input file is missing", () => {
+    expect(runCli([join(dir, "absent.info"), join(dir, "unused.info")])).toBe(1);
+    expect(existsSync(join(dir, "unused.info"))).toBe(false);
+  });
+
+  test("returns 1 rather than writing an empty report", () => {
+    const input = join(dir, "all-unhit.info");
+    const output = join(dir, "never-written.info");
+    writeFileSync(input, ["SF:src/a.ts", "DA:1,0", "end_of_record"].join("\n"));
+
+    expect(runCli([input, output])).toBe(1);
+    expect(existsSync(output)).toBe(false);
+  });
+
+  test("returns 2 when either argument is missing", () => {
+    expect(runCli([join(dir, "in.info")])).toBe(2);
+    expect(runCli([])).toBe(2);
   });
 });

--- a/supervisor/tests/scripts/lcov-hits-only.test.ts
+++ b/supervisor/tests/scripts/lcov-hits-only.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, test } from "bun:test";
+import { hitsOnly } from "../../scripts/lcov-hits-only";
+
+/**
+ * Issue #300. The filter's whole job is to make the mock-isolated `bun test`
+ * runs contribute coverage WITHOUT letting them redefine the denominator: a
+ * suite that merely imports a module still emits DA records for it, and Bun
+ * instruments a different (larger) line set in those runs. Uploading them raw
+ * measured 57.53% -> 42.57% on relay.ts and 77.21% -> 73.61% overall.
+ *
+ * So the invariants under test are (1) zero-hit records never survive, and
+ * (2) merging a filtered report into a base report can only ever flip a line
+ * unhit -> hit, never grow the line total. AC-2 of the issue's journey AC.
+ */
+
+const DA = (report: string): Map<string, Map<number, number>> => {
+  const out = new Map<string, Map<number, number>>();
+  let sf = "";
+  for (const line of report.split("\n")) {
+    if (line.startsWith("SF:")) {
+      sf = line.slice(3);
+      if (!out.has(sf)) out.set(sf, new Map());
+    } else if (line.startsWith("DA:")) {
+      const parts = line.slice(3).split(",");
+      out.get(sf)!.set(Number(parts[0]), Number(parts[1]));
+    }
+  }
+  return out;
+};
+
+describe("hitsOnly", () => {
+  test("keeps executed lines and drops zero-hit ones", () => {
+    const filtered = hitsOnly(
+      ["SF:src/a.ts", "DA:1,3", "DA:2,0", "DA:3,1", "LF:3", "LH:2", "end_of_record"].join("\n"),
+    );
+
+    const lines = DA(filtered).get("src/a.ts")!;
+    expect([...lines.keys()].sort((x, y) => x - y)).toEqual([1, 3]);
+    expect(lines.get(1)).toBe(3);
+  });
+
+  test("recomputes LF/LH/FNF/FNH to match what survived", () => {
+    const filtered = hitsOnly(
+      [
+        "SF:src/a.ts",
+        "FN:1,covered",
+        "FN:9,nope",
+        "FNDA:2,covered",
+        "FNDA:0,nope",
+        "DA:1,2",
+        "DA:9,0",
+        "FNF:2",
+        "FNH:1",
+        "LF:2",
+        "LH:1",
+        "end_of_record",
+      ].join("\n"),
+    );
+
+    // Every retained line is hit by construction, so found == hit.
+    expect(filtered).toContain("LF:1");
+    expect(filtered).toContain("LH:1");
+    expect(filtered).toContain("FNF:1");
+    expect(filtered).toContain("FNH:1");
+    expect(filtered).toContain("FNDA:2,covered");
+    expect(filtered).not.toContain("nope");
+  });
+
+  test("drops a file whose lines were all unhit", () => {
+    const filtered = hitsOnly(
+      [
+        "SF:src/never-run.ts",
+        "DA:1,0",
+        "DA:2,0",
+        "end_of_record",
+        "SF:src/run.ts",
+        "DA:1,5",
+        "end_of_record",
+      ].join("\n"),
+    );
+
+    expect(filtered).not.toContain("src/never-run.ts");
+    expect(filtered).toContain("SF:src/run.ts");
+  });
+
+  test("returns empty output when nothing was executed", () => {
+    expect(hitsOnly(["SF:src/a.ts", "DA:1,0", "end_of_record"].join("\n"))).toBe("");
+  });
+
+  test("merging a filtered report never grows the base line total (#300 AC-2)", () => {
+    // Base = the curated run. Isolated = a suite that only *imports* src/a.ts,
+    // so it instruments MORE lines (1..4) but executes only line 2.
+    const base = ["SF:src/a.ts", "DA:1,1", "DA:2,0", "end_of_record"].join("\n");
+    const isolated = [
+      "SF:src/a.ts",
+      "DA:1,0",
+      "DA:2,7",
+      "DA:3,0",
+      "DA:4,0",
+      "end_of_record",
+    ].join("\n");
+
+    const baseLines = DA(base).get("src/a.ts")!;
+    const addedLines = DA(hitsOnly(isolated)).get("src/a.ts")!;
+
+    // The spurious lines 3 and 4 are gone; only the genuine hit on 2 remains.
+    expect([...addedLines.keys()]).toEqual([2]);
+
+    const merged = new Map(baseLines);
+    for (const [no, hits] of addedLines) merged.set(no, (merged.get(no) ?? 0) + hits);
+
+    expect(merged.size).toBe(baseLines.size); // denominator untouched
+    expect([...merged.values()].filter((h) => h > 0).length).toBe(2); // 1 -> 2 hit
+  });
+
+  test("tolerates a report with no trailing end_of_record", () => {
+    expect(hitsOnly(["SF:src/a.ts", "DA:1,1"].join("\n"))).toContain("SF:src/a.ts");
+  });
+});


### PR DESCRIPTION
Closes #300

## 何をしたか

カバレッジゲートの blocking 昇格（Epic miyashita337/agent-base#420 Phase 2）。あわせて、昇格の前提を崩していた計測バグを直した。

| 対象 | before | after |
|---|---|---|
| `codecov/patch` (target 70%) | `informational: true`（常に緑） | **`informational: false`（blocking）** |
| `codecov/project` (ratchet) | `informational: true` | `informational: true` 据え置き（→ #404） |
| mock-isolated 4 suite のカバレッジ | 破棄 | `--coverage-dir` 分離 + 個別アップロード |

## 昇格条件の再判定

`informational: true` の codecov status は **conclusion が常に success** になる。よって「マージ済み PR が全部緑だった」は dogfood の証拠にならない。実判定は check-run の `output.title` 側にある。

```bash
SHA=$(gh pr view 403 --json headRefOid --jq '.headRefOid')
gh api "repos/miyashita337/claude-hub/commits/$SHA/check-runs" \
  --jq '.check_runs[] | select(.name=="codecov/patch") | .output.title'
```

#296 マージ以降の 20 PR を実測すると、3 件が target 70% 未満だった。

| PR | 実判定 | 分類 |
|---|---|---|
| #378 | 27.58% of diff hit | **false positive** |
| #387 | 54.32% of diff hit | 真の未テスト（CLI の main ブロック） |
| #403 | 57.14% of diff hit | 真の未テスト（実 iTerm2 経路 + CLI main） |

## #378 が false positive だった理由

#378 は `adapters.ts` (+20) を変更し、その担保テスト `adapters-hassession.test.ts` (+37) を**同じ PR で追加している**。それでも 27.58% と判定された。

原因は `ci.yml` の mock-isolated ステップ 4 本が `--coverage` なしで走っていたこと。`mock.module("child_process")` が Bun ではプロセスグローバルなため curated リストと同居できず独立プロセスにしているが、その際 `lcov.info` を上書きしないよう `--coverage` を外していた。結果、これらの suite が実行した行が Codecov には未実行として報告されていた。

## なぜ raw マージではなく zero-hit 除去なのか

isolated レポートをそのまま送ると **かえって悪化する**。ある suite が module を import しただけでも DA レコードは出力され、しかも Bun はその実行でより広い行集合を計装する。実測:

| ファイル | curated 単独 | raw マージ | zero-hit 除去後 |
|---|---|---|---|
| `src/session/adapters.ts` | 38.18% (105/275) | 57.82% (170/294) | **61.82% (170/275)** |
| `src/session/tmux.ts` | 70.59% (24/34) | 65.96% (31/47) | **91.18% (31/34)** |
| `src/session/relay.ts` | 57.53% (126/219) | 42.57% (126/296) | **57.53% (126/219)** |
| ALL FILES | 77.21% (5929/7679) | 73.61% (6001/8152) | **78.15% (6001/7679)** |

`relay-nonblocking` は `relay.ts` に新規 hit を 1 行も足さない一方、未実行の計装行を 77 行持ち込む。raw マージは全体を 77.21% → 73.61% に**下げる**。

`supervisor/scripts/lcov-hits-only.ts` で zero-hit レコードを落とすと、curated 実行が分母の唯一の源として残り、isolated 実行は「その行が実行された」証拠だけを足せる。上表のとおり分母（7679）は完全に不変で、hit だけが 5929 → 6001 に増える。今日のベースラインに対して隠れる行はない。

## 昇格条件 2（relay.ts の tmux エラー分岐）: 選択肢 (a) で決着

ETIMEDOUT 分岐は `adapters-hassession.test.ts` が既に担保している。足りなかったのはテストではなく**計測**だった。(b) file-level 除外は coverage-policy.md §5 の anti-gaming に反するため不採用。(c) relay 専用の低め target も、計測を直せば不要。

## codecov/project を昇格しない理由

過去 20 PR と main 直近 6 commit の check-runs を走査したが、**`codecov/project` は一度も投稿されていない**（出るのは `codecov/patch` のみ）。原因は未特定（確度:低）。投稿されない status は dogfood できず、required status check に足せば PR が永久に pending になる。→ #404

## 統合ジャーニーAC 検証結果

| AC | 内容 | 検証手段 | 結果 |
|---|---|---|---|
| AC-1 | patch 70% 未満で `codecov/patch` が赤になる | `codecov.yml` の `patch.default.informational` が `false`（`yq` で確認）。実チェックは本 PR 自身の codecov 結果で観測 | 設定 PASS / 実挙動は本 PR で観測 |
| AC-2 | mock-isolated テストの担保が patch に届く | curated + isolated を zero-hit 除去して合算し、分母不変で `adapters.ts` 38.18%→61.82%、`tmux.ts` 70.59%→91.18%、全体 77.21%→78.15% を実測 | **PASS** |
| AC-3 | `codecov/project` を required にしない | 20 PR + main 6 commit の check-runs に `codecov/project` が不在、`project.informational: true` を維持 | **PASS** |

## テスト

- `supervisor/tests/scripts/lcov-hits-only.test.ts` を追加（6 ケース）。zero-hit 除去、`LF`/`LH`/`FNF`/`FNH` の再計算、全行未実行ファイルの除去、そして **「フィルタ済みレポートをマージしても分母は増えない」** という AC-2 の不変条件を固定する
- `ci.yml` の curated リストに編入済み（`bun scripts/lint-gating-coverage.ts` が 103 ファイル中 101 gated / 2 excluded / 0 ungated で PASS）
- `bunx tsc --noEmit` エラー 0
- lint 3 種（blocking-in-timers / no-sync-exec / access-policy）PASS

ローカルのフル suite では `lint-blocking-in-timers` の tree-scan ガードと `worktree-real-git`、シェル系 2 本が落ちるが、いずれも本変更とは無関係の macOS 側 5s タイムアウト由来。`worktree-real-git` は単独実行で 15/15 PASS、`lint-blocking-in-timers` は成果物ディレクトリの有無に関係なく 2 回に 1 回落ちる（`src/**/*.ts` のみを走査するため、追加した `scripts/` 配下のファイルは対象外）。

## follow-up

- #404 `codecov/project` が投稿されない原因の特定と、昇格か撤退かの決定
- #405 低カバレッジ 3 ファイルの残債（`resource-monitor.ts` 34.55% / `session-activity-watchdog.ts` 18.18% / `primary-compact.ts` 20.00%）
- #406 branch protection / required status checks の要否（現状このリポジトリには protection も ruleset も存在しない）

---

## レビュー中に見つけて直したこと

### 1. codecov の自動探索が raw レポートを再混入させていた

初回 CI 実行のログに `Found 5 coverage files to report` と出ており、**zero-hit 除去で取り除いたはずの raw な lcov.info 4 本がそのままアップロードされていた**。`codecov-action` は `disable_search` が既定 `false` のため、`files` の指定に加えてツリー内の lcov を自動探索する。分母が膨らむ状態をそのまま再現してしまうため、対策を二重にした。

- フィルタ直後に raw な `lcov.info` を削除する
- 全 5 アップロードステップに `disable_search: true` を付ける

修正後のログでは全ステップが `--disable-search` 付きで `Found 1 coverage files to report` になっている。

### 2. CLI の fail-fast ガードが計測にも回帰テストにも乗っていなかった

`import.meta.main` ブロックの中にあるガード（入力欠落 / 実行行ゼロ / 引数不足）は別プロセス実行でしか叩けず、カバレッジにも乗らなかった。exit code を返す `runCli` として切り出し、`import.meta.main` はその戻り値を `process.exit` に渡すだけにした。結果 `scripts/lcov-hits-only.ts` は lines 74.60% → **98.48%**。

これらのガードは飾りではない。アップロードは `fail_ci_if_error: false` なので、スクリプトが空ファイルを吐いたり入力欠落を見逃したりすると、isolated 分のカバレッジが**全 PR で静かに消える**（RW-029 と同型）。

## 無関係な CI flake（#408 で分離）

3 回目の CI で `action/token` の "tampered signature fails verification" が落ちたが、本変更とは無関係の**既存 flaky テスト**。署名の末尾 1 文字を `A` ↔ `B` で反転して改ざんを作っているが、base64url の末尾文字は有意ビットを 4 bit しか持たず、`A` と `B` の差は復号時に無視される 1 bit のみ。末尾が `A` の署名では改ざんがバイト列として no-op になり検証が通ってしまう。実測で **20000 件中 1293 件 (6.46%)**。`verifySignature` の実装は正しく、テスト側の欠陥。→ #408

再実行で pass、以降 5 チェックすべて green。

## 最終確認

```
codecov/patch  success  98.48% of diff hit (target 70.00%)   ← informational: false（blocking）下での実判定
check-runs     E2E Tests / Type Check / Routing Tests / Unit Tests / codecov/patch
               （codecov/project は不在 = AC-3）
```
