### PR TITLE
test: 低カバレッジ 3 ファイルのテスト債務を解消する（resource-monitor / session-activity-watchdog / primary-compact、#405）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -148,6 +148,8 @@ jobs:
                    tests/session/stall-heartbeat.test.ts \
                    tests/session/context-budget.test.ts \
                    tests/session/session-activity-watchdog.test.ts \
+                   tests/session/resource-monitor.test.ts \
+                   tests/session/primary-compact.test.ts \
                    tests/hijoguchi-routing/p0.test.ts \
                    tests/e2e/ac-verification.test.ts \
                    tests/scripts/lint-gating-coverage.test.ts \

--- a/supervisor/src/session/primary-compact.ts
+++ b/supervisor/src/session/primary-compact.ts
@@ -30,16 +30,42 @@ const DEFAULT_SOCKET_ARGS: readonly string[] = [];
  * Async (execFile, not execFileSync) so the 2 s probe never blocks the
  * Supervisor's single Discord event loop if tmux is slow to respond
  * (gemini-code-assist review on #213).
+ *
+ * `tmuxPath` defaults to the real {@link TMUX_PATH} and exists only so a test
+ * can point the probe at a stub executable (#405). Faking the binary — rather
+ * than the function — keeps the real `execFile` call, its 2 s timeout and the
+ * `resolve(!err)` mapping under test, while never touching the DEFAULT tmux
+ * socket where the operator's live claudeHubExit session lives (CLAUDE.md
+ * absolute rule: the Supervisor must not manage that session's lifecycle).
  */
-export function claudeHubExitSessionAlive(): Promise<boolean> {
+export function claudeHubExitSessionAlive(
+  tmuxPath: string = TMUX_PATH
+): Promise<boolean> {
   return new Promise((resolve) => {
     execFile(
-      TMUX_PATH,
+      tmuxPath,
       ["has-session", "-t", CLAUDEHUBEXIT_TMUX_SESSION],
       { timeout: 2000 },
       (err) => resolve(!err)
     );
   });
+}
+
+/**
+ * Seams for {@link compactClaudeHubExit} (#405). Both default to the real
+ * cross-socket implementations; a test overrides them so the send *sequence*
+ * (empty-intent guard → liveness probe → relay) is verified without a live
+ * claudeHubExit session on the default tmux socket.
+ */
+export interface CompactClaudeHubExitDeps {
+  /** Liveness probe. Defaults to {@link claudeHubExitSessionAlive}. */
+  isAlive?: () => Promise<boolean>;
+  /** Key relay. Defaults to {@link sendToPane}. */
+  send?: (
+    tmuxSessionName: string,
+    text: string,
+    socketArgs: readonly string[]
+  ) => Promise<void>;
 }
 
 /**
@@ -53,19 +79,24 @@ export function claudeHubExitSessionAlive(): Promise<boolean> {
  * (mode-exit / Escape / `send-keys -l` / `C-m`) so the battle-tested,
  * injection-safe relay path is the single source of truth (RW-019/045/047).
  */
-export async function compactClaudeHubExit(intent: string): Promise<void> {
+export async function compactClaudeHubExit(
+  intent: string,
+  deps: CompactClaudeHubExitDeps = {}
+): Promise<void> {
   if (!intent.trim()) {
     throw new Error("compact intent must be non-empty (RW-032)");
   }
+  const isAlive = deps.isAlive ?? claudeHubExitSessionAlive;
+  const send = deps.send ?? sendToPane;
   // Pre-flight liveness probe. There is a benign TOCTOU vs the send below (the
   // session could die in the gap), but sendToPane would then throw anyway and
   // the command layer surfaces it the same way — so this only upgrades the
   // user-facing message to a clear "session dead" instead of a raw tmux error.
   // Worth one extra cross-socket RTT on a manual, infrequent command.
-  if (!(await claudeHubExitSessionAlive())) {
+  if (!(await isAlive())) {
     throw new Error("claudeHubExit session dead");
   }
-  await sendToPane(
+  await send(
     CLAUDEHUBEXIT_TMUX_SESSION,
     `/compact ${intent}`,
     DEFAULT_SOCKET_ARGS

--- a/supervisor/src/session/resource-monitor.ts
+++ b/supervisor/src/session/resource-monitor.ts
@@ -18,26 +18,42 @@ export interface ResourceMonitorDeps {
    * periodic observation half. Defaults to a fresh observe-mode controller.
    */
   admission?: AdmissionController;
+  /**
+   * Poll interval. Defaults to {@link RESOURCE_CHECK_INTERVAL_MS} (30 s).
+   * Injectable so a test can drive `start()`/`stop()` without a 30 s wall-clock
+   * wait — same seam as {@link import("./reaper").ReaperDeps}.checkIntervalMs.
+   */
+  checkIntervalMs?: number;
+  /**
+   * Per-session RSS ceiling in MB. Defaults to {@link
+   * MAX_MEMORY_PER_SESSION_MB} (2 GB). Injectable so a test can exercise the
+   * over-limit teardown branch against a REAL `ps` reading of a real pid
+   * (lowering the ceiling instead of faking the measurement), the same way
+   * {@link import("./reaper").ReaperDeps}.idleTimeoutMs makes the reap branch
+   * reachable without waiting out the real threshold.
+   */
+  maxMemoryMb?: number;
 }
 
 export class ResourceMonitor {
   private timer: ReturnType<typeof setInterval> | null = null;
   private readonly admission: AdmissionController;
+  private readonly checkIntervalMs: number;
+  private readonly maxMemoryMb: number;
 
   constructor(
     private sessionManager: SessionManager,
     deps: ResourceMonitorDeps = {},
   ) {
     this.admission = deps.admission ?? new AdmissionController();
+    this.checkIntervalMs = deps.checkIntervalMs ?? RESOURCE_CHECK_INTERVAL_MS;
+    this.maxMemoryMb = deps.maxMemoryMb ?? MAX_MEMORY_PER_SESSION_MB;
   }
 
   start(): void {
-    this.timer = setInterval(
-      () => this.check(),
-      RESOURCE_CHECK_INTERVAL_MS
-    );
+    this.timer = setInterval(() => this.check(), this.checkIntervalMs);
     console.log(
-      `[ResourceMonitor] Started (check every ${RESOURCE_CHECK_INTERVAL_MS / 1000}s, limit ${MAX_MEMORY_PER_SESSION_MB}MB)`
+      `[ResourceMonitor] Started (check every ${this.checkIntervalMs / 1000}s, limit ${this.maxMemoryMb}MB)`
     );
   }
 
@@ -74,9 +90,9 @@ export class ResourceMonitor {
         if (isNaN(rssKB)) continue;
 
         const rssMB = rssKB / 1024;
-        if (rssMB > MAX_MEMORY_PER_SESSION_MB) {
+        if (rssMB > this.maxMemoryMb) {
           console.error(
-            `[ResourceMonitor] ${session.channelName} (PID ${session.pid}) exceeded memory limit: ${rssMB.toFixed(0)}MB > ${MAX_MEMORY_PER_SESSION_MB}MB`
+            `[ResourceMonitor] ${session.channelName} (PID ${session.pid}) exceeded memory limit: ${rssMB.toFixed(0)}MB > ${this.maxMemoryMb}MB`
           );
           await this.sessionManager.stop(threadId, "resource_limit");
         }

--- a/supervisor/tests/session/primary-compact.test.ts
+++ b/supervisor/tests/session/primary-compact.test.ts
@@ -1,0 +1,148 @@
+import { describe, test, expect, beforeAll, afterAll } from "bun:test";
+import { chmodSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+  CLAUDEHUBEXIT_TMUX_SESSION,
+  claudeHubExitSessionAlive,
+  compactClaudeHubExit,
+} from "../../src/session/primary-compact";
+
+/**
+ * Issue #405 — test debt for `src/session/primary-compact.ts`, which had no
+ * test at all (0% funcs). This module is the ONE sanctioned place where the
+ * Supervisor reaches across the tmux socket boundary to the claudeHubExit
+ * session, so the properties worth pinning are the boundary ones:
+ *   - it targets the `claudeHubExit` session on the DEFAULT socket (empty
+ *     socket args), never the Supervisor's `-L claude-hub` socket (RW-019),
+ *   - it relays through {@link sendToPane} rather than a second send sequence,
+ *   - it refuses an empty intent (RW-032),
+ *   - a dead session surfaces as an error instead of silently dropped keys
+ *     (#199 AC3).
+ *
+ * Nothing here touches the real default socket: the liveness probe is pointed
+ * at a stub executable, and the relay is injected. Creating or probing a real
+ * `claudeHubExit` session would collide with the operator's live one, which
+ * CLAUDE.md forbids the Supervisor from managing.
+ */
+
+let binDir: string;
+/** Stub "tmux" that exits 0 → has-session succeeds → session considered alive. */
+let tmuxAlive: string;
+/** Stub "tmux" that exits 1 → has-session fails → session considered dead. */
+let tmuxDead: string;
+
+beforeAll(() => {
+  binDir = mkdtempSync(join(tmpdir(), "primary-compact-"));
+  tmuxAlive = join(binDir, "tmux-alive");
+  tmuxDead = join(binDir, "tmux-dead");
+  writeFileSync(tmuxAlive, "#!/bin/sh\nexit 0\n");
+  writeFileSync(tmuxDead, "#!/bin/sh\nexit 1\n");
+  chmodSync(tmuxAlive, 0o755);
+  chmodSync(tmuxDead, 0o755);
+});
+
+afterAll(() => {
+  rmSync(binDir, { recursive: true, force: true });
+});
+
+describe("claudeHubExitSessionAlive", () => {
+  test("resolves true when has-session succeeds", async () => {
+    expect(await claudeHubExitSessionAlive(tmuxAlive)).toBe(true);
+  });
+
+  test("resolves false when has-session fails (no server / no such session)", async () => {
+    expect(await claudeHubExitSessionAlive(tmuxDead)).toBe(false);
+  });
+
+  test("treats a missing tmux binary as dead instead of rejecting", async () => {
+    // Best-effort by design: a spawn error (ENOENT) must not bubble out of the
+    // probe, or a mis-set TMUX_PATH would turn a `/session compact` into an
+    // unhandled rejection instead of the "session dead" ephemeral.
+    const alive = await claudeHubExitSessionAlive(join(binDir, "no-such-tmux"));
+    expect(alive).toBe(false);
+  });
+});
+
+describe("compactClaudeHubExit", () => {
+  function recorder() {
+    const sends: Array<{
+      session: string;
+      text: string;
+      socketArgs: readonly string[];
+    }> = [];
+    return {
+      sends,
+      send: async (
+        session: string,
+        text: string,
+        socketArgs: readonly string[]
+      ) => {
+        sends.push({ session, text, socketArgs });
+      },
+    };
+  }
+
+  test("relays /compact <intent> to claudeHubExit on the DEFAULT socket", async () => {
+    const { sends, send } = recorder();
+    await compactClaudeHubExit("relay work", {
+      isAlive: async () => true,
+      send,
+    });
+    expect(sends).toHaveLength(1);
+    expect(sends[0]!.session).toBe(CLAUDEHUBEXIT_TMUX_SESSION);
+    expect(sends[0]!.text).toBe("/compact relay work");
+    // Empty socket args = default socket. A non-empty value here would mean the
+    // keystroke went to the Supervisor's own `-L claude-hub` server instead.
+    expect(sends[0]!.socketArgs).toEqual([]);
+  });
+
+  test("passes the intent through verbatim (spaces and slashes preserved)", async () => {
+    const { sends, send } = recorder();
+    await compactClaudeHubExit("keep #199 AC1 / socket notes", {
+      isAlive: async () => true,
+      send,
+    });
+    expect(sends[0]!.text).toBe("/compact keep #199 AC1 / socket notes");
+  });
+
+  test("rejects an empty or whitespace-only intent before probing (RW-032)", async () => {
+    for (const intent of ["", "   ", "\n\t"]) {
+      const { sends, send } = recorder();
+      let probed = false;
+      await expect(
+        compactClaudeHubExit(intent, {
+          isAlive: async () => {
+            probed = true;
+            return true;
+          },
+          send,
+        })
+      ).rejects.toThrow("compact intent must be non-empty (RW-032)");
+      // The guard is first: no cross-socket probe, no keystroke.
+      expect(probed).toBe(false);
+      expect(sends).toHaveLength(0);
+    }
+  });
+
+  test("throws 'claudeHubExit session dead' and sends nothing when the probe fails (#199 AC3)", async () => {
+    const { sends, send } = recorder();
+    await expect(
+      compactClaudeHubExit("anything", { isAlive: async () => false, send })
+    ).rejects.toThrow("claudeHubExit session dead");
+    expect(sends).toHaveLength(0);
+  });
+
+  test("propagates a relay failure instead of reporting success", async () => {
+    // Silent success on a failed send is the exact failure mode #199 AC3 calls
+    // out: the user would believe the compact landed when no keys were sent.
+    await expect(
+      compactClaudeHubExit("boom", {
+        isAlive: async () => true,
+        send: async () => {
+          throw new Error("not in a mode");
+        },
+      })
+    ).rejects.toThrow("not in a mode");
+  });
+});

--- a/supervisor/tests/session/resource-monitor.test.ts
+++ b/supervisor/tests/session/resource-monitor.test.ts
@@ -1,0 +1,200 @@
+import { describe, test, expect, spyOn } from "bun:test";
+import { ResourceMonitor } from "../../src/session/resource-monitor";
+import { AdmissionController } from "../../src/session/admission";
+import type { SessionManager } from "../../src/session/manager";
+import type { SessionInfo, StopReason } from "../../src/session/types";
+
+/**
+ * Issue #405 — test debt for `src/session/resource-monitor.ts`. Before this
+ * file only `sampleLoad()` was exercised (from tests/session/admission.test.ts,
+ * #295); the timer lifecycle and the whole `check()` teardown path had no test.
+ *
+ * `check()` is driven against the REAL `ps -o rss= -p <pid>` — no child_process
+ * mock. Two properties make that deterministic:
+ *   - the current test process is always a live pid with a real, small RSS, and
+ *   - the over-limit branch is reached by lowering the injected ceiling
+ *     (`maxMemoryMb: 0`) instead of faking the measurement.
+ * So the exec, the `parseInt`, the KB→MB conversion and the comparison are all
+ * the production ones. `ps -o rss= -p <pid>` is POSIX and behaves identically on
+ * the macOS dev machine and the ubuntu-latest runner (exit 1 for an unknown
+ * pid, which is what the error branch below relies on).
+ */
+
+function makeSession(over: Partial<SessionInfo>): SessionInfo {
+  const now = new Date();
+  return {
+    id: "s1",
+    channelName: "claude-hub",
+    threadId: "t1",
+    projectDir: "/repo",
+    pid: process.pid,
+    process: null as unknown as SessionInfo["process"],
+    startedAt: now,
+    lastActivityAt: now,
+    status: "running",
+    ...over,
+  } as SessionInfo;
+}
+
+function makeManager(sessions: Map<string, SessionInfo>): {
+  manager: SessionManager;
+  stopCalls: Array<{ threadId: string; reason: StopReason }>;
+  entriesCalls: () => number;
+} {
+  const stopCalls: Array<{ threadId: string; reason: StopReason }> = [];
+  let entriesCalls = 0;
+  const manager = {
+    entries: () => {
+      entriesCalls++;
+      return sessions.entries();
+    },
+    // Mirrors the real SessionManager: stop() removes the session from the live
+    // map, which is precisely the mid-loop mutation the Array.from() snapshot in
+    // check() exists to survive (gemini PR #297 HIGH).
+    stop: async (threadId: string, reason: StopReason) => {
+      stopCalls.push({ threadId, reason });
+      sessions.delete(threadId);
+    },
+  } as unknown as SessionManager;
+  return { manager, stopCalls, entriesCalls: () => entriesCalls };
+}
+
+/** A pid that cannot be running: above the macOS pid ceiling, absent on Linux. */
+const DEAD_PID = 999_999;
+
+/**
+ * Idle-load admission stub. The real controller samples the HOST's load average,
+ * so on a busy dev machine every check() below would emit a "high load" WARN —
+ * log noise unrelated to what these tests assert, and a hidden dependency on the
+ * machine's state. The WARN path itself is covered in
+ * tests/session/admission.test.ts (#295).
+ */
+function quietAdmission(): AdmissionController {
+  return new AdmissionController({
+    sampler: { sample: () => ({ load1: 0, cores: 8, freeMemRatio: 1 }) },
+    mode: "observe",
+  });
+}
+
+describe("ResourceMonitor.check (memory teardown)", () => {
+  test("stops a session whose RSS exceeds the ceiling, with reason resource_limit", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t1", makeSession({ threadId: "t1", pid: process.pid })],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // Real `ps` on this process: any live process has RSS > 0 MB, so a 0 MB
+      // ceiling makes the over-limit branch deterministic without faking `ps`.
+      await new ResourceMonitor(manager, { maxMemoryMb: 0, admission: quietAdmission() }).check();
+      expect(stopCalls).toEqual([{ threadId: "t1", reason: "resource_limit" }]);
+      expect(errSpy).toHaveBeenCalledTimes(1);
+      expect(String(errSpy.mock.calls[0]![0])).toContain("exceeded memory limit");
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  test("leaves a session below the ceiling alone (no false teardown)", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["t1", makeSession({ threadId: "t1", pid: process.pid })],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    // The default 2 GB ceiling is far above a bun test process's real RSS.
+    await new ResourceMonitor(manager, { admission: quietAdmission() }).check();
+    expect(stopCalls).toHaveLength(0);
+    expect(sessions.has("t1")).toBe(true);
+  });
+
+  test("skips sessions with no pid before ever spawning ps", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["nopid", makeSession({ threadId: "nopid", pid: 0 })],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    // maxMemoryMb 0 would stop ANY measured session, so a silent run proves the
+    // `if (!session.pid) continue` guard short-circuited first.
+    await new ResourceMonitor(manager, { maxMemoryMb: 0, admission: quietAdmission() }).check();
+    expect(stopCalls).toHaveLength(0);
+  });
+
+  test("a dead pid (ps exits non-zero) is swallowed and does not abort the scan", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["dead", makeSession({ threadId: "dead", pid: DEAD_PID })],
+      ["live", makeSession({ threadId: "live", pid: process.pid })],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await new ResourceMonitor(manager, { maxMemoryMb: 0, admission: quietAdmission() }).check();
+      // "dead" throws inside the try and is left to SessionManager cleanup;
+      // "live" is still visited afterwards — the catch must not end the loop.
+      expect(stopCalls).toEqual([
+        { threadId: "live", reason: "resource_limit" },
+      ]);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  test("iterates a snapshot, so stop() deleting entries mid-loop cannot skip a session", async () => {
+    const sessions = new Map<string, SessionInfo>([
+      ["a", makeSession({ threadId: "a", pid: process.pid })],
+      ["b", makeSession({ threadId: "b", pid: process.pid })],
+      ["c", makeSession({ threadId: "c", pid: process.pid })],
+    ]);
+    const { manager, stopCalls } = makeManager(sessions);
+    const errSpy = spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await new ResourceMonitor(manager, { maxMemoryMb: 0, admission: quietAdmission() }).check();
+      // Every session is over the 0 MB ceiling, so each must be stopped exactly
+      // once even though each stop() deletes from the map being iterated.
+      expect(stopCalls.map((c) => c.threadId).sort()).toEqual(["a", "b", "c"]);
+      expect(sessions.size).toBe(0);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  test("samples system load on every pass (observe-only WARN, #295)", async () => {
+    const { manager } = makeManager(new Map());
+    const rm = new ResourceMonitor(manager, { admission: quietAdmission() });
+    const sampleSpy = spyOn(rm, "sampleLoad");
+    await rm.check();
+    expect(sampleSpy).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("ResourceMonitor timer lifecycle", () => {
+  test("start() polls on the configured interval and stop() halts it", async () => {
+    const { manager, entriesCalls } = makeManager(new Map());
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    const rm = new ResourceMonitor(manager, { checkIntervalMs: 5, admission: quietAdmission() });
+    try {
+      rm.start();
+      expect(String(logSpy.mock.calls[0]![0])).toContain("[ResourceMonitor] Started");
+
+      // Each check() pass calls entries() exactly once, so it is an exact tick
+      // counter. Poll for ticks rather than sleeping a fixed time.
+      const deadline = Date.now() + 2000;
+      while (entriesCalls() < 2 && Date.now() < deadline) {
+        await Bun.sleep(5);
+      }
+      expect(entriesCalls()).toBeGreaterThanOrEqual(2);
+
+      rm.stop();
+      const afterStop = entriesCalls();
+      await Bun.sleep(40); // >= 8 intervals: a live timer would tick again
+      expect(entriesCalls()).toBe(afterStop);
+    } finally {
+      rm.stop();
+      logSpy.mockRestore();
+    }
+  });
+
+  test("stop() is safe before start() and idempotent", () => {
+    const { manager } = makeManager(new Map());
+    const rm = new ResourceMonitor(manager, { checkIntervalMs: 5, admission: quietAdmission() });
+    expect(() => rm.stop()).not.toThrow();
+    expect(() => rm.stop()).not.toThrow();
+  });
+});

--- a/supervisor/tests/session/session-activity-watchdog.test.ts
+++ b/supervisor/tests/session/session-activity-watchdog.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { test, expect, describe, spyOn } from "bun:test";
 import {
   classifyActivity,
   buildActivityWarning,
@@ -341,6 +341,62 @@ describe("ActivityWatchdog.check (periodic scan)", () => {
     expect(notifications).toHaveLength(2);
   });
 
+  test("an isAlive() rejection skips that session and does not abort the scan (#405)", async () => {
+    const nowRef = { t: 7 * HOUR };
+    const sessions = new Map<string, FakeSession>([
+      ["boom", { startedAt: new Date(0), lastActivityAt: new Date(0) }],
+      ["ok", { startedAt: new Date(0), lastActivityAt: new Date(0) }],
+    ]);
+    const notified: string[] = [];
+    const warnSpy = spyOn(console, "warn").mockImplementation(() => {});
+    const wd = new ActivityWatchdog({
+      entries: () => sessions.entries(),
+      isAlive: async (id) => {
+        if (id === "boom") throw new Error("tmux unreachable");
+        return true;
+      },
+      notify: (threadId) => {
+        notified.push(threadId);
+      },
+      thresholds: T,
+      now: () => nowRef.t,
+    });
+    try {
+      await wd.check();
+      // "boom" is skipped (liveness unknown → stay quiet, the reaper owns it)
+      // but the scan continues to "ok".
+      expect(notified).toEqual(["ok"]);
+      expect(warnSpy).toHaveBeenCalled();
+      expect(String(warnSpy.mock.calls[0]![0])).toContain("isAlive(boom) threw");
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  test("awaits an async isAlive (the real sessionManager.livenessOf shape, #227 PR-3)", async () => {
+    const nowRef = { t: 7 * HOUR };
+    const sessions = new Map<string, FakeSession>([
+      ["a", { startedAt: new Date(0), lastActivityAt: new Date(0) }],
+    ]);
+    const notified: string[] = [];
+    const wd = new ActivityWatchdog({
+      entries: () => sessions.entries(),
+      // Resolves on a later microtask: a non-awaiting implementation would see
+      // a truthy Promise for a DEAD session and warn about it.
+      isAlive: async () => {
+        await Promise.resolve();
+        return false;
+      },
+      notify: (threadId) => {
+        notified.push(threadId);
+      },
+      thresholds: T,
+      now: () => nowRef.t,
+    });
+    await wd.check();
+    expect(notified).toHaveLength(0);
+  });
+
   test("a notify() failure does not abort the scan of other sessions", async () => {
     const nowRef = { t: 7 * HOUR };
     const sessions = new Map<string, FakeSession>([
@@ -362,5 +418,102 @@ describe("ActivityWatchdog.check (periodic scan)", () => {
     // both were visited despite the first throwing
     expect(seen).toContain("boom");
     expect(seen).toContain("ok");
+  });
+});
+
+describe("ActivityWatchdog timer lifecycle (#405)", () => {
+  type FakeSession = { startedAt: Date; lastActivityAt: Date };
+
+  function makeWatchdog(intervalMs: number) {
+    const sessions = new Map<string, FakeSession>();
+    let scans = 0;
+    const wd = new ActivityWatchdog({
+      // entries() is called exactly once per check() pass, so it is an exact
+      // tick counter — no wall-clock assumption beyond "a tick happened".
+      entries: () => {
+        scans++;
+        return sessions.entries();
+      },
+      isAlive: () => true,
+      notify: () => {},
+      thresholds: T,
+      intervalMs,
+      now: () => 0,
+    });
+    return { wd, scans: () => scans };
+  }
+
+  test("start() drives check() on the configured interval and stop() halts it", async () => {
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    const debugSpy = spyOn(console, "debug").mockImplementation(() => {});
+    const { wd, scans } = makeWatchdog(5);
+    try {
+      wd.start();
+      expect(String(logSpy.mock.calls[0]![0])).toContain(
+        "[ActivityWatchdog] Started"
+      );
+
+      const deadline = Date.now() + 2000;
+      while (scans() < 2 && Date.now() < deadline) {
+        await Bun.sleep(5);
+      }
+      expect(scans()).toBeGreaterThanOrEqual(2);
+
+      wd.stop();
+      const afterStop = scans();
+      await Bun.sleep(40); // >= 8 intervals: a live timer would tick again
+      expect(scans()).toBe(afterStop);
+    } finally {
+      wd.stop();
+      logSpy.mockRestore();
+      debugSpy.mockRestore();
+    }
+  });
+
+  test("start() is idempotent — a second call does not add a second timer", async () => {
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    const debugSpy = spyOn(console, "debug").mockImplementation(() => {});
+    const { wd, scans } = makeWatchdog(10);
+    try {
+      wd.start();
+      wd.start(); // early-returns; the log line is the observable proof
+      expect(logSpy).toHaveBeenCalledTimes(1);
+
+      const deadline = Date.now() + 2000;
+      while (scans() < 1 && Date.now() < deadline) {
+        await Bun.sleep(5);
+      }
+      wd.stop();
+      const afterStop = scans();
+      // A leaked second interval would keep ticking after the single stop().
+      await Bun.sleep(50);
+      expect(scans()).toBe(afterStop);
+    } finally {
+      wd.stop();
+      logSpy.mockRestore();
+      debugSpy.mockRestore();
+    }
+  });
+
+  test("stop() is safe before start() and idempotent", () => {
+    const { wd } = makeWatchdog(10);
+    expect(() => wd.stop()).not.toThrow();
+    expect(() => wd.stop()).not.toThrow();
+  });
+
+  test("the interval is unref'd so a running watchdog never holds the process open", () => {
+    const logSpy = spyOn(console, "log").mockImplementation(() => {});
+    const { wd } = makeWatchdog(60_000);
+    try {
+      wd.start();
+      // White-box on purpose: "does not keep the event loop alive" has no
+      // black-box assertion short of hanging the suite. hasRef() is the direct
+      // read of the flag start() sets.
+      const timer = (wd as unknown as { timer: { hasRef(): boolean } }).timer;
+      expect(timer.hasRef()).toBe(false);
+    } finally {
+      wd.stop();
+      logSpy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
Closes #405

## 概要

#300（patch 70% blocking 昇格）の昇格条件 3 で「未着手」と実測された 3 ファイルに、実コードを実行するテストを補充した。`codecov` の `ignore` へ追加する「解決」は選んでいない（`rules/general/coverage-policy.md` §5 anti-gaming）。§4 の除外事由（外部 API 直叩き / E2E 担保 / 単純委譲）に該当する部分も無かったため、除外は 1 件も追加していない。

## 計測（curated CI suite、ローカル実行 / bun 1.3.11）

| ファイル | before (funcs / lines) | after (funcs / lines) |
|---|---|---|
| `resource-monitor.ts` | 40.00% / 34.55% | **100.00% / 100.00%** |
| `primary-compact.ts` | 0.00% / 20.00% | **100.00% / 100.00%** |
| `session-activity-watchdog.ts` | 78.57% / 18.18% | **93.33% / 100.00%** |
| 全体 | 83.34% / 81.09% | **86.68% / 85.17%** |

before は Issue #405 本文の実測値と完全一致（同じ curated リストを再実行して確認）。

## 変更内容

### 1. `tests/session/resource-monitor.test.ts`（新規）

`sampleLoad()` だけが `tests/session/admission.test.ts`（#295）で触れられており、timer lifecycle と `check()` のテアダウン経路は無テストだった。

`check()` は **`child_process` を mock せず、実際の `ps -o rss= -p <pid>` を叩く**。決定性は次の 2 点で担保している。

- テストプロセス自身が常に生きた pid で、RSS も実在する
- over-limit 分岐へは **計測を偽装せず ceiling を下げて**（`maxMemoryMb: 0`）到達させる

つまり exec / `parseInt` / KB→MB 換算 / 比較はすべて本番実装のまま検証される。`ps -o rss= -p <pid>` は POSIX で、macOS と ubuntu-latest のどちらでも未知 pid に対し exit 1 を返す（error 分岐のテストがこれに依存）。

カバーした分岐: over-limit teardown（`reason: "resource_limit"`）/ 閾値内は不介入 / `pid` 無しは `ps` を spawn せず skip / dead pid の catch でスキャンが止まらないこと / `Array.from` スナップショットにより `stop()` の map 削除で走査が飛ばないこと（gemini PR #297 HIGH の回帰ガード）/ 毎パスの `sampleLoad()`。

### 2. `tests/session/primary-compact.test.ts`（新規）

このモジュールは Supervisor が socket 境界を越えて claudeHubExit に触れる**唯一の許可された経路**なので、境界に関する性質を固定した。

- 宛先が `claudeHubExit` セッション かつ **DEFAULT socket**（`socketArgs` が空配列）であること — 非空なら Supervisor 自身の `-L claude-hub` に打ってしまう（RW-019）
- 送信が `sendToPane` 経由であること（第 2 の送信シーケンスを作らない、RW-019/045/047）
- 空 / 空白のみの intent を**probe より前に**拒否すること（RW-032、cross-socket probe すら走らない）
- dead セッション時は送信ゼロで `claudeHubExit session dead` を throw（#199 AC3）
- relay 失敗を握り潰さず伝播すること

**実 default socket には一切触れていない**: liveness probe はテンポラリのスタブ実行ファイル（`exit 0` / `exit 1`）を指す。実 `claudeHubExit` セッションを作る/掴むのは CLAUDE.md の不可侵ルール違反になるため採らなかった。

### 3. `tests/session/session-activity-watchdog.test.ts`（追記）

lines 18.18% の実体は **`start()` / `stop()` / interval callback が無テスト**だったこと。ここを埋めた。

- `start()` が設定 interval で `check()` を駆動し、`stop()` で止まること（固定 sleep ではなく tick 数のポーリングで判定）
- `start()` の冪等性（2 回目は早期 return し、timer を二重に張らない）
- interval が `unref` 済みであること（プロセスを起こし続けない）
- `isAlive()` が reject したセッションを skip しつつスキャンが継続すること
- 非同期 `isAlive` を `await` すること（`sessionManager.livenessOf` の実形状、#227 PR-3）

### 4. 本番コードの変更（DI seam のみ、挙動不変）

既定値は従来の定数と同一なので、production の振る舞いは変わらない。

- `ResourceMonitorDeps` に `checkIntervalMs` / `maxMemoryMb` を追加 — `ReaperDeps` の `checkIntervalMs` / `idleTimeoutMs` と同型の seam
- `claudeHubExitSessionAlive(tmuxPath = TMUX_PATH)` — 関数ではなく**バイナリ**を差し替える形にしたので、実 `execFile` / 2s timeout / `resolve(!err)` がテスト対象のまま残る
- `CompactClaudeHubExitDeps { isAlive?, send? }` を追加

### 5. `ci.yml`

新規 2 本を curated リストへ追加（`scripts/lint-gating-coverage.ts` が未 gate を検出するため必須）。

## 検証

```
bunx tsc --noEmit                        # OK
bun scripts/lint-gating-coverage.ts      # 105 files - 103 gated, 2 excluded, 0 ungated
bun scripts/lint-blocking-in-timers.ts   # OK
bun scripts/lint-no-sync-exec.ts         # OK
bun scripts/check-access-policy.ts --ci  # in sync
bun test <curated 97 files> --coverage   # 1213 tests
```

curated suite をローカルで before / after 実行し、失敗集合を比較した。差分は `tests/integration/worktree-real-git.test.ts` と `tests/action/token.test.ts` の flake のみで、いずれも**本 PR と無関係の既存ローカル環境 flake**であることを単独再実行で確認済み（worktree-real-git は連続実行で 3 fail → 12 fail、token は 0 fail → 1 fail（5000ms timeout、#398 と同型））。CI（ubuntu-latest）が正となる。

mock-isolated の 4 ステップも個別に実行して全 pass（adapters-hassession 6 / adapters 17 / tmux 8 / relay-nonblocking 2）。

## 統合ジャーニーAC

不要（Issue #405 記載の理由どおり）: 既存機能の振る舞いを変えないテスト追加のみで、ユーザー観測可能なフローの変更がない。DI seam の追加も既定値が従来定数と同一のため挙動不変。

## 調査メモ: Bun の lcov 行属性は当てにならない場面がある

`session-activity-watchdog.ts` の 18.18% を調べる過程で、Bun 1.3.11 の lcov **行**属性がこのファイルで誤っていることを実測した。`classifyActivity` と `longLivedBand` だけを呼ぶ最小 probe を書くと、hit が付いたのは実行され得ない `ActivityWatchdog.check` 側の行（262 / 334 / 336）だった。コメント除去版・非 ASCII 除去版でも同じ挙動で、原因はコメント量でも multibyte でもない。また同一ファイルで `FNF` が 14 / 11 と実行ごとに揺れる。

実務上の結論としては本 PR で問題は解消している（全関数が実行されたことで 100% に解決した）。ただし「関数は hit なのに行が 0」という状態は patch 70% が blocking な今、**偽 FAIL を生み得る**。単独 follow-up として起票するのが妥当だと考えるが、起票の要否は判断を仰ぎたい。

## 補足（本 PR では対応しない）

`ResourceMonitor.start()` には `ActivityWatchdog.start()` にある二重起動ガード（`if (this.timer) return;`）が無く、2 回呼ぶと 1 本目の timer が leak する。現状 `bot.ts:447` の 1 箇所からしか呼ばれないため潜在的で、本 Issue のスコープ（テスト債務）外なので触っていない。
