### PR TITLE
fix: 観測できないセッションを idle と誤判定して kill 候補にするのをやめる（#430）

### DIFF
--- a/scripts/cleanup-idle-claude.sh
+++ b/scripts/cleanup-idle-claude.sh
@@ -27,13 +27,17 @@
 #   own PATH omits) the lookup could not run at all. Every claude older than
 #   IDLE_MINUTES was therefore reported idle, including sessions mid-task.
 #
-#   Two positive signals replace it, tried in order:
+#   Two positive signals replace it:
 #     1. tmux pane activity — #{session_activity} / #{window_activity} of the
 #        pane whose pane_pid is the process (epoch seconds).
 #     2. transcript mtime — newest *.jsonl under
 #        $HOME/.claude/projects/<cwd with every [^A-Za-z0-9-] replaced by ->,
 #        the process cwd coming from lsof.
-#   Neither available => `unknown` => protected.
+#   Either one proving recent activity is enough to protect; when the first
+#   says "quiet" the second is consulted too and the NEWER reading wins, since
+#   the two measure different things (pane output vs. transcript writes) and a
+#   stale source must not veto a fresh one. Neither readable, or a reading that
+#   is not a usable epoch => `unknown` => protected.
 #
 # Exit codes:
 #   0 — completed (dry-run reported, or kills succeeded / no candidates)
@@ -51,6 +55,7 @@ ALLOWLIST="${CLEANUP_CLAUDE_ALLOWLIST_PIDS:-}"
 # deterministically without touching a live claude process.
 TMUX_BIN="${CLEANUP_CLAUDE_TMUX_BIN:-tmux}"
 LSOF_BIN="${CLEANUP_CLAUDE_LSOF_BIN:-lsof}"
+LSOF_FALLBACK="${CLEANUP_CLAUDE_LSOF_FALLBACK:-/usr/sbin/lsof}"
 PROJECTS_DIR="${CLEANUP_CLAUDE_PROJECTS_DIR:-${HOME:-}/.claude/projects}"
 KILL_GRACE_SECONDS="${CLEANUP_CLAUDE_KILL_GRACE_SECONDS:-10}"
 
@@ -70,6 +75,8 @@ Environment:
   CLEANUP_CLAUDE_LIST_SCRIPT         Override the process lister (testing)
   CLEANUP_CLAUDE_TMUX_BIN            Override the tmux binary (testing)
   CLEANUP_CLAUDE_LSOF_BIN            Override the lsof binary (testing)
+  CLEANUP_CLAUDE_LSOF_FALLBACK       Path tried when lsof is off PATH
+                                     (default /usr/sbin/lsof)
   CLEANUP_CLAUDE_PROJECTS_DIR        Override ~/.claude/projects (testing)
 EOF
 }
@@ -145,7 +152,13 @@ etime_to_minutes() {
     2) minutes="${parts[0]}" ;;
     *) minutes=0 ;;
   esac
-  echo $(( days * 24 * 60 + 10#$hours * 60 + 10#$minutes ))
+  # 10# on every field, days included: macOS `ps` zero-pads the day count
+  # ("08-01:02:03"), and bash reads a leading-zero literal as octal — so `08`
+  # and `09` are an arithmetic error that kills the whole run under `set -e`
+  # (even --dry-run, leaving the operator with no listing at all), while `10`
+  # through `17` are silently understated. Pre-existing; fixed here because it
+  # is the same class as the guards this script relies on (#430 review, should-4).
+  echo $(( 10#$days * 24 * 60 + 10#$hours * 60 + 10#$minutes ))
 }
 
 mtime_of() {
@@ -192,10 +205,38 @@ tmux_last_activity() {
     $1 == target {
       latest = $2 + 0;
       if ($3 + 0 > latest) latest = $3 + 0;
-      print latest;
+      # A tmux that does not understand these format variables substitutes the
+      # empty string, and "" + 0 is 0 — an epoch that reads as "idle since
+      # 1970", i.e. the most killable value there is. Printing nothing instead
+      # sends that case to `unknown`, which is what the header promises for
+      # "tmux answered but the answer is unusable" (#430 review, must-1).
+      if (latest > 0) print latest;
       exit;
     }
   ' <<<"$PANE_SNAPSHOT"
+}
+
+# Absolute path to a usable lsof, or non-zero when there is none.
+#
+# `lsof` off PATH is one half of the original defect: macOS ships it in
+# /usr/sbin, and the PATH the supervisor hands its tmux sessions
+# (~/.local/bin:~/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin) has
+# no /usr/sbin. Leaving the default as the bare name meant the transcript
+# source was dead by default in exactly the context this script runs in,
+# so processes with no tmux pane (interactive / orphan) could never be
+# observed at all (#430 review, should-2).
+resolve_lsof() {
+  if command -v "$LSOF_BIN" >/dev/null 2>&1; then
+    command -v "$LSOF_BIN"
+    return 0
+  fi
+  # Only fall back for the default; an explicit override that does not resolve
+  # is an operator error and must not be silently replaced.
+  if [ "$LSOF_BIN" = "lsof" ] && [ -x "$LSOF_FALLBACK" ]; then
+    echo "$LSOF_FALLBACK"
+    return 0
+  fi
+  return 1
 }
 
 # Epoch seconds of the newest transcript *.jsonl belonging to the process's
@@ -211,9 +252,10 @@ tmux_last_activity() {
 # or the rule changed) yields empty => `unknown` => protected, never "idle".
 transcript_last_mtime() {
   local pid="$1"
-  command -v "$LSOF_BIN" >/dev/null 2>&1 || return 0
+  local lsof_bin
+  lsof_bin=$(resolve_lsof) || return 0
   local cwd
-  cwd=$("$LSOF_BIN" -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/{sub(/^n/,""); print; exit}')
+  cwd=$("$lsof_bin" -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/{sub(/^n/,""); print; exit}')
   [ -z "$cwd" ] && return 0
   local encoded dir
   encoded=$(printf '%s' "$cwd" | sed 's/[^A-Za-z0-9-]/-/g')
@@ -235,7 +277,9 @@ transcript_last_mtime() {
 # Prints "<state> <detail>" where state is one of:
 #   active  — measured activity within the threshold: do not touch
 #   idle    — measured activity older than the threshold: eligible
-#   unknown — no observation source answered: protected (fail-safe)
+#   unknown — no source produced a usable reading: protected (fail-safe).
+#             Covers both "nothing answered" and "something answered with a
+#             value we cannot trust" (see tmux_last_activity's zero guard).
 #
 # The `unknown` state is the whole point of Issue #430. The previous
 # implementation had no such state: any failure to observe was reported as
@@ -243,31 +287,50 @@ transcript_last_mtime() {
 # kill candidate on this host.
 observe_activity() {
   local pid="$1" threshold_min="$2"
-  local now cutoff ts age_min
+  local now cutoff age_min
   now=$(date +%s)
   cutoff=$(( now - threshold_min * 60 ))
 
-  ts=$(tmux_last_activity "$pid")
-  if [ -z "$ts" ]; then
-    ts=$(transcript_last_mtime "$pid")
-    if [ -n "$ts" ]; then
-      age_min=$(( (now - ts) / 60 ))
-      if [ "$ts" -gt "$cutoff" ]; then
-        echo "active transcript-mtime ${age_min}m-ago"
-      else
-        echo "idle transcript-mtime ${age_min}m-ago"
-      fi
-      return 0
-    fi
+  local ts_tmux ts_file best source
+  ts_tmux=$(tmux_last_activity "$pid")
+
+  # Any single source proving recent activity is enough to protect, so stop as
+  # soon as one does. This also keeps the common case cheap: an lsof lookup
+  # costs ~0.5s per process, and a session tmux already vouched for does not
+  # need one.
+  if [ -n "$ts_tmux" ] && [ "$ts_tmux" -gt "$cutoff" ]; then
+    echo "active tmux-activity $(( (now - ts_tmux) / 60 ))m-ago"
+    return 0
+  fi
+
+  # tmux said "quiet" (or said nothing). Before treating that as idle, ask the
+  # other source — the sources measure different things (pane output vs.
+  # transcript writes) and the older one must not veto the newer. The same
+  # reasoning already applies inside tmux_last_activity, which takes the max of
+  # session_activity and window_activity (#430 review, should-3).
+  ts_file=$(transcript_last_mtime "$pid")
+
+  best=""
+  source=""
+  if [ -n "$ts_tmux" ]; then
+    best="$ts_tmux"
+    source="tmux-activity"
+  fi
+  if [ -n "$ts_file" ] && { [ -z "$best" ] || [ "$ts_file" -gt "$best" ]; }; then
+    best="$ts_file"
+    source="transcript-mtime"
+  fi
+
+  if [ -z "$best" ]; then
     echo "unknown no-activity-source (tmux pane and transcript both unreadable)"
     return 0
   fi
 
-  age_min=$(( (now - ts) / 60 ))
-  if [ "$ts" -gt "$cutoff" ]; then
-    echo "active tmux-activity ${age_min}m-ago"
+  age_min=$(( (now - best) / 60 ))
+  if [ "$best" -gt "$cutoff" ]; then
+    echo "active ${source} ${age_min}m-ago"
   else
-    echo "idle tmux-activity ${age_min}m-ago"
+    echo "idle ${source} ${age_min}m-ago"
   fi
 }
 
@@ -285,11 +348,12 @@ print_protected_reasons() {
   for r in "${PROTECTED_REASONS[@]}"; do echo "    - $r"; done
 }
 
-# Final-line-of-defense: verify a PID's argv[0] is actually `claude` (or
-# ends in `/claude`) before we'd ever signal it. The lister regex is
-# loose enough to include tmux/awk subshells whose argv embeds "claude"
-# somewhere; the category filter usually catches those, but if anything
-# slips through to the kill loop, this guard refuses to fire.
+# Final-line-of-defense: verify a PID's argv[0] is actually `claude` (or ends
+# in `/claude`) before we'd ever signal it. The lister regex is loose enough to
+# include tmux/awk subshells whose argv embeds "claude" somewhere; the category
+# filter usually catches those, but if anything slips through, this guard
+# refuses to fire. Called twice — once when the candidate is selected and again
+# in the kill loop, immediately before the signal.
 is_genuine_claude_executable() {
   local pid="$1"
   local argv0
@@ -396,6 +460,13 @@ for c in "${CANDIDATES[@]}"; do
   recheck=$(observe_activity "$pid" "$IDLE_MINUTES")
   if [ "${recheck%% *}" != "idle" ]; then
     echo "  -> SKIP $pid (re-check before signal: $recheck)"
+    continue
+  fi
+  # Re-assert identity here, not only at selection time, so the guard below
+  # holds at the instant the signal is sent — a pid can be recycled between
+  # the two, and this is the last statement before kill.
+  if ! is_genuine_claude_executable "$pid"; then
+    echo "  -> SKIP $pid (argv0 is no longer claude)"
     continue
   fi
   echo "  -> SIGTERM $pid"

--- a/scripts/cleanup-idle-claude.sh
+++ b/scripts/cleanup-idle-claude.sh
@@ -12,8 +12,28 @@
 #   - Never kills subagents (their parent claude would deadlock)
 #   - Skips PIDs listed in CLEANUP_CLAUDE_ALLOWLIST_PIDS env var (comma-separated)
 #   - Idle threshold: process must have been running >= IDLE_MINUTES (default 30)
-#                     AND its working directory's most-recently-modified .jsonl
-#                     transcript must be older than IDLE_MINUTES, OR no jsonl found.
+#                     AND we must have POSITIVELY OBSERVED that it has been
+#                     quiet for that long (see below)
+#   - Unobservable == protected. A process whose activity we cannot measure is
+#     never a candidate, and --apply re-observes every candidate immediately
+#     before signalling it.
+#
+# Activity observation (Issue #430):
+#   This used to ask lsof for .jsonl files the process holds OPEN and treat
+#   "no file found" as "idle". That is fail-DEADLY, and it fired constantly:
+#   claude appends to its transcript and closes it rather than holding the fd,
+#   so the lookup returns nothing even for a busy session — and on hosts where
+#   lsof is not on PATH (macOS keeps it in /usr/sbin, which the supervisor's
+#   own PATH omits) the lookup could not run at all. Every claude older than
+#   IDLE_MINUTES was therefore reported idle, including sessions mid-task.
+#
+#   Two positive signals replace it, tried in order:
+#     1. tmux pane activity — #{session_activity} / #{window_activity} of the
+#        pane whose pane_pid is the process (epoch seconds).
+#     2. transcript mtime — newest *.jsonl under
+#        $HOME/.claude/projects/<cwd with every [^A-Za-z0-9-] replaced by ->,
+#        the process cwd coming from lsof.
+#   Neither available => `unknown` => protected.
 #
 # Exit codes:
 #   0 — completed (dry-run reported, or kills succeeded / no candidates)
@@ -25,6 +45,14 @@ set -euo pipefail
 MODE="dry-run"
 IDLE_MINUTES="${IDLE_MINUTES:-30}"
 ALLOWLIST="${CLEANUP_CLAUDE_ALLOWLIST_PIDS:-}"
+
+# Injectable dependencies. Defaults are the plain command names / real lister;
+# the test suite points these at stubs so the observation logic can be driven
+# deterministically without touching a live claude process.
+TMUX_BIN="${CLEANUP_CLAUDE_TMUX_BIN:-tmux}"
+LSOF_BIN="${CLEANUP_CLAUDE_LSOF_BIN:-lsof}"
+PROJECTS_DIR="${CLEANUP_CLAUDE_PROJECTS_DIR:-${HOME:-}/.claude/projects}"
+KILL_GRACE_SECONDS="${CLEANUP_CLAUDE_KILL_GRACE_SECONDS:-10}"
 
 usage() {
   cat <<'EOF'
@@ -38,6 +66,11 @@ Options:
 Environment:
   IDLE_MINUTES                       Same as --idle-minutes
   CLEANUP_CLAUDE_ALLOWLIST_PIDS      Comma-separated PIDs to never touch
+  CLEANUP_CLAUDE_KILL_GRACE_SECONDS  Seconds between SIGTERM and SIGKILL (10)
+  CLEANUP_CLAUDE_LIST_SCRIPT         Override the process lister (testing)
+  CLEANUP_CLAUDE_TMUX_BIN            Override the tmux binary (testing)
+  CLEANUP_CLAUDE_LSOF_BIN            Override the lsof binary (testing)
+  CLEANUP_CLAUDE_PROJECTS_DIR        Override ~/.claude/projects (testing)
 EOF
 }
 
@@ -57,6 +90,11 @@ if ! [[ "$IDLE_MINUTES" =~ ^[0-9]+$ ]]; then
   exit 2
 fi
 
+if ! [[ "$KILL_GRACE_SECONDS" =~ ^[0-9]+$ ]]; then
+  echo "[cleanup-idle-claude] CLEANUP_CLAUDE_KILL_GRACE_SECONDS must be a non-negative integer" >&2
+  exit 2
+fi
+
 # Build allowlist as comma-bounded string (bash 3.2 / macOS default has no
 # associative arrays). RW-028 / RW-006: avoid `declare -A` and `readarray`
 # in scripts that ship to macOS hosts.
@@ -72,7 +110,7 @@ is_in_allowlist() {
 }
 
 # Reuse classify logic from the lister via subshell.
-LIST_SCRIPT="$(dirname "$0")/list-claude-processes.sh"
+LIST_SCRIPT="${CLEANUP_CLAUDE_LIST_SCRIPT:-$(dirname "$0")/list-claude-processes.sh}"
 if [ ! -x "$LIST_SCRIPT" ] && [ ! -f "$LIST_SCRIPT" ]; then
   echo "[cleanup-idle-claude] cannot find $LIST_SCRIPT" >&2
   exit 2
@@ -110,40 +148,142 @@ etime_to_minutes() {
   echo $(( days * 24 * 60 + 10#$hours * 60 + 10#$minutes ))
 }
 
-# Best-effort: check if the process's transcript jsonl was modified recently.
-# Returns 0 (true, recent) if any open *.jsonl was touched within IDLE_MINUTES,
-# 1 (false, idle) otherwise.
-has_recent_activity() {
-  local pid="$1" threshold="$2"
-  if ! command -v lsof >/dev/null 2>&1; then
-    # Without lsof we can't tell — assume idle to be conservative; the
-    # etime gate above already protects very short-lived processes.
-    return 1
+mtime_of() {
+  local f="$1"
+  if [[ "$OSTYPE" == darwin* ]]; then
+    stat -f '%m' "$f" 2>/dev/null || true
+  else
+    stat -c '%Y' "$f" 2>/dev/null || true
   fi
-  # Find any .jsonl file the process holds open and stat it.
-  local files
-  files=$(lsof -a -p "$pid" 2>/dev/null | awk '/\.jsonl$/{print $NF}')
-  [ -z "$files" ] && return 1
-  local now
+}
+
+# One `pane_pid session_activity window_activity` line per tmux pane, across
+# both the supervisor's socket and whatever socket this shell inherits.
+#
+# Taken as a single snapshot rather than per-PID: a live host runs a handful of
+# claude processes and each lookup would otherwise re-shell tmux twice, which
+# made the whole run take seconds. Refreshed explicitly (see --apply) whenever
+# a reading must be current rather than merely consistent.
+PANE_SNAPSHOT=""
+load_pane_snapshot() {
+  PANE_SNAPSHOT=""
+  command -v "$TMUX_BIN" >/dev/null 2>&1 || return 0
+  local socket_args out
+  for socket_args in "-L claude-hub" ""; do
+    # shellcheck disable=SC2086
+    out=$("$TMUX_BIN" $socket_args list-panes -a \
+            -F '#{pane_pid} #{session_activity} #{window_activity}' 2>/dev/null || true)
+    [ -n "$out" ] && PANE_SNAPSHOT="${PANE_SNAPSHOT}${out}"$'\n'
+  done
+  return 0
+}
+
+# Epoch seconds of the most recent tmux activity for the pane whose pane_pid is
+# $1, or empty when the pid owns no pane (or tmux is unavailable).
+#
+# `#{session_activity}` / `#{window_activity}` are epoch seconds. Both are read
+# and the larger wins: session_activity can lag behind the window that is
+# actually being written to (measured on the supervisor's socket: the live
+# session reported session_activity 8m old while window_activity was current).
+tmux_last_activity() {
+  local pid="$1"
+  [ -z "$PANE_SNAPSHOT" ] && return 0
+  awk -v target="$pid" '
+    $1 == target {
+      latest = $2 + 0;
+      if ($3 + 0 > latest) latest = $3 + 0;
+      print latest;
+      exit;
+    }
+  ' <<<"$PANE_SNAPSHOT"
+}
+
+# Epoch seconds of the newest transcript *.jsonl belonging to the process's
+# working directory, or empty when it cannot be located.
+#
+# Claude Code stores transcripts under
+# `~/.claude/projects/<cwd>/<session-uuid>.jsonl`, where <cwd> is the absolute
+# path with every character outside [A-Za-z0-9-] replaced by `-`. Verified
+# against live directories on this host, e.g.
+#   /Users/x/corp/.claude/worktrees/corp_selector_Proposal
+#     -> -Users-x-corp--claude-worktrees-corp-selector-Proposal
+# The encoding is an internal Claude Code detail, so a miss (directory absent,
+# or the rule changed) yields empty => `unknown` => protected, never "idle".
+transcript_last_mtime() {
+  local pid="$1"
+  command -v "$LSOF_BIN" >/dev/null 2>&1 || return 0
+  local cwd
+  cwd=$("$LSOF_BIN" -a -p "$pid" -d cwd -Fn 2>/dev/null | awk '/^n/{sub(/^n/,""); print; exit}')
+  [ -z "$cwd" ] && return 0
+  local encoded dir
+  encoded=$(printf '%s' "$cwd" | sed 's/[^A-Za-z0-9-]/-/g')
+  dir="${PROJECTS_DIR}/${encoded}"
+  [ -d "$dir" ] || return 0
+  local newest=0 f m
+  for f in "$dir"/*.jsonl; do
+    [ -e "$f" ] || continue
+    m=$(mtime_of "$f")
+    [ -z "$m" ] && continue
+    [ "$m" -gt "$newest" ] && newest="$m"
+  done
+  [ "$newest" -eq 0 ] && return 0
+  printf '%s' "$newest"
+}
+
+# Observe how long a process has been quiet.
+#
+# Prints "<state> <detail>" where state is one of:
+#   active  — measured activity within the threshold: do not touch
+#   idle    — measured activity older than the threshold: eligible
+#   unknown — no observation source answered: protected (fail-safe)
+#
+# The `unknown` state is the whole point of Issue #430. The previous
+# implementation had no such state: any failure to observe was reported as
+# idle, which is how a session that was actively working became the single
+# kill candidate on this host.
+observe_activity() {
+  local pid="$1" threshold_min="$2"
+  local now cutoff ts age_min
   now=$(date +%s)
-  local cutoff=$(( now - threshold * 60 ))
-  while IFS= read -r f; do
-    [ -z "$f" ] && continue
-    local mtime
-    if [[ "$OSTYPE" == darwin* ]]; then
-      mtime=$(stat -f '%m' "$f" 2>/dev/null || echo 0)
-    else
-      mtime=$(stat -c '%Y' "$f" 2>/dev/null || echo 0)
-    fi
-    if [ "$mtime" -gt "$cutoff" ]; then
+  cutoff=$(( now - threshold_min * 60 ))
+
+  ts=$(tmux_last_activity "$pid")
+  if [ -z "$ts" ]; then
+    ts=$(transcript_last_mtime "$pid")
+    if [ -n "$ts" ]; then
+      age_min=$(( (now - ts) / 60 ))
+      if [ "$ts" -gt "$cutoff" ]; then
+        echo "active transcript-mtime ${age_min}m-ago"
+      else
+        echo "idle transcript-mtime ${age_min}m-ago"
+      fi
       return 0
     fi
-  done <<<"$files"
-  return 1
+    echo "unknown no-activity-source (tmux pane and transcript both unreadable)"
+    return 0
+  fi
+
+  age_min=$(( (now - ts) / 60 ))
+  if [ "$ts" -gt "$cutoff" ]; then
+    echo "active tmux-activity ${age_min}m-ago"
+  else
+    echo "idle tmux-activity ${age_min}m-ago"
+  fi
 }
 
 CANDIDATES=()
 PROTECTED_REASONS=()
+
+# bash 3.2 (macOS default) expands "${arr[@]}" of an EMPTY array to an unbound
+# variable error under `set -u`, so every iteration of an array that can be
+# empty needs a length guard. PROTECTED_REASONS is empty whenever every listed
+# process becomes a candidate — rare on a live host, which is why this only
+# surfaced under test (RW-028 / RW-006).
+print_protected_reasons() {
+  [ "${#PROTECTED_REASONS[@]}" -eq 0 ] && return 0
+  local r
+  for r in "${PROTECTED_REASONS[@]}"; do echo "    - $r"; done
+}
 
 # Final-line-of-defense: verify a PID's argv[0] is actually `claude` (or
 # ends in `/claude`) before we'd ever signal it. The lister regex is
@@ -159,6 +299,8 @@ is_genuine_claude_executable() {
   base="${argv0##*/}"
   [ "$base" = "claude" ]
 }
+
+load_pane_snapshot
 
 for row in "${ROWS[@]}"; do
   # Columns are space-padded by printf in the lister.
@@ -184,22 +326,36 @@ for row in "${ROWS[@]}"; do
     PROTECTED_REASONS+=("$local_pid: etime ${local_minutes}m < threshold ${IDLE_MINUTES}m")
     continue
   fi
-  if has_recent_activity "$local_pid" "$IDLE_MINUTES"; then
-    PROTECTED_REASONS+=("$local_pid: recent .jsonl activity within ${IDLE_MINUTES}m")
-    continue
-  fi
+  # Cheap identity guard before the observation work: the lister's regex also
+  # catches its own awk subshell, and there is no point measuring the activity
+  # of something we would refuse to signal anyway.
   if ! is_genuine_claude_executable "$local_pid"; then
     PROTECTED_REASONS+=("$local_pid: argv0 is not claude (lister false positive)")
     continue
   fi
-  CANDIDATES+=("$local_cat $local_pid $local_etime")
+  local_observation=$(observe_activity "$local_pid" "$IDLE_MINUTES")
+  local_state="${local_observation%% *}"
+  local_detail="${local_observation#* }"
+  case "$local_state" in
+    active)
+      PROTECTED_REASONS+=("$local_pid: active — $local_detail")
+      continue
+      ;;
+    unknown)
+      # Fail-safe (#430): we could not measure this process, so we must not
+      # assume it is doing nothing.
+      PROTECTED_REASONS+=("$local_pid: activity unobservable, protected — $local_detail")
+      continue
+      ;;
+  esac
+  CANDIDATES+=("$local_cat $local_pid $local_etime $local_detail")
 done
 
 echo "[cleanup-idle-claude] mode: $MODE  idle_threshold: ${IDLE_MINUTES}m"
 if [ "${#CANDIDATES[@]}" -eq 0 ]; then
   echo "  No idle claude processes found above threshold."
   echo "  Protected (skipped): ${#PROTECTED_REASONS[@]}"
-  for r in "${PROTECTED_REASONS[@]}"; do echo "    - $r"; done
+  print_protected_reasons
   exit 0
 fi
 
@@ -208,30 +364,58 @@ for c in "${CANDIDATES[@]}"; do
   echo "    - $c"
 done
 echo "  Protected (${#PROTECTED_REASONS[@]} skipped):"
-for r in "${PROTECTED_REASONS[@]}"; do echo "    - $r"; done
+print_protected_reasons
 
 if [ "$MODE" = "dry-run" ]; then
   echo
-  echo "  Run with --apply to send SIGTERM (then SIGKILL after 10s) to candidates."
+  echo "  Each candidate line ends with the measurement that proved it idle."
+  echo "  Run with --apply to send SIGTERM (then SIGKILL after ${KILL_GRACE_SECONDS}s) to candidates;"
+  echo "  --apply re-measures every candidate immediately before signalling it."
   exit 0
 fi
 
-# --apply: SIGTERM, wait, SIGKILL stragglers.
+# --apply: re-observe, SIGTERM, wait, SIGKILL stragglers.
+#
+# The re-observation is not redundant with the loop above. Candidates are
+# selected from a snapshot; between that snapshot and the signal a session can
+# wake up (a Discord message lands, a queued dispatch starts). Re-measuring
+# immediately before each SIGTERM keeps "never kill a working session" true at
+# the instant it matters, not merely when the list was built (#430).
+#
+# SIGKILL only ever targets a pid we actually SIGTERMed. `KILLED_STR` is a
+# comma-bounded string rather than an array because bash 3.2 (macOS default)
+# errors on "${arr[@]}" when the array is empty under `set -u`, and this list
+# is empty whenever every candidate woke up (RW-028 / RW-006).
 exit_code=0
+KILLED_STR=","
 for c in "${CANDIDATES[@]}"; do
   read -ra cf <<<"$c"
   pid="${cf[1]}"
+  # Fresh reading, not the snapshot the candidate list was built from.
+  load_pane_snapshot
+  recheck=$(observe_activity "$pid" "$IDLE_MINUTES")
+  if [ "${recheck%% *}" != "idle" ]; then
+    echo "  -> SKIP $pid (re-check before signal: $recheck)"
+    continue
+  fi
   echo "  -> SIGTERM $pid"
   if ! kill -TERM "$pid" 2>/dev/null; then
     echo "     failed (process gone or no permission)"
     exit_code=1
     continue
   fi
+  KILLED_STR="${KILLED_STR}${pid},"
 done
-sleep 10
+if [ "$KILLED_STR" = "," ]; then
+  echo "[cleanup-idle-claude] no process was signalled (all candidates woke up)"
+  echo "[cleanup-idle-claude] done (exit $exit_code)"
+  exit "$exit_code"
+fi
+sleep "$KILL_GRACE_SECONDS"
 for c in "${CANDIDATES[@]}"; do
   read -ra cf <<<"$c"
   pid="${cf[1]}"
+  [[ "$KILLED_STR" == *",${pid},"* ]] || continue
   if kill -0 "$pid" 2>/dev/null; then
     echo "  -> still alive, SIGKILL $pid"
     if ! kill -KILL "$pid" 2>/dev/null; then

--- a/scripts/list-claude-processes.sh
+++ b/scripts/list-claude-processes.sh
@@ -5,9 +5,12 @@
 #   supervisor      — Channel-Supervisor's own bun process (com.claude-hub.supervisor)
 #   hijoguchi       — claudeHubExit bot (com.claude-hub.hijoguchi)
 #   tmux-supervised — claude running inside a tmux session managed by the supervisor
-#                     (the parent tmux process itself is the supervisor's tmux socket)
-#   tmux-other      — claude running inside any other tmux session
-#   subagent        — claude whose parent PID is itself a `claude` process (Task tool)
+#                     (on the `-L claude-hub` socket AND named by the supervisor's
+#                     own `claude-<threadId12>` formula)
+#   tmux-other      — claude in any other tmux session, INCLUDING hand-made
+#                     sessions that merely share the `-L claude-hub` socket (#430)
+#   subagent        — claude whose parent process is the claude binary (Task tool);
+#                     matched on argv[0] basename, never a substring (#430)
 #   interactive     — claude attached to a user's tty (no tmux), top-level
 #   orphan          — anything that doesn't match the above
 #
@@ -68,6 +71,37 @@ tmux_session_for_pid() {
   echo ""
 }
 
+# argv[0] basename of a pid (e.g. `claude` for /Users/x/.local/bin/claude).
+# Empty output + non-zero exit when the pid is gone.
+#
+# Issue #430: classification must never test for the SUBSTRING "claude" in a
+# full command line. The supervisor's tmux server runs as
+#   tmux -L claude-hub new-session -d -s claude-<threadId> ... exec .../claude ...
+# so its argv contains "claude" three times over. Comparing the basename of
+# argv[0] instead answers the actual question ("is this process the claude
+# binary?") and is immune to socket / session names that merely spell it.
+argv0_basename() {
+  local pid="$1" argv0
+  argv0=$(ps -p "$pid" -o command= 2>/dev/null | awk '{print $1}')
+  [ -z "$argv0" ] && return 1
+  printf '%s' "${argv0##*/}"
+}
+
+# Does a tmux session name follow the supervisor's own naming formula?
+#
+# SessionManager.tmuxSessionNameFor() builds every session it starts as
+# `claude-<first 12 chars of the Discord thread id>`
+# (supervisor/src/session/manager.ts). Thread ids are numeric snowflakes, so a
+# supervisor-managed name always matches ^claude-[0-9]{1,12}$.
+#
+# Issue #430: hand-made sessions on the same socket (observed: `claude-x`,
+# `claude-tricky` — 9h idle, zero input) used to inherit the "never touch a
+# Discord session" protection and could never be reclaimed. Only names that
+# carry the supervisor's formula get that protection now.
+is_supervisor_session_name() {
+  [[ "$1" =~ ^claude-[0-9]{1,12}$ ]]
+}
+
 # Decide whether a given pid was launched by the supervisor's tmux socket.
 # We check: ancestor chain contains a tmux process whose argv contains
 # `-L claude-hub`.
@@ -101,8 +135,11 @@ cwd_for_pid() {
 }
 
 # Categorise one row.
+# $4 is the pid's tmux session name (empty when it owns no pane). It is passed
+# in rather than looked up here because `main` needs the same value for its
+# output column, and each lookup shells out to tmux once per socket.
 classify() {
-  local pid="$1" ppid="$2" cmd="$3"
+  local pid="$1" ppid="$2" cmd="$3" tsess="${4:-}"
   local parent_cmd
   parent_cmd=$(ps -p "$ppid" -o command= 2>/dev/null || true)
 
@@ -116,19 +153,28 @@ classify() {
     echo "hijoguchi"
     return
   fi
-  # subagent (parent is itself claude)
-  if [[ "$parent_cmd" == *claude* && "$parent_cmd" != *"start-hijoguchi"* ]]; then
+  # subagent (parent process IS the claude binary — Task tool child).
+  # Basename comparison, not a substring of the parent's argv: see
+  # argv0_basename() for why (#430).
+  if [ "$(argv0_basename "$ppid" || true)" = "claude" ]; then
     echo "subagent"
     return
   fi
-  # supervisor-managed tmux session
+  # supervisor-managed tmux session: on the supervisor's socket AND carrying
+  # its naming formula. A session on that socket whose name we resolved and
+  # which does NOT match the formula is a hand-made session — reclaimable, so
+  # it is demoted to `tmux-other`. If the name could not be resolved at all we
+  # keep the protected category: never demote a session we failed to observe
+  # (fail-safe, #430).
   if is_supervisor_tmux_chain "$pid"; then
+    if [ -n "$tsess" ] && ! is_supervisor_session_name "$tsess"; then
+      echo "tmux-other"
+      return
+    fi
     echo "tmux-supervised"
     return
   fi
   # other tmux
-  local tsess
-  tsess=$(tmux_session_for_pid "$pid")
   if [ -n "$tsess" ]; then
     echo "tmux-other"
     return
@@ -154,8 +200,8 @@ main() {
     "CATEGORY" "PID" "PPID" "ETIME" "RSS_MB" "TMUX_SESSION" "CMD"
   while IFS=$'\t' read -r pid ppid etime rss cmd; do
     local cat tsess rss_mb
-    cat=$(classify "$pid" "$ppid" "$cmd")
     tsess=$(tmux_session_for_pid "$pid")
+    cat=$(classify "$pid" "$ppid" "$cmd" "$tsess")
     rss_mb=$(( rss / 1024 ))
     # Truncate long cmd for readability.
     local short_cmd="${cmd:0:80}"
@@ -164,4 +210,9 @@ main() {
   done <<<"$rows"
 }
 
-main "$@"
+# `LIST_CLAUDE_PROCESSES_LIB_ONLY=1 source scripts/list-claude-processes.sh`
+# loads the classification predicates without taking a process snapshot, so the
+# test suite can assert on them directly (#430). Any other invocation lists.
+if [ "${LIST_CLAUDE_PROCESSES_LIB_ONLY:-}" != "1" ]; then
+  main "$@"
+fi

--- a/scripts/list-claude-processes.sh
+++ b/scripts/list-claude-processes.sh
@@ -49,8 +49,11 @@ tmux_session_for_pid() {
   fi
   # Try the supervisor socket first (Issue #83), then default.
   for socket_args in "-L claude-hub" ""; do
-    # shellcheck disable=SC2086
     local panes
+    # Directive must sit on the command it covers, not on the declaration above
+    # it: $socket_args is split into argv on purpose ("-L claude-hub" is two
+    # words), which is what SC2086 flags.
+    # shellcheck disable=SC2086
     panes=$(tmux $socket_args list-panes -a -F '#{pane_pid} #{session_name}' 2>/dev/null || true)
     [ -z "$panes" ] && continue
     local sess
@@ -109,7 +112,12 @@ is_supervisor_tmux_chain() {
   local pid="$1"
   local cur="$pid"
   for _ in 1 2 3 4 5 6 7 8 9 10; do
-    [ -z "$cur" ] || [ "$cur" = "0" ] || [ "$cur" = "1" ] && return 1
+    # `case` rather than a `||` chain ending in `&& return 1`: that form works
+    # only because `||` and `&&` share a precedence and associate left, so
+    # adding one more condition silently changes what the `&&` applies to.
+    case "$cur" in
+      "" | 0 | 1) return 1 ;;
+    esac
     local cmd
     cmd=$(ps -p "$cur" -o command= 2>/dev/null || true)
     if [ -z "$cmd" ]; then

--- a/supervisor/tests/scripts/cleanup-idle-claude.test.ts
+++ b/supervisor/tests/scripts/cleanup-idle-claude.test.ts
@@ -1,8 +1,16 @@
 // Smoke tests for scripts/cleanup-idle-claude.sh and scripts/list-claude-processes.sh
-// These scripts inspect live host processes; tests verify CLI surface and
-// non-destructive default behavior without asserting on specific live PIDs.
-import { test, expect, describe } from "bun:test";
+// These scripts inspect live host processes; the first two describes verify the
+// CLI surface and non-destructive default behavior without asserting on
+// specific live PIDs.
+//
+// The Issue #430 describes below are hermetic instead: they inject a fake
+// process lister, a fake tmux, a fake lsof and a fake ~/.claude/projects tree,
+// and only ever signal symlink-to-`sleep` stubs the test itself spawned. No
+// real claude process is read for its state or sent a signal.
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
 import { resolve } from "path";
+import { chmodSync, mkdirSync, mkdtempSync, symlinkSync, utimesSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
 
 const CLEANUP = resolve(import.meta.dir, "../../../scripts/cleanup-idle-claude.sh");
 const LIST = resolve(import.meta.dir, "../../../scripts/list-claude-processes.sh");
@@ -41,13 +49,13 @@ describe("cleanup-idle-claude.sh", () => {
     expect(exitCode).toBe(0);
     expect(stdout).toMatch(/mode:\s*dry-run/);
     expect(stdout).toContain("[cleanup-idle-claude]");
-  });
+  }, 30_000);
 
   test("--dry-run respects --idle-minutes override", async () => {
     const { exitCode, stdout } = await run(CLEANUP, ["--dry-run", "--idle-minutes", "1440"]);
     expect(exitCode).toBe(0);
     expect(stdout).toMatch(/idle_threshold:\s*1440m/);
-  });
+  }, 30_000);
 
   test("ALLOWLIST env protects listed PIDs from candidate set", async () => {
     const selfPid = process.pid;
@@ -56,7 +64,7 @@ describe("cleanup-idle-claude.sh", () => {
     });
     expect(exitCode).toBe(0);
     expect(stdout).not.toMatch(new RegExp(`-\\s+\\w+\\s+${selfPid}\\s`));
-  });
+  }, 30_000);
 });
 
 describe("list-claude-processes.sh", () => {
@@ -66,5 +74,331 @@ describe("list-claude-processes.sh", () => {
     expect(stdout).toContain("CATEGORY");
     expect(stdout).toContain("PID");
     expect(stdout).toContain("CMD");
+  }, 30_000);
+});
+
+// ---------------------------------------------------------------------------
+// Issue #430 — hermetic fixtures
+// ---------------------------------------------------------------------------
+
+/**
+ * A process that `is_genuine_claude_executable` accepts: a symlink to `sleep`
+ * named `claude`, so `ps -o command=` reports argv[0] with basename `claude`.
+ * `sleep` needs no interpreter, which keeps argv[0] ours on both macOS and
+ * Linux (a #! script would report the interpreter instead).
+ */
+interface Stub {
+  pid: number;
+  proc: ReturnType<typeof Bun.spawn>;
+}
+
+let root = "";
+let claudeBin = "";
+const stubs: Stub[] = [];
+
+function spawnClaudeStub(): Stub {
+  const proc = Bun.spawn([claudeBin, "600"], { stdout: "ignore", stderr: "ignore" });
+  const stub = { pid: proc.pid, proc };
+  stubs.push(stub);
+  return stub;
+}
+
+/** Write an executable bash stub and return its path. */
+function writeStub(name: string, body: string): string {
+  const path = `${root}/bin/${name}`;
+  writeFileSync(path, `#!/bin/bash\n${body}\n`);
+  chmodSync(path, 0o755);
+  return path;
+}
+
+/**
+ * Fake `tmux`: answers `list-panes -a -F '#{pane_pid} #{session_activity}
+ * #{window_activity}'` from a fixture file, ignoring the socket flags (the real
+ * script probes `-L claude-hub` and the inherited socket; both must see the
+ * same fixture). `name` keeps concurrent fixtures from overwriting each other.
+ */
+function fakeTmux(name: string, lines: string[]): string {
+  const fixture = `${root}/tmux-panes-${name}.txt`;
+  writeFileSync(fixture, lines.length ? lines.join("\n") + "\n" : "");
+  return writeStub(`tmux-${name}`, `cat ${JSON.stringify(fixture)}`);
+}
+
+/** Fake `lsof`: maps `-p <pid> -d cwd -Fn` to a cwd, in lsof's -F field format. */
+function fakeLsof(cwdByPid: Record<number, string>): string {
+  const cases = Object.entries(cwdByPid)
+    .map(([pid, cwd]) => `    ${pid}) echo "n${cwd}" ;;`)
+    .join("\n");
+  return writeStub(
+    "lsof",
+    [
+      "pid=''",
+      'while [ $# -gt 0 ]; do',
+      '  if [ "$1" = "-p" ]; then pid="$2"; shift 2; else shift; fi',
+      "done",
+      'case "$pid" in',
+      cases,
+      "esac",
+      "exit 0",
+    ].join("\n")
+  );
+}
+
+/**
+ * Fake process lister. ETIME is dictated here rather than measured, so a
+ * one-second-old stub can stand in for a long-lived session and exercise the
+ * gates past the elapsed-time check.
+ */
+function fakeLister(rows: { category: string; pid: number; etime?: string }[]): string {
+  const body = rows
+    .map(
+      (r) =>
+        `printf "%-16s  %-7s  %-7s  %-12s  %-8s  %-30s  %s\\n" ${JSON.stringify(
+          r.category
+        )} ${r.pid} 1 ${JSON.stringify(r.etime ?? "10:00:00")} 100 "-" "claude"`
+    )
+    .join("\n");
+  return writeStub(
+    "fake-lister",
+    ['printf "%s\\n" "CATEGORY  PID  PPID  ETIME  RSS_MB  TMUX_SESSION  CMD"', body].join("\n")
+  );
+}
+
+/** Seed a transcript directory for `cwd` with its newest jsonl aged `ageSec`. */
+function seedTranscript(cwd: string, ageSec: number): void {
+  const encoded = cwd.replace(/[^A-Za-z0-9-]/g, "-");
+  const dir = `${root}/projects/${encoded}`;
+  mkdirSync(dir, { recursive: true });
+  const file = `${dir}/00000000-0000-0000-0000-000000000000.jsonl`;
+  writeFileSync(file, "{}\n");
+  const when = new Date(Date.now() - ageSec * 1000);
+  utimesSync(file, when, when);
+}
+
+beforeAll(() => {
+  root = mkdtempSync(`${tmpdir()}/cleanup-idle-430-`);
+  mkdirSync(`${root}/bin`, { recursive: true });
+  mkdirSync(`${root}/projects`, { recursive: true });
+  claudeBin = `${root}/bin/claude`;
+  // `sleep` lives in /bin on both macOS and the Linux CI runner.
+  symlinkSync("/bin/sleep", claudeBin);
+});
+
+afterAll(() => {
+  // Only stubs this file spawned. Never a real claude.
+  for (const s of stubs) {
+    try {
+      s.proc.kill("SIGKILL");
+    } catch {
+      // Already exited (the --apply test kills some of them on purpose).
+    }
+  }
+});
+
+/** Run the cleanup script against injected observation sources. */
+async function runCleanup(
+  args: string[],
+  opts: { lister: string; tmux?: string; lsof?: string }
+) {
+  return run(CLEANUP, args, {
+    CLEANUP_CLAUDE_LIST_SCRIPT: opts.lister,
+    // A path that does not exist makes `command -v` fail, which is exactly how
+    // the source reports "this observation channel is unavailable".
+    CLEANUP_CLAUDE_TMUX_BIN: opts.tmux ?? `${root}/bin/no-such-tmux`,
+    CLEANUP_CLAUDE_LSOF_BIN: opts.lsof ?? `${root}/bin/no-such-lsof`,
+    CLEANUP_CLAUDE_PROJECTS_DIR: `${root}/projects`,
+    CLEANUP_CLAUDE_KILL_GRACE_SECONDS: "1",
+  });
+}
+
+function candidateSection(stdout: string): string {
+  const start = stdout.indexOf("Candidates (");
+  if (start < 0) return "";
+  const end = stdout.indexOf("Protected (", start);
+  return stdout.slice(start, end < 0 ? undefined : end);
+}
+
+describe("cleanup-idle-claude.sh — activity observation (#430)", () => {
+  test("AC-1: a session with current tmux activity is protected, not a candidate", async () => {
+    const busy = spawnClaudeStub();
+    const now = Math.floor(Date.now() / 1000);
+    const { exitCode, stdout } = await runCleanup(["--dry-run"], {
+      lister: fakeLister([{ category: "interactive", pid: busy.pid }]),
+      tmux: fakeTmux("busy", [`${busy.pid} ${now} ${now}`]),
+    });
+    expect(exitCode).toBe(0);
+    expect(candidateSection(stdout)).not.toContain(String(busy.pid));
+    expect(stdout).toContain(`${busy.pid}: active — tmux-activity`);
+  });
+
+  test("AC-1: a session whose transcript was just written is protected", async () => {
+    const busy = spawnClaudeStub();
+    const cwd = `${root}/work-busy`;
+    seedTranscript(cwd, 60);
+    const { exitCode, stdout } = await runCleanup(["--dry-run"], {
+      lister: fakeLister([{ category: "interactive", pid: busy.pid }]),
+      lsof: fakeLsof({ [busy.pid]: cwd }),
+    });
+    expect(exitCode).toBe(0);
+    expect(candidateSection(stdout)).not.toContain(String(busy.pid));
+    expect(stdout).toContain(`${busy.pid}: active — transcript-mtime`);
+  });
+
+  test("AC-2: an untouched tmux session is a candidate (not shielded as subagent)", async () => {
+    const dormant = spawnClaudeStub();
+    const long_ago = Math.floor(Date.now() / 1000) - 9 * 3600;
+    const { exitCode, stdout } = await runCleanup(["--dry-run"], {
+      lister: fakeLister([{ category: "tmux-other", pid: dormant.pid }]),
+      tmux: fakeTmux("dormant", [`${dormant.pid} ${long_ago} ${long_ago}`]),
+    });
+    expect(exitCode).toBe(0);
+    expect(candidateSection(stdout)).toContain(String(dormant.pid));
+    // The measurement that justified the kill is printed for review.
+    expect(stdout).toMatch(new RegExp(`${dormant.pid}\\s+\\S+\\s+tmux-activity \\d+m-ago`));
+  });
+
+  test("AC-3: with no observation source at all, nothing is a candidate", async () => {
+    const a = spawnClaudeStub();
+    const b = spawnClaudeStub();
+    const { exitCode, stdout } = await runCleanup(["--dry-run"], {
+      lister: fakeLister([
+        { category: "interactive", pid: a.pid },
+        { category: "tmux-other", pid: b.pid },
+      ]),
+      // Neither tmux nor lsof resolvable — the state this host is actually in
+      // (lsof lives in /usr/sbin, absent from the supervisor's PATH).
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("No idle claude processes found above threshold.");
+    expect(stdout).toContain(`${a.pid}: activity unobservable, protected`);
+    expect(stdout).toContain(`${b.pid}: activity unobservable, protected`);
+  });
+
+  test("AC-3 regression: lsof answering with no transcript is unknown, not idle", async () => {
+    // The exact shape of the original defect: lsof runs fine, but nothing maps
+    // the process to a transcript. That must not read as "quiet".
+    const stub = spawnClaudeStub();
+    const { exitCode, stdout } = await runCleanup(["--dry-run"], {
+      lister: fakeLister([{ category: "interactive", pid: stub.pid }]),
+      lsof: fakeLsof({ [stub.pid]: `${root}/cwd-with-no-project-dir` }),
+    });
+    expect(exitCode).toBe(0);
+    expect(candidateSection(stdout)).not.toContain(String(stub.pid));
+    expect(stdout).toContain(`${stub.pid}: activity unobservable, protected`);
+  });
+
+  test("--apply re-measures and skips a candidate that woke up, killing only the idle one", async () => {
+    const woken = spawnClaudeStub();
+    const dormant = spawnClaudeStub();
+    const now = Math.floor(Date.now() / 1000);
+    const long_ago = now - 9 * 3600;
+
+    const lister = writeStub(
+      "fake-lister-apply",
+      [
+        'printf "%s\\n" "CATEGORY  PID  PPID  ETIME  RSS_MB  TMUX_SESSION  CMD"',
+        `printf "%-16s  %-7s  %-7s  %-12s  %-8s  %-30s  %s\\n" "tmux-other" ${woken.pid} 1 "10:00:00" 100 "-" "claude"`,
+        `printf "%-16s  %-7s  %-7s  %-12s  %-8s  %-30s  %s\\n" "tmux-other" ${dormant.pid} 1 "10:00:00" 100 "-" "claude"`,
+      ].join("\n")
+    );
+
+    // A session can wake up between the moment the candidate list is built and
+    // the moment the signal is sent, so the fixture has to change mid-run. The
+    // stub therefore serves `before` until it has been called `switch` times,
+    // then `after`. `switch` is not hardcoded: the dry-run below counts how
+    // many calls one full selection pass makes, so this stays correct if the
+    // script ever probes a different number of tmux sockets.
+    const counter = `${root}/apply-tmux-calls`;
+    const switchAt = `${root}/apply-tmux-switch`;
+    const before = `${root}/apply-panes-before.txt`;
+    const after = `${root}/apply-panes-after.txt`;
+    writeFileSync(before, `${woken.pid} ${long_ago} ${long_ago}\n${dormant.pid} ${long_ago} ${long_ago}\n`);
+    writeFileSync(after, `${woken.pid} ${now} ${now}\n${dormant.pid} ${long_ago} ${long_ago}\n`);
+    writeFileSync(counter, "0");
+    writeFileSync(switchAt, "999999");
+    const tmux = writeStub(
+      "tmux-apply",
+      [
+        `n=$(cat ${JSON.stringify(counter)})`,
+        "n=$((n + 1))",
+        `printf '%s' "$n" > ${JSON.stringify(counter)}`,
+        `switch=$(cat ${JSON.stringify(switchAt)})`,
+        `if [ "$n" -le "$switch" ]; then cat ${JSON.stringify(before)}; else cat ${JSON.stringify(after)}; fi`,
+      ].join("\n")
+    );
+
+    // Calibration pass: nothing switches, so both processes look idle and both
+    // become candidates. This is also the state the old code would have acted
+    // on blindly.
+    const dry = await runCleanup(["--dry-run"], { lister, tmux });
+    expect(candidateSection(dry.stdout)).toContain(String(woken.pid));
+    expect(candidateSection(dry.stdout)).toContain(String(dormant.pid));
+    const callsPerPass = Number(await Bun.file(counter).text());
+    expect(callsPerPass).toBeGreaterThan(0);
+
+    // Apply pass: identical selection, then `woken` is reported active from the
+    // first re-measurement onward.
+    writeFileSync(counter, "0");
+    writeFileSync(switchAt, String(callsPerPass));
+    const applied = await runCleanup(["--apply"], { lister, tmux });
+    expect(applied.exitCode).toBe(0);
+    expect(applied.stdout).toContain(`SKIP ${woken.pid}`);
+    expect(applied.stdout).toContain(`SIGTERM ${dormant.pid}`);
+    expect(applied.stdout).not.toContain(`SIGTERM ${woken.pid}`);
+
+    // The woken stub is still running; the dormant one is gone.
+    expect(() => process.kill(woken.pid, 0)).not.toThrow();
+    await dormant.proc.exited;
+  }, 20_000);
+});
+
+describe("list-claude-processes.sh — classification predicates (#430)", () => {
+  /** Source the lister as a library and evaluate one expression against it. */
+  async function evalInLister(snippet: string) {
+    const proc = Bun.spawn(
+      ["bash", "-c", `LIST_CLAUDE_PROCESSES_LIB_ONLY=1 source ${JSON.stringify(LIST)}; ${snippet}`],
+      { env: { PATH: process.env.PATH ?? "" }, stdout: "pipe", stderr: "pipe" }
+    );
+    const exitCode = await proc.exited;
+    const stdout = await new Response(proc.stdout).text();
+    return { exitCode, stdout: stdout.trim() };
+  }
+
+  test("supervisor-formula session names are recognised, hand-made ones are not", async () => {
+    // `claude-<threadId12>` per SessionManager.tmuxSessionNameFor().
+    for (const name of ["claude-153700777499", "claude-1"]) {
+      const { exitCode } = await evalInLister(`is_supervisor_session_name ${JSON.stringify(name)}`);
+      expect(exitCode).toBe(0);
+    }
+    // The two sessions that Issue #430 found permanently shielded.
+    for (const name of ["claude-x", "claude-tricky", "claude-", "claude-1537007774990"]) {
+      const { exitCode } = await evalInLister(`is_supervisor_session_name ${JSON.stringify(name)}`);
+      expect(exitCode).not.toBe(0);
+    }
+  });
+
+  test("a parent whose argv merely contains 'claude' is not read as the claude binary", async () => {
+    // Shaped like the real supervisor tmux server:
+    //   /opt/homebrew/bin/tmux -L claude-hub new-session -d -s claude-<id> ...
+    // Its command line spells "claude", its argv[0] basename does not.
+    const dir = `${root}/claude-hub`;
+    mkdirSync(dir, { recursive: true });
+    const tmuxLike = `${dir}/tmux`;
+    symlinkSync("/bin/sleep", tmuxLike);
+    const proc = Bun.spawn([tmuxLike, "600"], { stdout: "ignore", stderr: "ignore" });
+    stubs.push({ pid: proc.pid, proc });
+
+    const { stdout } = await evalInLister(`argv0_basename ${proc.pid}`);
+    expect(stdout).toBe("tmux");
+
+    // Guard the premise: the substring test the old classifier used would have
+    // matched here, which is how every pane on that socket became a "subagent".
+    const cmd = Bun.spawnSync(["ps", "-p", String(proc.pid), "-o", "command="]);
+    expect(cmd.stdout.toString()).toContain("claude");
+  });
+
+  test("argv0_basename reports 'claude' for a real claude-named process", async () => {
+    const stub = spawnClaudeStub();
+    const { stdout } = await evalInLister(`argv0_basename ${stub.pid}`);
+    expect(stdout).toBe("claude");
   });
 });

--- a/supervisor/tests/scripts/cleanup-idle-claude.test.ts
+++ b/supervisor/tests/scripts/cleanup-idle-claude.test.ts
@@ -1,12 +1,13 @@
-// Smoke tests for scripts/cleanup-idle-claude.sh and scripts/list-claude-processes.sh
-// These scripts inspect live host processes; the first two describes verify the
-// CLI surface and non-destructive default behavior without asserting on
-// specific live PIDs.
+// Tests for scripts/cleanup-idle-claude.sh and scripts/list-claude-processes.sh.
 //
-// The Issue #430 describes below are hermetic instead: they inject a fake
-// process lister, a fake tmux, a fake lsof and a fake ~/.claude/projects tree,
-// and only ever signal symlink-to-`sleep` stubs the test itself spawned. No
-// real claude process is read for its state or sent a signal.
+// Everything about the decision logic is hermetic: a fake process lister, a
+// fake tmux, a fake lsof and a fake ~/.claude/projects tree are injected, and
+// the only pids ever signalled are symlink-to-`sleep` stubs this file spawned.
+// No real claude process is read for its state or sent a signal.
+//
+// Exactly two cases touch the live host ("live host smoke"), and both tolerate
+// a machine with nothing running — they assert the scripts survive a real
+// process table, not that any particular process is up.
 import { test, expect, describe, beforeAll, afterAll } from "bun:test";
 import { resolve } from "path";
 import { chmodSync, mkdirSync, mkdtempSync, symlinkSync, utimesSync, writeFileSync } from "fs";
@@ -26,56 +27,6 @@ async function run(script: string, args: string[] = [], env: Record<string, stri
   const stderr = await new Response(proc.stderr).text();
   return { exitCode, stdout, stderr };
 }
-
-describe("cleanup-idle-claude.sh", () => {
-  test("--help exits 0 and prints usage with expected sections", async () => {
-    const { exitCode, stdout } = await run(CLEANUP, ["--help"]);
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain("Usage:");
-    expect(stdout).toContain("--dry-run");
-    expect(stdout).toContain("--apply");
-    expect(stdout).toContain("--idle-minutes");
-    expect(stdout).toContain("CLEANUP_CLAUDE_ALLOWLIST_PIDS");
-  });
-
-  test("unknown flag exits 2", async () => {
-    const { exitCode, stderr } = await run(CLEANUP, ["--bogus-flag"]);
-    expect(exitCode).toBe(2);
-    expect(stderr).toContain("unknown arg");
-  });
-
-  test("default run is dry-run (no signals sent) and exits 0", async () => {
-    const { exitCode, stdout } = await run(CLEANUP, []);
-    expect(exitCode).toBe(0);
-    expect(stdout).toMatch(/mode:\s*dry-run/);
-    expect(stdout).toContain("[cleanup-idle-claude]");
-  }, 30_000);
-
-  test("--dry-run respects --idle-minutes override", async () => {
-    const { exitCode, stdout } = await run(CLEANUP, ["--dry-run", "--idle-minutes", "1440"]);
-    expect(exitCode).toBe(0);
-    expect(stdout).toMatch(/idle_threshold:\s*1440m/);
-  }, 30_000);
-
-  test("ALLOWLIST env protects listed PIDs from candidate set", async () => {
-    const selfPid = process.pid;
-    const { exitCode, stdout } = await run(CLEANUP, ["--dry-run"], {
-      CLEANUP_CLAUDE_ALLOWLIST_PIDS: String(selfPid),
-    });
-    expect(exitCode).toBe(0);
-    expect(stdout).not.toMatch(new RegExp(`-\\s+\\w+\\s+${selfPid}\\s`));
-  }, 30_000);
-});
-
-describe("list-claude-processes.sh", () => {
-  test("runs and prints CATEGORY header", async () => {
-    const { exitCode, stdout } = await run(LIST, []);
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain("CATEGORY");
-    expect(stdout).toContain("PID");
-    expect(stdout).toContain("CMD");
-  }, 30_000);
-});
 
 // ---------------------------------------------------------------------------
 // Issue #430 — hermetic fixtures
@@ -163,6 +114,33 @@ function fakeLister(rows: { category: string; pid: number; etime?: string }[]): 
   );
 }
 
+/**
+ * A PATH carrying everything the script shells out to EXCEPT lsof — the state
+ * a macOS host is in, where lsof lives in /usr/sbin and the PATH the supervisor
+ * hands its tmux sessions does not include it. Built by resolving each tool so
+ * it works on the Linux CI runner too.
+ */
+function pathWithoutLsof(): string {
+  const dir = `${root}/bin-nolsof`;
+  mkdirSync(dir, { recursive: true });
+  // Everything cleanup-idle-claude.sh (and the fixtures it runs) shells out to.
+  for (const cmd of [
+    "bash", "ps", "awk", "date", "stat", "sed", "tr", "sleep", "tail", "cat", "dirname",
+  ]) {
+    const real = Bun.which(cmd);
+    if (!real) throw new Error(`test setup: ${cmd} not found on PATH`);
+    try {
+      symlinkSync(real, `${dir}/${cmd}`);
+    } catch {
+      // Already linked by an earlier call.
+    }
+  }
+  if (Bun.which("lsof", { PATH: dir })) {
+    throw new Error("test setup: lsof leaked into the lsof-free PATH");
+  }
+  return dir;
+}
+
 /** Seed a transcript directory for `cwd` with its newest jsonl aged `ageSec`. */
 function seedTranscript(cwd: string, ageSec: number): void {
   const encoded = cwd.replace(/[^A-Za-z0-9-]/g, "-");
@@ -197,7 +175,13 @@ afterAll(() => {
 /** Run the cleanup script against injected observation sources. */
 async function runCleanup(
   args: string[],
-  opts: { lister: string; tmux?: string; lsof?: string }
+  opts: {
+    lister: string;
+    tmux?: string;
+    lsof?: string;
+    lsofFallback?: string;
+    env?: Record<string, string>;
+  }
 ) {
   return run(CLEANUP, args, {
     CLEANUP_CLAUDE_LIST_SCRIPT: opts.lister,
@@ -205,8 +189,12 @@ async function runCleanup(
     // the source reports "this observation channel is unavailable".
     CLEANUP_CLAUDE_TMUX_BIN: opts.tmux ?? `${root}/bin/no-such-tmux`,
     CLEANUP_CLAUDE_LSOF_BIN: opts.lsof ?? `${root}/bin/no-such-lsof`,
+    // Neutralised by default so the host's real /usr/sbin/lsof cannot make an
+    // "lsof unavailable" case quietly become an available one.
+    CLEANUP_CLAUDE_LSOF_FALLBACK: opts.lsofFallback ?? `${root}/bin/no-such-fallback`,
     CLEANUP_CLAUDE_PROJECTS_DIR: `${root}/projects`,
     CLEANUP_CLAUDE_KILL_GRACE_SECONDS: "1",
+    ...(opts.env ?? {}),
   });
 }
 
@@ -216,6 +204,78 @@ function candidateSection(stdout: string): string {
   const end = stdout.indexOf("Protected (", start);
   return stdout.slice(start, end < 0 ? undefined : end);
 }
+
+describe("cleanup-idle-claude.sh — CLI surface", () => {
+  test("--help exits 0 and prints usage with expected sections", async () => {
+    const { exitCode, stdout } = await run(CLEANUP, ["--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Usage:");
+    expect(stdout).toContain("--dry-run");
+    expect(stdout).toContain("--apply");
+    expect(stdout).toContain("--idle-minutes");
+    expect(stdout).toContain("CLEANUP_CLAUDE_ALLOWLIST_PIDS");
+  });
+
+  test("unknown flag exits 2", async () => {
+    const { exitCode, stderr } = await run(CLEANUP, ["--bogus-flag"]);
+    expect(exitCode).toBe(2);
+    expect(stderr).toContain("unknown arg");
+  });
+
+  test("default run is dry-run (no signals sent) and exits 0", async () => {
+    const { exitCode, stdout } = await runCleanup([], {
+      lister: fakeLister([{ category: "interactive", pid: spawnClaudeStub().pid }]),
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/mode:\s*dry-run/);
+    expect(stdout).toContain("[cleanup-idle-claude]");
+  });
+
+  test("--dry-run respects --idle-minutes override", async () => {
+    const { exitCode, stdout } = await runCleanup(["--dry-run", "--idle-minutes", "1440"], {
+      lister: fakeLister([{ category: "interactive", pid: spawnClaudeStub().pid }]),
+    });
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/idle_threshold:\s*1440m/);
+  });
+
+  test("ALLOWLIST env protects a listed PID from the candidate set", async () => {
+    // The pid must actually appear in the lister's output for this to assert
+    // anything — pointing it at the test runner's own pid (which the lister
+    // never emits) made the original expectation vacuously true.
+    const stub = spawnClaudeStub();
+    const long_ago = Math.floor(Date.now() / 1000) - 9 * 3600;
+    const { exitCode, stdout } = await runCleanup(["--dry-run"], {
+      lister: fakeLister([{ category: "tmux-other", pid: stub.pid }]),
+      tmux: fakeTmux("allowlist", [`${stub.pid} ${long_ago} ${long_ago}`]),
+      env: { CLEANUP_CLAUDE_ALLOWLIST_PIDS: String(stub.pid) },
+    });
+    expect(exitCode).toBe(0);
+    expect(candidateSection(stdout)).not.toContain(String(stub.pid));
+    expect(stdout).toContain(`${stub.pid}: in CLEANUP_CLAUDE_ALLOWLIST_PIDS`);
+  });
+});
+
+// The only two cases that read the live host. They assert the scripts survive
+// a real process table; everything about the decision logic is pinned
+// hermetically below. Both tolerate a host with no claude running (the CI
+// runner), so neither depends on something happening to be up.
+describe("live host smoke", () => {
+  test("list-claude-processes.sh runs read-only and exits 0", async () => {
+    const { exitCode, stdout } = await run(LIST, []);
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/CATEGORY\s+PID|No claude processes found\./);
+  }, 30_000);
+
+  test("cleanup --dry-run against the real process table exits 0", async () => {
+    const { exitCode, stdout } = await run(CLEANUP, ["--dry-run"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toMatch(/mode:\s*dry-run|no claude processes found/);
+    // A dry run reports; it never reaches the signalling branch. (The footer
+    // mentions SIGTERM as advice, so match the action line specifically.)
+    expect(stdout).not.toContain("-> SIGTERM");
+  }, 30_000);
+});
 
 describe("cleanup-idle-claude.sh — activity observation (#430)", () => {
   test("AC-1: a session with current tmux activity is protected, not a candidate", async () => {
@@ -349,6 +409,143 @@ describe("cleanup-idle-claude.sh — activity observation (#430)", () => {
     expect(() => process.kill(woken.pid, 0)).not.toThrow();
     await dormant.proc.exited;
   }, 20_000);
+});
+
+describe("cleanup-idle-claude.sh — review follow-ups (#433)", () => {
+  test("must-1: tmux answering with unusable activity fields is unknown, not idle", async () => {
+    // A tmux that does not understand #{session_activity} substitutes the empty
+    // string. `"" + 0` is 0 in awk, and epoch 0 is the most idle value there
+    // is — so the pane used to come back as a kill candidate "29443860m-ago".
+    const stub = spawnClaudeStub();
+    const { exitCode, stdout } = await runCleanup(["--dry-run"], {
+      lister: fakeLister([{ category: "tmux-other", pid: stub.pid }]),
+      tmux: fakeTmux("empty-fields", [`${stub.pid}  `]),
+    });
+    expect(exitCode).toBe(0);
+    expect(candidateSection(stdout)).not.toContain(String(stub.pid));
+    expect(stdout).toContain(`${stub.pid}: activity unobservable, protected`);
+  });
+
+  test("must-1: a zero epoch is rejected even when it is the only reading", async () => {
+    const stub = spawnClaudeStub();
+    const { stdout } = await runCleanup(["--dry-run"], {
+      lister: fakeLister([{ category: "tmux-other", pid: stub.pid }]),
+      tmux: fakeTmux("zero-epoch", [`${stub.pid} 0 0`]),
+    });
+    expect(candidateSection(stdout)).not.toContain(String(stub.pid));
+    // The give-away of the old behaviour: an age measured from 1970.
+    expect(stdout).not.toMatch(/\d{7,}m-ago/);
+  });
+
+  test("should-2: lsof off PATH is found at the fallback path", async () => {
+    const stub = spawnClaudeStub();
+    const cwd = `${root}/work-fallback`;
+    seedTranscript(cwd, 60);
+    const { stdout } = await runCleanup(["--dry-run"], {
+      lister: fakeLister([{ category: "interactive", pid: stub.pid }]),
+      // Unresolvable as a bare name, exactly like macOS's /usr/sbin/lsof under
+      // the PATH the supervisor hands its sessions.
+      lsof: "lsof",
+      lsofFallback: fakeLsof({ [stub.pid]: cwd }),
+      env: { PATH: pathWithoutLsof() },
+    });
+    expect(stdout).toContain(`${stub.pid}: active — transcript-mtime`);
+  });
+
+  test("should-2: an explicit lsof override that does not resolve is never substituted", async () => {
+    // The fallback exists to repair the default. An operator who names a
+    // binary and gets a different one back would be worse than the bug.
+    const stub = spawnClaudeStub();
+    const cwd = `${root}/work-no-substitute`;
+    seedTranscript(cwd, 60);
+    const { stdout } = await runCleanup(["--dry-run"], {
+      lister: fakeLister([{ category: "interactive", pid: stub.pid }]),
+      lsof: `${root}/bin/no-such-lsof-override`,
+      lsofFallback: fakeLsof({ [stub.pid]: cwd }),
+    });
+    expect(stdout).toContain(`${stub.pid}: activity unobservable, protected`);
+  });
+
+  test("should-3: a fresh transcript wins over a stale tmux reading", async () => {
+    // The two sources measure different things (pane output vs. transcript
+    // writes). Stopping at the first non-empty answer let the older one veto
+    // the newer; the newest reading has to win.
+    const stub = spawnClaudeStub();
+    const cwd = `${root}/work-fresh-transcript`;
+    seedTranscript(cwd, 60);
+    const long_ago = Math.floor(Date.now() / 1000) - 9 * 3600;
+    const { stdout } = await runCleanup(["--dry-run"], {
+      lister: fakeLister([{ category: "tmux-other", pid: stub.pid }]),
+      tmux: fakeTmux("stale", [`${stub.pid} ${long_ago} ${long_ago}`]),
+      lsof: fakeLsof({ [stub.pid]: cwd }),
+    });
+    expect(candidateSection(stdout)).not.toContain(String(stub.pid));
+    expect(stdout).toContain(`${stub.pid}: active — transcript-mtime`);
+  });
+
+  test("should-3: both sources stale still yields idle, reported from the newer one", async () => {
+    const stub = spawnClaudeStub();
+    const cwd = `${root}/work-both-stale`;
+    seedTranscript(cwd, 4 * 3600);
+    const long_ago = Math.floor(Date.now() / 1000) - 9 * 3600;
+    const { stdout } = await runCleanup(["--dry-run"], {
+      lister: fakeLister([{ category: "tmux-other", pid: stub.pid }]),
+      tmux: fakeTmux("both-stale", [`${stub.pid} ${long_ago} ${long_ago}`]),
+      lsof: fakeLsof({ [stub.pid]: cwd }),
+    });
+    const candidates = candidateSection(stdout);
+    expect(candidates).toContain(String(stub.pid));
+    // 4h transcript is newer than the 9h tmux reading, so it is what gets shown.
+    expect(candidates).toContain("transcript-mtime");
+  });
+
+  test("should-4: a zero-padded ETIME day count does not abort the run", async () => {
+    // macOS `ps` prints "08-01:02:03"; bash reads a leading zero as octal, so
+    // `08` was an arithmetic error that took the whole run down under `set -e`
+    // — including --dry-run, leaving the operator with no listing at all.
+    const stub = spawnClaudeStub();
+    const long_ago = Math.floor(Date.now() / 1000) - 9 * 3600;
+    for (const etime of ["08-01:02:03", "09-00:00:00", "10-00:00:00"]) {
+      const { exitCode, stdout } = await runCleanup(["--dry-run"], {
+        lister: fakeLister([{ category: "tmux-other", pid: stub.pid, etime }]),
+        tmux: fakeTmux(`etime-${etime.slice(0, 2)}`, [`${stub.pid} ${long_ago} ${long_ago}`]),
+      });
+      expect(exitCode).toBe(0);
+      expect(stdout).toContain("[cleanup-idle-claude]");
+      // Decimal, not octal: 10 days must clear a 12000-minute (8.3d) threshold.
+      expect(candidateSection(stdout)).toContain(String(stub.pid));
+    }
+  }, 20_000);
+
+  test("should-4: 10 days is read as decimal, not octal", async () => {
+    const stub = spawnClaudeStub();
+    // Quiet for longer than the threshold below, so only the ETIME gate is
+    // under test here.
+    const long_ago = Math.floor(Date.now() / 1000) - 20 * 24 * 3600;
+    // 10 days = 14400 minutes decimal, but 8 days = 11520 if read as octal —
+    // which would fall short of this threshold and protect the process.
+    const { stdout } = await runCleanup(["--dry-run", "--idle-minutes", "12000"], {
+      lister: fakeLister([{ category: "tmux-other", pid: stub.pid, etime: "10-00:00:00" }]),
+      tmux: fakeTmux("etime-decimal", [`${stub.pid} ${long_ago} ${long_ago}`]),
+    });
+    expect(candidateSection(stdout)).toContain(String(stub.pid));
+  });
+
+  test("should-1: the identity guard is re-asserted in the kill loop", async () => {
+    // Behavioural coverage is not constructible (it needs a pid to be recycled
+    // into a non-claude process between selection and signal), so this pins the
+    // wiring the comment claims: the guard runs again after the re-observation
+    // and before `kill -TERM`.
+    const src = await Bun.file(CLEANUP).text();
+    const applyIdx = src.indexOf("KILLED_STR=\",\"");
+    const guardCalls = [...src.matchAll(/is_genuine_claude_executable "\$/g)].map((m) => m.index ?? -1);
+    expect(applyIdx).toBeGreaterThan(-1);
+    expect(guardCalls.length).toBeGreaterThanOrEqual(2);
+    expect(guardCalls.some((i) => i > applyIdx)).toBe(true);
+    expect(src.indexOf("kill -TERM")).toBeGreaterThan(
+      guardCalls.filter((i) => i > applyIdx)[0] as number
+    );
+  });
 });
 
 describe("list-claude-processes.sh — classification predicates (#430)", () => {


### PR DESCRIPTION
Closes #430

`scripts/cleanup-idle-claude.sh` は稼働中のセッションを唯一の kill 候補に挙げ、完全に未使用のセッションを恒久的に保護していた。`--apply` を実行すると作業中の claude に SIGTERM を送る状態だった。

## 原因（いずれも実測で確定）

### (a) 活動判定が観測失敗時に「活動なし」へ倒れていた

`has_recent_activity()` は lsof で open 中の `.jsonl` を探し、見つからなければ idle と結論していた。実測すると **2 段階**で失敗する。

| 観測 | 実測値 |
|---|---|
| `command -v lsof`（PATH 上） | 失敗。macOS の lsof は `/usr/sbin/lsof` にあり、supervisor が tmux に渡す PATH（`~/.local/bin:~/.bun/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin`）に `/usr/sbin` が無い |
| `/usr/sbin/lsof -a -p <pid>`（フルパス） | 30 行返るが `.jsonl` は **0 件**。claude は transcript を追記して close するため fd を保持していない |

つまり lsof が使えても使えなくても常に「活動なし」に倒れ、`IDLE_MINUTES` を超えた claude はすべて idle と報告されていた。

### (b) 分類器が tmux 配下をすべて subagent にしていた

`classify()` は親プロセスの argv に文字列 `claude` が含まれるかで subagent を判定していた。supervisor の tmux サーバの argv は実測で

```
/opt/homebrew/bin/tmux -L claude-hub new-session -d -s claude-153700777499 ... exec ".../claude" --session-id ...
```

＝ `claude` を 3 回含む。このため同ソケット上の pane はすべて `subagent` で確定し、`tmux-supervised` の判定に到達しなかった。

## 変更

- **`observe_activity()`（active / idle / **unknown** の 3 状態）を導入**。「静止していたことの積極的な証拠」を 2 経路で取る:
  1. tmux pane の `#{session_activity}` / `#{window_activity}`（epoch 秒。大きい方を採用 — 実測で session 側が window 側より 8 分遅れるケースを確認）
  2. cwd から導出した `~/.claude/projects/<encoded>/*.jsonl` の mtime。encoded は「`[^A-Za-z0-9-]` を `-` に置換」で、実在ディレクトリ 3 件と照合済み
  どちらも得られなければ `unknown` → **保護**。encoding 規則が将来変わってもディレクトリ不在 → `unknown` → 保護に倒れるので、kill 側に倒れることはない
- **`--apply` は SIGTERM 直前に再観測**し、候補が起きていれば skip する。SIGKILL の対象も実際に SIGTERM した pid のみ
- **分類を argv[0] の basename 比較に変更**。あわせて `tmux-supervised` を「claude-hub ソケット上 **かつ** supervisor の命名式 `claude-<threadId12>`（`manager.ts` の `tmuxSessionNameFor`）」に限定し、同ソケットを間借りしただけの手製セッションは `tmux-other` へ降格。セッション名を解決できなかった場合は降格せず保護側に倒す
- **副次的に、bash 3.2 + `set -u` で空配列の `"${arr[@]}"` が unbound variable になる潜在バグを修正**。全プロセスが候補になると dry-run が exit 1 で落ちていた（テストで発覚）
- 性能: tmux pane snapshot を 1 回だけ取得し、`tmux_session_for_pid` の結果を `classify` と表示列で共有（`--apply` の再観測時のみ明示的に取り直す）

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | 稼働中セッションが候補に入らない | 実機 `--dry-run --idle-minutes 60`（PID 5973 は 43 分静止） | 候補外 | `Protected: 5973: active — transcript-mtime 43m-ago` | PASS |
| AC-1 | 同上（hermetic / tmux 経路） | `bun test -t "AC-1: a session with current tmux"` | 候補外・active 表示 | pass | PASS |
| AC-1 | 同上（hermetic / transcript 経路） | `bun test -t "AC-1: a session whose transcript"` | 候補外・active 表示 | pass | PASS |
| AC-2 | 未使用セッションが候補に入る | 実機 `--dry-run` | 32939 / 32954 が候補 | `tmux-other 32939 tmux-activity 379m-ago` / `32954 同` | PASS |
| AC-2 | 同上（hermetic） | `bun test -t "AC-2: an untouched"` | 候補に含まれる | pass | PASS |
| AC-3 | 観測源ゼロで全 idle にしない | 実機 `CLEANUP_CLAUDE_TMUX_BIN=/nonexistent CLEANUP_CLAUDE_LSOF_BIN=/nonexistent ... --dry-run` | 候補 0 件 | `No idle claude processes found above threshold.` / 全件 `activity unobservable, protected` | PASS |
| AC-3 | lsof は動くが transcript が無い（元の欠陥の形） | `bun test -t "AC-3 regression"` | idle ではなく unknown | pass | PASS |
| 追加 | `--apply` が起きた候補を skip し idle のみ kill | `bun test -t "--apply re-measures"` | SKIP 出力 + 稼働側が生存 | pass | PASS |
| 追加 | supervisor 命名式の判別 | `bun test -t "supervisor-formula session names"` | `claude-153700777499` 可 / `claude-x`・`claude-tricky` 不可 | pass | PASS |
| 追加 | argv に claude を含む親を claude と誤認しない | `bun test -t "a parent whose argv merely contains"` | basename `tmux` | pass | PASS |
| 回帰 | スイート全体 | `bun test tests/scripts/cleanup-idle-claude.test.ts` | 全件 pass | 15 pass / 0 fail | PASS |
| 回帰 | 型チェック | `bunx tsc --noEmit` | exit 0 | exit 0 | PASS |
| 回帰 | CI gating lint | `bun scripts/lint-gating-coverage.ts` | ungated 0 | `110 file(s) — 108 gated, 2 excluded, 0 ungated` | PASS |
| 回帰 | routing-tests job の shell スイート 5 件 | `bash scripts/test-*.sh` | 全 PASS | 5/5 PASS | PASS |

全体: 14/14 PASS。

### 修正前後の実機比較（いずれも `--dry-run`）

修正前:

```
Candidates (1):
  - interactive 5973 09:56:23          <- 稼働中
Protected (8 skipped):
  - 32939, 32954: protected category=subagent   <- 9時間未使用
```

修正後:

```
Candidates (2):
  - tmux-other 32939 tmux-activity 379m-ago
  - tmux-other 32954 tmux-activity 379m-ago
Protected:
  - 45978: protected category=tmux-supervised
  - 5973: active — transcript-mtime 43m-ago
```

## テスト方針

`supervisor/tests/scripts/cleanup-idle-claude.test.ts` を 6 → 15 ケースに拡張した（既存の CI gating に載っているファイルなので `ci.yml` の変更は不要）。

新規ケースは hermetic で、fake lister / fake tmux / fake lsof / fake projects tree を env 経由で注入する。**signal を送る対象はテスト自身が spawn した `sleep` への symlink stub のみ**で、実 claude プロセスの状態は読みも書きもしない。`--apply` の再観測を検証するケースは、tmux stub の呼び出し回数で fixture を切り替えるが、切り替え点は先行する dry-run で自己計測するため、将来 socket の探索数が変わっても壊れない。

注入用 env（`CLEANUP_CLAUDE_LIST_SCRIPT` / `_TMUX_BIN` / `_LSOF_BIN` / `_PROJECTS_DIR` / `_KILL_GRACE_SECONDS`）は `--help` に記載した。

## 補足

- 本スクリプトは launchd にも crontab にも登録されていない（参照 0 件）ため、今回の不具合が自動実行で発火したことはない。手動 dry-run 専用ツールとしての `--apply` の破壊力に対する fail-safe 化が本 PR の主眼
- Issue が「範囲外だが関連」として挙げた `reaper.ts` が supervisor 未登録の tmux セッションを構造的に見られない件は、本 PR では扱っていない（別途検討）
