### PR TITLE
feat: relay 到達率を latency-logger の delivered field で計測する（#223）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,7 @@ jobs:
                    tests/session/dispatch-queue.test.ts \
                    tests/session/admission.test.ts \
                    tests/session/latency-logger.test.ts \
+                   tests/scripts/analyze-relay-latency.test.ts \
                    tests/session/manager-input-ready.test.ts \
                    tests/session/progress-buffer.test.ts \
                    tests/session/salvage-reply.test.ts \

--- a/scripts/analyze-relay-latency.sh
+++ b/scripts/analyze-relay-latency.sh
@@ -92,6 +92,46 @@ else
   echo "dominant: n/a (no segment data)"
 fi
 
+# === Delivery (Issue #223): 到達率 ===
+#
+# 「relay 応答がユーザーに届いたか」の二値 (writer 側 latency-logger.ts の
+# delivered field) を全期間 + 日次で集計する。修正の前後で日次 rate を見比べれば
+# silent regression (誰も気付かない到達率の劣化, RW-023 型) を検知できる。
+#
+# attempts は delivered field を持つ行だけを数える: #223 以前の行は field 自体が
+# 無く、delivered とも dropped とも判定できないため、分母に入れると rate が
+# 実態より低く出てしまう。
+DELIVERY=$(jq -rs '
+  [.[] | select(.delivered != null)] as $rec |
+  ($rec | length) as $attempts |
+  ([$rec[] | select(.delivered)] | length) as $delivered |
+  "\($attempts)|\($delivered)"' "${LOG_PATH}")
+DELIVERY_ATTEMPTS=$(echo "${DELIVERY}" | cut -d'|' -f1)
+DELIVERY_OK=$(echo "${DELIVERY}" | cut -d'|' -f2)
+
+echo
+if [ "${DELIVERY_ATTEMPTS}" -eq 0 ]; then
+  echo "=== Delivery (全期間) ==="
+  echo "attempts=0 (delivered field を持つ計測がまだありません)"
+else
+  DELIVERY_DROPPED=$((DELIVERY_ATTEMPTS - DELIVERY_OK))
+  DELIVERY_RATE=$(jq -rn --argjson d "${DELIVERY_OK}" --argjson a "${DELIVERY_ATTEMPTS}" \
+    '($d / $a * 1000 | round / 10)')
+  echo "=== Delivery (全期間) ==="
+  echo "attempts=${DELIVERY_ATTEMPTS} delivered=${DELIVERY_OK} dropped=${DELIVERY_DROPPED} rate=${DELIVERY_RATE}%"
+
+  echo
+  echo "=== Delivery (日次) ==="
+  jq -rs '
+    [.[] | select(.delivered != null)]
+    | group_by(.timestamp[:10])[]
+    | . as $day
+    | ($day | length) as $attempts
+    | ([$day[] | select(.delivered)] | length) as $delivered
+    | "\($day[0].timestamp[:10]) attempts=\($attempts) delivered=\($delivered) dropped=\($attempts - $delivered) rate=\($delivered / $attempts * 1000 | round / 10)%"
+  ' "${LOG_PATH}"
+fi
+
 # error_segment 集計 (ある場合のみ)
 ERROR_COUNT=$(jq -s '[.[] | select(.error_segment != null)] | length' "${LOG_PATH}")
 if [ "${ERROR_COUNT}" -gt 0 ]; then

--- a/supervisor/src/session/latency-logger.ts
+++ b/supervisor/src/session/latency-logger.ts
@@ -45,6 +45,19 @@ export interface RelayLatencyRecord {
   total_ms: number;
   /** error 発生 segment 名 (success 時は undefined) */
   error_segment?: string;
+  /**
+   * この relay ターンの応答がユーザーに届いたか (Issue #223)。
+   *
+   * true = 応答 chunk を返せた / false = tmux 送信失敗 or relay 待ち失敗で届かず。
+   * 「届いたか」の二値だけを持つ: 失敗の内訳は既に error_segment ("b" = 送信失敗、
+   * "d_e_c" = 待ち失敗) が持っており、欠けていたのは二値化と日次到達率の算出手段
+   * だけだったため (Issue #223 の設計)。
+   *
+   * optional なのは #223 以前に書かれた行との互換のため。consumer
+   * (scripts/analyze-relay-latency.sh) は field を持つ行だけを attempts に数え、
+   * 旧行が到達率を薄めないようにしている。
+   */
+  delivered?: boolean;
 }
 
 let logPath = DEFAULT_LATENCY_LOG_PATH;
@@ -99,6 +112,11 @@ export interface LatencyTracker {
   markStart(segment: keyof typeof SEGMENT_NAMES): void;
   markEnd(segment: keyof typeof SEGMENT_NAMES): void;
   setError(segment: string): void;
+  /**
+   * この relay ターンが応答を届けられたかを記録する (Issue #223)。
+   * flush() の前に呼ぶ。呼ばなければ delivered field は出力されない。
+   */
+  setDelivered(ok: boolean): void;
   flush(): RelayLatencyRecord;
 }
 
@@ -107,6 +125,7 @@ export function createLatencyTracker(sessionId: string): LatencyTracker {
   const segments: Partial<Record<keyof typeof SEGMENT_NAMES, number>> = {};
   const trackerStart = performance.now();
   let errorSegment: string | undefined;
+  let delivered: boolean | undefined;
 
   return {
     markStart(segment) {
@@ -123,6 +142,9 @@ export function createLatencyTracker(sessionId: string): LatencyTracker {
     setError(segment) {
       errorSegment = segment;
     },
+    setDelivered(ok) {
+      delivered = ok;
+    },
     flush() {
       const record: RelayLatencyRecord = {
         timestamp: new Date().toISOString(),
@@ -133,6 +155,9 @@ export function createLatencyTracker(sessionId: string): LatencyTracker {
       };
       if (errorSegment) {
         record.error_segment = errorSegment;
+      }
+      if (delivered !== undefined) {
+        record.delivered = delivered;
       }
       recordRelayLatency(record);
       return record;

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -413,6 +413,9 @@ export async function relayMessage(
   } catch (err) {
     tracker.markEnd("b");
     tracker.setError("b");
+    // Issue #223: the message never reached the pane, so this turn delivered
+    // nothing to the user — the dropped half of the delivery rate.
+    tracker.setDelivered(false);
     tracker.flush();
     // Issue #74: keep the raw tmux cause in logs + `RelayResult.error`, but
     // NEVER forward it into the Discord chunk (it would surface as a bogus
@@ -495,6 +498,10 @@ export async function relayMessage(
   if (result.error) {
     tracker.setError("d_e_c");
   }
+  // Issue #223: `result.error` covers both the relay timeout and an error
+  // response, i.e. exactly the cases where the user got no answer back. Anything
+  // else means a response chunk was produced for this turn.
+  tracker.setDelivered(!result.error);
   tracker.flush();
 
   // Note: downloaded attachments are intentionally NOT deleted here. They used

--- a/supervisor/tests/scripts/analyze-relay-latency.test.ts
+++ b/supervisor/tests/scripts/analyze-relay-latency.test.ts
@@ -1,0 +1,133 @@
+// Consumer tests for scripts/analyze-relay-latency.sh — the delivery-rate
+// section added in Issue #223.
+//
+// This is the deterministic form of #223's 統合ジャーニーAC ("run the script →
+// the Delivery 日次 section shows a rate% per day"): the script is fed a fixture
+// JSONL and its stdout is asserted, so the AC is re-checked on every CI run
+// instead of relying on a one-off manual look at the real log.
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join, resolve } from "path";
+
+const SCRIPT = resolve(
+  import.meta.dir,
+  "../../../scripts/analyze-relay-latency.sh"
+);
+
+async function run(logPath: string) {
+  const proc = Bun.spawn(["bash", SCRIPT, logPath], {
+    env: { PATH: process.env.PATH ?? "", HOME: process.env.HOME ?? "" },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const exitCode = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  return { exitCode, stdout, stderr };
+}
+
+/** One JSONL line in the shape latency-logger.ts writes. */
+function record(
+  timestamp: string,
+  extra: Record<string, unknown> = {}
+): string {
+  return JSON.stringify({
+    timestamp,
+    session_id: "claude-test",
+    load_avg_1m: 1.5,
+    segments: { b: 10, c: 0, d_e_c: 900 },
+    total_ms: 910,
+    ...extra,
+  });
+}
+
+describe("analyze-relay-latency.sh delivery rate (#223)", () => {
+  let tmpDir: string;
+  let logPath: string;
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), "analyze-relay-latency-test-"));
+    logPath = join(tmpDir, "relay-latency-log.jsonl");
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  function writeLog(lines: string[]): void {
+    writeFileSync(logPath, lines.join("\n") + "\n", "utf8");
+  }
+
+  test("reports overall attempts / delivered / dropped / rate", async () => {
+    writeLog([
+      record("2026-08-10T01:00:00.000Z", { delivered: true }),
+      record("2026-08-10T02:00:00.000Z", { delivered: true }),
+      record("2026-08-10T03:00:00.000Z", {
+        delivered: false,
+        error_segment: "d_e_c",
+      }),
+      record("2026-08-10T04:00:00.000Z", {
+        delivered: false,
+        error_segment: "b",
+      }),
+    ]);
+
+    const { exitCode, stdout } = await run(logPath);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("=== Delivery (全期間) ===");
+    expect(stdout).toContain(
+      "attempts=4 delivered=2 dropped=2 rate=50%"
+    );
+  });
+
+  test("breaks the rate down per day (the #223 journey AC)", async () => {
+    writeLog([
+      record("2026-08-10T01:00:00.000Z", { delivered: true }),
+      record("2026-08-10T02:00:00.000Z", { delivered: true }),
+      record("2026-08-10T03:00:00.000Z", { delivered: false }),
+      record("2026-08-11T01:00:00.000Z", { delivered: true }),
+      record("2026-08-11T02:00:00.000Z", { delivered: false }),
+    ]);
+
+    const { exitCode, stdout } = await run(logPath);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("=== Delivery (日次) ===");
+    // Per-day lines are what a "before vs after the fix" comparison reads.
+    expect(stdout).toContain(
+      "2026-08-10 attempts=3 delivered=2 dropped=1 rate=66.7%"
+    );
+    expect(stdout).toContain(
+      "2026-08-11 attempts=2 delivered=1 dropped=1 rate=50%"
+    );
+  });
+
+  test("excludes pre-#223 records (no delivered field) from the rate", async () => {
+    writeLog([
+      // Legacy row: neither delivered nor dropped — counting it either way
+      // would misreport the rate.
+      record("2026-08-09T01:00:00.000Z"),
+      record("2026-08-10T01:00:00.000Z", { delivered: true }),
+      record("2026-08-10T02:00:00.000Z", { delivered: false }),
+    ]);
+
+    const { exitCode, stdout } = await run(logPath);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("attempts=2 delivered=1 dropped=1 rate=50%");
+    expect(stdout).not.toContain("2026-08-09 attempts=");
+  });
+
+  test("says so plainly when no record carries delivery info yet", async () => {
+    writeLog([record("2026-08-09T01:00:00.000Z")]);
+
+    const { exitCode, stdout } = await run(logPath);
+
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("attempts=0");
+    // No divide-by-zero, no bogus 0% / 100% claim.
+    expect(stdout).not.toContain("rate=");
+  });
+});

--- a/supervisor/tests/session/latency-logger.test.ts
+++ b/supervisor/tests/session/latency-logger.test.ts
@@ -97,6 +97,40 @@ describe("latency-logger", () => {
     expect(record.error_segment).toBe("b");
   });
 
+  test("setDelivered(true) records delivered:true (#223)", () => {
+    const tracker = createLatencyTracker("delivered-ok");
+    tracker.setDelivered(true);
+    const record = tracker.flush();
+
+    expect(record.delivered).toBe(true);
+    const written = JSON.parse(readFileSync(logPath, "utf8").trim());
+    expect(written.delivered).toBe(true);
+  });
+
+  test("setDelivered(false) records delivered:false alongside error_segment (#223)", () => {
+    // The tmux-send failure path: the turn errored in segment "b" AND nothing
+    // reached the user. Both facts are recorded — error_segment says where it
+    // broke, delivered says whether the user got an answer.
+    const tracker = createLatencyTracker("delivered-drop");
+    tracker.setError("b");
+    tracker.setDelivered(false);
+    const record = tracker.flush();
+
+    expect(record.delivered).toBe(false);
+    expect(record.error_segment).toBe("b");
+  });
+
+  test("delivered is omitted entirely when setDelivered is never called (#223)", () => {
+    // Back-compat: records written before #223 carry no `delivered` key, and the
+    // consumer excludes them from the rate rather than counting them as drops.
+    const tracker = createLatencyTracker("no-delivery-info");
+    const record = tracker.flush();
+
+    expect(record.delivered).toBeUndefined();
+    const written = JSON.parse(readFileSync(logPath, "utf8").trim());
+    expect("delivered" in written).toBe(false);
+  });
+
   test("getLatencyLogPath returns the currently configured path", () => {
     expect(getLatencyLogPath()).toBe(logPath);
   });


### PR DESCRIPTION
## 目的

「修正のたびに効果計測を立てたい」（Discord 通知の信頼性を修正ごとに測り、**silent regression** = 誰も気付かない劣化を防ぐ。RW-023 型）への**薄い実装**（#223）。

新規 writer は作らない。supervisor 内で唯一の構造化 JSONL writer である `latency-logger.ts` を最小拡張し、集計は既存 consumer `scripts/analyze-relay-latency.sh` への追記で賄う。

## 変更点

### writer（`latency-logger.ts`）

| 追加 | 内容 |
|---|---|
| `RelayLatencyRecord.delivered?: boolean` | 「その relay ターンの応答がユーザーに届いたか」の二値 |
| `LatencyTracker.setDelivered(ok)` | `flush()` 時に載せる。未設定なら field 自体を出さない |

失敗の**内訳**は既存 `error_segment`（`b` = tmux 送信失敗 / `d_e_c` = relay 待ち失敗）が既に持っている。欠けていたのは**二値化と日次到達率の算出手段**だけなので、そこだけを足した（#223 の設計どおり）。

### 結線（`relay.ts` 2 箇所）

- tmux 送信失敗（segment `b` の catch）→ `setDelivered(false)`
- relay 待ち完了 → `setDelivered(!result.error)`（`result.error` は timeout とエラー応答の両方＝ユーザーに答えが返らなかったケースを覆う）

### consumer（`scripts/analyze-relay-latency.sh`）

```
=== Delivery (全期間) ===
attempts=4 delivered=2 dropped=2 rate=50%

=== Delivery (日次) ===
2026-08-10 attempts=3 delivered=2 dropped=1 rate=66.7%
2026-08-11 attempts=2 delivered=1 dropped=1 rate=50%
```

`attempts` は **`delivered` field を持つ行だけ**を数える。#223 以前の行は delivered とも dropped とも判定できず、分母に入れると rate が実態より低く出るため。delivered 付きの行が 0 件なら rate を出さずその旨を明示する（0 除算・偽の 0% を出さない）。

## 統合ジャーニーAC

Issue 記載の AC をそのままテスト化した（手動の一回きり確認ではなく CI で毎回再検証される形にした）:

| 操作 | 期待結果 | 検証 |
|---|---|---|
| `bash scripts/analyze-relay-latency.sh` を実行 | 「Delivery 日次」に日付ごとの `rate=` が出る | `tests/scripts/analyze-relay-latency.test.ts`（fixture 入力 → stdout 断言）**PASS** |
| latency JSONL に `delivered` が記録される | `delivered:true/false` が 1 行 JSON に載る | `tests/session/latency-logger.test.ts` 追加 3 ケース **PASS** |

## テスト

新規 `tests/scripts/analyze-relay-latency.test.ts`（4 ケース）: 全期間集計 / **日次 rate（AC 本体）** / 旧行を分母から除外 / delivered 0 件時に rate を出さない。
`tests/session/latency-logger.test.ts` に 3 ケース追加: `true` / `false` と `error_segment` の併記 / 未設定時は field を出さない（後方互換）。

実測:

```
CI whitelist 相当 (96 files): 1185 pass / 0 fail / 13 skip
bunx tsc --noEmit: エラーなし
scripts/lint-gating-coverage.ts: 104 files — 102 gated, 2 excluded, 0 ungated
```

## やらないこと（#223 の設計どおり）

- 専用 JSONL の新設（consumer 二重化 → RW-023 リスク。既存 record に相乗り）
- Pushover 個別到達率 / ダッシュボード / CI gate（実データで drop が出てから検討）
- `thread.send` 失敗（bot.ts 側の別ターン）はスコープ外

## 撤退基準（Issue 記載）

3 か月運用して `delivered:false` が一度も観測されない、または到達率が常に 100% で推移が判断に使われない場合、field と集計セクションを削除する。

Closes #223
