### PR TITLE
feat(relay): 朝レポ配信を契機に CEO セッションへ決裁を問わせる受け口を追加（#426）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,6 +188,7 @@ jobs:
                    tests/session/dispatch-integration.test.ts \
                    tests/session/dispatch-headless.test.ts \
                    tests/session/dispatch-report.test.ts \
+                   tests/session/corp-brief.test.ts \
                    tests/session/artifact-probe.test.ts \
                    tests/session/orchestrate.test.ts \
                    tests/session/adapters-executor.test.ts \

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -1357,19 +1357,20 @@ export async function startBot(token: string): Promise<void> {
         return true;
 
       case "ambiguous":
-        // Two or more running sessions on this channel: which one is "the CEO"
-        // is not decidable from here, and guessing would inject HQ instructions
-        // into the wrong session. Refuse and report (AC-3 applies equally).
+        // Two or more candidate sessions remain after the orchestrator filter:
+        // which one is "the CEO" is not decidable from here, and guessing would
+        // inject HQ instructions into the wrong session. Refuse and report
+        // (AC-3 applies equally — this must not fail silently either).
         console.warn(
-          `[Bot] Brief ambiguous in channel ${channelName} (date=${decision.date}, running=${decision.count}); not injected`
+          `[Bot] Brief ambiguous in channel ${channelName} (date=${decision.date}, candidates=${decision.count}); not injected`
         );
         await postToChannel(
-          `⚠️ 朝レポ（${decision.date}）の着信を受けましたが、**${config.displayName}** で ${decision.count} 件のセッションが稼働中のため投入先を特定できません。\n` +
+          `⚠️ 朝レポ（${decision.date}）の着信を受けましたが、**${config.displayName}** で投入先候補が ${decision.count} 件あるため特定できません。\n` +
             `不要なセッションを停止してから再送してください（決裁は未実行です）。`
         );
         notifyPushover(
           "朝レポの決裁依頼が未達",
-          `#${channelName} で ${decision.count} 件のセッションが稼働中のため ${decision.date} の朝レポ決裁の投入先を特定できませんでした。`
+          `#${channelName} で投入先候補が ${decision.count} 件あるため ${decision.date} の朝レポ決裁を投入できませんでした。`
         ).catch((err) =>
           console.warn("[Bot] brief ambiguous pushover failed:", err)
         );

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -87,6 +87,11 @@ import {
 } from "./session/dispatch";
 import { DispatchQueue } from "./session/dispatch-queue";
 import {
+  BRIEF_DISABLED_ENV,
+  evaluateBriefTrigger,
+  isBriefCommand,
+} from "./session/corp-brief";
+import {
   ORCHESTRATE_PREFIX,
   parseOrchestrateCommand,
   runOrchestrate,
@@ -1247,6 +1252,185 @@ export async function startBot(token: string): Promise<void> {
     }
   }
 
+  // Issue #426: handle a `/brief <YYYY-MM-DD>` message from an allowed external
+  // source (corp's dispatch bot) — wake the channel's ALREADY RUNNING session so
+  // it puts the morning brief's proposals to the chairman (corp#112 AC-1).
+  // Returns true when the message was a brief attempt and was fully handled
+  // (caller must stop), false when it is not a brief and normal processing
+  // should continue.
+  //
+  // This is the second exception to the blanket `message.author.bot` drop, and
+  // it is deliberately the SAME shape and the SAME authorization as
+  // handleDispatchMessage (`isDispatchSourceAllowed`, fail-closed) — a new
+  // authorization model would be a new way to get it wrong. Two things make it
+  // strictly weaker than dispatch, by design:
+  //   - it starts no session (it only injects into one that is already running);
+  //   - it accepts no caller text. The single external input is a `YYYY-MM-DD`
+  //     token; the injected sentence is a fixed template built in corp-brief.ts.
+  //     That is what stops this path from becoming a way to hand the HQ session
+  //     arbitrary instructions and bypass the approval gate.
+  async function handleBriefMessage(message: Message): Promise<boolean> {
+    // Same entry shape as dispatch: a non-thread message in a known channel
+    // whose text starts with the trigger token.
+    if (message.channel.isThread()) return false;
+    const content = message.content ?? "";
+    if (!isBriefCommand(content)) return false;
+
+    const channelName =
+      "name" in message.channel ? (message.channel.name as string) : "";
+    const config = CHANNEL_MAP.get(channelName);
+    if (!config) {
+      // Unknown channel: not a valid brief target. Treat as "not handled" so a
+      // non-bot author still flows through normal processing; a bot author is
+      // dropped by the caller's bot guard.
+      return false;
+    }
+
+    // All of the decision logic (kill-switch → authorization → parse → target
+    // resolution, in that order) lives in the pure evaluator so it is testable
+    // without a gateway or a real SessionManager. Only the side effects are here.
+    const decision = evaluateBriefTrigger({
+      content,
+      channelId: message.channel.id,
+      sourceId: message.author.id,
+      policy: loadAccessPolicy(),
+      sessions: sessionManager.listRunningByChannel(channelName),
+    });
+
+    const textChannel = message.channel as TextChannel;
+    const postToChannel = async (text: string): Promise<void> => {
+      try {
+        await textChannel.send(text);
+      } catch (err) {
+        console.error(
+          `[Bot] Brief notice failed in channel ${channelName}:`,
+          err
+        );
+      }
+    };
+
+    switch (decision.action) {
+      case "ignore":
+        return false;
+
+      case "disabled":
+        console.warn(
+          `[Bot] Brief disabled by kill-switch (${BRIEF_DISABLED_ENV}) in channel ${channelName}; not injected`
+        );
+        return true;
+
+      case "denied":
+        // Identifier-free denial log; never log the source/channel snowflake or
+        // the message body. Consume the message either way: by here it is a
+        // `/brief` in a known channel, which the normal relay path never acts on.
+        console.warn(
+          `[Bot] Brief denied (reason=${decision.reason}) in channel ${channelName}; not injected`
+        );
+        return true;
+
+      case "rejected":
+        // The source is authorized but the command is malformed. `reason` is a
+        // fixed literal from the parser (never echoed user text).
+        console.warn(
+          `[Bot] Brief rejected in channel ${channelName}: ${decision.reason}`
+        );
+        await postToChannel(`⚠️ ${decision.reason}`);
+        return true;
+
+      case "no_session":
+        // AC-3: must not fail silently. The brief arrived but there was nobody
+        // to hand it to — say so on the channel and page, so a stopped CEO
+        // session is noticed the same morning instead of days later.
+        console.warn(
+          `[Bot] Brief undeliverable in channel ${channelName} (date=${decision.date}): no running session`
+        );
+        await postToChannel(
+          `⚠️ 朝レポ（${decision.date}）の着信を受けましたが、**${config.displayName}** の稼働中セッションがありません。\n` +
+            `\`/session start <branch>\` で起動してから再送してください（決裁は未実行です）。`
+        );
+        notifyPushover(
+          "朝レポの決裁依頼が未達",
+          `#${channelName} に稼働中セッションが無いため ${decision.date} の朝レポ決裁を依頼できませんでした。`
+        ).catch((err) =>
+          console.warn("[Bot] brief no-session pushover failed:", err)
+        );
+        return true;
+
+      case "ambiguous":
+        // Two or more running sessions on this channel: which one is "the CEO"
+        // is not decidable from here, and guessing would inject HQ instructions
+        // into the wrong session. Refuse and report (AC-3 applies equally).
+        console.warn(
+          `[Bot] Brief ambiguous in channel ${channelName} (date=${decision.date}, running=${decision.count}); not injected`
+        );
+        await postToChannel(
+          `⚠️ 朝レポ（${decision.date}）の着信を受けましたが、**${config.displayName}** で ${decision.count} 件のセッションが稼働中のため投入先を特定できません。\n` +
+            `不要なセッションを停止してから再送してください（決裁は未実行です）。`
+        );
+        notifyPushover(
+          "朝レポの決裁依頼が未達",
+          `#${channelName} で ${decision.count} 件のセッションが稼働中のため ${decision.date} の朝レポ決裁の投入先を特定できませんでした。`
+        ).catch((err) =>
+          console.warn("[Bot] brief ambiguous pushover failed:", err)
+        );
+        return true;
+
+      case "inject": {
+        console.log(
+          `[Bot] Brief accepted in channel ${channelName} (date=${decision.date}, thread=${decision.threadId})`
+        );
+        // Non-blocking on purpose: sendMessage waits for the session's Stop hook
+        // (minutes), so awaiting it inside the gateway handler would stall
+        // MessageCreate — the same reason dispatch hands off to its queue rather
+        // than awaiting runDispatch. enqueueForThread also keeps this ordered
+        // against a concurrent user message in that thread (one relay at a time).
+        enqueueForThread(decision.threadId, async () => {
+          // Discord I/O is best-effort here and never aborts the injection: a
+          // failed post must not cost us the wake-up itself (the whole point of
+          // the trigger). Failures are logged, never swallowed.
+          const channel = await client.channels
+            .fetch(decision.threadId)
+            .catch((err: unknown) => {
+              console.error(
+                `[Bot] Brief thread fetch failed for ${decision.threadId}:`,
+                err
+              );
+              return null;
+            });
+          const send = async (text: string): Promise<void> => {
+            if (!channel?.isThread()) return;
+            try {
+              await channel.send(text);
+            } catch (err) {
+              console.error(
+                `[Bot] Brief post failed in thread ${decision.threadId}:`,
+                err
+              );
+            }
+          };
+          // Marker first: the wake-up is observable in the thread even if the
+          // session answers slowly (or the relay later errors).
+          await send(
+            `📣 朝レポ（${decision.date}）の着信を受け、CEO セッションへ決裁の確認を依頼します。`
+          );
+          const result = await sessionManager.sendMessage(
+            decision.threadId,
+            decision.text
+          );
+          if (result.error) {
+            console.error(
+              `[Bot] Brief relay error in thread ${decision.threadId}: ${result.error}`
+            );
+          }
+          for (const chunk of result.chunks) {
+            if (chunk.trim()) await send(chunk);
+          }
+        });
+        return true;
+      }
+    }
+  }
+
   // Message relay: thread messages → Claude Code → thread reply
   const handleMessageCreate = async (message: Message): Promise<void> => {
     // Issue #32 / S7 (dispatch transport): intercept `/dispatch` from an allowed
@@ -1268,6 +1452,18 @@ export async function startBot(token: string): Promise<void> {
       if (await handleOrchestrateMessage(message)) return;
     } catch (err) {
       console.error("[Bot] Orchestrate handler error:", err);
+      return;
+    }
+
+    // Issue #426: intercept `/brief` from an allowed external source BEFORE the
+    // blanket bot/webhook drop below (same shape as the dispatch intercept).
+    // Without this, corp's morning brief can never reach the CEO session and
+    // corp#112's AC-1 (tap-to-decide) has no trigger. Fail-closed inside
+    // handleBriefMessage via isDispatchSourceAllowed (access.json `dispatchFrom`).
+    try {
+      if (await handleBriefMessage(message)) return;
+    } catch (err) {
+      console.error("[Bot] Brief handler error:", err);
       return;
     }
 

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -54,6 +54,7 @@ import {
   onAskUser,
   onAskExpired,
   hasPendingAsk,
+  hasRecentAsk,
   resolveAskUser,
   askExpiredNotice,
 } from "./session/relay-server";
@@ -90,6 +91,7 @@ import {
   BRIEF_DISABLED_ENV,
   evaluateBriefTrigger,
   isBriefCommand,
+  type RecentBrief,
 } from "./session/corp-brief";
 import {
   ORCHESTRATE_PREFIX,
@@ -1252,6 +1254,12 @@ export async function startBot(token: string): Promise<void> {
     }
   }
 
+  // Issue #426: the last brief injected per channel, for the (channel, date)
+  // idempotency guard. In-memory on purpose: it only has to outlive corp's
+  // delivery retries (minutes), and a Supervisor restart re-arming the trigger
+  // is the safer failure direction than persisting a stale "already delivered".
+  const recentBriefByChannel = new Map<string, RecentBrief>();
+
   // Issue #426: handle a `/brief <YYYY-MM-DD>` message from an allowed external
   // source (corp's dispatch bot) — wake the channel's ALREADY RUNNING session so
   // it puts the morning brief's proposals to the chairman (corp#112 AC-1).
@@ -1286,15 +1294,23 @@ export async function startBot(token: string): Promise<void> {
       return false;
     }
 
-    // All of the decision logic (kill-switch → authorization → parse → target
-    // resolution, in that order) lives in the pure evaluator so it is testable
-    // without a gateway or a real SessionManager. Only the side effects are here.
+    // All of the decision logic (kill-switch → authorization → parse →
+    // idempotency → target resolution → ask guard, in that order) lives in the
+    // pure evaluator so it is testable without a gateway or a real
+    // SessionManager. Only the side effects are here.
     const decision = evaluateBriefTrigger({
       content,
       channelId: message.channel.id,
       sourceId: message.author.id,
       policy: loadAccessPolicy(),
       sessions: sessionManager.listRunningByChannel(channelName),
+      // `hasRecentAsk`, not `hasPendingAsk`: the TUI dialog the ask hook falls
+      // back to appears AFTER the ask settles, so `hasPendingAsk` alone is false
+      // at exactly the moment a dangerous dialog is on screen
+      // (relay-server.ts). This path types into the pane — and `sendToPane`
+      // leads with Escape — so it takes the wider of the two windows.
+      askPending: hasRecentAsk,
+      recentBrief: recentBriefByChannel.get(channelName),
     });
 
     const textChannel = message.channel as TextChannel;
@@ -1317,6 +1333,13 @@ export async function startBot(token: string): Promise<void> {
         console.warn(
           `[Bot] Brief disabled by kill-switch (${BRIEF_DISABLED_ENV}) in channel ${channelName}; not injected`
         );
+        // The kill-switch is a deliberate operator action, but corp cannot see
+        // this Supervisor's env — from its side the post would just vanish.
+        // Same "never fail silently" bar as no_session / ambiguous, minus the
+        // page (nothing is broken).
+        await postToChannel(
+          `🛑 朝レポの決裁依頼は kill-switch（\`${BRIEF_DISABLED_ENV}\`）で停止中のため実行しませんでした。`
+        );
         return true;
 
       case "denied":
@@ -1337,6 +1360,43 @@ export async function startBot(token: string): Promise<void> {
         await postToChannel(`⚠️ ${decision.reason}`);
         return true;
 
+      case "duplicate":
+        // Idempotency: corp retrying its delivery (or a manual re-post) must not
+        // interrupt the running conversation twice for the same day. Not a
+        // failure — the brief WAS delivered — so it is logged and posted but
+        // never paged.
+        console.log(
+          `[Bot] Brief already delivered in channel ${channelName} (date=${decision.date}, ${Math.round(decision.elapsedMs / 1000)}s ago); not injected again`
+        );
+        await postToChannel(
+          `ℹ️ 朝レポ（${decision.date}）の決裁依頼は既に実行済みのため、二重の割り込みを避けて見送りました。`
+        );
+        return true;
+
+      case "deferred":
+        // The one capability /dispatch and /orchestrate do not have: this types
+        // into a session that was ALREADY running, whose state we do not own.
+        // While an AskUserQuestion is outstanding the chairman may be mid-decision,
+        // and `sendToPane` leads with Escape — injecting here could discard a
+        // pending decision (or worse, answer it) with the chairman not present.
+        // The human relay path refuses the same way (#370), so this does too.
+        console.warn(
+          `[Bot] Brief deferred in channel ${channelName} (date=${decision.date}, thread=${decision.threadId}): an AskUserQuestion is outstanding; not injected`
+        );
+        await postToChannel(
+          `⏸️ 朝レポ（${decision.date}）の決裁依頼を見送りました。**${config.displayName}** が会長の回答待ち（AskUserQuestion）のため、` +
+            `割り込むと保留中の決裁を壊すおそれがあります。\n` +
+            `先に保留中の質問へ回答してください。回答後、朝レポの決裁が必要なら会長がスレッドで指示してください` +
+            `（corp は自動で再送しません）。`
+        );
+        notifyPushover(
+          "朝レポの決裁依頼を見送り",
+          `#${channelName} が回答待ちのため ${decision.date} の朝レポ決裁を投入しませんでした。保留中の質問に回答してください。`
+        ).catch((err) =>
+          console.warn("[Bot] brief deferred pushover failed:", err)
+        );
+        return true;
+
       case "no_session":
         // AC-3: must not fail silently. The brief arrived but there was nobody
         // to hand it to — say so on the channel and page, so a stopped CEO
@@ -1344,9 +1404,13 @@ export async function startBot(token: string): Promise<void> {
         console.warn(
           `[Bot] Brief undeliverable in channel ${channelName} (date=${decision.date}): no running session`
         );
+        // Addressed to the chairman, not to corp: corp posted this trigger and
+        // will not post it again on its own, so "resend it" would be an
+        // instruction with nobody to carry it out. Say what a human can do.
         await postToChannel(
-          `⚠️ 朝レポ（${decision.date}）の着信を受けましたが、**${config.displayName}** の稼働中セッションがありません。\n` +
-            `\`/session start <branch>\` で起動してから再送してください（決裁は未実行です）。`
+          `⚠️ 朝レポ（${decision.date}）の着信を受けましたが、**${config.displayName}** の稼働中セッションがありません（決裁は未実行）。\n` +
+            `\`/session start <branch>\` で起動したうえで、スレッドで朝レポの決裁を指示してください。` +
+            `corp は自動で再送しません。`
         );
         notifyPushover(
           "朝レポの決裁依頼が未達",
@@ -1365,8 +1429,8 @@ export async function startBot(token: string): Promise<void> {
           `[Bot] Brief ambiguous in channel ${channelName} (date=${decision.date}, candidates=${decision.count}); not injected`
         );
         await postToChannel(
-          `⚠️ 朝レポ（${decision.date}）の着信を受けましたが、**${config.displayName}** で投入先候補が ${decision.count} 件あるため特定できません。\n` +
-            `不要なセッションを停止してから再送してください（決裁は未実行です）。`
+          `⚠️ 朝レポ（${decision.date}）の着信を受けましたが、**${config.displayName}** で投入先候補が ${decision.count} 件あるため特定できません（決裁は未実行）。\n` +
+            `不要なセッションを停止したうえで、スレッドで朝レポの決裁を指示してください。corp は自動で再送しません。`
         );
         notifyPushover(
           "朝レポの決裁依頼が未達",
@@ -1380,6 +1444,15 @@ export async function startBot(token: string): Promise<void> {
         console.log(
           `[Bot] Brief accepted in channel ${channelName} (date=${decision.date}, thread=${decision.threadId})`
         );
+        // Recorded at DECISION time, not after the relay resolves: the relay
+        // takes minutes, and a retry arriving in that window is exactly the
+        // double-interruption this guards against. Only the `inject` branch
+        // records, so a brief that ended as deferred / no_session stays
+        // re-triggerable.
+        recentBriefByChannel.set(channelName, {
+          date: decision.date,
+          atMs: Date.now(),
+        });
         // Non-blocking on purpose: sendMessage waits for the session's Stop hook
         // (minutes), so awaiting it inside the gateway handler would stall
         // MessageCreate — the same reason dispatch hands off to its queue rather

--- a/supervisor/src/session/corp-brief.ts
+++ b/supervisor/src/session/corp-brief.ts
@@ -24,7 +24,9 @@
  *      これが「本社セッションへ任意の指示を注入して承認ゲートを迂回する」ことに対する
  *      主防御になる。レポート本文は CEO セッションが自分で `~/corp` から読む。
  *   4. 投入先スレッドは `listRunningByChannel(<channel>)` で**決定的に**解決する。
- *      ちょうど 1 件のときだけ注入し、0 件 / 2 件以上は注入せず通知する（推測で選ばない）。
+ *      オーケストレーター（branch が `orchestrate-` 始まり）だけは機械的な印で
+ *      候補から除き（{@link selectBriefTargets}）、残りがちょうど 1 件のときだけ
+ *      注入する。0 件 / 2 件以上は注入せず通知する（推測で選ばない）。
  *
  * *誰が* トリガーできるかは access policy 側の設定であり、本モジュールは corp 固有の
  * 送信元を一切ハードコードしない（`dispatch.ts` と同じ方針）。#corp が最初の利用者
@@ -41,6 +43,7 @@ import {
   type AccessPolicy,
   type DispatchDecisionReason,
 } from "../config/access-policy";
+import { ORCHESTRATE_BRANCH_PREFIX } from "./orchestrate";
 
 /** リテラルのトリガートークン。corp 側が同じ文字列を post する。 */
 export const BRIEF_PREFIX = "/brief";
@@ -149,6 +152,28 @@ export function buildBriefInjection(date: string): string {
 /** 投入先候補セッションの最小面（実 SessionInfo が構造的に満たす）。 */
 export interface BriefSessionRef {
   threadId: string;
+  branch?: string;
+}
+
+/**
+ * 投入先の候補から、CEO セッションでないと**決定的に**判る行を除く。
+ *
+ * `listRunningByChannel` は channelName と status でしか絞らないため、#corp では
+ * `/orchestrate` で起動したオーケストレーター（branch が
+ * {@link ORCHESTRATE_BRANCH_PREFIX} 始まり）も同じ候補集合に入る。これを残すと
+ * CEO セッションとの同時稼働で毎回 `ambiguous`（＝朝レポ未達）になる。
+ *
+ * 除外の根拠は `orchestrateBranchName()` が付ける固定 prefix という**機械的な印**
+ * だけに限る（推測でセッションを選り分けない）。それ以外の候補が複数残る場合は
+ * 従来どおり `ambiguous` に倒す。hub work セッションは channelName が
+ * `claude-hub-work` なので、そもそも #corp の候補に入らない。
+ */
+export function selectBriefTargets(
+  sessions: readonly BriefSessionRef[],
+): BriefSessionRef[] {
+  return sessions.filter(
+    (s) => !(s.branch ?? "").startsWith(ORCHESTRATE_BRANCH_PREFIX),
+  );
 }
 
 export interface BriefTriggerInput {
@@ -229,7 +254,7 @@ export function evaluateBriefTrigger(input: BriefTriggerInput): BriefDecision {
   }
 
   const { date } = parsed;
-  const sessions = input.sessions;
+  const sessions = selectBriefTargets(input.sessions);
   if (sessions.length === 0) {
     return { action: "no_session", date };
   }

--- a/supervisor/src/session/corp-brief.ts
+++ b/supervisor/src/session/corp-brief.ts
@@ -1,0 +1,246 @@
+/**
+ * 朝レポ契機の CEO セッション起こし（#426 / corp#112 の AC-1）。
+ *
+ * corp が朝レポ（CEO 提案 `[D1]..[Dn]`）を #corp へ配信しても、`bot.ts` の
+ * `if (message.author.bot) return;` が bot / webhook のメッセージを一律 drop する
+ * ため、corp スレッドで稼働中の CEO セッションは「朝レポが来た」ことを知れない。
+ * その結果「朝レポ → CEO が決裁を問う → 会長がタップ → 決裁実行」というジャーニーが
+ * 起点で成立しない（#412 のボタン UI / #416 の回答待ちが揃っても、質問を発生させる
+ * 主体が居ない）。
+ *
+ * 本モジュールはその受け口を、**既存 `/dispatch` と同じ認可・同じ入口形状**で用意する:
+ *
+ *   1. トリガーは既知チャンネルの**非スレッド**メッセージ `/brief <YYYY-MM-DD>`。
+ *      corp の朝レポ配信 webhook ではなく、corp の **dispatch bot**（別 identity）が
+ *      post する。webhook URL はそれ自体が bearer credential であり、かつ自由文の
+ *      レポート本文を運ぶ経路でもあるため、権限（トリガー）と内容（本文）を別
+ *      identity に分けておく。
+ *   2. 認可は {@link isDispatchSourceAllowed} を**そのまま**再利用する。policy 不在 /
+ *      channel 未登録 / `dispatchFrom` 未列挙 の 3 つの deny がそのまま効く
+ *      （fail-closed）。新しい認可モデルを書かない = 新しい抜け道を作らない。
+ *   3. **セッションへ注入する文字列は claude-hub が組み立て、自由文を一切受け取らない**。
+ *      外部から受け取るのは `YYYY-MM-DD` という閉じたトークン 1 個だけで、
+ *      `/dispatch <branch> <N>` → `/impl <N>` を claude-hub 側で構築するのと同型。
+ *      これが「本社セッションへ任意の指示を注入して承認ゲートを迂回する」ことに対する
+ *      主防御になる。レポート本文は CEO セッションが自分で `~/corp` から読む。
+ *   4. 投入先スレッドは `listRunningByChannel(<channel>)` で**決定的に**解決する。
+ *      ちょうど 1 件のときだけ注入し、0 件 / 2 件以上は注入せず通知する（推測で選ばない）。
+ *
+ * *誰が* トリガーできるかは access policy 側の設定であり、本モジュールは corp 固有の
+ * 送信元を一切ハードコードしない（`dispatch.ts` と同じ方針）。#corp が最初の利用者
+ * というだけで、機構としては CHANNEL_MAP に載っている任意のチャンネルで動く。
+ *
+ * 判断はすべて純関数 {@link evaluateBriefTrigger} に閉じており、Discord ゲートウェイも
+ * 実 SessionManager も無しで単体テストできる。副作用（注入・通知・投稿）は呼び出し元
+ * （bot.ts）が持つ。
+ */
+
+import {
+  envDispatchAllowedSourceIds,
+  isDispatchSourceAllowed,
+  type AccessPolicy,
+  type DispatchDecisionReason,
+} from "../config/access-policy";
+
+/** リテラルのトリガートークン。corp 側が同じ文字列を post する。 */
+export const BRIEF_PREFIX = "/brief";
+
+/** kill-switch の env 名（corp 側 `CORP_DISPATCH_DISABLED` と対称）。 */
+export const BRIEF_DISABLED_ENV = "CORP_BRIEF_DISABLED";
+
+/** `YYYY-MM-DD` の形式チェック（実在日かどうかは別途カレンダー検証する）。 */
+const BRIEF_DATE_RE = /^(\d{4})-(\d{2})-(\d{2})$/;
+
+/**
+ * この経路を止める kill-switch。`CORP_BRIEF_DISABLED` が空文字 / `0` 以外なら停止。
+ * 「止める」方向は安全側なので、値の細かな解釈で迷わないよう緩めに判定する。
+ */
+export function isBriefDisabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const raw = (env[BRIEF_DISABLED_ENV] ?? "").trim();
+  return raw.length > 0 && raw !== "0";
+}
+
+/**
+ * `/brief` トークンで始まるメッセージか（`/briefing` などは対象外）。認可より前に
+ * 走る安価な早期判定で、無関係なメッセージで access policy を読まないためにある。
+ */
+export function isBriefCommand(content: string): boolean {
+  const trimmed = content.trim();
+  return trimmed === BRIEF_PREFIX || trimmed.startsWith(BRIEF_PREFIX + " ");
+}
+
+export type ParsedBrief =
+  | { kind: "ok"; date: string }
+  | { kind: "not_brief" }
+  | { kind: "error"; reason: string };
+
+/**
+ * 実在する日付か。`2026-02-30` のような「形式は合っているが存在しない日」を弾く。
+ * UTC で組み立ててからフィールドが保存されているかを見る（`new Date("2026-02-30")`
+ * のような文字列パースはランタイム差でロールオーバーするため使わない）。
+ */
+function isRealDate(token: string): boolean {
+  const m = BRIEF_DATE_RE.exec(token);
+  if (!m) return false;
+  const year = Number(m[1]);
+  const month = Number(m[2]);
+  const day = Number(m[3]);
+  const dt = new Date(Date.UTC(year, month - 1, day));
+  return (
+    dt.getUTCFullYear() === year &&
+    dt.getUTCMonth() === month - 1 &&
+    dt.getUTCDate() === day
+  );
+}
+
+/**
+ * `/brief <YYYY-MM-DD>` を厳格にパースする。引数は日付 1 個**だけ**で、それ以外は
+ * すべて error（fail-closed）。自由文を通す余地をここで断つのが本モジュールの要。
+ */
+export function parseBriefCommand(content: string): ParsedBrief {
+  if (!isBriefCommand(content)) return { kind: "not_brief" };
+
+  const rest = content.trim().slice(BRIEF_PREFIX.length).trim();
+  const parts = rest.length > 0 ? rest.split(/\s+/) : [];
+
+  if (parts.length === 0) {
+    return {
+      kind: "error",
+      reason: `日付が指定されていません（${BRIEF_PREFIX} <YYYY-MM-DD>）。`,
+    };
+  }
+  if (parts.length > 1) {
+    // 追加トークンを黙って捨てると「自由文を渡したつもり」が通ったように見える。
+    // 拒否して呼び出し元に気付かせる。
+    return {
+      kind: "error",
+      reason: `引数は日付 1 つだけです（${BRIEF_PREFIX} <YYYY-MM-DD>）。`,
+    };
+  }
+  const date = parts[0] as string;
+  if (!isRealDate(date)) {
+    return {
+      kind: "error",
+      reason: "日付は YYYY-MM-DD 形式（実在する日付）で指定してください。",
+    };
+  }
+  return { kind: "ok", date };
+}
+
+/**
+ * セッションへ注入する文字列を組み立てる。**外部入力は検証済みの `date` だけ**で、
+ * 残りは固定リテラル。`date` は {@link BRIEF_DATE_RE} を通過した数字とハイフンのみ
+ * なので、テンプレートへ埋めても指示文を注入できない。
+ *
+ * relay は `tmux send-keys -l` の途中送信を避けるため改行を空白へ潰す
+ * （`relay.ts` flattenForSendKeys）。潰される前提に依存しないよう最初から 1 行で作る。
+ */
+export function buildBriefInjection(date: string): string {
+  return (
+    `【朝レポ着信 ${date}】corp の朝レポ配信を claude-hub が検知しました。` +
+    `~/corp の ${date} 分の朝レポ（CEO 提案 [D1]..[Dn]）を読み、` +
+    `どの提案を承認するかを AskUserQuestion で会長に問うてください。` +
+    `会長の回答を得るまで、dispatch など承認を要する操作は実行しないこと。`
+  );
+}
+
+/** 投入先候補セッションの最小面（実 SessionInfo が構造的に満たす）。 */
+export interface BriefSessionRef {
+  threadId: string;
+}
+
+export interface BriefTriggerInput {
+  /** 受信メッセージ本文。 */
+  content: string;
+  /** 送信先チャンネルの snowflake（access policy のキー）。 */
+  channelId: string;
+  /** 送信元（bot / webhook）の snowflake。 */
+  sourceId: string;
+  /** 読み込み済み access policy。`null` = 読めなかった（fail-closed で deny）。 */
+  policy: AccessPolicy | null;
+  /** 当該チャンネルで running のセッション（`listRunningByChannel` の結果）。 */
+  sessions: BriefSessionRef[];
+  /** kill-switch 判定用。省略時 `process.env`。 */
+  env?: Record<string, string | undefined>;
+  /** `DISPATCH_ALLOWED_SOURCE_IDS` 相当。省略時 env から読む（dispatch と共用）。 */
+  envAllowedSourceIds?: string[];
+}
+
+/**
+ * 判定結果。副作用は持たず、呼び出し元がこの action に応じて実行する。
+ * `ignore` 以外はすべて「メッセージを消費した（通常処理へ流さない）」を意味する。
+ */
+export type BriefDecision =
+  /** `/brief` ではない → 通常処理へ流す。 */
+  | { action: "ignore" }
+  /** kill-switch で停止中。 */
+  | { action: "disabled" }
+  /** 認可されない送信元 / チャンネル（fail-closed）。reason は粗い enum のみ。 */
+  | { action: "denied"; reason: DispatchDecisionReason }
+  /** 認可済みだがコマンドが不正。 */
+  | { action: "rejected"; reason: string }
+  /** 注入する（対象スレッドがちょうど 1 件）。 */
+  | { action: "inject"; date: string; threadId: string; text: string }
+  /** 稼働中セッションが無い → 注入せず通知（サイレントに落とさない）。 */
+  | { action: "no_session"; date: string }
+  /** 稼働中セッションが複数 → 曖昧なので注入せず通知（推測で選ばない）。 */
+  | { action: "ambiguous"; date: string; count: number };
+
+/**
+ * トリガーの可否と投入先を決める純関数。評価順は次で固定する:
+ *
+ *   1. `/brief` か（安価な形式判定。違えば policy を読まない）
+ *   2. kill-switch
+ *   3. **認可**（fail-closed。ここを通らなければパースもしない）
+ *   4. コマンドのパース（自由文を拒否）
+ *   5. 投入先スレッドの決定（1 件のときだけ inject）
+ *
+ * 3 が 4 より先なのは既存 `handleDispatchMessage` と同じ順序で、認可されない送信元の
+ * 入力を一切解釈しないため（`tests/guards/access-enforcement-wired.test.ts` が
+ * dispatch と同様にこの順序を固定する）。
+ */
+export function evaluateBriefTrigger(input: BriefTriggerInput): BriefDecision {
+  if (!isBriefCommand(input.content)) return { action: "ignore" };
+
+  if (isBriefDisabled(input.env ?? process.env)) {
+    return { action: "disabled" };
+  }
+
+  const decision = isDispatchSourceAllowed(
+    input.policy,
+    input.channelId,
+    input.sourceId,
+    input.envAllowedSourceIds ?? envDispatchAllowedSourceIds(),
+  );
+  if (!decision.allowed) {
+    return { action: "denied", reason: decision.reason };
+  }
+
+  const parsed = parseBriefCommand(input.content);
+  if (parsed.kind === "not_brief") {
+    // isBriefCommand を通った以上ここへは来ないが、fail-closed に倒す
+    // （黙って通常処理へ流さない）。
+    return { action: "rejected", reason: "コマンド形式が不正です。" };
+  }
+  if (parsed.kind === "error") {
+    return { action: "rejected", reason: parsed.reason };
+  }
+
+  const { date } = parsed;
+  const sessions = input.sessions;
+  if (sessions.length === 0) {
+    return { action: "no_session", date };
+  }
+  if (sessions.length > 1) {
+    return { action: "ambiguous", date, count: sessions.length };
+  }
+
+  return {
+    action: "inject",
+    date,
+    threadId: (sessions[0] as BriefSessionRef).threadId,
+    text: buildBriefInjection(date),
+  };
+}

--- a/supervisor/src/session/corp-brief.ts
+++ b/supervisor/src/session/corp-brief.ts
@@ -27,6 +27,11 @@
  *      オーケストレーター（branch が `orchestrate-` 始まり）だけは機械的な印で
  *      候補から除き（{@link selectBriefTargets}）、残りがちょうど 1 件のときだけ
  *      注入する。0 件 / 2 件以上は注入せず通知する（推測で選ばない）。
+ *   5. **稼働中セッションへ打鍵する唯一の外部トリガー**なので、割り込みの安全弁を 2 つ持つ:
+ *      対象スレッドが AskUserQuestion の回答待ちなら注入しない（`askPending`）、
+ *      同じ日付を直近に注入済みなら二度割り込まない（{@link BRIEF_DEDUP_WINDOW_MS}）。
+ *      dispatch / orchestrate は**自分が起こしたばかりのセッション**にしか打鍵しないため
+ *      この論点を持たない。ここだけは brief のほうが強い能力を持つ。
  *
  * *誰が* トリガーできるかは access policy 側の設定であり、本モジュールは corp 固有の
  * 送信元を一切ハードコードしない（`dispatch.ts` と同じ方針）。#corp が最初の利用者
@@ -176,6 +181,24 @@ export function selectBriefTargets(
   );
 }
 
+/**
+ * 同じ日付の brief を再び受けても投入しない時間窓（冪等性）。
+ *
+ * corp 側の配信リトライや手動 re-post で同じ `(channel, date)` が二度来ると、
+ * **稼働中の会話に二度割り込む**（`enqueueForThread` が直列化するので状態は壊れないが、
+ * 会長との対話は二度中断される）。corp の dispatch スケジューラが 30 分周期なので、
+ * その 1 サイクル分をまたいで吸収できる 60 分を既定にする。窓を無期限にしないのは、
+ * 初回の注入がセッション側で活きなかったときに**同じ日付で意図的に再投入する**余地を
+ * 残すため（無期限だと当日中は二度と起こせなくなる）。
+ */
+export const BRIEF_DEDUP_WINDOW_MS = 60 * 60_000;
+
+/** 直近に注入済みの brief（冪等性判定の入力）。 */
+export interface RecentBrief {
+  date: string;
+  atMs: number;
+}
+
 export interface BriefTriggerInput {
   /** 受信メッセージ本文。 */
   content: string;
@@ -187,6 +210,23 @@ export interface BriefTriggerInput {
   policy: AccessPolicy | null;
   /** 当該チャンネルで running のセッション（`listRunningByChannel` の結果）。 */
   sessions: BriefSessionRef[];
+  /**
+   * 対象スレッドで AskUserQuestion が保留中（またはその直後の猶予窓）か。
+   *
+   * **必須**（省略可にしない）。この経路は「既に走っていて状態の分からないセッション」へ
+   * 打鍵する唯一の外部トリガーで、`sendToPane` は毎回先頭に `Escape` を送る。会長が
+   * 回答を検討している最中に打てば、保留中の決裁が本人不在で消えるか、最悪 fallback
+   * dialog の既定が選ばれる（#412 / #416 / #423 が閉じた失敗クラスそのもの）。
+   * 呼び出し側は `hasRecentAsk`（= 保留中 + settle 直後の猶予）を渡すこと。
+   */
+  askPending: (threadId: string) => boolean;
+  /**
+   * 同じチャンネルで直近に注入した brief。`undefined` = 記録なし。
+   * {@link BRIEF_DEDUP_WINDOW_MS} 以内に同じ日付が来たら投入しない。
+   */
+  recentBrief?: RecentBrief;
+  /** 冪等性判定の基準時刻。省略時 `Date.now()`。 */
+  nowMs?: number;
   /** kill-switch 判定用。省略時 `process.env`。 */
   env?: Record<string, string | undefined>;
   /** `DISPATCH_ALLOWED_SOURCE_IDS` 相当。省略時 env から読む（dispatch と共用）。 */
@@ -208,6 +248,10 @@ export type BriefDecision =
   | { action: "rejected"; reason: string }
   /** 注入する（対象スレッドがちょうど 1 件）。 */
   | { action: "inject"; date: string; threadId: string; text: string }
+  /** 同じ日付を直近に注入済み → 二度割り込まない（冪等性）。 */
+  | { action: "duplicate"; date: string; elapsedMs: number }
+  /** 対象セッションが会長の回答待ち → 注入せず通知（割り込まない）。 */
+  | { action: "deferred"; date: string; threadId: string }
   /** 稼働中セッションが無い → 注入せず通知（サイレントに落とさない）。 */
   | { action: "no_session"; date: string }
   /** 稼働中セッションが複数 → 曖昧なので注入せず通知（推測で選ばない）。 */
@@ -220,11 +264,14 @@ export type BriefDecision =
  *   2. kill-switch
  *   3. **認可**（fail-closed。ここを通らなければパースもしない）
  *   4. コマンドのパース（自由文を拒否）
- *   5. 投入先スレッドの決定（1 件のときだけ inject）
+ *   5. 冪等性（同じ日付を直近に注入済みなら二度割り込まない）
+ *   6. 投入先スレッドの決定（1 件のときだけ先へ進む）
+ *   7. **回答待ちの割り込み回避**（保留中なら注入しない）
  *
  * 3 が 4 より先なのは既存 `handleDispatchMessage` と同じ順序で、認可されない送信元の
  * 入力を一切解釈しないため（`tests/guards/access-enforcement-wired.test.ts` が
- * dispatch と同様にこの順序を固定する）。
+ * dispatch と同様にこの順序を固定する）。7 が最後なのは、対象スレッドが確定して
+ * 初めて「そのスレッドが回答待ちか」を問えるため。
  */
 export function evaluateBriefTrigger(input: BriefTriggerInput): BriefDecision {
   if (!isBriefCommand(input.content)) return { action: "ignore" };
@@ -254,6 +301,19 @@ export function evaluateBriefTrigger(input: BriefTriggerInput): BriefDecision {
   }
 
   const { date } = parsed;
+
+  // 冪等性: 同じ日付を直近に注入済みなら、稼働中の会話へ二度割り込まない。
+  // 記録は inject したときだけ残す契約なので、no_session / deferred で終わった
+  // brief の再送はここで止まらない（止めると回復手段が消える）。
+  const now = input.nowMs ?? Date.now();
+  const recent = input.recentBrief;
+  if (recent && recent.date === date) {
+    const elapsedMs = now - recent.atMs;
+    if (elapsedMs >= 0 && elapsedMs < BRIEF_DEDUP_WINDOW_MS) {
+      return { action: "duplicate", date, elapsedMs };
+    }
+  }
+
   const sessions = selectBriefTargets(input.sessions);
   if (sessions.length === 0) {
     return { action: "no_session", date };
@@ -262,10 +322,21 @@ export function evaluateBriefTrigger(input: BriefTriggerInput): BriefDecision {
     return { action: "ambiguous", date, count: sessions.length };
   }
 
+  const threadId = (sessions[0] as BriefSessionRef).threadId;
+
+  // 会長が AskUserQuestion に回答している最中（およびその直後の猶予窓）には
+  // 打鍵しない。人間の relay 経路は同じ状況で tmux へ流さず resolveAskUser へ
+  // 回している（bot.ts / #370）。こちらは Discord の返信ではなく生の打鍵で、
+  // しかも `sendToPane` は先頭に Escape を送るため、割り込みの害はより大きい。
+  // no_session / ambiguous と同じ「推測で触らない」方針の延長。
+  if (input.askPending(threadId)) {
+    return { action: "deferred", date, threadId };
+  }
+
   return {
     action: "inject",
     date,
-    threadId: (sessions[0] as BriefSessionRef).threadId,
+    threadId,
     text: buildBriefInjection(date),
   };
 }

--- a/supervisor/tests/guards/access-enforcement-wired.test.ts
+++ b/supervisor/tests/guards/access-enforcement-wired.test.ts
@@ -114,3 +114,61 @@ describe("dispatch transport is wired fail-closed (#32 / S7)", () => {
     }
   });
 });
+
+/**
+ * Issue #426: the brief trigger is the SECOND exception to the blanket
+ * bot/webhook drop, and it injects instructions into the already-running HQ
+ * session. Behavioral coverage (fail-closed authorization, closed date token,
+ * target resolution) lives in tests/session/corp-brief.test.ts; this guard fixes
+ * the wiring so a refactor cannot move the interception after the drop (making
+ * it dead) or move the authorization after the injection (making it bypassable).
+ */
+describe("brief trigger is wired fail-closed (#426)", () => {
+  test("bot.ts intercepts brief BEFORE the bot/webhook drop", async () => {
+    const src = await read("src/bot.ts");
+    const briefIdx = src.indexOf("handleBriefMessage(message)");
+    const botDropIdx = src.indexOf("if (message.author.bot) return;");
+    expect(briefIdx).toBeGreaterThan(-1);
+    expect(botDropIdx).toBeGreaterThan(-1);
+    expect(briefIdx).toBeLessThan(botDropIdx);
+  });
+
+  test("the brief evaluator authorizes with the dispatch gate, before parsing", async () => {
+    const src = await read("src/session/corp-brief.ts");
+    // Reuses the existing dispatch-source gate rather than inventing a second
+    // authorization model.
+    expect(src).toContain("isDispatchSourceAllowed");
+    // `isDispatchSourceAllowed(` (with the paren) matches only the call site —
+    // the import lists the bare identifier — so this compares real positions.
+    const authIdx = src.indexOf("isDispatchSourceAllowed(");
+    const parseIdx = src.indexOf("parseBriefCommand(input.content)");
+    expect(authIdx).toBeGreaterThan(-1);
+    expect(parseIdx).toBeGreaterThan(-1);
+    // An unauthorized source's message must not be interpreted at all.
+    expect(authIdx).toBeLessThan(parseIdx);
+    expect(src).toContain("decision.allowed");
+  });
+
+  test("bot.ts only injects on the evaluator's inject verdict", async () => {
+    const src = await read("src/bot.ts");
+    const evalIdx = src.indexOf("evaluateBriefTrigger({");
+    // `decision.text` is the injected sentence and exists only on the `inject`
+    // verdict, so its presence after the evaluator pins the order.
+    const injectIdx = src.indexOf("decision.text");
+    expect(evalIdx).toBeGreaterThan(-1);
+    expect(injectIdx).toBeGreaterThan(-1);
+    expect(evalIdx).toBeLessThan(injectIdx);
+  });
+
+  test("brief denial logs do not interpolate raw source/channel ids or body", async () => {
+    const src = await read("src/bot.ts");
+    const denialLines = src
+      .split("\n")
+      .filter((l) => /Brief denied|Brief rejected/.test(l));
+    expect(denialLines.length).toBeGreaterThan(0);
+    for (const line of denialLines) {
+      expect(line).not.toContain("message.author.id");
+      expect(line).not.toContain("message.content");
+    }
+  });
+});

--- a/supervisor/tests/guards/access-enforcement-wired.test.ts
+++ b/supervisor/tests/guards/access-enforcement-wired.test.ts
@@ -160,6 +160,16 @@ describe("brief trigger is wired fail-closed (#426)", () => {
     expect(evalIdx).toBeLessThan(injectIdx);
   });
 
+  test("bot.ts feeds the real ask guard into the evaluator (#432 must-1)", async () => {
+    // The evaluator requires `askPending`, so it cannot be forgotten — but it
+    // CAN be defeated by passing a constant. This pins the live predicate:
+    // `hasRecentAsk` (pending + the post-settle grace window), not
+    // `hasPendingAsk`, because the TUI dialog the ask hook falls back to appears
+    // after the ask settles. This path types into the pane, Escape first.
+    const src = await read("src/bot.ts");
+    expect(src).toContain("askPending: hasRecentAsk");
+  });
+
   test("brief denial logs do not interpolate raw source/channel ids or body", async () => {
     const src = await read("src/bot.ts");
     const denialLines = src

--- a/supervisor/tests/session/corp-brief.test.ts
+++ b/supervisor/tests/session/corp-brief.test.ts
@@ -1,0 +1,272 @@
+import { describe, test, expect } from "bun:test";
+import {
+  BRIEF_DISABLED_ENV,
+  BRIEF_PREFIX,
+  buildBriefInjection,
+  evaluateBriefTrigger,
+  isBriefCommand,
+  isBriefDisabled,
+  parseBriefCommand,
+  type BriefSessionRef,
+  type BriefTriggerInput,
+} from "../../src/session/corp-brief";
+import type { AccessPolicy } from "../../src/config/access-policy";
+
+/**
+ * Issue #426: corp posts `/brief <YYYY-MM-DD>` to a known channel and the
+ * channel's already-running session is asked to put the morning brief's
+ * proposals to the chairman (corp#112 AC-1).
+ *
+ * This path can hand instructions to the HQ session, so the tests below fix the
+ * two properties that keep it from becoming an approval-gate bypass:
+ *
+ *   1. **fail-closed authorization** — the same `dispatchFrom` gate as
+ *      `/dispatch`, denying on missing policy / unconfigured channel / empty
+ *      list / unlisted source;
+ *   2. **no free text** — the only external input is a `YYYY-MM-DD` token and
+ *      the injected sentence is built here, so extra tokens are rejected rather
+ *      than forwarded.
+ */
+
+const CHANNEL_ID = "111111111111111111";
+const CORP_BOT_ID = "222222222222222222";
+const OTHER_ID = "333333333333333333";
+
+/** Policy that authorizes CORP_BOT_ID on CHANNEL_ID (the intended setup). */
+function allowingPolicy(): AccessPolicy {
+  return {
+    groups: {
+      [CHANNEL_ID]: {
+        requireMention: false,
+        allowFrom: [],
+        dispatchFrom: [CORP_BOT_ID],
+      },
+    },
+  };
+}
+
+const ONE_SESSION: BriefSessionRef[] = [{ threadId: "thread-1" }];
+
+/**
+ * Base input for the evaluator. `env` / `envAllowedSourceIds` are always passed
+ * explicitly so a stray `CORP_BRIEF_DISABLED` / `DISPATCH_ALLOWED_SOURCE_IDS`
+ * in the developer's shell cannot change the verdict under test.
+ */
+function input(over: Partial<BriefTriggerInput> = {}): BriefTriggerInput {
+  return {
+    content: `${BRIEF_PREFIX} 2026-08-13`,
+    channelId: CHANNEL_ID,
+    sourceId: CORP_BOT_ID,
+    policy: allowingPolicy(),
+    sessions: ONE_SESSION,
+    env: {},
+    envAllowedSourceIds: [],
+    ...over,
+  };
+}
+
+describe("isBriefCommand / parseBriefCommand", () => {
+  test("recognises the exact trigger token", () => {
+    expect(isBriefCommand("/brief 2026-08-13")).toBe(true);
+    expect(isBriefCommand("  /brief 2026-08-13  ")).toBe(true);
+    expect(isBriefCommand("/brief")).toBe(true);
+  });
+
+  test("does not match a different command with the same prefix", () => {
+    // `/briefing` must not be mistaken for `/brief` (token boundary).
+    expect(isBriefCommand("/briefing 2026-08-13")).toBe(false);
+    expect(isBriefCommand("/dispatch corp-dispatch-42 42")).toBe(false);
+    expect(isBriefCommand("朝レポです")).toBe(false);
+  });
+
+  test("parses a valid date", () => {
+    const r = parseBriefCommand("/brief 2026-08-13");
+    expect(r.kind).toBe("ok");
+    if (r.kind === "ok") expect(r.date).toBe("2026-08-13");
+  });
+
+  test("accepts a real leap day", () => {
+    const r = parseBriefCommand("/brief 2024-02-29");
+    expect(r.kind).toBe("ok");
+  });
+
+  test("returns not_brief for an unrelated message", () => {
+    expect(parseBriefCommand("こんにちは").kind).toBe("not_brief");
+  });
+
+  test("rejects a missing date", () => {
+    const r = parseBriefCommand("/brief");
+    expect(r.kind).toBe("error");
+  });
+
+  test("rejects extra tokens (no free text may ride along)", () => {
+    // The whole point of the closed token: anything beyond the date is refused,
+    // never silently dropped and never forwarded into the session.
+    const r = parseBriefCommand("/brief 2026-08-13 rm -rf ~");
+    expect(r.kind).toBe("error");
+  });
+
+  test("rejects a malformed date", () => {
+    for (const bad of [
+      "/brief 2026/08/13",
+      "/brief 26-08-13",
+      "/brief 2026-8-13",
+      "/brief today",
+      "/brief 2026-08-13T00:00",
+    ]) {
+      expect(parseBriefCommand(bad).kind).toBe("error");
+    }
+  });
+
+  test("rejects a well-formed but non-existent date", () => {
+    for (const bad of ["/brief 2026-02-30", "/brief 2026-13-01", "/brief 2026-00-10"]) {
+      expect(parseBriefCommand(bad).kind).toBe("error");
+    }
+  });
+});
+
+describe("buildBriefInjection", () => {
+  test("embeds the date and asks for AskUserQuestion", () => {
+    const text = buildBriefInjection("2026-08-13");
+    expect(text).toContain("2026-08-13");
+    expect(text).toContain("AskUserQuestion");
+  });
+
+  test("is a single line (relay flattens newlines for tmux send-keys)", () => {
+    expect(buildBriefInjection("2026-08-13")).not.toContain("\n");
+  });
+});
+
+describe("isBriefDisabled (kill-switch)", () => {
+  test("off by default", () => {
+    expect(isBriefDisabled({})).toBe(false);
+    expect(isBriefDisabled({ [BRIEF_DISABLED_ENV]: "" })).toBe(false);
+    expect(isBriefDisabled({ [BRIEF_DISABLED_ENV]: "0" })).toBe(false);
+  });
+
+  test("any other value disables (stopping is the safe direction)", () => {
+    expect(isBriefDisabled({ [BRIEF_DISABLED_ENV]: "1" })).toBe(true);
+    expect(isBriefDisabled({ [BRIEF_DISABLED_ENV]: "true" })).toBe(true);
+  });
+});
+
+describe("evaluateBriefTrigger — authorization is fail-closed", () => {
+  test("denies when the policy is unavailable (missing / unparsable file)", () => {
+    const d = evaluateBriefTrigger(input({ policy: null }));
+    expect(d.action).toBe("denied");
+    if (d.action === "denied") expect(d.reason).toBe("policy_unavailable");
+  });
+
+  test("denies when the channel is not configured in groups", () => {
+    // The live access.json has no group for #corp today, so this is the current
+    // real-world state: the trigger is refused until the group is added.
+    const d = evaluateBriefTrigger(input({ policy: { groups: {} } }));
+    expect(d.action).toBe("denied");
+    if (d.action === "denied") expect(d.reason).toBe("channel_not_configured");
+  });
+
+  test("denies when dispatchFrom is empty (empty is NOT 'any source')", () => {
+    const policy: AccessPolicy = {
+      groups: { [CHANNEL_ID]: { requireMention: false, allowFrom: [], dispatchFrom: [] } },
+    };
+    const d = evaluateBriefTrigger(input({ policy }));
+    expect(d.action).toBe("denied");
+    if (d.action === "denied") expect(d.reason).toBe("source_not_allowlisted");
+  });
+
+  test("denies when dispatchFrom is absent entirely", () => {
+    const policy: AccessPolicy = {
+      groups: { [CHANNEL_ID]: { requireMention: false, allowFrom: [CORP_BOT_ID] } },
+    };
+    const d = evaluateBriefTrigger(input({ policy }));
+    expect(d.action).toBe("denied");
+    if (d.action === "denied") expect(d.reason).toBe("source_not_allowlisted");
+  });
+
+  test("denies a sender that is not the allowlisted source", () => {
+    const d = evaluateBriefTrigger(input({ sourceId: OTHER_ID }));
+    expect(d.action).toBe("denied");
+    if (d.action === "denied") expect(d.reason).toBe("source_not_allowlisted");
+  });
+
+  test("denies before parsing — a malformed command from an unlisted source is 'denied', not 'rejected'", () => {
+    // Order matters: an unauthorized source's input must not be interpreted at
+    // all (same order as handleDispatchMessage).
+    const d = evaluateBriefTrigger(
+      input({ sourceId: OTHER_ID, content: "/brief まったくの自由文" }),
+    );
+    expect(d.action).toBe("denied");
+  });
+
+  test("a denied source never reaches inject, even with exactly one session", () => {
+    const d = evaluateBriefTrigger(input({ policy: null, sessions: ONE_SESSION }));
+    expect(d.action).not.toBe("inject");
+  });
+
+  test("allows the source listed in the env allowlist (shared with /dispatch)", () => {
+    const d = evaluateBriefTrigger(
+      input({ sourceId: OTHER_ID, envAllowedSourceIds: [OTHER_ID] }),
+    );
+    expect(d.action).toBe("inject");
+  });
+
+  test("the env allowlist does not bypass the 'channel must be configured' gate", () => {
+    const d = evaluateBriefTrigger(
+      input({ policy: { groups: {} }, envAllowedSourceIds: [CORP_BOT_ID] }),
+    );
+    expect(d.action).toBe("denied");
+    if (d.action === "denied") expect(d.reason).toBe("channel_not_configured");
+  });
+});
+
+describe("evaluateBriefTrigger — trigger handling", () => {
+  test("ignores a message that is not a /brief", () => {
+    expect(evaluateBriefTrigger(input({ content: "おはようございます" })).action).toBe(
+      "ignore",
+    );
+  });
+
+  test("kill-switch stops an otherwise valid trigger", () => {
+    const d = evaluateBriefTrigger(input({ env: { [BRIEF_DISABLED_ENV]: "1" } }));
+    expect(d.action).toBe("disabled");
+  });
+
+  test("rejects a malformed command from an authorized source", () => {
+    const d = evaluateBriefTrigger(input({ content: "/brief 2026-02-30" }));
+    expect(d.action).toBe("rejected");
+    if (d.action === "rejected") expect(d.reason.length).toBeGreaterThan(0);
+  });
+
+  test("injects into the single running session", () => {
+    const d = evaluateBriefTrigger(input());
+    expect(d.action).toBe("inject");
+    if (d.action === "inject") {
+      expect(d.threadId).toBe("thread-1");
+      expect(d.date).toBe("2026-08-13");
+      expect(d.text).toBe(buildBriefInjection("2026-08-13"));
+    }
+  });
+
+  test("reports no_session when nothing is running (AC-3: never silent)", () => {
+    const d = evaluateBriefTrigger(input({ sessions: [] }));
+    expect(d.action).toBe("no_session");
+    if (d.action === "no_session") expect(d.date).toBe("2026-08-13");
+  });
+
+  test("refuses to guess when several sessions are running", () => {
+    const d = evaluateBriefTrigger(
+      input({ sessions: [{ threadId: "thread-1" }, { threadId: "thread-2" }] }),
+    );
+    expect(d.action).toBe("ambiguous");
+    if (d.action === "ambiguous") expect(d.count).toBe(2);
+  });
+
+  test("the injected text carries no caller-supplied text", () => {
+    // A rejected command cannot contribute text, and an accepted one only ever
+    // contributes the date — so nothing from the wire can appear verbatim.
+    const marker = "IGNORE-PREVIOUS-INSTRUCTIONS";
+    const d = evaluateBriefTrigger(input({ content: `/brief 2026-08-13 ${marker}` }));
+    expect(d.action).toBe("rejected");
+    expect(JSON.stringify(d)).not.toContain(marker);
+  });
+});

--- a/supervisor/tests/session/corp-brief.test.ts
+++ b/supervisor/tests/session/corp-brief.test.ts
@@ -7,10 +7,12 @@ import {
   isBriefCommand,
   isBriefDisabled,
   parseBriefCommand,
+  selectBriefTargets,
   type BriefSessionRef,
   type BriefTriggerInput,
 } from "../../src/session/corp-brief";
 import type { AccessPolicy } from "../../src/config/access-policy";
+import { ORCHESTRATE_BRANCH_PREFIX } from "../../src/session/orchestrate";
 
 /**
  * Issue #426: corp posts `/brief <YYYY-MM-DD>` to a known channel and the
@@ -253,12 +255,68 @@ describe("evaluateBriefTrigger — trigger handling", () => {
     if (d.action === "no_session") expect(d.date).toBe("2026-08-13");
   });
 
-  test("refuses to guess when several sessions are running", () => {
+  test("refuses to guess when several candidate sessions are running", () => {
     const d = evaluateBriefTrigger(
       input({ sessions: [{ threadId: "thread-1" }, { threadId: "thread-2" }] }),
     );
     expect(d.action).toBe("ambiguous");
     if (d.action === "ambiguous") expect(d.count).toBe(2);
+  });
+});
+
+describe("selectBriefTargets — orchestrator sessions are not candidates", () => {
+  test("drops orchestrator sessions, keeps the rest", () => {
+    const kept = selectBriefTargets([
+      { threadId: "ceo" },
+      { threadId: "orc", branch: `${ORCHESTRATE_BRANCH_PREFIX}20260813-0700` },
+      { threadId: "worktree", branch: "corp-brief-work" },
+    ]);
+    expect(kept.map((s) => s.threadId)).toEqual(["ceo", "worktree"]);
+  });
+
+  test("an orchestrator running alongside the CEO session does not block the brief", () => {
+    // Regression for the failure mode CodeRabbit flagged on PR #432: without
+    // the filter this pair is `ambiguous`, so the morning brief silently never
+    // reaches the CEO whenever an orchestrator happens to be up.
+    const d = evaluateBriefTrigger(
+      input({
+        sessions: [
+          { threadId: "thread-1", branch: "corp" },
+          {
+            threadId: "thread-orc",
+            branch: `${ORCHESTRATE_BRANCH_PREFIX}20260813-0700`,
+          },
+        ],
+      }),
+    );
+    expect(d.action).toBe("inject");
+    if (d.action === "inject") expect(d.threadId).toBe("thread-1");
+  });
+
+  test("an orchestrator alone is not a target (no CEO session to ask)", () => {
+    const d = evaluateBriefTrigger(
+      input({
+        sessions: [
+          {
+            threadId: "thread-orc",
+            branch: `${ORCHESTRATE_BRANCH_PREFIX}20260813-0700`,
+          },
+        ],
+      }),
+    );
+    expect(d.action).toBe("no_session");
+  });
+
+  test("two non-orchestrator sessions still refuse (the filter narrows, it does not guess)", () => {
+    const d = evaluateBriefTrigger(
+      input({
+        sessions: [
+          { threadId: "thread-1", branch: "corp" },
+          { threadId: "thread-2", branch: "corp-dispatch-99" },
+        ],
+      }),
+    );
+    expect(d.action).toBe("ambiguous");
   });
 
   test("the injected text carries no caller-supplied text", () => {

--- a/supervisor/tests/session/corp-brief.test.ts
+++ b/supervisor/tests/session/corp-brief.test.ts
@@ -1,5 +1,6 @@
 import { describe, test, expect } from "bun:test";
 import {
+  BRIEF_DEDUP_WINDOW_MS,
   BRIEF_DISABLED_ENV,
   BRIEF_PREFIX,
   buildBriefInjection,
@@ -52,7 +53,8 @@ const ONE_SESSION: BriefSessionRef[] = [{ threadId: "thread-1" }];
 /**
  * Base input for the evaluator. `env` / `envAllowedSourceIds` are always passed
  * explicitly so a stray `CORP_BRIEF_DISABLED` / `DISPATCH_ALLOWED_SOURCE_IDS`
- * in the developer's shell cannot change the verdict under test.
+ * in the developer's shell cannot change the verdict under test. `askPending`
+ * defaults to "nothing outstanding" so only the tests that care set it.
  */
 function input(over: Partial<BriefTriggerInput> = {}): BriefTriggerInput {
   return {
@@ -61,6 +63,7 @@ function input(over: Partial<BriefTriggerInput> = {}): BriefTriggerInput {
     sourceId: CORP_BOT_ID,
     policy: allowingPolicy(),
     sessions: ONE_SESSION,
+    askPending: () => false,
     env: {},
     envAllowedSourceIds: [],
     ...over,
@@ -106,6 +109,32 @@ describe("isBriefCommand / parseBriefCommand", () => {
     // never silently dropped and never forwarded into the session.
     const r = parseBriefCommand("/brief 2026-08-13 rm -rf ~");
     expect(r.kind).toBe("error");
+  });
+
+  test("rejects extra content on a following line (LF / CRLF / CR)", () => {
+    // A multi-line body is the most ordinary shape for a bot post, so this is
+    // the likeliest way free text would try to ride along. It is refused today
+    // because the split is `/\s+/` (newlines are whitespace) — pin it, so a
+    // future line-oriented rewrite ("look at the first line only", `split(" ")`)
+    // fails here instead of quietly forwarding the rest into the HQ session.
+    for (const sep of ["\n", "\r\n", "\r"]) {
+      const r = parseBriefCommand(`/brief 2026-08-13${sep}rm -rf ~`);
+      expect(r.kind).toBe("error");
+    }
+  });
+
+  test("rejects control characters riding on the date token", () => {
+    // NUL / ESC / RTL-override attached to an otherwise valid date. None of
+    // these are whitespace, so they stay part of the token and the anchored
+    // date regex refuses them rather than trimming them off. Written as \\u
+    // escapes on purpose — an invisible byte in a test file is unreviewable.
+    for (const bad of [
+      "/brief 2026-08-13\u0000",
+      "/brief 2026-08-13\u001b[31m",
+      "/brief \u202e2026-08-13",
+    ]) {
+      expect(parseBriefCommand(bad).kind).toBe("error");
+    }
   });
 
   test("rejects a malformed date", () => {
@@ -261,6 +290,120 @@ describe("evaluateBriefTrigger — trigger handling", () => {
     );
     expect(d.action).toBe("ambiguous");
     if (d.action === "ambiguous") expect(d.count).toBe(2);
+  });
+});
+
+/**
+ * PR #432 review, must-1. This is the one capability `/dispatch` and
+ * `/orchestrate` do not have: they only ever type into a session they just
+ * started, while `/brief` types into a session that was ALREADY running and
+ * whose state it does not own. `sendToPane` leads every send with `Escape`, so
+ * injecting while the chairman has an AskUserQuestion open could discard the
+ * pending decision — or, if Escape picks a fallback dialog's default, answer it
+ * on their behalf. That is the failure class #412 / #416 / #423 just closed.
+ */
+describe("evaluateBriefTrigger — never interrupts a pending decision (#432 must-1)", () => {
+  test("defers instead of injecting when the target thread is awaiting an answer", () => {
+    const d = evaluateBriefTrigger(input({ askPending: () => true }));
+    expect(d.action).toBe("deferred");
+    if (d.action === "deferred") {
+      expect(d.threadId).toBe("thread-1");
+      expect(d.date).toBe("2026-08-13");
+    }
+  });
+
+  test("the guard is asked about the RESOLVED target thread, not any thread", () => {
+    // A pending ask on some other thread must not block this channel's brief,
+    // and a pending ask on the target must block it — so the predicate has to
+    // receive the thread the injection would actually go to.
+    const asked: string[] = [];
+    const d = evaluateBriefTrigger(
+      input({
+        sessions: [{ threadId: "thread-target" }],
+        askPending: (threadId) => {
+          asked.push(threadId);
+          return threadId === "someone-else";
+        },
+      }),
+    );
+    expect(asked).toEqual(["thread-target"]);
+    expect(d.action).toBe("inject");
+  });
+
+  test("the ask guard runs even for an otherwise perfect trigger", () => {
+    // Guards against a refactor that checks askPending only on some branch:
+    // authorized, well-formed, exactly one target — and still deferred.
+    const d = evaluateBriefTrigger(
+      input({ policy: allowingPolicy(), askPending: () => true }),
+    );
+    expect(d.action).not.toBe("inject");
+  });
+
+  test("no target session means no ask question to answer (no_session wins)", () => {
+    // Ordering check: with zero candidates there is no thread to ask about, so
+    // the predicate must not be consulted with a bogus id.
+    let called = false;
+    const d = evaluateBriefTrigger(
+      input({
+        sessions: [],
+        askPending: () => {
+          called = true;
+          return true;
+        },
+      }),
+    );
+    expect(d.action).toBe("no_session");
+    expect(called).toBe(false);
+  });
+});
+
+/**
+ * PR #432 review, should-1. corp retrying a failed delivery (or a manual
+ * re-post) must not interrupt the running conversation twice for the same day.
+ */
+describe("evaluateBriefTrigger — same-day idempotency (#432 should-1)", () => {
+  const NOW = 1_760_000_000_000;
+
+  test("a repeat of the same date inside the window is not injected again", () => {
+    const d = evaluateBriefTrigger(
+      input({
+        nowMs: NOW,
+        recentBrief: { date: "2026-08-13", atMs: NOW - 60_000 },
+      }),
+    );
+    expect(d.action).toBe("duplicate");
+    if (d.action === "duplicate") expect(d.elapsedMs).toBe(60_000);
+  });
+
+  test("a repeat AFTER the window is allowed (a deliberate re-trigger stays possible)", () => {
+    const d = evaluateBriefTrigger(
+      input({
+        nowMs: NOW,
+        recentBrief: { date: "2026-08-13", atMs: NOW - BRIEF_DEDUP_WINDOW_MS - 1 },
+      }),
+    );
+    expect(d.action).toBe("inject");
+  });
+
+  test("a different date is never a duplicate", () => {
+    const d = evaluateBriefTrigger(
+      input({
+        content: "/brief 2026-08-14",
+        nowMs: NOW,
+        recentBrief: { date: "2026-08-13", atMs: NOW - 60_000 },
+      }),
+    );
+    expect(d.action).toBe("inject");
+  });
+
+  test("de-dup does not mask a deferred/no_session retry", () => {
+    // The caller records only on `inject`, so a brief that ended as deferred
+    // leaves no record — this pins the evaluator side of that contract: with no
+    // record, the retry is evaluated normally rather than swallowed.
+    const d = evaluateBriefTrigger(
+      input({ nowMs: NOW, recentBrief: undefined, askPending: () => false }),
+    );
+    expect(d.action).toBe("inject");
   });
 });
 


### PR DESCRIPTION
Closes #426

## 目的

corp が朝レポ（CEO 提案 `[D1]..[Dn]`）を #corp へ配信しても、`bot.ts` の `if (message.author.bot) return;` が bot / webhook のメッセージを一律 drop するため、corp スレッドで稼働中の CEO セッションは「朝レポが来た」ことを知れなかった。そのため corp#112 の AC-1「朝レポが届く → タップで決められる UI が表示される」は、#412（ボタン UI）と #416（回答待ち 5 時間）が両方揃っても**質問を発生させる主体が居ない**ため未達のままだった。

本 PR は Issue の設計調査コメントの推奨案（案 1、ただしトリガーは #corp の非スレッドメッセージのまま据え置き）をそのまま実装する。

## 変更点

| ファイル | 内容 |
|---|---|
| `supervisor/src/session/corp-brief.ts`（新規） | `/brief <YYYY-MM-DD>` の厳格パース、注入文字列の組み立て、判定純関数 `evaluateBriefTrigger` |
| `supervisor/src/bot.ts` | `handleBriefMessage` を dispatch / orchestrate intercept の隣に追加し、bot drop の**前**に呼ぶ。副作用（注入・通知・投稿）のみ担当 |
| `supervisor/tests/session/corp-brief.test.ts`（新規） | 43 件（パース境界 / 認可 deny / kill-switch / 投入先 0・1・複数件 / オーケストレーター除外） |
| `supervisor/tests/guards/access-enforcement-wired.test.ts` | 配線ガード 5 件を追加（順序 3 件 + 拒否ログ + ask ガードの結線） |
| `.github/workflows/ci.yml` | test whitelist へ 1 行（`lint-gating-coverage` が未 gate を落とすため必須） |

## 設計（なぜこの形か）

これは「本社セッションに指示を注入できる」経路なので、誤ると承認ゲートの迂回路になる。強度は次の 3 点で担保している。

1. **認可は既存 `isDispatchSourceAllowed` をそのまま再利用**（fail-closed）。policy 不在 / channel 未登録 / `dispatchFrom` 未列挙 の 3 つの deny がそのまま効く。新しい認可モデルを書かない = 新しい抜け道を作らない。
2. **注入文字列は claude-hub が組み立て、自由文を一切受け取らない**。外部から受け取るのは `YYYY-MM-DD` という閉じたトークン 1 個だけで、余分なトークンは黙って捨てず**拒否**する。`/dispatch <branch> <N>` → `/impl <N>` を claude-hub 側で構築するのと同型で、これが主防御。レポート本文は CEO セッションが自分で `~/corp` から読む。
3. **トリガーの identity を配信 webhook と分ける**。朝レポ配信 webhook は認可対象にしない（webhook URL 自体が bearer credential であり、かつ自由文の本文を運ぶ経路でもあるため）。post するのは corp の **dispatch bot**（別 identity）。片方の失効・ローテーションが他方を壊さない。

評価順は `/brief か → kill-switch → 認可 → パース → 投入先解決` で固定し、**認可されない送信元の入力は一切解釈しない**（既存 `handleDispatchMessage` と同じ順序。ガードテストで固定）。

その他:

- 投入先は `listRunningByChannel(<channel>)` で決定的に解決する。オーケストレーター（branch が `orchestrate-` 始まり）だけは機械的な印で候補から除き（`selectBriefTargets`）、残りが**ちょうど 1 件のときだけ**注入する。0 件 / 2 件以上は注入せず、channel 投稿 + Pushover で通知する（推測で選ばない）。
- 注入は `enqueueForThread` 経由の**非ブロッキング**。`sendMessage` はセッションの Stop hook を最大 5 時間待つため、gateway ハンドラ内で await すると MessageCreate が止まる（dispatch がキューへ渡して即返すのと同じ理由）。同スレッドへの同時 relay も既存キューで直列化される。
- **稼働中セッションへ打鍵する唯一の外部トリガー**なので、割り込みの安全弁を 2 つ持つ（レビュー must-1 / should-1）:
  - 対象スレッドが AskUserQuestion の回答待ち（`hasRecentAsk`）なら注入せず `deferred` として通知する。`sendToPane` は毎回先頭に `Escape` を送るため、会長が決裁を検討している最中に打つと保留中の決裁が本人不在で消えうる。人間の relay 経路が同じ状況で `resolveAskUser` に回している（#370）のと同じ判断。
  - 同じ `(channel, date)` を直近 60 分に注入済みなら `duplicate` として投入しない（corp の配信リトライで二度割り込まない）。記録は `inject` のときだけ残すので、`deferred` / `no_session` で終わった brief の再送は止まらない。
- kill-switch `CORP_BRIEF_DISABLED`（corp 側 `CORP_DISPATCH_DISABLED` と対称）。停止中も channel に 1 行返す（corp からは Supervisor の env が見えないため）。
- 拒否ログは粗い reason enum のみで、送信元 snowflake も本文も出さない（既存 dispatch と同じ）。
- corp 固有の送信元は一切ハードコードしない。機構としては `CHANNEL_MAP` に載っている任意のチャンネルで動き、#corp が最初の利用者というだけ。

## ⚠️ 要設定: `~/.claude/channels/discord/access.json`（コード外の運用作業）

現状 **#corp は `groups` に登録が無い**ため、この経路は fail-closed で拒否される（`reason=channel_not_configured`）。有効化には corp チャンネルの group 追加が必要。

```json
"<corp channel id>": {
  "requireMention": true,
  "allowFrom": ["<会長の user id>"],
  "dispatchFrom": ["<corp dispatch bot の user id>"]
}
```

**`allowFrom` を明示することが重要**（レビュー時にここを見てほしい）。`allowFrom` を省略 / 空にすると `isSenderAllowed` の仕様上「そのチャンネルの任意メンバー」を意味するため、`dispatchFrom` を足したつもりが**人間の relay 経路（thread での @mention）まで同時に開く**。これまで #corp は「channel 未登録 → 一律 deny」だったので、group 新設は human relay 側の実質的な緩和にもなる点に注意。

id の求め方:

- corp channel id: corp の `registry.yaml`（`delivery` / dispatch channel の設定）または Discord クライアントの「ID をコピー」
- corp dispatch bot の user id: `CORP_DISPATCH_BOT_TOKEN` で動く Bot のアプリケーション（Discord Developer Portal）、または実際に post させた後の supervisor ログ

（`access.json` は本 worktree の外にあるため、本 PR では読み取りも編集も行っていない。設定は会長側で実施。）

## corp 側の残作業（別 Issue 推奨）

本 PR は claude-hub 側の**受け口**だけ。ジャーニーを閉じるには corp 側に次が必要:

1. 朝レポ配信の成功後、dispatch bot で corp チャンネルへ `/brief <YYYY-MM-DD>` を post する
2. corp `CLAUDE.md` に「brief を受けたら決裁を AskUserQuestion で問う。自分で決裁を代行しない」を明記する（CEO セッションが実際に質問を出すことは claude-hub のコードでは保証できない）

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | 配信を契機に CEO セッションへ決裁を問わせる（受け口の成立） | `bun test tests/session/corp-brief.test.ts`（"injects into the single running session"）+ `tests/guards/access-enforcement-wired.test.ts`（"intercepts brief BEFORE the bot/webhook drop"） | 稼働中 1 件のスレッドへ注入判定、かつ bot drop より前で intercept | 33 pass / 0 fail、ガード 4 件 pass | **PASS（機構）** |
| AC-1 | 同上・実配信での end-to-end（実際に質問メッセージがスレッドへ出る） | 実 Discord + 実 corp 配信 | 当該スレッドに AskUserQuestion が出る | **未検証**（access.json 未設定・corp 側の `/brief` post 未実装・supervisor 再起動が必要なため本 PR 内では実行不能） | **未検証** |
| AC-2 | allowlist 外の送信元は fail-closed で拒否 | `bun test tests/session/corp-brief.test.ts` | policy 不在 / channel 未登録 / `dispatchFrom` 空 / `dispatchFrom` 不在 / 送信元不一致 の 5 パターンで `denied`、かつセッションが 1 件あっても `inject` にならない | 全て `denied`（reason enum も一致）、`inject` にならないことも確認 | **PASS** |
| AC-2 | 認可がパースより前（不正入力を解釈しない） | 同上（"denies before parsing" / ガード "authorizes with the dispatch gate, before parsing"） | 未認可 + 不正コマンド → `rejected` ではなく `denied` | `denied` | **PASS** |
| AC-3 | セッション不在時にサイレントに落ちない | `bun test tests/session/corp-brief.test.ts`（"reports no_session"）+ `bot.ts` の `no_session` 分岐（channel 投稿 + `notifyPushover`） | `no_session` 判定 → 通知 | 判定は pass。**通知の実発報は未検証**（実 Discord / Pushover 資格情報が要る） | **PASS（判定）/ 通知は未検証** |
| AC-3 | 投入先が曖昧（複数稼働）でも黙って選ばない | 同上（"refuses to guess"） | `ambiguous` + 件数 | `ambiguous` / count=2 | **PASS** |
| AC-4 | 既存を壊さない（CI curated set） | `SUPERVISOR_DB_PATH=":memory:" bun test <ci.yml の whitelist 103 ファイル>` | 全 pass | 1358 pass / 3 skip / **0 fail**（レビュー対応後の再実行は 1361 pass / 1 fail = `worktree-real-git` の並列実行時タイムアウト。単体実行で 15 pass / 0 fail を確認済みのローカル flake） | **PASS** |
| AC-5 | mock 隔離テスト（CI が別プロセスで回す 4 ファイル） | 各ファイル個別に `bun test` | 全 pass | 6 / 20 / 8 / 2 = 36 pass, 0 fail | **PASS** |
| AC-6 | 型検査 | `bunx tsc --noEmit` | エラーなし | 出力なし（exit 0） | **PASS** |
| AC-7 | 新規テストが CI で gate される | `bun scripts/lint-gating-coverage.ts` | ungated 0 | `111 test file(s) — 109 gated, 2 excluded, 0 ungated` | **PASS** |
| AC-8 | オーケストレーター併走で朝レポが未達にならない（レビュー指摘の回帰） | `bun test tests/session/corp-brief.test.ts`（`selectBriefTargets` 4 件） | CEO 併走 → `inject` / 単独 → `no_session` / 非オーケストレーター 2 件 → `ambiguous` | 33 pass / 0 fail | **PASS** |
| AC-9 | 会長の回答待ちに割り込まない（レビュー must-1） | `bun test tests/session/corp-brief.test.ts`（ask ガード 4 件）+ 配線ガード | ask 保留中 → `deferred` / 述語には解決済み threadId が渡る / 候補 0 件では呼ばない / `askPending: hasRecentAsk` が配線されている | 43 pass / 0 fail、ガード 12 pass | **PASS** |
| AC-10 | 同じ日付の再投入で二度割り込まない（レビュー should-1） | 同上（冪等性 4 件） | 窓内 → `duplicate` / 窓外・別日付・記録なし → `inject` | 同上 | **PASS** |
| AC-11 | 複数行・制御文字が自由文として通らない（レビュー should-2） | 同上（パーサ 2 件） | LF / CRLF / CR / NUL / ESC / RTL override すべて `error` | 同上 | **PASS** |

### 既知の pre-existing failure（本 PR 起因ではない）

- `tests/guards/shell-exec-safety.test.ts` の 1 件が `src/infra/db.ts:125` の interpolated SQL を理由に fail する。**変更を stash した clean な `main`（`c421916`）でも同じく fail する**ことを実測確認済み。
- `bun test`（`supervisor/` 全体を 1 プロセスで一括実行）は 34 fail するが、これは `mock.module("child_process")` が Bun でプロセスグローバルなことによる相互汚染で、`ci.yml` 自身がこれらのファイルを別プロセスに分離している既知事象（AC-5 で個別 pass を確認）。

## 未解決の論点（申し送り、follow-up Issue 候補）

1. ~~**#corp で orchestrator セッションが同時稼働していると `ambiguous` で未達になる**~~ → **対応済み**（9e18069、CodeRabbit も同じ点を指摘）。`selectBriefTargets` で branch が `orchestrate-` 始まりのセッションを候補から除いた。非オーケストレーターの候補が複数残る場合は従来どおり `ambiguous` に倒す。
2. **CEO セッション不在時の自動起動はしない**（初版は通知のみ）。毎朝新規起動すると `MAX_SESSIONS=10` を消費し続け、idle reaper（30 日）では回収が追いつかず executor 飽和を招くため。自動起動するなら dispatch 同様の自動停止条件とセットで別途設計が要る。
3. **実運用順序**: #423（自動回答の停止）→ #416（回答待ち延長）→ 本 PR。前 2 件はマージ済み。
4. 反映には **supervisor の再起動**が必要。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzoXfTLSh56CjXpM3sza8p


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `/brief <YYYY-MM-DD>` コマンドで、許可された外部ソースから朝レポートをセッションへ投稿できるようになりました。
  * 対象セッションを自動判定し、該当しない場合や複数ある場合は安全に通知します。
  * 応答待ち中のセッションへの投稿延期、同日レポートの重複防止、対象外セッションの除外に対応しました。

* **テスト**
  * 朝レポート機能とセレクター連携の自動テストをCIに追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->