### PR TITLE
[一時] #300 AC-1 実測: patch 70% 未満で codecov/patch が赤になるかの確認（確認後 close）

### DIFF
--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -523,3 +523,22 @@ export const realSessionEffects: SessionEffects = {
   executor: realExecutorAdapter,
   issueReporter: realIssueReporterAdapter,
 };
+
+// 一時追加（#300 AC-1 の実測用）。テストから一度も呼ばれない分岐だけを持つ。
+// 確認後に PR ごと close して削除する。
+export function gateProbeClassify(n: number): string {
+  if (n < 0) { return "negative"; }
+  if (n === 0) { return "zero"; }
+  if (n < 10) { return "small"; }
+  if (n < 100) { return "medium"; }
+  if (n < 1000) { return "large"; }
+  return "huge";
+}
+
+export function gateProbeSum(values: number[]): number {
+  let total = 0;
+  for (const v of values) {
+    if (Number.isFinite(v)) { total += v; }
+  }
+  return total;
+}


### PR DESCRIPTION
#300 の AC-1「変更行のカバレッジが 70% 未満の PR が赤になる」を実測するためだけの使い捨て PR。**マージしない。確認後すぐ close する。**

追加したのは未テストの関数のみ（patch coverage 0% 想定）。`codecov/patch` の conclusion が `failure` になり、`output.title` に target 70.00% 未達の実数が出ることを確認する。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **テスト**
  - カバレッジゲート検証を強化しました。
  - 数値の分類や有限値の集計を確認できるようになりました。
- **ユーザーへの影響**
  - アプリケーションの通常の機能や画面に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->