### PR TITLE
fix(ci): close 済み Issue から in-progress を自動除去する workflow を追加する（#417）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,6 +138,7 @@ jobs:
                    tests/infra/db.test.ts \
                    tests/infra/db-isolation.test.ts \
                    tests/infra/hook-wiring-check.test.ts \
+                   tests/infra/issue-progress-cleanup-workflow.test.ts \
                    tests/session/dialog-detect.test.ts \
                    tests/session/dialog-watchdog.test.ts \
                    tests/session/relay-send-failure.test.ts \

--- a/.github/workflows/issue-progress-cleanup.yml
+++ b/.github/workflows/issue-progress-cleanup.yml
@@ -1,0 +1,36 @@
+name: Issue Progress Cleanup
+
+# Issue #417: remove the `in-progress` label once an issue is closed.
+#
+# `in-progress` is the PDCA duplicate-work guard: `commands/pdca.md` Step 0-3
+# refuses to start an issue that already carries it, reading the label as
+# "another session owns this". Step 4-6 deliberately leaves the label on at the
+# end of a run and delegates removal to *this* workflow — which did not exist,
+# so nothing ever took it off. Six already-closed issues (#300 #382 #383 #386
+# #388 #389) had accumulated a stale label, and stale labels make the guard
+# lie: an issue nobody is working on looks taken and gets skipped.
+#
+# Trigger on `closed` rather than on PR merge so every close path is covered —
+# squash merge via `Closes #N`, `gh issue close`, and closing by hand alike.
+on:
+  issues:
+    types: [closed]
+
+# Only the label write is needed. Everything else stays read-only.
+permissions:
+  issues: write
+
+jobs:
+  remove-in-progress:
+    name: Remove in-progress label
+    runs-on: ubuntu-latest
+    # Skip the API call entirely for the common case (an issue closed without
+    # the label), so the job stays a no-op instead of erroring on a 404.
+    if: contains(github.event.issue.labels.*.name, 'in-progress')
+    steps:
+      - name: Remove label
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: gh issue edit "$ISSUE_NUMBER" --remove-label in-progress

--- a/supervisor/tests/infra/issue-progress-cleanup-workflow.test.ts
+++ b/supervisor/tests/infra/issue-progress-cleanup-workflow.test.ts
@@ -1,0 +1,81 @@
+import { test, expect, describe } from "bun:test";
+import { existsSync, readFileSync } from "fs";
+import { resolve } from "path";
+
+/**
+ * Issue #417: the `in-progress` label must be removed automatically when an
+ * issue closes.
+ *
+ * `commands/pdca.md` Step 4-6 leaves the label on at the end of a PDCA run and
+ * delegates removal to `.github/workflows/issue-progress-cleanup.yml`. That
+ * file never existed, so nothing removed it — and because `in-progress` is the
+ * duplicate-work guard (Step 0-3 skips any issue that carries it), the stale
+ * labels made the guard report work that nobody was doing.
+ *
+ * A workflow cannot be executed from a unit test, so this asserts the contract
+ * the guard depends on: the trigger fires on every close path, the token can
+ * actually write labels, and the step removes the right label. Those are the
+ * parts that, if silently edited away, would put us back to a lying guard with
+ * no other signal (RW-029: a silently-green CI is worse than a red one).
+ */
+const WORKFLOW_PATH = resolve(
+  import.meta.dir,
+  "../../../.github/workflows/issue-progress-cleanup.yml"
+);
+
+interface CleanupWorkflow {
+  on?: { issues?: { types?: string[] } };
+  permissions?: Record<string, string>;
+  jobs?: Record<
+    string,
+    { if?: string; steps?: { run?: string; env?: Record<string, string> }[] }
+  >;
+}
+
+function loadWorkflow(): CleanupWorkflow {
+  return Bun.YAML.parse(
+    readFileSync(WORKFLOW_PATH, "utf8")
+  ) as CleanupWorkflow;
+}
+
+describe("issue-progress-cleanup workflow (#417)", () => {
+  test("the workflow file pdca.md delegates to actually exists", () => {
+    expect(existsSync(WORKFLOW_PATH)).toBe(true);
+  });
+
+  test("triggers on issue close, not on PR merge", () => {
+    // Closing happens via `Closes #N` on a squash merge, `gh issue close`, and
+    // the web UI. Keying on the close event covers all three; keying on merge
+    // would miss the latter two.
+    expect(loadWorkflow().on?.issues?.types).toEqual(["closed"]);
+  });
+
+  test("grants issues:write so the label removal is permitted", () => {
+    // Without this the default read-only GITHUB_TOKEN makes the step fail —
+    // and the label would silently stay on, which is the bug being fixed.
+    expect(loadWorkflow().permissions?.issues).toBe("write");
+  });
+
+  test("removes the in-progress label", () => {
+    const jobs = loadWorkflow().jobs ?? {};
+    const runs = Object.values(jobs)
+      .flatMap((job) => job.steps ?? [])
+      .map((step) => step.run ?? "");
+
+    expect(
+      runs.some(
+        (run) => run.includes("--remove-label") && run.includes("in-progress")
+      )
+    ).toBe(true);
+  });
+
+  test("only runs when the closed issue carries the label", () => {
+    // Guard keeps the job a no-op for the vast majority of closes instead of
+    // calling the API (and failing) for issues that never had the label.
+    const jobs = Object.values(loadWorkflow().jobs ?? {});
+    expect(jobs.length).toBeGreaterThan(0);
+    expect(
+      jobs.every((job) => (job.if ?? "").includes("in-progress"))
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## 目的

`commands/pdca.md` Step 4-6 が「merge 時に `.github/workflows/issue-progress-cleanup.yml` が自動除去する想定」でラベルを残置するのに、**その workflow が存在しなかった**（#417）。誰も外さないため close 済み Issue にラベルが残り続けていた。

`in-progress` は **PDCA の重複着手ガード**の信号（Step 0-3 は同ラベル付き Issue を「他セッション作業中」とみなして skip する）。残留するとガードが嘘をつき、**誰も作業していない Issue が着手不能に見える**。実際 Epic #411 の実行時、open な in-progress 7 件（#357 / #338 / #170 / #144 / #106 / #101 / #78）に対応する稼働セッションは 1 つも無く、稼働判定を tmux とプロセスで手作業裏取りする必要があった。

## 変更点

`.github/workflows/issue-progress-cleanup.yml` を追加:

| 項目 | 内容 | 理由 |
|---|---|---|
| trigger | `issues: [closed]` | `Closes #N` の squash merge / `gh issue close` / 手動 close の**全経路**を覆う。PR merge を trigger にすると後 2 者を取りこぼす |
| permissions | `issues: write` のみ | ラベル書き込みに必要な最小権限（既定の read-only token では失敗し、ラベルが黙って残る＝本バグの再現） |
| job 条件 | `contains(github.event.issue.labels.*.name, 'in-progress')` | ラベル未保持の close では API を呼ばず no-op。大多数の close で無駄打ち・404 を避ける |

## テスト

workflow は単体テストから実行できないため、**ガードが依存する契約**を `Bun.YAML` でパースして検証する（`tests/infra/issue-progress-cleanup-workflow.test.ts`、5 ケース）:

1. pdca.md が委譲先にしているファイルが実在する
2. trigger が issue close である（merge 起点ではない）
3. `issues: write` が付与されている
4. `--remove-label in-progress` を実行している
5. ラベル保持時のみ job が走る

これらが黙って書き換わると「ガードが嘘をつく状態」に逆戻りし、他に検知手段が無い（RW-029: silently-green CI は red より悪い）。ci.yml の whitelist にも登録済み。

実測:

```
CI whitelist 相当 (98 files): 1199 pass / 0 fail / 13 skip
bunx tsc --noEmit: エラーなし
scripts/lint-gating-coverage.ts: 106 files — 104 gated, 2 excluded, 0 ungated
```

> 検証中に `tests/scripts/cleanup-idle-claude.test.ts` が 3 件 timeout（exit 143）したが、**本変更とは無関係**と確認済み。同ファイルは稼働中のホストプロセスを走査する設計で、並行する PDCA セッション 3 本でマシンが飽和した瞬間に 5s timeout を超えたもの。unmodified main での対照実行 6 pass / 0 fail、負荷が下がった後の本ブランチ再実行も 6 pass / 0 fail（`git diff origin/main` は ci.yml の 1 行のみ）。

## 統合ジャーニーAC

Issue #417 記載の 3 項目。**AC-1 / AC-2 は merge 後に実イベントでのみ判定可能**（workflow はデフォルトブランチに存在して初めて発火するため、本 PR の CI では検証できない）。

| AC | 内容 | 本 PR 時点 | merge 後の判定方法 |
|---|---|---|---|
| AC-1 | squash merge の自動 close でラベルが外れる | 未検証（要 merge） | 本 PR merge による #417 自動 close 自体が最初の実測になる |
| AC-2 | `gh issue close` でも外れる | 未検証（要 merge） | 任意の in-progress 付き Issue を手動 close して確認 |
| AC-3 | `gh issue list --label in-progress --state closed` が 0 件 | **未達（6 件残存）** | 既存分は workflow の遡及対象外のため、merge 後に手動で一括除去する |

AC-3 の既存 6 件（#300 #382 #383 #386 #388 #389）は過去に close 済みでイベントが発火しないため、merge 後に別途除去する。

Closes #417


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Issueがクローズされた際、付与されている「in-progress」ラベルを自動的に削除するようになりました。
  * 対象ラベルが付いたIssueのみ処理されます。

* **テスト**
  * ラベル削除ワークフローの動作条件と権限設定を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->