### PR TITLE
fix: lint 回帰ガード 2 本に明示 timeout を設定して 5s 境界の flaky を解消する（#398）

### DIFF
--- a/supervisor/tests/scripts/lint-blocking-in-timers.test.ts
+++ b/supervisor/tests/scripts/lint-blocking-in-timers.test.ts
@@ -86,19 +86,19 @@ setTimeout(doWork, 100);`;
   });
 
   // Unlike the fixture cases above, this one parses the *whole* source tree with
-  // the TypeScript compiler — ~1.7s of CPU for today's 66 files, and it grows with
-  // the tree. Bun's 5000ms default left almost no headroom, so a loaded CI runner
-  // tipped it over and the guard failed for timing reasons rather than a real
-  // violation (Issue #398).
+  // the TypeScript compiler, so its cost scales with the tree rather than with a
+  // fixed fixture. That cost is small when it gets a CPU to itself — 115ms on a
+  // CI runner — but it is not what sets the wall time. CPU contention is: the same
+  // scan ran 5.2s on a developer machine at load average 30 and 37s at load 45,
+  // against Bun's 5000ms default. That is why the guard failed for timing reasons
+  // rather than for a real violation (Issue #398).
   //
-  // The budget is deliberately far above the measured cost. Wall time here is set
-  // by CPU contention, not by the work: the same scan measured ~1.7s of CPU but
-  // took 37s wall on a developer machine at load average 45. A tight budget also
-  // buys nothing, because this body is bounded CPU work with no I/O, timers, or
-  // network — it has no hang mode to catch, it either finishes or the machine is
-  // starved. So the number is chosen to swallow contention, not to bound the work.
-  // Only this test is widened; the fixture cases keep the 5s default so a genuine
-  // hang there still fails fast.
+  // So the budget below is sized to swallow contention, not to bound the work, and
+  // it is deliberately far above the cost of the scan itself. A tight budget buys
+  // nothing here anyway: this body is bounded CPU work with no I/O, timers, or
+  // network, so it has no hang mode to catch — it either finishes or the machine
+  // is starved. Only this test is widened; the fixture cases keep the 5s default
+  // so a genuine hang there still fails fast.
   test(
     "the production source tree is clean (regression guard)",
     async () => {

--- a/supervisor/tests/scripts/lint-blocking-in-timers.test.ts
+++ b/supervisor/tests/scripts/lint-blocking-in-timers.test.ts
@@ -85,15 +85,33 @@ setTimeout(doWork, 100);`;
     expect(v[0]!.callee).toBe("execSync");
   });
 
-  test("the production source tree is clean (regression guard)", async () => {
-    const { Glob } = await import("bun");
-    const files = [...new Glob("src/**/*.ts").scanSync(".")];
-    expect(files.length).toBeGreaterThan(0);
-    const all = [];
-    for (const f of files) {
-      const text = await Bun.file(f).text();
-      all.push(...lintSource(f, text));
-    }
-    expect(all).toEqual([]);
-  });
+  // Unlike the fixture cases above, this one parses the *whole* source tree with
+  // the TypeScript compiler — ~1.7s of CPU for today's 66 files, and it grows with
+  // the tree. Bun's 5000ms default left almost no headroom, so a loaded CI runner
+  // tipped it over and the guard failed for timing reasons rather than a real
+  // violation (Issue #398).
+  //
+  // The budget is deliberately far above the measured cost. Wall time here is set
+  // by CPU contention, not by the work: the same scan measured ~1.7s of CPU but
+  // took 37s wall on a developer machine at load average 45. A tight budget also
+  // buys nothing, because this body is bounded CPU work with no I/O, timers, or
+  // network — it has no hang mode to catch, it either finishes or the machine is
+  // starved. So the number is chosen to swallow contention, not to bound the work.
+  // Only this test is widened; the fixture cases keep the 5s default so a genuine
+  // hang there still fails fast.
+  test(
+    "the production source tree is clean (regression guard)",
+    async () => {
+      const { Glob } = await import("bun");
+      const files = [...new Glob("src/**/*.ts").scanSync(".")];
+      expect(files.length).toBeGreaterThan(0);
+      const all = [];
+      for (const f of files) {
+        const text = await Bun.file(f).text();
+        all.push(...lintSource(f, text));
+      }
+      expect(all).toEqual([]);
+    },
+    120_000
+  );
 });

--- a/supervisor/tests/scripts/lint-no-sync-exec.test.ts
+++ b/supervisor/tests/scripts/lint-no-sync-exec.test.ts
@@ -78,15 +78,25 @@ await execFileAsync("tmux", []);`;
     expect(lintSource("src/session/x.ts", src)).toHaveLength(0);
   });
 
-  test("the production src/session/** tree is clean (regression guard)", async () => {
-    const { Glob } = await import("bun");
-    const files = [...new Glob("src/session/**/*.ts").scanSync(".")];
-    expect(files.length).toBeGreaterThan(0);
-    const all = [];
-    for (const f of files) {
-      const text = await Bun.file(f).text();
-      all.push(...lintSource(f, text));
-    }
-    expect(all).toEqual([]);
-  });
+  // Same timing hazard, same reasoning as the sibling guard in
+  // lint-blocking-in-timers.test.ts (Issue #398): parsing all 49 src/session/**
+  // files with the TypeScript compiler is bounded CPU work that grows with the
+  // tree, Bun's 5000ms default gave it no headroom on a loaded runner, and the
+  // budget below is sized to swallow CPU contention rather than to bound the work.
+  // Widen only this test; the fixture cases above keep the 5s default.
+  test(
+    "the production src/session/** tree is clean (regression guard)",
+    async () => {
+      const { Glob } = await import("bun");
+      const files = [...new Glob("src/session/**/*.ts").scanSync(".")];
+      expect(files.length).toBeGreaterThan(0);
+      const all = [];
+      for (const f of files) {
+        const text = await Bun.file(f).text();
+        all.push(...lintSource(f, text));
+      }
+      expect(all).toEqual([]);
+    },
+    120_000
+  );
 });

--- a/supervisor/tests/scripts/lint-no-sync-exec.test.ts
+++ b/supervisor/tests/scripts/lint-no-sync-exec.test.ts
@@ -80,10 +80,11 @@ await execFileAsync("tmux", []);`;
 
   // Same timing hazard, same reasoning as the sibling guard in
   // lint-blocking-in-timers.test.ts (Issue #398): parsing all 49 src/session/**
-  // files with the TypeScript compiler is bounded CPU work that grows with the
-  // tree, Bun's 5000ms default gave it no headroom on a loaded runner, and the
-  // budget below is sized to swallow CPU contention rather than to bound the work.
-  // Widen only this test; the fixture cases above keep the 5s default.
+  // files with the TypeScript compiler is bounded CPU work that scales with the
+  // tree, and under CPU contention on a busy developer machine it overran Bun's
+  // 5000ms default even though it costs little on an uncontended runner. The
+  // budget below is sized to swallow that contention rather than to bound the
+  // work. Widen only this test; the fixture cases above keep the 5s default.
   test(
     "the production src/session/** tree is clean (regression guard)",
     async () => {


### PR DESCRIPTION
Closes #398

## 変更概要

CI の Unit Tests に gate されている lint 回帰ガード 2 本に、明示 timeout（120000ms）を設定した。Issue の**案 A（明示 timeout）**を採用。テストのみの変更で、production コードと lint の検出ロジックには一切触れていない。

- `supervisor/tests/scripts/lint-blocking-in-timers.test.ts`
- `supervisor/tests/scripts/lint-no-sync-exec.test.ts`

## 根本原因（実測）

両テストとも全ソースを走査して TypeScript コンパイラで parse するため、コストが固定 fixture ではなく**ソースツリーの規模に比例**する。内訳を CPU 時間で計測すると、支配項は parse:

| フェーズ | CPU 時間 |
|---|---|
| glob 走査 | 約 2ms |
| 66 ファイル読み込み | 約 80ms |
| **parse + AST 走査（`lintSource`）** | **約 1700ms**（高負荷・cold JIT 下での計測） |

ただし **wall time を決めているのは走査コストそのものではなく CPU の奪い合い**だった。同じ走査の実測値:

| 環境 | 実測 |
|---|---|
| CI ランナー（本 PR の Unit Tests ジョブ） | **115.42ms** |
| 開発機 load average 30 | 5.2s（＝5000ms 既定を超過して FAIL） |
| 開発機 load average 45 | **37.0s** |

つまり CI 専有環境では 115ms で終わる処理が、混雑した開発機では 5s 既定を突き抜ける。Issue 本文の 5004〜5643ms も、記載の再現手順どおりローカルの 2 ファイル実行で得られた値であり、本 PR の CI 実測（115ms）と整合する。

`test(name, fn, timeoutMs)` と既定 5000ms は、インストール済みの型定義 `node_modules/bun-types/test.d.ts`（398 行目・458-464 行目）で確認済み。

## 案 B / C を採らなかった理由

- **案 B（`Promise.all` で並列化）**: parse は同期 CPU 処理なので、await を並列化しても短縮できるのは読み込みの約 80ms のみ（全体約 1780ms のうち 4.5%）。効果がほぼない
- **案 C（キャッシュ）**: YAGNI

## timeout 値が 30000ms ではなく 120000ms である理由

Issue は例示として 30000ms を挙げていたが、**実測で不足**したため引き上げた。30000ms を設定した状態で再現ループを回したところ、負荷の高い開発機（load average 45）で当該ガードが **37026ms** に達して FAIL した。

上記のとおり wall time を決めているのは処理量ではなく **CPU の奪い合い**で、CI では 115ms の処理が同じコードのまま 37s まで伸びる。加えてこの本体は I/O もタイマーもネットワークも持たない**有界な CPU 処理**であり、hang するモードが無い（完了するか、マシンが飢餓状態かのどちらか）。したがって短い budget は欠陥検知にほぼ寄与せず、長い budget にコストもない。値は「処理量を縛る」ためではなく「CPU 競合を吸収する」ために選んでいる。

回帰ガード以外の fixture テストは **5s 既定のまま**据え置いた。そちらで本物の hang が起きた場合は従来どおり即座に落ちる。

## 統合ジャーニーAC の検証結果

| AC | 検証内容 | 結果 |
|---|---|---|
| AC-1 | 再現ループ 10 回で 2 テストとも 10/10 PASS | **PASS**（`(fail)` 0 件。load average 30 の環境で実施＝5s 既定でも 30s でも FAIL していた負荷条件） |
| AC-2 | 違反を一時混入させ、当該ガードが FAIL する（検知力の維持） | **PASS**（下記） |

AC-2 は `src/session/worktree.ts` に `setTimeout` 内 `execSync` を一時混入させて実行した。両ガードとも FAIL し、かつ**タイムアウトではなく assertion で**落ちたことを確認している:

```
error: expect(received).toEqual(expected)
+   {
+     "callee": "execSync",
+     "file": "src/session/worktree.ts",
+     "line": 454,
+   },
```

混入は検証後に revert 済み（`git status` で production 差分ゼロを確認）。

## その他の検証

- `bunx tsc --noEmit` → exit 0
- `bun scripts/lint-blocking-in-timers.ts` / `lint-no-sync-exec.ts` / `lint-gating-coverage.ts` → いずれも exit 0
- CI の Unit Tests 相当（99 ファイル）をローカル実行 → 変更した 2 ファイルの失敗は **0 件**

なお、ローカル実行では tmux アダプタ系など 32 件が FAIL したが、これらは**本変更前の baseline で 40 件 FAIL**しており（同一ファイル群）、macOS のパス差と高負荷による既存の環境要因。`main` の直近 CI は 3 回連続 success で、CI 上では発生していない。本 PR とは無関係のため起票不要と判断した。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * TypeScriptソース全体を対象とする回帰テストを非同期形式に変更しました。
  * ソース解析テストのタイムアウトを120秒に延長し、CPU負荷による実行時間の変動に対応しました。
  * テスト間のタイムアウト設定の違いを説明するコメントを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->