### PR TITLE
fix(test): action/token の改竄検知を決定論化し subprocess 起因の 5s timeout を解消する（#401）

### DIFF
--- a/supervisor/tests/action/token.test.ts
+++ b/supervisor/tests/action/token.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, describe } from "bun:test";
+import { test, expect, describe, setDefaultTimeout } from "bun:test";
 import { execFileSync } from "child_process";
 import { existsSync, mkdtempSync, writeFileSync } from "fs";
 import { tmpdir, homedir } from "os";
@@ -18,6 +18,16 @@ import {
  * the cross-language contract, plus a best-effort round-trip against the real
  * action-token.sh source when it is reachable from origin/main.
  */
+
+// Every test here mints tokens by spawning bash + openssl (and the round-trip
+// test also shells out to git twice), so the file is subprocess-bound rather
+// than compute-bound. Spawn latency has a long tail: measuring the round-trip
+// helper over 40 local samples gave min 1272ms / p50 2396ms / p90 4972ms /
+// max 30671ms, i.e. p90 sits right on bun's 5000ms default. That made
+// unrelated tests time out at ~1 run in 25 with nothing else running
+// (Issue #401 AC-1 surfaced it in `isExpired` and in the round-trip test).
+// Raise the budget for the file; no assertion or timing expectation changes.
+setDefaultTimeout(60_000);
 
 const KEY = "test-shared-key-abc123";
 
@@ -156,9 +166,39 @@ describe("action/token verifySignature (contract with openssl)", () => {
     const token = genToken("compact", "/Users/x/wt/issue-441");
     const parsed = parseToken(token);
     if (!parsed.ok) throw new Error("parse failed");
-    // Flip a character in the signature.
-    const badSig = parsed.sig.slice(0, -1) + (parsed.sig.endsWith("A") ? "B" : "A");
+    // Flip the FIRST character: all six of its bits map to real digest bits, so
+    // any change alters the decoded bytes. Do NOT tamper the LAST character —
+    // two of its bits are dropped on decode, so rewriting them leaves the bytes
+    // identical and this assertion fails ~1/16 of the time (Issue #401). The
+    // next test pins that decode behaviour so the reason stays visible.
+    const badSig = (parsed.sig.startsWith("A") ? "B" : "A") + parsed.sig.slice(1);
+    expect(badSig).not.toBe(parsed.sig);
     expect(verifySignature(parsed.payload, badSig, KEY)).toBe(false);
+  });
+
+  // Why the tamper above must not touch the last character (Issue #401): a
+  // 32-byte HMAC is 43 base64url chars, and 42 of them already carry 252 bits.
+  // The last char therefore holds only 4 significant bits plus 2 that decode
+  // drops, so rewriting those 2 produces a DIFFERENT STRING for the SAME BYTES.
+  // That is signature malleability (several encodings of one digest), not
+  // forgery — an attacker still needs the correct 32 bytes, and the nonce is in
+  // the payload — so verifySignature accepting it is correct, not a hole.
+  test("non-canonical signature encoding decodes to the same bytes and still verifies", () => {
+    const B64URL = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
+    const token = genToken("compact", "/Users/x/wt/issue-441");
+    const parsed = parseToken(token);
+    if (!parsed.ok) throw new Error("parse failed");
+    expect(parsed.sig).toHaveLength(43);
+
+    // A canonical 43rd char always lands on a 4-char boundary (low 2 bits zero),
+    // so the three chars after it re-encode the very same 32 bytes.
+    const lastIdx = B64URL.indexOf(parsed.sig.slice(-1));
+    expect(lastIdx % 4).toBe(0);
+    const nonCanonical = parsed.sig.slice(0, -1) + B64URL.charAt(lastIdx + 1);
+
+    expect(nonCanonical).not.toBe(parsed.sig);
+    expect(base64urlToBuffer(nonCanonical).equals(base64urlToBuffer(parsed.sig))).toBe(true);
+    expect(verifySignature(parsed.payload, nonCanonical, KEY)).toBe(true);
   });
 
   test("tampered payload (target swapped) fails verification", () => {


### PR DESCRIPTION
Closes #401

## 変更概要

`tests/action/token.test.ts` の `tampered signature fails verification` が約 1/16 の確率で FAIL していた問題を、改竄位置を **署名の先頭 1 文字** へ移して決定論化する。Issue の推奨案 A を採用。

### 原因（実測で確定）

HMAC-SHA256 は 32 バイト = base64url 43 文字。先頭 42 文字で既に 252 bit を担うため、**43 文字目の有効ビットは 4 bit しかなく、残り 2 bit は decode 時に捨てられる**。

修正前のテストは末尾 1 文字を `A` → `B` へ書き換えていたが、これは捨てられる 2 bit だけを変える操作だった。末尾が `A` の署名（確率 1/16）では decode 後のバイト列が完全に同一になり、改竄になっていない。`verifySignature` は正しく `true` を返し、`toBe(false)` が落ちていた。

### 修正内容

| 変更 | 内容 |
|---|---|
| 改竄位置 | 末尾 1 文字 → **先頭 1 文字**。先頭文字は 6 bit すべてが byte 0 の上位 6 bit に対応するため、書き換えれば必ず別のバイト列になる |
| ガード追加 | `expect(badSig).not.toBe(parsed.sig)` で「改竄後も文字列が同じ」を検知 |
| 説明テスト追加 | 非正準エンコードが同一バイト列へ decode され検証を通ることを明示（下記） |

`src/action/token.ts` は **変更していない**。問題はテストの改竄生成が不正確だったことであり、検証側の実装ではないため。

### セキュリティ影響: なし

末尾書き換えが通るのは署名の **malleability**（同一ダイジェストに対する複数のエンコード表現）であって forgery ではない。攻撃者は依然として正しい 32 バイトを必要とし、nonce はペイロード側にあり `consumeActionNonce` のワンタイム性も回避できない。

この挙動を放置すると将来また「なぜ末尾書き換えが通るのか」で混乱するため、`non-canonical signature encoding decodes to the same bytes and still verifies` として明示テスト化し、意図的な許容であることをコメントで残した。

## 併せて解消した別系統の flaky（AC-1 検証中に発見）

AC-1（50 回連続で FAIL 0 件）を実行したところ、**本件とは無関係な 2 つのテストが timeout で FAIL** した。

```
(fail) ... > round-trip against the real agent-base action-token.sh [5122.07ms]
(fail) action/token isExpired > token past iat+ttl is expired [5811.38ms]
  ^ this test timed out after 5000ms.
```

本ファイルの全テストは bash + openssl を spawn してトークンを生成し、round-trip テストは加えて git を 2 回叩くため、compute ではなく **subprocess bound**。round-trip ヘルパを 40 サンプル計測した結果:

| 区間 | min | p50 | p90 | max |
|---|---|---|---|---|
| git show ×2 | 270 | 986 | 2235 | 3969 ms |
| action-token.sh | 553 | 1347 | 2995 | 26701 ms |
| **合計** | 1272 | 2396 | **4972** | **30671 ms** |

p90 = 4972ms が bun の既定 5000ms とほぼ同値で、他に何も動かしていない状態でも 25 回に 1 回ほど timeout していた。個別テストへの timeout 付与は whack-a-mole になるため、`setDefaultTimeout(60_000)` でファイル単位の予算を引き上げた。**assertion もタイミング期待も変更していない。**

CI には `~/agent-base` が存在せず round-trip は skip されるため、この flaky は**ローカル限定**（CI は本 PR 前後で影響なし）。

> **未解明として残す点**: `action-token.sh` 区間に p50 1347ms に対し **26701ms** の外れ値がある。timeout 引き上げで FAIL は止まるが、この裾の原因（temp dir からの初回 exec に伴う macOS 側のスキャン等が疑わしいが未検証）は説明できていない。必要なら follow-up Issue を切ります。

## 検証結果

### 修正前の再現（実測）

決定論的再現（末尾が `A` の署名を探索）:

```
sig      : UJ6vXxM4v6cqJFpEPOdzvw9YULwnnCSFOUAkk9HQHsA (len 43)
badSig   : UJ6vXxM4v6cqJFpEPOdzvw9YULwnnCSFOUAkk9HQHsB
Expected : verifySignature(payload, badSig, KEY) === false
Actual   : verifySignature(payload, badSig, KEY) === true
```

テストスイート経由（64 回実行、左が回数・右が FAIL 件数）:

```
  58 0
   6 1
```

64 回中 6 回 FAIL = **9.4%**（理論値 6.25%）。

### 不変条件の確認（20000 サンプル）

修正が「FAIL 率を下げた」のではなく **決定論的である**ことを、ランダム 32 バイト 20000 件で確認した。

```
samples                              : 20000
sig length != 43                     : 0
first-char flip was a NO-OP (must 0) : 0
last char idx % 4 != 0 (must 0)      : 0
non-canonical bytes DIFFER (must 0)  : 0
```

反例 0 件。先頭文字の書き換えは**必ず**バイト列を変え、新規テストが依拠する「正準な 43 文字目は 4 文字境界に載る」という不変条件も常に成立する（= 新規テスト自体は flaky でない）。

## 統合ジャーニーAC 検証結果

| AC | 操作 | 期待 | 実測 | 判定 |
|---|---|---|---|---|
| AC-1 | 修正後に当該テストを 50 回連続実行 | 出力が `0` のみ（FAIL 0 件） | 50 回すべて `0`（sort -u の出力が `0` のみ） | **PASS** |
| AC-2 | 正規トークンで検証 | `valid openssl-generated token verifies with the shared key` が PASS | 1 pass / 0 fail | **PASS** |

AC-1 検証コマンド:

```bash
cd supervisor && for i in $(seq 50); do
  SUPERVISOR_DB_PATH=":memory:" bun test tests/action/token.test.ts 2>&1 | grep -c "^(fail)"
done | sort -u
```

## その他のチェック

| 項目 | コマンド | 結果 |
|---|---|---|
| 型チェック | `bunx tsc --noEmit` | exit 0（エラー 0 件） |
| CI gating lint | `bun scripts/lint-gating-coverage.ts` | 103 test files — 101 gated, 2 excluded, 0 ungated |
| 変更範囲 | `git diff --stat` | 1 file, +43 / -3（テストのみ。`src/` 無変更） |
| base 同期 | `git rebase origin/main` | ecf966b（origin/main 8e66feb 上、conflict なし）。rebase 後も 13 pass / 0 fail |
