### PR TITLE
fix: DB=stopped かつ tmux 生存の orphan セッションを起動時に回収する（#246）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -131,6 +131,7 @@ jobs:
                    tests/session/manager.test.ts \
                    tests/session/manager-resume.test.ts \
                    tests/session/manager-liveness.test.ts \
+                   tests/session/manager-orphan-gc.test.ts \
                    tests/commands/session-interaction.test.ts \
                    tests/commands/session-resume.test.ts \
                    tests/hooks/stop-relay.test.ts \

--- a/supervisor/src/infra/db.ts
+++ b/supervisor/src/infra/db.ts
@@ -273,6 +273,33 @@ export function getSessionByThreadId(
     .get(threadId) as SessionRow | undefined;
 }
 
+/**
+ * Most-recent session row whose `thread_id` starts with `prefix`, regardless of
+ * status. Used by the orphan GC (Issue #246) to map a live tmux session name
+ * back to its owning row: the name only carries the first 12 characters of the
+ * threadId (`SessionManager.tmuxSessionNameFor`), so an exact match is
+ * impossible and the truncated prefix is all we have.
+ *
+ * `substr(thread_id, 1, ?)` — rather than `LIKE prefix || '%'` — keeps the
+ * comparison literal: `_` and `%` in a prefix would otherwise be treated as
+ * LIKE wildcards and could match an unrelated thread (a tmux session belonging
+ * to another row must never be reaped on a fuzzy match).
+ *
+ * Returns `undefined` when no row owns the prefix, which the GC reads as "not
+ * ours — leave it alone".
+ */
+export function getLatestSessionByThreadPrefix(
+  prefix: string
+): SessionRow | undefined {
+  if (prefix.length === 0) return undefined;
+  const db = getDb();
+  return db
+    .prepare(
+      `SELECT * FROM sessions WHERE substr(thread_id, 1, ?) = ? ORDER BY started_at DESC LIMIT 1`
+    )
+    .get(prefix.length, prefix) as SessionRow | undefined;
+}
+
 export function getRunningSessionsByChannel(
   channelName: string
 ): SessionRow[] {

--- a/supervisor/src/session/adapters-fake.ts
+++ b/supervisor/src/session/adapters-fake.ts
@@ -46,6 +46,10 @@ export class FakeTmuxAdapter implements TmuxAdapter {
     return this.sessions.has(name);
   }
 
+  async listSessions(): Promise<string[]> {
+    return this.list();
+  }
+
   async getPid(name: string): Promise<number | null> {
     return this.sessions.get(name)?.pid ?? null;
   }

--- a/supervisor/src/session/adapters.ts
+++ b/supervisor/src/session/adapters.ts
@@ -44,6 +44,18 @@ export interface TmuxAdapter {
   newSession(name: string, command: string): Promise<void>;
   killSession(name: string): Promise<void>;
   hasSession(name: string): Promise<boolean>;
+  /**
+   * Every live session name on the supervisor's tmux socket
+   * (`tmux list-sessions -F '#{session_name}'`). Used by the orphan GC
+   * (Issue #246) to find tmux sessions the DB believes are already stopped.
+   *
+   * Returns `[]` both when no tmux server is running (the expected empty case)
+   * and when the call fails or times out: "liveness unknown" must degrade to
+   * "nothing to reap" so the GC can never kill a session on incomplete
+   * information. This is the mirror image of {@link hasSession}'s #238/#369
+   * contract — both resolve uncertainty in favour of leaving tmux alone.
+   */
+  listSessions(): Promise<string[]>;
   getPid(name: string): Promise<number | null>;
   ensureSocketConfigured(): Promise<void>;
   /**
@@ -289,6 +301,26 @@ export const realTmuxAdapter: TmuxAdapter = {
         `[tmux] has-session: no session ${name} (exit=${e?.code ?? "?"})`
       );
       return false;
+    }
+  },
+  async listSessions() {
+    try {
+      const { stdout } = await execFileAsync(
+        TMUX_PATH,
+        [...TMUX_ARGS, "list-sessions", "-F", "#{session_name}"],
+        { encoding: "utf8", timeout: TMUX_CALL_TIMEOUT_MS }
+      );
+      return stdout
+        .split("\n")
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+    } catch (err) {
+      // "no server running on ..." is the ordinary idle case and exits non-zero,
+      // so it must stay quiet. A timeout is worth surfacing (the server is
+      // wedged) but still yields [] — see the interface doc: the GC treats an
+      // empty list as "no orphans", never as "kill everything".
+      warnIfTmuxTimeout("list-sessions", "*", err);
+      return [];
     }
   },
   async getPid(name) {

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -2315,21 +2315,32 @@ export class SessionManager {
    *   - a DB row must claim the threadId prefix; an unknown name is logged and
    *     left running,
    *   - rows still marked `running` are skipped (the loop above owns them), and
-   *   - sessions currently live in memory are skipped, so a future non-startup
-   *     caller cannot reap an active session.
+   *   - sessions live in memory *or mid-start* are skipped, so neither an active
+   *     session nor one being launched right now can be reaped.
    * `listSessions()` returning [] on error/timeout (see its contract) means an
    * unreachable tmux server reaps nothing rather than guessing.
+   *
+   * The mid-start guard is load-bearing, not belt-and-braces (PR #413 review).
+   * Recovery is kicked off from the constructor and nobody awaits it, so a
+   * `/session start` can run concurrently — and {@link launchStart} creates the
+   * tmux session (`newSession`) well before it publishes the session to
+   * `this.sessions` and inserts the DB row. In that window the brand-new tmux
+   * session is in neither, so a *previous* stopped row on the same thread would
+   * make this sweep kill the session the user just started. {@link pendingStarts}
+   * is registered synchronously before that first await (and released in
+   * start()/resumeSession()'s finally, including on failure), so excluding it
+   * closes the window exactly.
    */
   private async reapOrphanTmuxSessions(handled: Set<string>): Promise<void> {
     const liveNames = await this.effects.tmux.listSessions();
-    const inMemory = new Set(
-      Array.from(this.sessions.keys()).map((threadId) =>
+    const protectedNames = new Set(
+      [...this.sessions.keys(), ...this.pendingStarts].map((threadId) =>
         this.tmuxSessionName(threadId)
       )
     );
     for (const name of liveNames) {
       if (!name.startsWith(TMUX_SESSION_PREFIX)) continue;
-      if (handled.has(name) || inMemory.has(name)) continue;
+      if (handled.has(name) || protectedNames.has(name)) continue;
       const threadPrefix = name.slice(TMUX_SESSION_PREFIX.length);
       const row = getLatestSessionByThreadPrefix(threadPrefix);
       if (!row) {

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -16,6 +16,7 @@ import {
   getRunningSessions,
   getSessionByClaudeSessionId,
   getSessionByThreadId,
+  getLatestSessionByThreadPrefix,
   type SessionRow,
 } from "../infra/db";
 import {
@@ -56,6 +57,13 @@ import {
 
 const DEFAULT_CLAUDE_PATH = resolve(homedir(), ".local", "bin", "claude");
 const TMUX_SESSION_PREFIX = "claude-";
+
+/**
+ * `stopped_reason` written by the startup orphan-tmux sweep (Issue #246).
+ * Exported so tests assert one source of truth, mirroring
+ * {@link import("./orphan-dispatch-reaper").ORPHAN_REAP_REASON}.
+ */
+export const ORPHAN_TMUX_REAP_REASON: StopReason = "orphan_tmux_reaped";
 
 /**
  * Resolve the `claude` executable path at use-time (not module-load-time) so the
@@ -2258,9 +2266,13 @@ export class SessionManager {
 
   private async recoverFromDb(): Promise<void> {
     const rows = getRunningSessions();
+    // Issue #246: names handled by this pass, so the orphan sweep below does not
+    // look at (or re-kill) a session this loop already dealt with.
+    const handled = new Set<string>();
     for (const row of rows) {
       if (row.thread_id) {
         const tmuxName = this.tmuxSessionName(row.thread_id);
+        handled.add(tmuxName);
         if (await this.effects.tmux.hasSession(tmuxName)) {
           console.log(
             `[SessionManager] Found running tmux session ${tmuxName}, killing (supervisor restart)`
@@ -2274,6 +2286,70 @@ export class SessionManager {
       // them here would discard uncommitted work without an explicit teardown.
       // Only /session stop removes a worktree (Q3).
       updateSessionStatus(row.id, "stopped", "supervisor_restart");
+    }
+    await this.reapOrphanTmuxSessions(handled);
+  }
+
+  /**
+   * Reap orphan tmux sessions — the GC blind spot of Issue #246.
+   *
+   * {@link recoverFromDb}'s loop above only walks DB `status='running'` rows, so
+   * a session that reached **DB=stopped while its tmux stayed alive** is invisible
+   * to it. That combination is reachable: {@link watchTmuxSession}'s tmux_exited
+   * branch drops the session from the in-memory map and writes `stopped` to the
+   * DB but deliberately does NOT `killSession` (#154 keeps the worktree, and #238
+   * showed the "exit" can be a false teardown under tmux contention). The result
+   * is a tmux session nobody owns: gone from `this.sessions` so the idle Reaper /
+   * OrphanDispatchReaper never see it, and `status='stopped'` so the restart loop
+   * skips it. It squats CPU and its pane until the machine reboots — in the #238
+   * live repro even `/session stop` answered "no running sessions".
+   *
+   * The sweep runs from the tmux side instead of the DB side on purpose: asking
+   * tmux once for its live sessions costs a single call, whereas probing every
+   * distinct stopped thread would cost one `has-session` per row (108 on the
+   * live DB at the time of writing, and growing without bound) on every restart.
+   *
+   * Safety rules — an orphan is only killed on positive evidence of ownership:
+   *   - the name must carry our {@link TMUX_SESSION_PREFIX} (someone else's tmux
+   *     session on this socket is never touched),
+   *   - a DB row must claim the threadId prefix; an unknown name is logged and
+   *     left running,
+   *   - rows still marked `running` are skipped (the loop above owns them), and
+   *   - sessions currently live in memory are skipped, so a future non-startup
+   *     caller cannot reap an active session.
+   * `listSessions()` returning [] on error/timeout (see its contract) means an
+   * unreachable tmux server reaps nothing rather than guessing.
+   */
+  private async reapOrphanTmuxSessions(handled: Set<string>): Promise<void> {
+    const liveNames = await this.effects.tmux.listSessions();
+    const inMemory = new Set(
+      Array.from(this.sessions.keys()).map((threadId) =>
+        this.tmuxSessionName(threadId)
+      )
+    );
+    for (const name of liveNames) {
+      if (!name.startsWith(TMUX_SESSION_PREFIX)) continue;
+      if (handled.has(name) || inMemory.has(name)) continue;
+      const threadPrefix = name.slice(TMUX_SESSION_PREFIX.length);
+      const row = getLatestSessionByThreadPrefix(threadPrefix);
+      if (!row) {
+        console.warn(
+          `[SessionManager] tmux session ${name} matches our prefix but no DB row claims it — leaving it alone (#246)`
+        );
+        continue;
+      }
+      if (row.status === "running") continue;
+      console.log(
+        `[SessionManager] Reaping orphan tmux session ${name} (DB status=${row.status}, reason=${row.stopped_reason ?? "?"}) (#246)`
+      );
+      await this.effects.tmux.killSession(name);
+      this.cleanupRelayUrlFile(row.project_dir);
+      // Re-stamp the reason so the reap is auditable in the DB; the row is
+      // already `stopped`, and — as in the loop above — the worktree stays put
+      // because this is not an explicit teardown (#154). The reason is distinct
+      // from OrphanDispatchReaper's `orphan_reaped` so the two paths stay
+      // tellable apart (see StopReason in types.ts).
+      updateSessionStatus(row.id, "stopped", ORPHAN_TMUX_REAP_REASON);
     }
   }
 

--- a/supervisor/src/session/types.ts
+++ b/supervisor/src/session/types.ts
@@ -65,4 +65,8 @@ export interface SessionHealthInfo {
   lastActivityAt: string;
 }
 
-export type StopReason = "manual" | "idle_timeout" | "resource_limit" | "error" | "tmux_exited" | "supervisor_restart" | "self_heal_restart" | "goal_complete" | "orphan_reaped" | "health_reaped" | "headless_exited" | "headless_timeout";
+// `orphan_reaped` is the OrphanDispatchReaper's idle-dispatch reap;
+// `orphan_tmux_reaped` is the startup sweep for a tmux session whose DB row was
+// already stopped (Issue #246). They are kept distinct so the DB says which of
+// the two paths retired a session.
+export type StopReason = "manual" | "idle_timeout" | "resource_limit" | "error" | "tmux_exited" | "supervisor_restart" | "self_heal_restart" | "goal_complete" | "orphan_reaped" | "orphan_tmux_reaped" | "health_reaped" | "headless_exited" | "headless_timeout";

--- a/supervisor/tests/infra/db.test.ts
+++ b/supervisor/tests/infra/db.test.ts
@@ -5,7 +5,7 @@ process.env.SUPERVISOR_DB_PATH = ":memory:";
 
 // Reset module cache to pick up the env var
 // Import after setting env
-const { getDb, insertSession, updateSessionStatus, updateSessionActivity, getRunningSessions, getRunningSessionByThread, getRunningSessionsByChannel, getLastSessionByChannel, getSessionByClaudeSessionId, getSessionByThreadId } = await import("../../src/infra/db");
+const { getDb, insertSession, updateSessionStatus, updateSessionActivity, getRunningSessions, getRunningSessionByThread, getRunningSessionsByChannel, getLastSessionByChannel, getSessionByClaudeSessionId, getSessionByThreadId, getLatestSessionByThreadPrefix } = await import("../../src/infra/db");
 
 describe("infra/db (in-memory)", () => {
   beforeEach(() => {
@@ -107,6 +107,63 @@ describe("infra/db (in-memory)", () => {
 
     // No row → null (bun:sqlite convention, treated as "not found" by callers).
     expect(getSessionByThreadId("thread-never-seen")).toBeNull();
+  });
+
+  test("getLatestSessionByThreadPrefix maps a truncated tmux name back to its row (#246)", () => {
+    // The orphan GC only knows threadId.slice(0, 12) — the tmux session name
+    // keeps nothing more — so the lookup must match on that prefix.
+    insertSession({
+      id: "prefix-old",
+      channel_name: "team-salary",
+      thread_id: "123456789012345",
+      project_dir: "/tmp/test",
+      pid: null,
+      claude_session_id: null,
+      started_at: "2026-06-01T10:00:00.000Z",
+      last_activity_at: "2026-06-01T10:00:00.000Z",
+      status: "stopped",
+    });
+    insertSession({
+      id: "prefix-new",
+      channel_name: "team-salary",
+      thread_id: "123456789012999",
+      project_dir: "/tmp/test",
+      pid: null,
+      claude_session_id: null,
+      started_at: "2026-06-02T10:00:00.000Z",
+      last_activity_at: "2026-06-02T10:00:00.000Z",
+      status: "running",
+    });
+
+    // Both threads share the first 12 chars (the tmux name is the same for
+    // both): the newest row wins, mirroring getSessionByThreadId.
+    expect(getLatestSessionByThreadPrefix("123456789012")?.id).toBe("prefix-new");
+    // A longer prefix still resolves to the row it belongs to.
+    expect(getLatestSessionByThreadPrefix("123456789012345")?.id).toBe("prefix-old");
+    // Unknown prefix → not found, which the GC reads as "not ours".
+    expect(getLatestSessionByThreadPrefix("999999999999")).toBeNull();
+    // Empty prefix must never match everything (it would make the GC reap an
+    // arbitrary row's tmux session).
+    expect(getLatestSessionByThreadPrefix("")).toBeUndefined();
+  });
+
+  test("getLatestSessionByThreadPrefix treats LIKE wildcards literally (#246)", () => {
+    insertSession({
+      id: "wildcard-victim",
+      channel_name: "team-salary",
+      thread_id: "555555555555abc",
+      project_dir: "/tmp/test",
+      pid: null,
+      claude_session_id: null,
+      started_at: "2026-06-03T10:00:00.000Z",
+      last_activity_at: "2026-06-03T10:00:00.000Z",
+      status: "stopped",
+    });
+
+    // With a LIKE-based query these would match the row above; substr() keeps
+    // the comparison literal so an unrelated tmux name cannot claim it.
+    expect(getLatestSessionByThreadPrefix("_____________")).toBeNull();
+    expect(getLatestSessionByThreadPrefix("%")).toBeNull();
   });
 
   test("updateSessionStatus changes status and reason", () => {

--- a/supervisor/tests/session/adapters.test.ts
+++ b/supervisor/tests/session/adapters.test.ts
@@ -178,6 +178,37 @@ describe("realTmuxAdapter.hasSession (#148 review)", () => {
   });
 });
 
+describe("realTmuxAdapter.listSessions (#246)", () => {
+  test("parses one session name per line and drops blanks", async () => {
+    execFileStdout = "claude-111111111111\nclaude-222222222222\n\n";
+
+    const names = await realTmuxAdapter.listSessions();
+
+    expect(names).toEqual(["claude-111111111111", "claude-222222222222"]);
+    expect(execFileCalls[0]?.file).toBe(TMUX_PATH);
+    expect(execFileCalls[0]?.args).toEqual([
+      ...TMUX_ARGS,
+      "list-sessions",
+      "-F",
+      "#{session_name}",
+    ]);
+  });
+
+  test("returns [] when tmux exits non-zero (no server running)", async () => {
+    // The orphan GC reads [] as "nothing to reap" — an unreachable tmux server
+    // must never be mistaken for "every session is gone".
+    execFileError = Object.assign(new Error("no server running"), { code: 1 });
+
+    expect(await realTmuxAdapter.listSessions()).toEqual([]);
+  });
+
+  test("passes a positive timeout", async () => {
+    await realTmuxAdapter.listSessions();
+
+    expect(execFileCalls[0]?.opts?.timeout).toBeGreaterThan(0);
+  });
+});
+
 describe("realTmuxAdapter.getPid (#148 review)", () => {
   test("uses execFile and parses pane_pid", async () => {
     execFileStdout = "12345\n";

--- a/supervisor/tests/session/manager-orphan-gc.test.ts
+++ b/supervisor/tests/session/manager-orphan-gc.test.ts
@@ -1,9 +1,13 @@
 import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdirSync } from "fs";
+import { tmpdir } from "os";
+import { resolve } from "path";
 
 import {
   SessionManager,
   ORPHAN_TMUX_REAP_REASON,
 } from "../../src/session/manager";
+import type { ChannelConfig } from "../../src/config/channels";
 import {
   createFakeEffects,
   type FakeSessionEffects,
@@ -159,6 +163,63 @@ describe("SessionManager orphan tmux GC (#246)", () => {
     expect(byId.get("restarted-new")).toBe("supervisor_restart");
     // The stale row is left untouched — it was not re-stamped as an orphan.
     expect(byId.get("restarted-old")).toBe("tmux_exited");
+  });
+
+  test("does not reap a session that is mid-start while recovery runs (PR #413 review)", async () => {
+    // Recovery is kicked off by the constructor and nobody awaits it, so a
+    // /session start can overlap it. launchStart creates the tmux session before
+    // it publishes to `sessions` / inserts the DB row, so during that window the
+    // only thing marking the session as ours is `pendingStarts`. With an older
+    // stopped row on the same thread present, a sweep that ignored pendingStarts
+    // would kill the session the user just started.
+    seedSession("previous-run", ORPHAN_THREAD, "stopped", "tmux_exited");
+
+    // Gate A holds the sweep inside listSessions; gate B holds launchStart at
+    // its PID poll — i.e. after newSession, before sessions.set.
+    let releaseSweep!: () => void;
+    const sweepGate = new Promise<void>((r) => (releaseSweep = r));
+    let releasePid!: () => void;
+    const pidGate = new Promise<void>((r) => (releasePid = r));
+
+    const realListSessions = effects.tmux.listSessions.bind(effects.tmux);
+    effects.tmux.listSessions = async () => {
+      await sweepGate;
+      return realListSessions();
+    };
+    const realGetPid = effects.tmux.getPid.bind(effects.tmux);
+    effects.tmux.getPid = async (name: string) => {
+      await pidGate;
+      return realGetPid(name);
+    };
+
+    const dir = resolve(tmpdir(), `orphan-gc-start-${process.pid}`);
+    mkdirSync(dir, { recursive: true });
+    const config: ChannelConfig = {
+      channelName: "test-channel",
+      dir,
+      displayName: "Test Channel",
+    };
+
+    manager = new SessionManager({ effects, gracefulKillTimeoutMs: 0 });
+    const started = manager.start(config, ORPHAN_THREAD);
+
+    // Let start() get past newSession and park on the PID poll.
+    while (!(await realListSessions()).includes(orphanTmux)) {
+      await new Promise((r) => setTimeout(r, 5));
+    }
+
+    releaseSweep();
+    await manager.recovery;
+
+    // The mid-start session survived, and the stale row was not re-stamped.
+    expect(await effects.tmux.hasSession(orphanTmux)).toBe(true);
+    expect(getSessionByThreadId(ORPHAN_THREAD)?.stopped_reason).toBe(
+      "tmux_exited"
+    );
+
+    releasePid();
+    await started;
+    expect(await effects.tmux.hasSession(orphanTmux)).toBe(true);
   });
 
   test("reaps nothing when tmux cannot be listed (empty list degrades safely)", async () => {

--- a/supervisor/tests/session/manager-orphan-gc.test.ts
+++ b/supervisor/tests/session/manager-orphan-gc.test.ts
@@ -1,0 +1,177 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+
+import {
+  SessionManager,
+  ORPHAN_TMUX_REAP_REASON,
+} from "../../src/session/manager";
+import {
+  createFakeEffects,
+  type FakeSessionEffects,
+} from "../../src/session/adapters-fake";
+import {
+  getDb,
+  insertSession,
+  getSessionByThreadId,
+} from "../../src/infra/db";
+
+/**
+ * Issue #246 — orphan GC blind spot.
+ *
+ * `recoverFromDb` only walked DB `status='running'` rows, so the
+ * **DB=stopped + tmux alive** combination (produced by `watchTmuxSession`'s
+ * tmux_exited branch, which marks the row stopped but deliberately does not
+ * kill tmux) was reaped by nobody: absent from the in-memory map the reapers
+ * iterate, and absent from the restart sweep. These tests pin the sweep that
+ * closes it, plus the safety rules that keep it from killing anything it does
+ * not positively own.
+ *
+ * The DB is isolated by supervisor/bunfig.toml's `[test].preload`
+ * (tests/setup/db-isolation.ts), so these rows never touch the real
+ * sessions.db.
+ */
+describe("SessionManager orphan tmux GC (#246)", () => {
+  let manager: SessionManager | undefined;
+  let effects: FakeSessionEffects;
+
+  // The tmux name only keeps threadId.slice(0, 12), so these two must differ
+  // *within* the first 12 characters or they would collide onto one session.
+  const ORPHAN_THREAD = "911100000000111";
+  const RUNNING_THREAD = "922200000000222";
+  const orphanTmux = SessionManager.tmuxSessionNameFor(ORPHAN_THREAD);
+  const runningTmux = SessionManager.tmuxSessionNameFor(RUNNING_THREAD);
+
+  function seedSession(
+    id: string,
+    threadId: string,
+    status: string,
+    stoppedReason?: string,
+    startedAt: string = new Date().toISOString()
+  ): void {
+    insertSession({
+      id,
+      channel_name: "test-channel",
+      thread_id: threadId,
+      project_dir: "/tmp/orphan-gc-test",
+      pid: null,
+      claude_session_id: null,
+      started_at: startedAt,
+      last_activity_at: startedAt,
+      status,
+    });
+    if (stoppedReason) {
+      getDb()
+        .prepare(`UPDATE sessions SET stopped_reason = ? WHERE id = ?`)
+        .run(stoppedReason, id);
+    }
+  }
+
+  /** Construct the manager (its constructor kicks off recovery) and await it. */
+  async function recover(): Promise<void> {
+    manager = new SessionManager({ effects, gracefulKillTimeoutMs: 0 });
+    await manager.recovery;
+  }
+
+  beforeEach(() => {
+    getDb().exec("DELETE FROM sessions");
+    effects = createFakeEffects();
+    manager = undefined;
+  });
+
+  afterEach(async () => {
+    await manager?.shutdownAll();
+  });
+
+  test("reaps a tmux session whose DB row is already stopped", async () => {
+    seedSession("orphan-1", ORPHAN_THREAD, "stopped", "tmux_exited");
+    await effects.tmux.newSession(orphanTmux, "claude");
+
+    await recover();
+
+    expect(await effects.tmux.hasSession(orphanTmux)).toBe(false);
+    expect(getSessionByThreadId(ORPHAN_THREAD)?.stopped_reason).toBe(
+      ORPHAN_TMUX_REAP_REASON
+    );
+    // Distinct from OrphanDispatchReaper's idle-dispatch reap, so the DB shows
+    // which path retired the session.
+    expect(ORPHAN_TMUX_REAP_REASON).toBe("orphan_tmux_reaped");
+  });
+
+  test("leaves a prefixed tmux session with no owning DB row alone", async () => {
+    // Nothing seeded: no row claims this threadId prefix. Killing on a name
+    // match alone would let the GC reap a session it cannot prove is ours.
+    const unknown = SessionManager.tmuxSessionNameFor("900000000000999");
+    await effects.tmux.newSession(unknown, "claude");
+
+    await recover();
+
+    expect(await effects.tmux.hasSession(unknown)).toBe(true);
+  });
+
+  test("never touches tmux sessions outside the supervisor's name prefix", async () => {
+    seedSession("orphan-2", ORPHAN_THREAD, "stopped", "tmux_exited");
+    await effects.tmux.newSession("my-own-editor", "vim");
+
+    await recover();
+
+    expect(await effects.tmux.hasSession("my-own-editor")).toBe(true);
+  });
+
+  test("running rows keep the supervisor_restart path, not orphan_reaped", async () => {
+    seedSession("running-1", RUNNING_THREAD, "running");
+    await effects.tmux.newSession(runningTmux, "claude");
+
+    await recover();
+
+    // Killed by the pre-existing restart loop — the sweep must not claim it and
+    // must not double-kill it under a different reason.
+    expect(await effects.tmux.hasSession(runningTmux)).toBe(false);
+    expect(getSessionByThreadId(RUNNING_THREAD)?.stopped_reason).toBe(
+      "supervisor_restart"
+    );
+  });
+
+  test("skips a thread whose latest row is running even when an older row is stopped", async () => {
+    // Same thread restarted: the stale stopped row must not make the sweep
+    // treat the live session as an orphan. Timestamps are explicit because
+    // "latest row" is ordered by started_at.
+    seedSession(
+      "restarted-old",
+      RUNNING_THREAD,
+      "stopped",
+      "tmux_exited",
+      "2026-01-01T00:00:00.000Z"
+    );
+    seedSession(
+      "restarted-new",
+      RUNNING_THREAD,
+      "running",
+      undefined,
+      "2026-01-02T00:00:00.000Z"
+    );
+    await effects.tmux.newSession(runningTmux, "claude");
+
+    await recover();
+
+    const rows = getDb()
+      .prepare(`SELECT id, stopped_reason FROM sessions WHERE thread_id = ?`)
+      .all(RUNNING_THREAD) as { id: string; stopped_reason: string | null }[];
+    const byId = new Map(rows.map((r) => [r.id, r.stopped_reason]));
+    expect(byId.get("restarted-new")).toBe("supervisor_restart");
+    // The stale row is left untouched — it was not re-stamped as an orphan.
+    expect(byId.get("restarted-old")).toBe("tmux_exited");
+  });
+
+  test("reaps nothing when tmux cannot be listed (empty list degrades safely)", async () => {
+    seedSession("orphan-3", ORPHAN_THREAD, "stopped", "tmux_exited");
+    // listSessions() returns [] both for "no server" and for a failed/timed-out
+    // call (see TmuxAdapter.listSessions). The row must be left exactly as it
+    // was rather than being recorded as reaped.
+    effects.tmux.listSessions = async () => [];
+
+    await recover();
+
+    expect(getSessionByThreadId(ORPHAN_THREAD)?.stopped_reason).toBe(
+      "tmux_exited"
+    );
+  });
+});


### PR DESCRIPTION
## 目的

`recoverFromDb` が DB `status='running'` の行しか走査せず、**DB=stopped かつ tmux 生存**の orphan を誰も reap しない GC 盲点（#246）を塞ぐ。

その組み合わせは実在の経路で発生する: `watchTmuxSession` の tmux_exited 分岐は in-memory map から session を落として DB を `stopped` にするが、`killSession` は呼ばない（#154 の worktree 保全 + #238 が示した false teardown）。結果、

- in-memory から消えるので Reaper / OrphanDispatchReaper の走査対象外
- DB が running でないので再起動時の復旧ループの対象外

となり、tmux セッションがマシン再起動まで居座る（#238 のライブ再現では `/session stop` すら「稼働中セッションはありません」で空振りした）。

## 変更点

| 対象 | 内容 |
|---|---|
| `adapters.ts` | `TmuxAdapter.listSessions()` を追加（`tmux list-sessions -F '#{session_name}'`）。**エラー/タイムアウト時は `[]`** を返す契約 — tmux 不達を「全滅」と誤読せず「何も刈らない」に倒す（`hasSession` の #238/#369 契約の鏡像） |
| `manager.ts` | `recoverFromDb` 後段に `reapOrphanTmuxSessions` を追加。tmux 側から**1 回だけ**列挙して orphan を kill |
| `types.ts` | `StopReason` に `orphan_tmux_reaped` を追加（OrphanDispatchReaper の `orphan_reaped` と別値） |
| `db.ts` | `getLatestSessionByThreadPrefix()` — tmux 名は threadId の先頭 12 文字しか持たないため、prefix から所有行を引く |
| `ci.yml` | 新規テストを whitelist に登録（未登録だと `lint-gating-coverage` が FAIL する = #248/#385 の仕組み） |

### 設計判断

**なぜ tmux 側から列挙するか**: DB 側から「stopped な全 thread」を舐めると `has-session` が行数分走る（実 DB で distinct 108 件、以後も単調増加）。tmux への 1 コールで済む方向に倒した。

**安全側の判定**（所有の積極的証拠があるものだけ kill する）:

1. 名前が supervisor の prefix (`claude-`) を持つこと — 他人の tmux セッションには触れない
2. DB 行がその threadId prefix を主張していること — 該当行なしは warn ログのみで放置
3. その行が `running` でないこと — running は従来ループの担当
4. in-memory に生存していないこと — 将来 startup 以外から呼ばれても稼働中を刈らない

**worktree は削除しない**（#154）。明示 teardown ではないため、`supervisor_restart` 経路と同じ扱い。

## 統合ジャーニーAC

Issue #246 は「不要・理由: ユーザー操作フローを持たない内部 GC のため。検証は manager の単体/結合テストで決定的に行う」と宣言済み。宣言どおり単体テストで決定的に検証した。

## テスト

新規 `tests/session/manager-orphan-gc.test.ts`（6 ケース）:

| # | ケース | 期待 |
|---|---|---|
| 1 | DB=stopped + tmux 生存 | kill され `stopped_reason=orphan_tmux_reaped` |
| 2 | prefix 一致だが DB 行なし | **生存したまま**（所有を証明できないものは刈らない） |
| 3 | prefix 外の tmux セッション | 不干渉 |
| 4 | DB=running 行 | 従来の `supervisor_restart` 経路のまま（二重 kill / 誤 reason なし） |
| 5 | 同一 thread の stale stopped 行 + 新しい running 行 | 生存判定を誤らず stale 行も書き換えない |
| 6 | `listSessions()` が `[]` | 何も刈らず DB も書き換えない |

加えて `getLatestSessionByThreadPrefix`（prefix 一致 / 空 prefix ガード / LIKE ワイルドカードを literal 扱い）と `realTmuxAdapter.listSessions`（パース / 非ゼロ終了で `[]` / timeout 付与）の単体テストを追加。

実測:

```
CI whitelist 相当 (96 files): 1186 pass / 0 fail / 13 skip
tests/session/adapters.test.ts (別プロセス): 20 pass / 0 fail
bunx tsc --noEmit: エラーなし
scripts/lint-gating-coverage.ts: 104 files — 102 gated, 2 excluded, 0 ungated
```

## 残る範囲（本 PR 外）

本 PR は **Supervisor 起動時**の sweep（Issue の「起動時 or 定期 GC」のうち前者）。稼働中に発生した orphan は次回再起動まで残る。定期 GC 化は実データで頻度が見えてから判断する（先回りしない）。

Closes #246


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 孤立した tmux セッションを検出し、安全に停止・整理できるようになりました。
  * セッション状態をより正確に確認し、重複処理を防止します。
  * tmux セッション一覧の取得に対応しました。

* **バグ修正**
  * tmux の取得失敗やタイムアウト時に、安全に処理を継続できるよう改善しました。

* **テスト**
  * セッション回収、DB復旧、tmux連携などの自動テスト範囲を拡張しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->