### PR TITLE
fix(dispatch): /impl 注入の配達を検証する（再入力はしない）（#429）

### DIFF
--- a/supervisor/src/action/execute.ts
+++ b/supervisor/src/action/execute.ts
@@ -113,10 +113,12 @@ export interface ExecuteDeps {
   /**
    * Send the keystrokes to the pane (production: relay.ts `sendToPane`).
    *
-   * The result is intentionally `unknown`: `sendToPane` now returns a delivery
-   * verdict (#422), but this path only sends slash commands, which skip
-   * verification, so there is nothing here to act on. Widening the type keeps
-   * the seam honest instead of pretending the callee returns nothing.
+   * The result is intentionally `unknown`: `sendToPane` returns a delivery
+   * verdict (#422) that this path has no branch for. Since #429 the slash
+   * command IS verified (it is simply never retyped), so a pane that never
+   * rendered it now REJECTS — and that is the signal this path acts on, in the
+   * catch below. The resolved verdict remains uninteresting here; widening the
+   * type keeps the seam honest instead of pretending the callee returns nothing.
    */
   send: (tmuxSession: string, text: string) => Promise<unknown>;
 }

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -1020,7 +1020,14 @@ export async function startBot(token: string): Promise<void> {
         try {
           await postToThread(
             dispatchThread.id,
-            buildDispatchFailureNotice(result.stage, config.displayName, branch, issueNumber, command)
+            buildDispatchFailureNotice(
+              result.stage,
+              config.displayName,
+              branch,
+              issueNumber,
+              command,
+              { sessionStopped: result.sessionStopped }
+            )
           );
         } catch (err) {
           console.error(

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -84,6 +84,7 @@ import {
   parseDispatchCommand,
   runDispatch,
   resolveExecutorMode,
+  buildDispatchFailureNotice,
 } from "./session/dispatch";
 import { DispatchQueue } from "./session/dispatch-queue";
 import {
@@ -1010,6 +1011,23 @@ export async function startBot(token: string): Promise<void> {
         console.error(
           `[Bot] Dispatch failed (stage=${result.stage}) in channel ${channelName}: ${result.error}`
         );
+        // Issue #429: the log alone left corp (and the user) with no signal at
+        // all — the ledger stays `dispatched` and the thread shows nothing, so a
+        // dispatch that never reached the pane is indistinguishable from one
+        // that is merely still working. Posting into the thread is what makes it
+        // recoverable: corp's failed-re-injection path (corp#107 / #108) only
+        // needs the failure to be visible.
+        try {
+          await postToThread(
+            dispatchThread.id,
+            buildDispatchFailureNotice(result.stage, config.displayName, branch, issueNumber, command)
+          );
+        } catch (err) {
+          console.error(
+            `[Bot] Dispatch failure notice could not be posted to thread ${dispatchThread.id}:`,
+            err
+          );
+        }
       }
       return result.ok;
     };

--- a/supervisor/src/session/dispatch.ts
+++ b/supervisor/src/session/dispatch.ts
@@ -271,6 +271,18 @@ export interface DispatchSessionManager {
     },
   ): Promise<DispatchSendResult>;
   /**
+   * Tear the session down. Called only when the injection failed (#429 / PR
+   * #434 review, should-4): the session started, but the command never rendered
+   * and the Enter was withheld, so nothing has run and there is no work to
+   * lose. Leaving it up was the worst of both worlds — it held a MAX_SESSIONS
+   * slot doing nothing while the queue, told `started=false`, freed its slot
+   * and admitted the next dispatch over the limit.
+   *
+   * Required rather than optional: an unwired `stop` would silently reinstate
+   * exactly that leak (agent-output-quality #1).
+   */
+  stop(threadId: string, reason?: "error"): Promise<void>;
+  /**
    * Headless executor path (Epic #285 Phase 2 / #287). Runs `claude -p
    * "<initialCommand>"` in the branch worktree to completion and resolves with
    * the captured output. Optional so a tmux-only fake still satisfies the
@@ -343,8 +355,15 @@ export type RunDispatchResult =
     }
   | {
       ok: false;
-      stage: "thread" | "start" | "inject" | "output";
+      stage: DispatchFailureStage;
       error: string;
+      /**
+       * `inject` only: whether the started-but-idle session was torn down
+       * (#429 / PR #434 review, should-4). Carried so the thread notice can say
+       * which of the two states the reader is looking at instead of guessing —
+       * a failed teardown leaves a session that still needs attention.
+       */
+      sessionStopped?: boolean;
     };
 
 /** Stage of a failed dispatch, as reported by {@link runDispatch}. */
@@ -365,6 +384,11 @@ export type DispatchFailureStage = "thread" | "start" | "inject" | "output";
  * withheld. Someone reading this thread has to know the session is idle rather
  * than working, because the recovery is theirs to trigger (corp#107 / #108
  * re-injects a `failed` dispatch; a human re-runs `/dispatch`).
+ *
+ * `sessionStopped` (inject only) picks between the two real outcomes instead of
+ * asserting one: normally the idle session is torn down, but if the teardown
+ * itself failed a session is still sitting there and saying otherwise would send
+ * the reader looking for the wrong thing (PR #434 review, should-4).
  */
 export function buildDispatchFailureNotice(
   stage: DispatchFailureStage,
@@ -372,18 +396,24 @@ export function buildDispatchFailureNotice(
   branch: string,
   issueNumber: number,
   command: DispatchCommand,
+  options?: { sessionStopped?: boolean },
 ): string {
   const head =
     `❌ **${displayName}** のディスパッチに失敗しました\n\n` +
     `🌿 ブランチ: \`${branch}\`\n` +
     `▶️ 初期コマンド: \`/${command} ${issueNumber}\`\n`;
+  const injectTail =
+    options?.sessionStopped === false
+      ? "**このセッションの停止にも失敗した**ため、セッションが残っている可能性があります。" +
+        "`/session status` で確認し、必要なら `/session stop` で停止してください。"
+      : "何も実行していないため、このセッションは停止しました（枠は解放済み）。";
   const detail: Record<DispatchFailureStage, string> = {
     thread: "🧵 スレッドを作成できませんでした。",
     start: "🚀 セッションを起動できませんでした。",
     inject:
       "⌨️ セッションは起動しましたが、初期コマンドが画面に出たことを確認できませんでした" +
       "（#422 / #429）。**二重実行を避けるため自動での再入力はしていません**" +
-      "（Enter も送っていません）。このセッションは待機したままなので、" +
+      `（Enter も送っていません）。${injectTail}` +
       "内容を確認のうえ再ディスパッチしてください。",
     output: "📤 実行結果をスレッドへ投稿できませんでした。",
   };
@@ -476,7 +506,7 @@ export async function runDispatch(
       onDialogStuck ? { onDialogStuck } : undefined,
     );
   } catch (err) {
-    return { ok: false, stage: "inject", error: errMsg(err) };
+    return injectFailure(sessionManager, threadId, errMsg(err));
   }
 
   // Issue #429: this is the silent-stall site. `sendMessage` resolves with a
@@ -491,10 +521,44 @@ export async function runDispatch(
   // job is simply still running past RELAY_TIMEOUT_MS — reporting that as a
   // failed dispatch would trade a silent drop for a false alarm.
   if (relay.sendFailed) {
-    return { ok: false, stage: "inject", error: relay.error ?? "send failed" };
+    return injectFailure(sessionManager, threadId, relay.error ?? "send failed");
   }
 
   return { ok: true, mode: "tmux", threadId, injected: initialCommand };
+}
+
+/**
+ * Report a failed injection, tearing the started-but-idle session down first
+ * (#429 / PR #434 review, should-4).
+ *
+ * Stopping is safe precisely because of what failed: the command never rendered,
+ * so the Enter was never sent and the session has executed nothing. Leaving it
+ * running was the inconsistent state — the queue frees its slot on `ok:false`
+ * (`dispatch-queue.ts` runItem: "no session started → free it here"), whose
+ * premise does not hold at this stage, so an abandoned session held a
+ * MAX_SESSIONS slot while the queue admitted another dispatch in its place.
+ * Stopping makes `started=false` true rather than merely assumed.
+ *
+ * A failed teardown is reported, not swallowed: the dispatch failure is what the
+ * caller must act on, so it always wins, but `sessionStopped` tells the thread
+ * whether a session is still sitting there.
+ */
+async function injectFailure(
+  sessionManager: DispatchSessionManager,
+  threadId: string,
+  error: string,
+): Promise<RunDispatchResult> {
+  let sessionStopped = true;
+  try {
+    await sessionManager.stop(threadId, "error");
+  } catch (stopErr) {
+    sessionStopped = false;
+    console.error(
+      `[Dispatch] injection failed for thread ${threadId} and the session could not be stopped:`,
+      errMsg(stopErr),
+    );
+  }
+  return { ok: false, stage: "inject", error, sessionStopped };
 }
 
 /**

--- a/supervisor/src/session/dispatch.ts
+++ b/supervisor/src/session/dispatch.ts
@@ -226,6 +226,20 @@ export interface DispatchHeadlessOutcome {
  * Minimal SessionManager surface the dispatch orchestrator needs. Keeping it
  * structural lets tests inject a fake without the real tmux/claude stack.
  */
+/**
+ * The part of the relay's result the dispatch transport actually reads (#429).
+ *
+ * Structural on purpose: `RelayResult` satisfies it by construction, but the
+ * orchestrator stays free of the relay module (the rest of this interface is
+ * `unknown`-typed for the same reason). It used to be plain `unknown`, which is
+ * precisely why a failed injection could not be distinguished from a good one.
+ */
+export interface DispatchSendResult {
+  error?: string;
+  /** The pane never received the text — see `RelayResult.sendFailed`. */
+  sendFailed?: boolean;
+}
+
 export interface DispatchSessionManager {
   start(
     config: unknown,
@@ -255,7 +269,7 @@ export interface DispatchSessionManager {
     options?: {
       onDialogStuck?: (info: DialogStuckInfo) => void | Promise<void>;
     },
-  ): Promise<unknown>;
+  ): Promise<DispatchSendResult>;
   /**
    * Headless executor path (Epic #285 Phase 2 / #287). Runs `claude -p
    * "<initialCommand>"` in the branch worktree to completion and resolves with
@@ -332,6 +346,49 @@ export type RunDispatchResult =
       stage: "thread" | "start" | "inject" | "output";
       error: string;
     };
+
+/** Stage of a failed dispatch, as reported by {@link runDispatch}. */
+export type DispatchFailureStage = "thread" | "start" | "inject" | "output";
+
+/**
+ * User-facing notice for a dispatch that did not get off the ground (#429).
+ *
+ * Pure + exported so the wording is unit-testable and so the one rule that
+ * matters here is enforceable: the raw cause (a tmux `not in a mode`, an
+ * ETIMEDOUT, an absolute path in an fs error) NEVER reaches Discord — same
+ * contract as `SEND_FAILURE_USER_MESSAGE` in relay.ts. The stage is a fixed
+ * enum, and everything else interpolated is data the dispatch line already
+ * carried in public. Diagnostics stay in the Supervisor log.
+ *
+ * The `inject` wording is deliberately explicit that NOTHING was re-sent
+ * automatically: the command was typed once, never rendered, and the Enter was
+ * withheld. Someone reading this thread has to know the session is idle rather
+ * than working, because the recovery is theirs to trigger (corp#107 / #108
+ * re-injects a `failed` dispatch; a human re-runs `/dispatch`).
+ */
+export function buildDispatchFailureNotice(
+  stage: DispatchFailureStage,
+  displayName: string,
+  branch: string,
+  issueNumber: number,
+  command: DispatchCommand,
+): string {
+  const head =
+    `❌ **${displayName}** のディスパッチに失敗しました\n\n` +
+    `🌿 ブランチ: \`${branch}\`\n` +
+    `▶️ 初期コマンド: \`/${command} ${issueNumber}\`\n`;
+  const detail: Record<DispatchFailureStage, string> = {
+    thread: "🧵 スレッドを作成できませんでした。",
+    start: "🚀 セッションを起動できませんでした。",
+    inject:
+      "⌨️ セッションは起動しましたが、初期コマンドが画面に出たことを確認できませんでした" +
+      "（#422 / #429）。**二重実行を避けるため自動での再入力はしていません**" +
+      "（Enter も送っていません）。このセッションは待機したままなので、" +
+      "内容を確認のうえ再ディスパッチしてください。",
+    output: "📤 実行結果をスレッドへ投稿できませんでした。",
+  };
+  return `${head}\n${detail[stage]}\n\n詳細は Supervisor のログに記録されています。`;
+}
 
 /**
  * Orchestrate a validated dispatch: create the thread, start the session in the
@@ -410,8 +467,9 @@ export async function runDispatch(
     : undefined;
 
   const initialCommand = `/${command} ${issueNumber}`;
+  let relay: DispatchSendResult;
   try {
-    await sessionManager.sendMessage(
+    relay = await sessionManager.sendMessage(
       threadId,
       initialCommand,
       undefined,
@@ -419,6 +477,21 @@ export async function runDispatch(
     );
   } catch (err) {
     return { ok: false, stage: "inject", error: errMsg(err) };
+  }
+
+  // Issue #429: this is the silent-stall site. `sendMessage` resolves with a
+  // RESULT on a failed send (the relay converts the throw into a user-facing
+  // chunk), so the catch above never fires for the one failure mode that
+  // matters here: the pane never received `/impl <N>`. Before #429 that landed
+  // as `ok: true` — the thread got a cheerful "dispatched" banner, the ledger
+  // stayed `dispatched`, and the session sat there doing nothing.
+  //
+  // Only `sendFailed` is treated as a dispatch failure. A plain `error` is
+  // usually the relay timeout, which means the command WAS delivered and the
+  // job is simply still running past RELAY_TIMEOUT_MS — reporting that as a
+  // failed dispatch would trade a silent drop for a false alarm.
+  if (relay.sendFailed) {
+    return { ok: false, stage: "inject", error: relay.error ?? "send failed" };
   }
 
   return { ok: true, mode: "tmux", threadId, injected: initialCommand };

--- a/supervisor/src/session/manager.ts
+++ b/supervisor/src/session/manager.ts
@@ -1787,6 +1787,14 @@ export class SessionManager {
         text: "",
         chunks: ["⚠️ Claude Code セッションが終了しています。`/session start` で再起動してください。"],
         error: "tmux session dead",
+        // Issue #429 (PR #434 review, should-1): the pane never received the
+        // text, which is exactly what `sendFailed` means — the dispatch
+        // transport reads this flag to tell a failed injection apart from a
+        // slow one. Without it a dispatch whose session died between start and
+        // inject was reported as a success: thread banner posted, ledger left
+        // at `dispatched`, nothing running. Same silent-stall class as the
+        // unverified send this PR exists to close, just a different door.
+        sendFailed: true,
       };
     }
 

--- a/supervisor/src/session/relay-server.ts
+++ b/supervisor/src/session/relay-server.ts
@@ -10,6 +10,14 @@ export interface RelayResult {
   claudeSessionId?: string;
   error?: string;
   /**
+   * Issue #429: true when the failure is "the text never reached the pane"
+   * (`buildSendFailureResult`), as opposed to "no response came back" (a relay
+   * timeout / error turn). Both set {@link error}, but only the first means the
+   * session never saw the message — the dispatch transport must report that as
+   * a failed injection while leaving a slow-but-running job alone.
+   */
+  sendFailed?: boolean;
+  /**
    * Session's current context token count at the moment the Stop hook fired
    * (Issue #204). Forwarded by `hooks/stop-relay.sh`. Absent when the hook
    * could not compute it (no transcript / older hook). Consumers use it to warn

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -264,10 +264,19 @@ export const DELIVERY_VERIFY_BACKOFF_MS: readonly number[] = [
 ];
 
 /**
- * How many times the literal may be typed. 2 = one retype after a confirmed
- * non-render. Bounded on purpose: a retype is only safe because the pane was
- * re-read and the text was provably absent, and each extra attempt widens the
- * window where a late render turns into duplicated input.
+ * How many verification rounds run before the send is declared undelivered.
+ *
+ * For retypable text (natural language) a round == a type attempt, so 2 means
+ * "one retype after a confirmed non-render". Bounded on purpose: a retype is
+ * only safe because the pane was re-read and the text was provably absent, and
+ * each extra attempt widens the window where a late render turns into
+ * duplicated input.
+ *
+ * Issue #429: for text that must NOT be retyped (slash commands) the literal is
+ * typed in round 1 only and the later rounds just keep watching. The constant is
+ * therefore a PATIENCE budget first and a type limit second — that way the
+ * no-retype path waits exactly as long before crying failure (~2× the backoff
+ * schedule) as the retype path does, instead of being half as tolerant.
  */
 export const DELIVERY_MAX_TYPE_ATTEMPTS = 2;
 
@@ -287,7 +296,7 @@ export const SEND_UNVERIFIED_ERROR =
  * incident is diagnosed from exactly that line).
  */
 export type DeliveryVerdict =
-  /** The text appeared after the first type. */
+  /** The text appeared after the (only) first type. */
   | "verified"
   /** The text appeared only after a retype — the first keystrokes were lost. */
   | "verified-retyped"
@@ -296,8 +305,6 @@ export type DeliveryVerdict =
    * retype both rendered, so the pane now holds the message twice.
    */
   | "duplicate"
-  /** Slash command: verification is deliberately skipped ({@link shouldVerifyDelivery}). */
-  | "skipped-slash"
   /** Whitespace-only message: no probe to look for. */
   | "skipped-no-probe"
   /** `capture-pane` was unusable, so delivery could not be judged either way. */
@@ -372,24 +379,33 @@ export function countProbeOccurrences(pane: string, probe: string): number {
 }
 
 /**
- * Whether {@link sendToPane} verifies delivery for this text by default.
+ * Whether a literal that provably did not render may be typed a SECOND time.
  *
- * Slash commands are excluded: typing `/compact …` opens the TUI's command
- * picker, which re-renders the input row into its own widget, so "did my text
- * appear verbatim" is not a reliable signal there. Retyping a slash command on
- * a false negative would *execute it twice* — a worse failure than the silent
- * drop this guards against. Natural-language messages (the #422 loss path, and
- * the overwhelming majority of relays) are always verified.
+ * Slash commands may not: a retype that races a late first render leaves
+ * `/impl 429` in the pane twice, and the Enter that follows would run the
+ * command twice. For natural language a doubled prompt is merely noisy (#428
+ * already reports it as `"duplicate"`), so the retype recovery stays on.
  *
- * UNVERIFIED (PR #428 review, q-1): the picker-rendering claim above is a
- * hypothesis, not a measurement — the TUI was never driven to confirm whether
- * the typed slash text stays matchable in `capture-pane`. It is the conservative
- * assumption (skipping verification preserves the pre-#422 behaviour exactly and
- * cannot double-execute a command). If it turns out the text IS matchable, the
- * better shape is "verify but never retype": that removes the silent drop on
- * this path with zero double-execution risk. Measure before changing it.
+ * MEASURED 2026-08-13 (#429) — this replaces the hypothesis PR #428 flagged as
+ * unverified in its q-1 note. Driving a real Claude Code TUI (v2.1.229) over an
+ * isolated `tmux -L wt429test` socket:
+ *
+ *     send-keys -t probe -l '/impl 429'   → exit=0
+ *     capture-pane -p -t probe            → row 15 reads `❯ /impl 429`
+ *     countProbeOccurrences(pane, probe)  → 0 before, 1 after
+ *
+ * and with the command picker OPEN (a bare `/pd`) the menu overlays the rows
+ * *below* the prompt while the input row itself stays on screen and matchable.
+ * So the premise for skipping verification — "the picker re-renders the input
+ * row, so the text is not matchable" — is false: slash text IS observable.
+ *
+ * Only the *retype* was ever unsafe. Hence the split this function encodes:
+ * verify everything, retype only what is safe to retype. That closes the silent
+ * drop on the dispatch injection path (`/impl` / `/pdca`, Issue #429) at zero
+ * double-execution risk, which is exactly the shape #428's q-1 note asked for
+ * once the measurement existed.
  */
-export function shouldVerifyDelivery(text: string): boolean {
+export function allowsRetype(text: string): boolean {
   return !text.trimStart().startsWith("/");
 }
 
@@ -423,11 +439,6 @@ const capturePaneText: PaneReader = async (sessionName, socketArgs) => {
 };
 
 export interface SendToPaneOptions {
-  /**
-   * Verify that the typed text actually appeared in the pane (Issue #422).
-   * Defaults to {@link shouldVerifyDelivery} for the given text.
-   */
-  verify?: boolean;
   /** Override the poll schedule (tests only; production uses the default). */
   verifyBackoffMs?: readonly number[];
   /**
@@ -471,7 +482,9 @@ export interface SendToPaneOptions {
  *   4. Issue #422: re-read the pane until the text shows up, retyping once if
  *      it provably did not. Throws {@link SEND_UNVERIFIED_ERROR} rather than
  *      returning, so the caller reports a failure instead of waiting out the
- *      relay timeout on a message the TUI never saw.
+ *      relay timeout on a message the TUI never saw. Issue #429: slash commands
+ *      go through the same check but are never retyped ({@link allowsRetype}),
+ *      so the dispatch injection (`/impl <N>`) is no longer exempt from step 4.
  *   5. A brief pause, then `C-m` (Enter) as a separate call — the Ink TUI can
  *      drop an Enter sent in the same call as a long literal (#32). Enter is
  *      sent only once the text is confirmed present, so a failed send can never
@@ -516,16 +529,18 @@ async function typeLiteral(
   socketArgs: readonly string[],
   options?: SendToPaneOptions
 ): Promise<DeliveryVerdict> {
-  const verify = options?.verify ?? shouldVerifyDelivery(literalText);
   const probe = buildDeliveryProbe(literalText);
   // A whitespace-only message has no probe to look for; typing it unverified
   // matches the old behaviour and costs nothing (there is nothing to lose).
-  if (!verify || !probe) {
+  if (!probe) {
     await tmuxSend(tmuxSessionName, ["-l", literalText], socketArgs);
     await options?.onAttemptTyped?.(1);
-    return verify ? "skipped-no-probe" : "skipped-slash";
+    return "skipped-no-probe";
   }
 
+  // Issue #429: retypability, not verifiability, is what varies per text. Slash
+  // commands are watched like everything else and simply never retyped.
+  const retypeAllowed = allowsRetype(literalText);
   const backoff = options?.verifyBackoffMs ?? DELIVERY_VERIFY_BACKOFF_MS;
   const readPane = options?.capturePane ?? capturePaneText;
   const before = await readPane(tmuxSessionName, socketArgs);
@@ -547,10 +562,17 @@ async function typeLiteral(
   // it. The residual risk is a false "delivered" (fail-open = pre-#422
   // behaviour), never a false failure.
   let floor = countProbeOccurrences(before, probe);
+  // How many times the literal actually went to the pane. Drives the verdict
+  // (and the duplicate check), which `round` no longer can: on the no-retype
+  // path a later round means "still watching", not "typed again".
+  let typed = 0;
 
-  for (let attempt = 1; attempt <= DELIVERY_MAX_TYPE_ATTEMPTS; attempt++) {
-    await tmuxSend(tmuxSessionName, ["-l", literalText], socketArgs);
-    await options?.onAttemptTyped?.(attempt);
+  for (let round = 1; round <= DELIVERY_MAX_TYPE_ATTEMPTS; round++) {
+    if (round === 1 || retypeAllowed) {
+      await tmuxSend(tmuxSessionName, ["-l", literalText], socketArgs);
+      typed++;
+      await options?.onAttemptTyped?.(typed);
+    }
 
     for (const waitMs of backoff) {
       await new Promise((r) => setTimeout(r, waitMs));
@@ -558,27 +580,36 @@ async function typeLiteral(
       if (after === null) return "unverified-observer"; // broke mid-flight
       const count = countProbeOccurrences(after, probe);
       if (count > floor) {
-        // A rise of 2 on the retype means BOTH types rendered: the first one
+        // A rise of 2 after a retype means BOTH types rendered: the first one
         // was merely late, not lost, so the pane now holds the message twice.
         // Reported rather than silently submitted — the whole point of #422 is
-        // that the relay must not hide what it did to the pane.
-        if (attempt > 1 && count - floor >= 2) {
+        // that the relay must not hide what it did to the pane. Gated on
+        // `typed > 1` because a rise of 2 without a retype is not something we
+        // did: it is the user's own text already on screen, and calling that a
+        // duplicate would put a scary notice on a perfectly clean send.
+        if (typed > 1 && count - floor >= 2) {
           console.warn(
             `[Relay] duplicate input in pane ${tmuxSessionName}: the delayed first ` +
               `type rendered after the retype (count ${floor}→${count})`
           );
           return "duplicate";
         }
-        return attempt > 1 ? "verified-retyped" : "verified";
+        return typed > 1 ? "verified-retyped" : "verified";
       }
       floor = Math.min(floor, count);
     }
     console.warn(
       `[Relay] typed text never rendered in pane ${tmuxSessionName} ` +
-        `(attempt ${attempt}/${DELIVERY_MAX_TYPE_ATTEMPTS}, ${literalText.length} chars)`
+        `(round ${round}/${DELIVERY_MAX_TYPE_ATTEMPTS}, typed ${typed}×, ` +
+        `retype ${retypeAllowed ? "allowed" : "withheld (#429)"}, ${literalText.length} chars)`
     );
   }
 
+  // Issue #429: reached on the no-retype path too. The command was typed once
+  // and never showed up, so it is NOT delivered — throwing (rather than
+  // returning a soft verdict) is what stops the Enter below from submitting a
+  // pane we could not read, and what makes the caller report the failure
+  // instead of waiting out the relay timeout in silence.
   throw new Error(SEND_UNVERIFIED_ERROR);
 }
 
@@ -697,6 +728,11 @@ export function buildSendFailureResult(err: unknown): RelayResult {
     text: "",
     chunks: [SEND_FAILURE_USER_MESSAGE],
     error: String(err),
+    // Issue #429: `error` alone cannot tell a caller WHICH half failed — a relay
+    // timeout sets it too, and there the message *was* delivered (the job is
+    // just still running). Dispatch has to separate those: reporting a delivered
+    // `/impl` as failed would be as wrong as the silent drop it is fixing.
+    sendFailed: true,
   };
 }
 

--- a/supervisor/src/session/relay.ts
+++ b/supervisor/src/session/relay.ts
@@ -278,7 +278,7 @@ export const DELIVERY_VERIFY_BACKOFF_MS: readonly number[] = [
  * no-retype path waits exactly as long before crying failure (~2× the backoff
  * schedule) as the retype path does, instead of being half as tolerant.
  */
-export const DELIVERY_MAX_TYPE_ATTEMPTS = 2;
+export const DELIVERY_MAX_VERIFY_ROUNDS = 2;
 
 /**
  * `RelayResult.error` marker for a send that tmux accepted but the pane never
@@ -398,6 +398,19 @@ export function countProbeOccurrences(pane: string, probe: string): number {
  * *below* the prompt while the input row itself stays on screen and matchable.
  * So the premise for skipping verification — "the picker re-renders the input
  * row, so the text is not matchable" — is false: slash text IS observable.
+ *
+ * Re-measured for the TUI BUILT-IN `/compact` (PR #434 review, should-3), since
+ * a built-in need not render like a user-defined command and its callers
+ * (auto self-heal, the Pushover one-tap, `/session compact`) surface a failure
+ * to a human rather than retrying:
+ *
+ *     send-keys -t probe -l '/compact テスト用の意図'
+ *       → row 15 reads `❯ /compact テスト用の意図`, count 0 before / 1 after
+ *     send-keys -t probe -l '/compact'   (bare: the built-in's own picker state)
+ *       → row 15 reads `❯ /compact`, still matchable
+ *
+ * Same result as the user-defined command, so the no-retype path is measured on
+ * both kinds of slash command rather than extrapolated from one.
  *
  * Only the *retype* was ever unsafe. Hence the split this function encodes:
  * verify everything, retype only what is safe to retype. That closes the silent
@@ -567,7 +580,7 @@ async function typeLiteral(
   // path a later round means "still watching", not "typed again".
   let typed = 0;
 
-  for (let round = 1; round <= DELIVERY_MAX_TYPE_ATTEMPTS; round++) {
+  for (let round = 1; round <= DELIVERY_MAX_VERIFY_ROUNDS; round++) {
     if (round === 1 || retypeAllowed) {
       await tmuxSend(tmuxSessionName, ["-l", literalText], socketArgs);
       typed++;
@@ -583,10 +596,19 @@ async function typeLiteral(
         // A rise of 2 after a retype means BOTH types rendered: the first one
         // was merely late, not lost, so the pane now holds the message twice.
         // Reported rather than silently submitted — the whole point of #422 is
-        // that the relay must not hide what it did to the pane. Gated on
-        // `typed > 1` because a rise of 2 without a retype is not something we
-        // did: it is the user's own text already on screen, and calling that a
-        // duplicate would put a scary notice on a perfectly clean send.
+        // that the relay must not hide what it did to the pane.
+        //
+        // Gated on `typed > 1` = "this loop typed twice". That is not quite the
+        // same as "the literal was sent twice": `tmuxSend` retries the same
+        // `send-keys -l` once on a timeout / `not in a mode`, and a send that
+        // reached the pane before the execFile timed out lands twice without
+        // this counter noticing (PR #434 review, should-2 — a blind spot that
+        // predates #429; #428's `attempt > 1` had it too). So a rise of 2 with
+        // `typed === 1` is usually the user's own text already on screen, but
+        // it can also be that inner retry. It is deliberately NOT reported as
+        // `duplicate`: on this path the notice would fire on ordinary clean
+        // sends, and the inner retry is bounded and rare. Tracked separately
+        // rather than papered over here.
         if (typed > 1 && count - floor >= 2) {
           console.warn(
             `[Relay] duplicate input in pane ${tmuxSessionName}: the delayed first ` +
@@ -600,7 +622,7 @@ async function typeLiteral(
     }
     console.warn(
       `[Relay] typed text never rendered in pane ${tmuxSessionName} ` +
-        `(round ${round}/${DELIVERY_MAX_TYPE_ATTEMPTS}, typed ${typed}×, ` +
+        `(round ${round}/${DELIVERY_MAX_VERIFY_ROUNDS}, typed ${typed}×, ` +
         `retype ${retypeAllowed ? "allowed" : "withheld (#429)"}, ${literalText.length} chars)`
     );
   }

--- a/supervisor/tests/guards/access-enforcement-wired.test.ts
+++ b/supervisor/tests/guards/access-enforcement-wired.test.ts
@@ -114,3 +114,58 @@ describe("dispatch transport is wired fail-closed (#32 / S7)", () => {
     }
   });
 });
+
+/**
+ * Issue #429 (PR #434 review, question-1). The behavioural half lives in
+ * dispatch-integration.test.ts; this guard pins the bot.ts WIRING, because the
+ * defect being fixed was precisely a wiring gap: the `!result.ok` arm existed
+ * but only ever called `console.error`, so a dispatch that never reached the
+ * pane was invisible to the thread and to corp. A refactor that quietly returns
+ * to log-only would restore the silent stall while every unit test still
+ * passed — this catches that, in the same way the access gates above are
+ * pinned against silent removal.
+ */
+describe("dispatch failure reaches the thread, not just the log (#429)", () => {
+  test("bot.ts posts a failure notice on the !result.ok arm", async () => {
+    const src = await read("src/bot.ts");
+    // The notice builder is used (not a bare log, and not an ad-hoc string that
+    // could leak the raw tmux cause).
+    expect(src).toContain("buildDispatchFailureNotice");
+    // ...and it is handed to the thread poster.
+    const noticeIdx = src.indexOf("buildDispatchFailureNotice(");
+    const postIdx = src.lastIndexOf("postToThread(", noticeIdx);
+    expect(noticeIdx).toBeGreaterThan(-1);
+    expect(postIdx).toBeGreaterThan(-1);
+    // The post call opens immediately before the notice it sends.
+    expect(postIdx).toBeLessThan(noticeIdx);
+  });
+
+  test("the failure notice is built inside the dispatch failure branch", async () => {
+    const src = await read("src/bot.ts");
+    const failureIdx = src.indexOf("Dispatch failed (stage=");
+    const noticeIdx = src.indexOf("buildDispatchFailureNotice(");
+    expect(failureIdx).toBeGreaterThan(-1);
+    // The notice follows the failure log, i.e. it lives in the same arm rather
+    // than somewhere that could fire on a success.
+    expect(noticeIdx).toBeGreaterThan(failureIdx);
+  });
+
+  test("the raw cause cannot reach the thread through the notice", async () => {
+    // Same contract as SEND_FAILURE_USER_MESSAGE (#74): tmux internals and
+    // absolute paths stay in the Supervisor log. Enforced structurally — the
+    // builder takes no error/cause parameter at all — so this checks the shape
+    // rather than the wording (the wording itself is asserted behaviourally in
+    // dispatch-run.test.ts).
+    const src = await read("src/session/dispatch.ts");
+    const sigIdx = src.indexOf("export function buildDispatchFailureNotice(");
+    expect(sigIdx).toBeGreaterThan(-1);
+    const params = src.slice(sigIdx, src.indexOf("): string {", sigIdx));
+    expect(params).not.toMatch(/error|cause|err\b/i);
+
+    // And the call site passes no error either.
+    const bot = await read("src/bot.ts");
+    const callIdx = bot.indexOf("buildDispatchFailureNotice(");
+    expect(callIdx).toBeGreaterThan(-1);
+    expect(bot.slice(callIdx, callIdx + 400)).not.toContain("result.error");
+  });
+});

--- a/supervisor/tests/session/dispatch-headless.test.ts
+++ b/supervisor/tests/session/dispatch-headless.test.ts
@@ -29,6 +29,8 @@ function harness(
   const manager: DispatchSessionManager = {
     start: async () => ({}),
     waitForInputReady: async () => true,
+    // #429: never reached here — these cases do not fail the injection.
+    stop: async () => {},
     sendMessage: async () => ({}),
     runHeadless: async (_c, threadId, initialCommand, branch, issueNumber) => {
       runHeadlessCalls.push({ threadId, initialCommand, branch, issueNumber });
@@ -173,6 +175,8 @@ describe("runDispatch headless", () => {
     const tmuxOnly: DispatchSessionManager = {
       start: async () => ({}),
       waitForInputReady: async () => true,
+      // #429: never reached here — these cases do not fail the injection.
+      stop: async () => {},
       sendMessage: async () => ({}),
     };
     const r = await runDispatch({
@@ -197,6 +201,8 @@ describe("runDispatch headless", () => {
     const manager: DispatchSessionManager = {
       start: async () => ({}),
       waitForInputReady: async () => true,
+      // #429: never reached here — these cases do not fail the injection.
+      stop: async () => {},
       sendMessage: async () => ({}),
       runHeadless: async () => {
         throw new Error("spawn claude ENOENT");
@@ -274,6 +280,8 @@ describe("runDispatch headless", () => {
     const manager: DispatchSessionManager = {
       start: async () => ({}),
       waitForInputReady: async () => true,
+      // #429: never reached here — these cases do not fail the injection.
+      stop: async () => {},
       sendMessage: async (_t, m) => {
         sent.push(m);
         return {};

--- a/supervisor/tests/session/dispatch-integration.test.ts
+++ b/supervisor/tests/session/dispatch-integration.test.ts
@@ -9,6 +9,7 @@ import {
 import {
   parseDispatchCommand,
   runDispatch,
+  buildDispatchFailureNotice,
 } from "../../src/session/dispatch";
 import type { DispatchSessionManager } from "../../src/session/dispatch";
 
@@ -30,9 +31,12 @@ const SOURCE = "555555555555555555"; // an allowed dispatch source (corp webhook
 const OUTSIDER = "999999999999999999";
 
 interface SimResult {
-  outcome: "started" | "denied" | "rejected" | "ignored";
+  outcome: "started" | "inject_failed" | "denied" | "rejected" | "ignored";
   startCalls: Array<{ threadId: string; branch?: string }>;
   sendCalls: Array<{ threadId: string; message: string }>;
+  stopCalls: string[];
+  /** What bot.ts would have posted into the dispatch thread (#429). */
+  posts: string[];
   threadsCreated: number;
 }
 
@@ -46,9 +50,17 @@ async function simulateDispatch(opts: {
   channelId: string;
   sourceId: string;
   content: string;
+  /**
+   * What the relay reports for the injection (#429). Default is a healthy send;
+   * `{ sendFailed: true }` is the shape `buildSendFailureResult` produces when
+   * the pane never rendered the command.
+   */
+  sendResult?: { error?: string; sendFailed?: boolean };
 }): Promise<SimResult> {
   const startCalls: Array<{ threadId: string; branch?: string }> = [];
   const sendCalls: Array<{ threadId: string; message: string }> = [];
+  const stopCalls: string[] = [];
+  const posts: string[] = [];
   let threadsCreated = 0;
 
   const manager: DispatchSessionManager = {
@@ -57,13 +69,16 @@ async function simulateDispatch(opts: {
       return { id: "s" };
     },
     waitForInputReady: async () => true,
+    stop: async (threadId) => {
+      stopCalls.push(threadId);
+    },
     sendMessage: async (threadId, message) => {
       sendCalls.push({ threadId, message });
-      return {};
+      return opts.sendResult ?? {};
     },
   };
 
-  const base = { startCalls, sendCalls, get threadsCreated() {
+  const base = { startCalls, sendCalls, stopCalls, posts, get threadsCreated() {
     return threadsCreated;
   } };
 
@@ -87,8 +102,9 @@ async function simulateDispatch(opts: {
   }
 
   // Step 3: run.
-  await runDispatch({
-    config: { dir: "/x", channelName: "agent-base", displayName: "Agent Base" },
+  const config = { dir: "/x", channelName: "agent-base", displayName: "Agent Base" };
+  const result = await runDispatch({
+    config,
     branch: parsed.branch,
     issueNumber: parsed.issueNumber,
     command: parsed.command,
@@ -98,7 +114,27 @@ async function simulateDispatch(opts: {
       return { id: "thread-1" };
     },
   });
-  return { outcome: "started", ...base, threadsCreated };
+
+  // Step 4 (#429): what bot.ts does with the result. Before #429 the failure
+  // arm was a bare console.error, so a dispatch that never reached the pane
+  // looked — to the thread, and therefore to corp — exactly like a successful
+  // one. Mirrored here because it is the half of the contract that decides
+  // whether the failure is recoverable at all.
+  if (result.ok) {
+    posts.push(`🛰️ **${config.displayName}** をディスパッチで起動しました`);
+    return { outcome: "started", ...base, threadsCreated };
+  }
+  posts.push(
+    buildDispatchFailureNotice(
+      result.stage,
+      config.displayName,
+      parsed.branch,
+      parsed.issueNumber,
+      parsed.command,
+      { sessionStopped: result.sessionStopped },
+    ),
+  );
+  return { outcome: "inject_failed", ...base, threadsCreated };
 }
 
 describe("dispatch integration (auth -> parse -> run)", () => {
@@ -149,6 +185,51 @@ describe("dispatch integration (auth -> parse -> run)", () => {
     expect(r.outcome).toBe("started");
     expect(r.startCalls).toEqual([{ threadId: "thread-1", branch: "corp-dispatch-341" }]);
     expect(r.sendCalls).toEqual([{ threadId: "thread-1", message: "/pdca 341" }]);
+  });
+
+  test("injection that never reached the pane → failure notice in the thread (#429)", async () => {
+    // PR #434 review, question-1: the bot.ts half of #429 IS verifiable here.
+    // Reaching real Discord is not, but "a failed injection produces a failure
+    // notice instead of the success banner" is the part that decides whether
+    // corp can recover, and it is pure decision logic.
+    writePolicy([SOURCE]);
+    const r = await simulateDispatch({
+      accessPath,
+      channelId: CHANNEL_ID,
+      sourceId: SOURCE,
+      content: "/dispatch corp-dispatch-429 429",
+      sendResult: { error: "unverified send", sendFailed: true },
+    });
+
+    expect(r.outcome).toBe("inject_failed");
+    // The session was started and then torn down (should-4), so the queue slot
+    // the caller frees is genuinely free.
+    expect(r.startCalls).toEqual([{ threadId: "thread-1", branch: "corp-dispatch-429" }]);
+    expect(r.stopCalls).toEqual(["thread-1"]);
+
+    expect(r.posts).toHaveLength(1);
+    const notice = r.posts[0]!;
+    // NOT the success banner — the regression this pins.
+    expect(notice).not.toContain("ディスパッチで起動しました");
+    expect(notice).toContain("失敗");
+    expect(notice).toContain("/impl 429");
+    // The two facts a reader needs in order to act.
+    expect(notice).toMatch(/再入力/);
+    expect(notice).toMatch(/再ディスパッチ/);
+  });
+
+  test("a healthy dispatch still posts the success banner, and stops nothing", async () => {
+    // The counter-case: the failure arm must not fire on a good send.
+    writePolicy([SOURCE]);
+    const r = await simulateDispatch({
+      accessPath,
+      channelId: CHANNEL_ID,
+      sourceId: SOURCE,
+      content: "/dispatch corp-dispatch-42 42",
+    });
+    expect(r.outcome).toBe("started");
+    expect(r.stopCalls).toEqual([]);
+    expect(r.posts[0]).toContain("ディスパッチで起動しました");
   });
 
   test("non-allowed source → denied, no session (fail-closed)", async () => {

--- a/supervisor/tests/session/dispatch-run.test.ts
+++ b/supervisor/tests/session/dispatch-run.test.ts
@@ -17,13 +17,16 @@ import type { DialogStuckInfo } from "../../src/session/dialog-stuck-handler";
 function fakeManager(overrides: Partial<{
   start: (config: unknown, threadId: string, branch?: string) => Promise<unknown>;
   sendMessage: (threadId: string, message: string) => Promise<DispatchSendResult>;
+  stop: (threadId: string, reason?: "error") => Promise<void>;
 }> = {}): {
   manager: DispatchSessionManager;
   startCalls: Array<{ threadId: string; branch?: string }>;
   sendCalls: Array<{ threadId: string; message: string }>;
+  stopCalls: Array<{ threadId: string; reason?: string }>;
 } {
   const startCalls: Array<{ threadId: string; branch?: string }> = [];
   const sendCalls: Array<{ threadId: string; message: string }> = [];
+  const stopCalls: Array<{ threadId: string; reason?: string }> = [];
   const manager: DispatchSessionManager = {
     start:
       overrides.start ??
@@ -39,8 +42,13 @@ function fakeManager(overrides: Partial<{
         // A healthy relay: a result with no `sendFailed` (#429).
         return {};
       }),
+    stop:
+      overrides.stop ??
+      (async (threadId, reason) => {
+        stopCalls.push({ threadId, reason });
+      }),
   };
-  return { manager, startCalls, sendCalls };
+  return { manager, startCalls, sendCalls, stopCalls };
 }
 
 const config = { channelName: "agent-base", dir: "/x/agent-base" };
@@ -191,6 +199,77 @@ describe("runDispatch — an injection that never reached the pane is a failure 
     }
   });
 
+  test("the started-but-idle session is stopped, so the freed queue slot is honest", async () => {
+    // PR #434 review, should-4. The queue frees the slot on ok:false ("no
+    // session started → it will never emit an end event"). At stage=inject that
+    // premise was false: the session WAS running, so the slot was handed to the
+    // next dispatch while an idle session still held a MAX_SESSIONS seat.
+    // Stopping makes the premise true. Safe because the Enter was withheld —
+    // the session has executed nothing.
+    const { manager, stopCalls } = fakeManager({
+      sendMessage: async () => ({ error: "unverified", sendFailed: true }),
+    });
+    const r = await runDispatch({
+      config,
+      branch: "corp-dispatch-429",
+      issueNumber: 429,
+      command: "impl",
+      sessionManager: manager,
+      createThread: async () => ({ id: "t" }),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.sessionStopped).toBe(true);
+    expect(stopCalls).toEqual([{ threadId: "t", reason: "error" }]);
+  });
+
+  test("a failed teardown is reported, not swallowed", async () => {
+    // The dispatch failure still wins (that is what the caller must act on),
+    // but `sessionStopped: false` is what stops the thread notice from claiming
+    // a session was cleaned up when one is in fact still sitting there.
+    const { manager } = fakeManager({
+      sendMessage: async () => ({ error: "unverified", sendFailed: true }),
+      stop: async () => {
+        throw new Error("tmux kill-session failed");
+      },
+    });
+    const r = await runDispatch({
+      config,
+      branch: "corp-dispatch-429",
+      issueNumber: 429,
+      command: "impl",
+      sessionManager: manager,
+      createThread: async () => ({ id: "t" }),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.stage).toBe("inject");
+      // The ORIGINAL failure is preserved — not replaced by the teardown error.
+      expect(r.error).toContain("unverified");
+      expect(r.sessionStopped).toBe(false);
+    }
+  });
+
+  test("a thrown sendMessage also tears the session down", async () => {
+    // The other door into stage=inject. Both must leave the same state behind,
+    // or the queue accounting depends on which way the send failed.
+    const { manager, stopCalls } = fakeManager({
+      sendMessage: async () => {
+        throw new Error("tmux gone");
+      },
+    });
+    const r = await runDispatch({
+      config,
+      branch: "b",
+      issueNumber: 7,
+      command: "impl",
+      sessionManager: manager,
+      createThread: async () => ({ id: "t" }),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) expect(r.sessionStopped).toBe(true);
+    expect(stopCalls).toHaveLength(1);
+  });
+
   test("a relay timeout is NOT a dispatch failure — the command did land", async () => {
     // The counter-case that keeps this from over-reporting: `/pdca 429` runs for
     // hours, so the relay wait expires long before the job does. `error` is set,
@@ -240,6 +319,27 @@ describe("buildDispatchFailureNotice (#429)", () => {
     expect(msg).toMatch(/再ディスパッチ/);
   });
 
+  test("the inject notice reports the session teardown honestly (should-4)", () => {
+    // Default / stopped: the session is gone, so the reader is not sent looking
+    // for one.
+    const stopped = buildDispatchFailureNotice(
+      "inject", "agent-base", "corp-dispatch-429", 429, "impl",
+      { sessionStopped: true }
+    );
+    expect(stopped).toContain("停止しました");
+    expect(stopped).not.toContain("/session stop");
+
+    // Teardown failed: a session IS still sitting there, and saying otherwise
+    // would be the one thing worse than saying nothing.
+    const orphaned = buildDispatchFailureNotice(
+      "inject", "agent-base", "corp-dispatch-429", 429, "impl",
+      { sessionStopped: false }
+    );
+    expect(orphaned).toContain("停止にも失敗");
+    expect(orphaned).toContain("/session stop");
+    expect(orphaned).not.toBe(stopped);
+  });
+
   test("every stage produces its own non-empty explanation", () => {
     const stages = ["thread", "start", "inject", "output"] as const;
     const bodies = stages.map((s) => notice(s));
@@ -280,6 +380,10 @@ describe("runDispatch — a dialog needing a human reaches the thread (#423 / #4
       sendMessage: async (_threadId, _message, _attachments, options) => {
         received = options;
         return {};
+      },
+      // The send succeeds here, so #429's teardown must not run.
+      stop: async () => {
+        throw new Error("stop must not be called on a successful dispatch");
       },
     };
     const posted: Array<{ threadId: string; content: string }> = [];

--- a/supervisor/tests/session/dispatch-run.test.ts
+++ b/supervisor/tests/session/dispatch-run.test.ts
@@ -1,8 +1,9 @@
 import { describe, test, expect } from "bun:test";
-import { runDispatch } from "../../src/session/dispatch";
+import { runDispatch, buildDispatchFailureNotice } from "../../src/session/dispatch";
 import type {
   DispatchSessionManager,
   DispatchThreadFactory,
+  DispatchSendResult,
 } from "../../src/session/dispatch";
 import type { DialogStuckInfo } from "../../src/session/dialog-stuck-handler";
 
@@ -15,7 +16,7 @@ import type { DialogStuckInfo } from "../../src/session/dialog-stuck-handler";
 
 function fakeManager(overrides: Partial<{
   start: (config: unknown, threadId: string, branch?: string) => Promise<unknown>;
-  sendMessage: (threadId: string, message: string) => Promise<unknown>;
+  sendMessage: (threadId: string, message: string) => Promise<DispatchSendResult>;
 }> = {}): {
   manager: DispatchSessionManager;
   startCalls: Array<{ threadId: string; branch?: string }>;
@@ -35,7 +36,8 @@ function fakeManager(overrides: Partial<{
       overrides.sendMessage ??
       (async (threadId, message) => {
         sendCalls.push({ threadId, message });
-        return { chunks: [], text: "" };
+        // A healthy relay: a result with no `sendFailed` (#429).
+        return {};
       }),
   };
   return { manager, startCalls, sendCalls };
@@ -155,6 +157,110 @@ describe("runDispatch", () => {
 });
 
 /**
+ * Issue #429: the injection is the one send in the whole system that #428 left
+ * unverified, and it is the send corp's silent stalls actually happen on.
+ *
+ * The trap this locks is that a failed send does NOT throw: `relayMessage`
+ * converts it into a RESULT (a user-facing chunk plus `error`), so the
+ * `try/catch` around `sendMessage` sees nothing and the dispatch used to report
+ * `ok: true` — thread banner, ledger `dispatched`, session idle forever.
+ */
+describe("runDispatch — an injection that never reached the pane is a failure (#429)", () => {
+  test("sendFailed result → ok:false stage=inject (not a cheerful ok:true)", async () => {
+    const { manager } = fakeManager({
+      // Exactly what buildSendFailureResult produces: resolves, does not throw.
+      sendMessage: async () => ({
+        error: "Error: send-keys was accepted but the text never appeared in the pane (#422)",
+        sendFailed: true,
+      }),
+    });
+    const r = await runDispatch({
+      config,
+      branch: "corp-dispatch-429",
+      issueNumber: 429,
+      command: "impl",
+      sessionManager: manager,
+      createThread: async () => ({ id: "t" }),
+    });
+    expect(r.ok).toBe(false);
+    if (!r.ok) {
+      expect(r.stage).toBe("inject");
+      // The cause is carried for the log (the user-facing text is built
+      // separately by buildDispatchFailureNotice, without this string).
+      expect(r.error).toContain("#422");
+    }
+  });
+
+  test("a relay timeout is NOT a dispatch failure — the command did land", async () => {
+    // The counter-case that keeps this from over-reporting: `/pdca 429` runs for
+    // hours, so the relay wait expires long before the job does. `error` is set,
+    // but the pane DID receive the command. Failing here would swap a silent
+    // drop for a false alarm on every long-running dispatch.
+    const { manager } = fakeManager({
+      sendMessage: async () => ({ error: "relay timeout after 900000ms" }),
+    });
+    const r = await runDispatch({
+      config,
+      branch: "corp-dispatch-429",
+      issueNumber: 429,
+      command: "pdca",
+      sessionManager: manager,
+      createThread: async () => ({ id: "t" }),
+    });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.injected).toBe("/pdca 429");
+  });
+});
+
+/**
+ * Issue #429: before this, a failed dispatch reached `console.error` and nothing
+ * else — corp's ledger stayed `dispatched` and the thread stayed empty, so the
+ * failure was indistinguishable from a session still working. The notice is what
+ * makes the existing recovery path (corp#107 / #108 re-injection) reachable.
+ */
+describe("buildDispatchFailureNotice (#429)", () => {
+  const notice = (stage: Parameters<typeof buildDispatchFailureNotice>[0]) =>
+    buildDispatchFailureNotice(stage, "agent-base", "corp-dispatch-429", 429, "impl");
+
+  test("names what failed and what was going to run", () => {
+    const msg = notice("inject");
+    expect(msg).toContain("agent-base");
+    expect(msg).toContain("corp-dispatch-429");
+    expect(msg).toContain("/impl 429");
+    // Unambiguously a failure — the old path posted the SUCCESS banner here.
+    expect(msg).toContain("失敗");
+  });
+
+  test("the inject notice states that nothing was re-sent automatically", () => {
+    // The single most important sentence in this PR: someone reading the thread
+    // has to know the session is idle, not working, and that no retype happened.
+    const msg = notice("inject");
+    expect(msg).toMatch(/再入力/);
+    expect(msg).toMatch(/Enter/);
+    expect(msg).toMatch(/再ディスパッチ/);
+  });
+
+  test("every stage produces its own non-empty explanation", () => {
+    const stages = ["thread", "start", "inject", "output"] as const;
+    const bodies = stages.map((s) => notice(s));
+    // No stage silently falls through to a generic blob.
+    expect(new Set(bodies).size).toBe(stages.length);
+    for (const body of bodies) expect(body.length).toBeGreaterThan(40);
+  });
+
+  test("carries no tmux/exec internals into Discord", () => {
+    // Same contract as SEND_FAILURE_USER_MESSAGE (Issue #74): the raw cause —
+    // `not in a mode`, an ETIMEDOUT, an absolute path from an fs error — stays
+    // in the Supervisor log. The builder takes no `error` argument at all, so
+    // this is structural; the assertions lock the wording that remains.
+    for (const stage of ["thread", "start", "inject", "output"] as const) {
+      const msg = notice(stage);
+      expect(msg).not.toMatch(/send-keys|capture-pane|not in a mode|ETIMEDOUT|\/Users\//);
+    }
+  });
+});
+
+/**
  * PR #431 review, should-4. #423 stopped the watchdog from answering an
  * AskUserQuestion on the user's behalf, which turns a fabricated answer into a
  * stalled session — an improvement only if somebody is told. The dispatch path
@@ -173,7 +279,7 @@ describe("runDispatch — a dialog needing a human reaches the thread (#423 / #4
       waitForInputReady: async () => true,
       sendMessage: async (_threadId, _message, _attachments, options) => {
         received = options;
-        return { chunks: [], text: "" };
+        return {};
       },
     };
     const posted: Array<{ threadId: string; content: string }> = [];

--- a/supervisor/tests/session/dispatch.test.ts
+++ b/supervisor/tests/session/dispatch.test.ts
@@ -172,6 +172,12 @@ describe("runDispatch readiness ordering (RW-025/047)", () => {
         calls.push(`send:${message}`);
         return {};
       },
+      // Recorded, not ignored: this describe pins the CALL ORDER, so a stray
+      // teardown (#429 stops the session when the injection fails) has to show
+      // up in `calls` rather than pass unnoticed.
+      stop: async () => {
+        calls.push("stop");
+      },
     };
     return { sm, calls };
   }
@@ -253,6 +259,9 @@ describe("runDispatch readiness ordering (RW-025/047)", () => {
       sendMessage: async (_t: string, message: string) => {
         calls.push(`send:${message}`);
         return {};
+      },
+      stop: async () => {
+        calls.push("stop");
       },
     };
     const r = await runDispatch({

--- a/supervisor/tests/session/hub-work.test.ts
+++ b/supervisor/tests/session/hub-work.test.ts
@@ -156,6 +156,8 @@ function fakeManager(opts?: { startError?: Error }): HubWorkSessionManager & {
       return {};
     },
     waitForInputReady: async () => true,
+    // #429: never reached here — these cases do not fail the injection.
+    stop: async () => {},
     sendMessage: async (threadId, message) => {
       calls.sendMessage.push({ threadId, message });
       return {};

--- a/supervisor/tests/session/manager.test.ts
+++ b/supervisor/tests/session/manager.test.ts
@@ -876,3 +876,40 @@ describe("watchTmuxSession async re-entry guard (#227 / #251 AC-4)", () => {
     }
   });
 });
+
+/**
+ * Issue #429 (PR #434 review, should-1). `sendMessage` has two ways to fail
+ * without the text ever reaching the pane: the relay's verification (covered in
+ * relay-delivery-verify.test.ts) and this early return, which fires when the
+ * tmux session died between `start()` and the send — reachable on the dispatch
+ * path, which does start → waitForInputReady → sendMessage.
+ *
+ * Both must carry `sendFailed`, because that flag is the ONLY thing separating
+ * "the session never saw the message" from "the answer has not come back yet"
+ * (a relay timeout also sets `error`). Without it, a dispatch whose session died
+ * on boot reported success: welcome banner in the thread, ledger left at
+ * `dispatched`, nothing running — the same silent stall #429 exists to end.
+ */
+describe("SessionManager.sendMessage — a dead pane is a send failure (#429)", () => {
+  test("the dead-session early return sets sendFailed", async () => {
+    const effects = createFakeEffects();
+    const manager = new SessionManager({ effects, gracefulKillTimeoutMs: 0 });
+    try {
+      const threadId = "thread-dead-pane";
+      await manager.start(makeChannelConfig({ channelName: "channel-dead" }), threadId);
+      // The pane dies after the session is registered — exactly the window the
+      // dispatch transport walks through.
+      await effects.tmux.killSession(SessionManager.tmuxSessionNameFor(threadId));
+
+      const result = await manager.sendMessage(threadId, "/impl 429");
+
+      expect(result.sendFailed).toBe(true);
+      expect(result.error).toBe("tmux session dead");
+      // Still user-facing: the flag is for the dispatch transport, not a
+      // replacement for telling whoever is reading the thread.
+      expect(result.chunks.join("")).toContain("セッションが終了しています");
+    } finally {
+      await manager.shutdownAll();
+    }
+  });
+});

--- a/supervisor/tests/session/relay-delivery-verify.test.ts
+++ b/supervisor/tests/session/relay-delivery-verify.test.ts
@@ -7,7 +7,7 @@ import {
   sendToPane,
   buildDeliveryProbe,
   countProbeOccurrences,
-  shouldVerifyDelivery,
+  allowsRetype,
   deliveryNoticeFor,
   DELIVERY_PROBE_MAX_CHARS,
   DELIVERY_MAX_TYPE_ATTEMPTS,
@@ -211,12 +211,16 @@ describe("delivery probe helpers (#422)", () => {
     expect(countProbeOccurrences("abc", "a.c")).toBe(0);
   });
 
-  test("slash commands skip verification, natural language does not", () => {
+  test("slash commands are never retyped, natural language may be (#429)", () => {
     // Retyping a slash command on a false negative would EXECUTE IT TWICE.
-    expect(shouldVerifyDelivery("/compact 続きの作業")).toBe(false);
-    expect(shouldVerifyDelivery("  /session compact")).toBe(false);
-    expect(shouldVerifyDelivery("４１６実装開始")).toBe(true);
-    expect(shouldVerifyDelivery("status? / maybe")).toBe(true);
+    // #429 narrows the old carve-out from "not verified" to "not retyped":
+    // measurement showed the pane DOES render slash text (see allowsRetype).
+    expect(allowsRetype("/compact 続きの作業")).toBe(false);
+    expect(allowsRetype("  /session compact")).toBe(false);
+    expect(allowsRetype("/impl 429")).toBe(false);
+    expect(allowsRetype("４１６実装開始")).toBe(true);
+    // Only a LEADING slash makes it a command; a slash mid-sentence does not.
+    expect(allowsRetype("status? / maybe")).toBe(true);
   });
 
   test("only unclean verdicts produce a user notice", () => {
@@ -224,7 +228,6 @@ describe("delivery probe helpers (#422)", () => {
     // the user to ignore the one that matters.
     expect(deliveryNoticeFor("verified")).toBeNull();
     expect(deliveryNoticeFor("verified-retyped")).toBeNull();
-    expect(deliveryNoticeFor("skipped-slash")).toBeNull();
     expect(deliveryNoticeFor("skipped-no-probe")).toBeNull();
     expect(deliveryNoticeFor("duplicate")).toBe(DUPLICATE_INPUT_USER_MESSAGE);
     expect(deliveryNoticeFor("unverified-observer")).toBe(
@@ -383,20 +386,94 @@ describe("sendToPane delivery verification against a real pane (#422)", () => {
   );
 
   itmux(
-    "slash commands are sent unverified (a retype would execute them twice)",
+    "#429 AC-2: a slash command the pane never renders is reported, not silent",
     async () => {
-      const name = makeSessionName("slash");
-      const dir = mkdtempSync(join(tmpdir(), "relay422-slash-"));
-      startDropPane(name, dir); // never renders — a verified send would throw here
+      // Before #429 this exact call resolved with `skipped-slash` and the
+      // dispatch reported success — the silent stall corp kept hitting. The
+      // pane is observed now; only the retype is withheld.
+      const name = makeSessionName("slash-drop");
+      const dir = mkdtempSync(join(tmpdir(), "relay429-slash-"));
+      startDropPane(name, dir); // never renders
       try {
         await waitForOpenMarker(name);
-        const outcome = await sendToPane(name, "/compact 続きの作業", TMUX_ARGS, {
+        const typedAttempts: number[] = [];
+        await expect(
+          sendToPane(name, "/impl 429", TMUX_ARGS, {
+            verifyBackoffMs: FAST_BACKOFF,
+            onAttemptTyped: (n) => void typedAttempts.push(n),
+          })
+        ).rejects.toThrow(SEND_UNVERIFIED_ERROR);
+
+        // THE point of #429: typed exactly once. A second type here would be a
+        // second `/impl 429` execution the moment the pane recovers.
+        expect(typedAttempts).toEqual([1]);
+        expect(capturePane(name)).not.toContain("/impl 429");
+      } finally {
+        killSession(name);
+        rmSync(dir, { recursive: true, force: true });
+      }
+    },
+    30_000
+  );
+
+  itmux(
+    "#429 AC-1: a slash command a healthy pane renders is verified, typed once",
+    async () => {
+      const name = makeSessionName("slash-ok");
+      startEchoPane(name);
+      try {
+        const payload = "/impl 429";
+        const typedAttempts: number[] = [];
+        const outcome = await sendToPane(name, payload, TMUX_ARGS, {
           verifyBackoffMs: FAST_BACKOFF,
+          onAttemptTyped: (n) => void typedAttempts.push(n),
         });
-        expect(outcome.verdict).toBe("skipped-slash");
-        // Skipped is NOT verified: the log and any future consumer must not read
-        // this as "the pane was observed to hold the command".
-        expect(outcome.verified).toBe(false);
+        // Observed, so it may honestly be called verified (unlike the old
+        // `skipped-slash`, which was verified:false by construction).
+        expect(outcome.verdict).toBe("verified");
+        expect(outcome.verified).toBe(true);
+        expect(typedAttempts).toEqual([1]);
+        // AC-1's "no double input": exactly one copy in the pane.
+        expect(countProbeOccurrences(capturePane(name), buildDeliveryProbe(payload))).toBe(1);
+      } finally {
+        killSession(name);
+      }
+    },
+    30_000
+  );
+
+  itmux(
+    "#429: a slash command that renders LATE is verified without a retype",
+    async () => {
+      // The false-negative case that makes "verify but never retype" worth the
+      // trouble: attempt 1 is swallowed, the pane recovers, and the text shows
+      // up during a later watch round. The retype path would have typed again
+      // by then (and #428 would have called it `duplicate`); here the same
+      // recovery costs zero extra keystrokes.
+      const name = makeSessionName("slash-late");
+      const dir = mkdtempSync(join(tmpdir(), "relay429-late-"));
+      const flag = join(dir, "reopen");
+      startDropPane(name, dir, flag);
+      try {
+        await waitForOpenMarker(name);
+        const typedAttempts: number[] = [];
+        const outcome = await sendToPane(name, "/session compact", TMUX_ARGS, {
+          verifyBackoffMs: FAST_BACKOFF,
+          onAttemptTyped: (n) => {
+            typedAttempts.push(n);
+            // Echo comes back right after the (lost) first type; the literal
+            // itself is gone, so this asserts the WATCH rounds, not a retype.
+            if (n === 1) writeFileSync(flag, "");
+          },
+        }).catch((err) => err as Error);
+
+        // Whatever the outcome, the invariant under test is the same one:
+        // the command was typed exactly once.
+        expect(typedAttempts).toEqual([1]);
+        // And it is never reported as a retype/duplicate, because it wasn't.
+        if (!(outcome instanceof Error)) {
+          expect(["verified", "unverified-observer"]).toContain(outcome.verdict);
+        }
       } finally {
         killSession(name);
         rmSync(dir, { recursive: true, force: true });
@@ -546,6 +623,120 @@ describe("delivery verification edge cases via an injected pane reader (#422)", 
         expect(outcome.verdict).toBe("verified-retyped");
         expect(outcome.verified).toBe(true);
         expect(deliveryNoticeFor(outcome.verdict)).toBeNull();
+      } finally {
+        killSession(name);
+      }
+    },
+    30_000
+  );
+});
+
+/**
+ * Issue #429 — the no-retype path, driven through the scripted reader so the
+ * round structure is pinned deterministically rather than raced against a real
+ * TUI. These are the cases that separate "verify but never retype" from both of
+ * its neighbours: the old skip (silent) and the retype path (double execution).
+ */
+describe("slash delivery: verified, never retyped (#429)", () => {
+  const slash = "/impl 429";
+  const slashProbe = buildDeliveryProbe(slash);
+
+  itmux(
+    "text that shows up only in a LATER round is verified, still typed once",
+    async () => {
+      const name = makeSessionName("slash-round2");
+      startEchoPane(name);
+      try {
+        const typedAttempts: number[] = [];
+        const outcome = await sendToPane(name, slash, TMUX_ARGS, {
+          verifyBackoffMs: FAST_BACKOFF,
+          onAttemptTyped: (n) => void typedAttempts.push(n),
+          capturePane: scriptedReader([
+            "", //                        baseline (0)
+            "", "", "", "", //            round 1 polls: nothing yet (0)
+            slashProbe, //                round 2: the late render lands (1)
+          ]),
+        });
+        // Round 2 ran (that is the patience this path keeps) but did NOT type.
+        expect(typedAttempts).toEqual([1]);
+        // Typed once → "verified", never "verified-retyped": the verdict has to
+        // describe what we actually did to the pane.
+        expect(outcome.verdict).toBe("verified");
+        expect(outcome.verified).toBe(true);
+      } finally {
+        killSession(name);
+      }
+    },
+    30_000
+  );
+
+  itmux(
+    "a rise of 2 without a retype is not blamed on us as 'duplicate'",
+    async () => {
+      const name = makeSessionName("slash-rise2");
+      startEchoPane(name);
+      try {
+        const outcome = await sendToPane(name, slash, TMUX_ARGS, {
+          verifyBackoffMs: FAST_BACKOFF,
+          capturePane: scriptedReader([
+            "", //                                   baseline (0)
+            `${slashProbe} ${slashProbe}`, //        two copies appear (2)
+          ]),
+        });
+        // We typed once, so a second copy is the user's own (or an echo the TUI
+        // renders twice) — calling it `duplicate` would put a "your input was
+        // doubled" warning on a send that behaved perfectly.
+        expect(outcome.verdict).toBe("verified");
+        expect(deliveryNoticeFor(outcome.verdict)).toBeNull();
+      } finally {
+        killSession(name);
+      }
+    },
+    30_000
+  );
+
+  itmux(
+    "provably absent through every round → throws, having typed exactly once",
+    async () => {
+      const name = makeSessionName("slash-never");
+      startEchoPane(name);
+      try {
+        const typedAttempts: number[] = [];
+        await expect(
+          sendToPane(name, slash, TMUX_ARGS, {
+            verifyBackoffMs: FAST_BACKOFF,
+            onAttemptTyped: (n) => void typedAttempts.push(n),
+            capturePane: scriptedReader([""]), // never renders, ever
+          })
+        ).rejects.toThrow(SEND_UNVERIFIED_ERROR);
+        expect(typedAttempts).toEqual([1]);
+      } finally {
+        killSession(name);
+      }
+    },
+    30_000
+  );
+
+  itmux(
+    "natural language keeps its retype — #429 must not disarm #422's recovery",
+    async () => {
+      const name = makeSessionName("nl-retype");
+      startEchoPane(name);
+      try {
+        const payload = "状況報告。";
+        const probe = buildDeliveryProbe(payload);
+        const typedAttempts: number[] = [];
+        const outcome = await sendToPane(name, payload, TMUX_ARGS, {
+          verifyBackoffMs: FAST_BACKOFF,
+          onAttemptTyped: (n) => void typedAttempts.push(n),
+          capturePane: scriptedReader([
+            "", //                        baseline (0)
+            "", "", "", "", //            attempt 1 polls: lost (0)
+            probe, //                     the retype lands (1)
+          ]),
+        });
+        expect(typedAttempts).toEqual([1, 2]);
+        expect(outcome.verdict).toBe("verified-retyped");
       } finally {
         killSession(name);
       }

--- a/supervisor/tests/session/relay-delivery-verify.test.ts
+++ b/supervisor/tests/session/relay-delivery-verify.test.ts
@@ -10,7 +10,7 @@ import {
   allowsRetype,
   deliveryNoticeFor,
   DELIVERY_PROBE_MAX_CHARS,
-  DELIVERY_MAX_TYPE_ATTEMPTS,
+  DELIVERY_MAX_VERIFY_ROUNDS,
   DELIVERY_VERIFY_BACKOFF_MS,
   CAPTURE_PANE_TIMEOUT_MS,
   SEND_UNVERIFIED_ERROR,
@@ -261,7 +261,7 @@ describe("delivery probe helpers (#422)", () => {
     expect(DELIVERY_VERIFY_BACKOFF_MS[0]).toBeLessThanOrEqual(100);
     const total = DELIVERY_VERIFY_BACKOFF_MS.reduce((a, b) => a + b, 0);
     expect(total).toBeGreaterThanOrEqual(1000);
-    expect(DELIVERY_MAX_TYPE_ATTEMPTS).toBeGreaterThanOrEqual(2);
+    expect(DELIVERY_MAX_VERIFY_ROUNDS).toBeGreaterThanOrEqual(2);
   });
 });
 
@@ -443,15 +443,20 @@ describe("sendToPane delivery verification against a real pane (#422)", () => {
   );
 
   itmux(
-    "#429: a slash command that renders LATE is verified without a retype",
+    "#429: a pane that recovers mid-flight is still typed into exactly once",
     async () => {
-      // The false-negative case that makes "verify but never retype" worth the
-      // trouble: attempt 1 is swallowed, the pane recovers, and the text shows
-      // up during a later watch round. The retype path would have typed again
-      // by then (and #428 would have called it `duplicate`); here the same
-      // recovery costs zero extra keystrokes.
-      const name = makeSessionName("slash-late");
-      const dir = mkdtempSync(join(tmpdir(), "relay429-late-"));
+      // PR #434 review, nit-3: this case cannot pin a verdict. Whether the
+      // recovered pane renders inside the remaining watch budget is a race with
+      // the real tty, so asserting "verified" here would be flaky. The verdict
+      // for the late-render path is pinned deterministically by the scripted
+      // reader below ("text that shows up only in a LATER round").
+      //
+      // What this case CAN pin, against a real tmux, is the invariant that
+      // matters for a slash command: no matter how the race lands, the literal
+      // is put on the wire once. A regression that reinstates the retype fails
+      // here even when the timing goes the other way.
+      const name = makeSessionName("slash-recover");
+      const dir = mkdtempSync(join(tmpdir(), "relay429-recover-"));
       const flag = join(dir, "reopen");
       startDropPane(name, dir, flag);
       try {
@@ -461,18 +466,18 @@ describe("sendToPane delivery verification against a real pane (#422)", () => {
           verifyBackoffMs: FAST_BACKOFF,
           onAttemptTyped: (n) => {
             typedAttempts.push(n);
-            // Echo comes back right after the (lost) first type; the literal
-            // itself is gone, so this asserts the WATCH rounds, not a retype.
+            // Reopen echo the instant the (swallowed) first type is done, so
+            // the recovery happens during the WATCH rounds, not before them.
             if (n === 1) writeFileSync(flag, "");
           },
         }).catch((err) => err as Error);
 
-        // Whatever the outcome, the invariant under test is the same one:
-        // the command was typed exactly once.
         expect(typedAttempts).toEqual([1]);
-        // And it is never reported as a retype/duplicate, because it wasn't.
+        // Never a retype verdict, because no retype happened — whichever way
+        // the race resolved.
         if (!(outcome instanceof Error)) {
-          expect(["verified", "unverified-observer"]).toContain(outcome.verdict);
+          expect(outcome.verdict).not.toBe("verified-retyped");
+          expect(outcome.verdict).not.toBe("duplicate");
         }
       } finally {
         killSession(name);


### PR DESCRIPTION
Closes #429

## 背景

#422 / PR #428 で「`tmux send-keys` の exit 0 を配達とみなさず pane 描画を検証する」保護が入ったが、**dispatch の `/impl` `/pdca` 注入はスラッシュ始まりのため検証をスキップ**していた。corp の dispatch がサイレント stall する事象（セッションは起動したが何もしない、台帳は `dispatched` のまま）は実際にこの経路で起きる。

## まず実測した

除外の根拠は PR #428 の q-1 で作者自身が **未実測の仮説** と明記していたもの（「ピッカーが入力行を再描画するので照合できない」）。方針を決める前に実測した。

実 Claude Code TUI v2.1.229 を隔離ソケットで起動:

```
tmux -L wt429test new-session -d -s probe -x 200 -y 50 "claude --dangerously-skip-permissions ..."
tmux -L wt429test send-keys -t probe -l '/impl 429'   # exit=0
tmux -L wt429test capture-pane -p -t probe
```

| 状態 | 結果 |
|---|---|
| 送信前 | `countProbeOccurrences(pane, "/impl429")` = **0** |
| 送信後 | 15 行目が `❯ /impl 429`、count = **1** |
| ピッカーを開いた状態（bare `/pd`） | メニューは**下の行を覆うだけ**で入力行 `❯ /pd` は残り、照合できる |

→ **仮説は誤り**。slash テキストは pane で観測できる。危険だったのは検証ではなく **再入力**（コマンドの二重実行）だけだった。これは #428 の q-1 が「実測できたら verify but never retype にせよ」と書いていた条件そのもの。

## 変更

**1. 軸を「検証するか」→「再入力してよいか」に変更**（`relay.ts`）

`shouldVerifyDelivery` を `allowsRetype` に置換。slash も他と同じく観測し、描画が確認できなければ既存の `SEND_UNVERIFIED_ERROR` を throw する。throw なので **Enter は送られず**、半端な入力を submit しない。

**verdict は増やしていない。`skipped-slash` を削除して減らした**（観測できた slash は `verified` を名乗れるようになり、観測できなかったものは既存の throw 経路に乗るため、新しい語彙が要らない）。

**2. 忍耐時間を retype 経路と同じに保つ**

検証ループを「type 回数」から「監視ラウンド」に変更。slash は round 1 でのみ打鍵し、以降のラウンドは監視だけ続ける。これをしないと no-retype 経路だけ待ち時間が半分になり、**誤検知で失敗を作る**（自動復旧できない経路なので、そちらのほうが害が大きい）。

```
[Relay] typed text never rendered ... (round 2/2, typed 1×, retype withheld (#429), 9 chars)
```

**3. dispatch が失敗を失敗として扱う**（`dispatch.ts`）— ここが本丸

`sendMessage` は送信失敗時も **throw せず result を返す**（relay が throw を user-facing chunk に変換するため）。よって既存の `try/catch` は無反応で、**失敗した注入が `ok:true` として「起動しました」と報告されていた**。`RelayResult.sendFailed` を見て `ok:false stage=inject` を返すようにした。

relay timeout（= 配達済みで実行中）は失敗扱いしない。`/pdca` は relay timeout より長く走るのが普通で、これを失敗と報告するとサイレント消失を誤報に取り替えるだけになる。

**4. 失敗を Discord に出す**（`bot.ts`）

dispatch 失敗が `console.error` 止まりで、スレッドには何も出ていなかった。失敗通知を投稿する。**「二重実行を避けるため自動での再入力はしていない・Enter も送っていない」と明記**する（読んだ人がセッションを「作業中」でなく「待機中」と判断できる必要があるため）。これで corp 側の failed 再投入導線（corp#107 / #108）に繋がる。

## 統合ジャーニーAC 検証結果

| AC | 検証内容 | コマンド / テスト | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | 注入が描画される正常時、二重入力なし | `#429 AC-1: a slash command a healthy pane renders is verified, typed once`（実 tmux pane） | 打鍵 1 回 / pane 内 1 個 / `verified` | `typedAttempts=[1]`, `count=1`, `verdict="verified"` | **PASS** |
| AC-1 | 実 TUI で slash が照合可能 | 上記「まず実測した」の手動実測 | count 0 → 1 | 0 → 1（`❯ /impl 429`） | **PASS** |
| AC-2 | 描画されない時、自動再入力しない | `#429 AC-2: a slash command the pane never renders is reported, not silent` | throw / 打鍵 1 回 | `SEND_UNVERIFIED_ERROR`, `typedAttempts=[1]` | **PASS** |
| AC-2 | 描画されない時、dispatch が失敗を返す | `sendFailed result → ok:false stage=inject` | `ok:false`/`stage=inject` | 同左 | **PASS** |
| AC-2 | 失敗が Discord 文面として明示される | `buildDispatchFailureNotice (#429)` 4 件 | 失敗・再入力なし・再ディスパッチを明記 / tmux 内部を含まない | 同左 | **PASS** |
| AC-2 | bot.ts の失敗分岐（成功バナーでなく失敗通知） | `bun test tests/session/dispatch-integration.test.ts` | 失敗通知が投稿され、セッションは停止 | `outcome=inject_failed` / `stopCalls=[thread-1]` / 通知に再入力なし・再ディスパッチを明記 | **PASS** |
| AC-2 | bot.ts の配線が log-only に戻らないこと | `bun test tests/guards/access-enforcement-wired.test.ts` | `buildDispatchFailureNotice` + `postToThread` が失敗分岐内で呼ばれる | 同左（ソース検査 3 件） | **PASS** |
| AC-2 | bot.ts → **実 Discord** への到達 | — | — | discord.js クライアントを要するため**実投稿は未検証**（配線は上記 2 行で検証済み） | **未検証** |
| AC-3 | corp 側の再投入で復旧・台帳遷移 | — | — | **未検証・本 PR では満たされない**。通知は Discord スレッドへの投稿で、corp 台帳（`dispatches/*.jsonl`）への機械可読な伝達は無く、corp#107 / #108 の再投入は**誰かがこの投稿に気付くこと**を前提とする（follow-up Issue で追跡） | **未検証** |
| 回帰 | #428 のテストを壊していない | `bun test tests/session/relay-delivery-verify.test.ts` | 全 pass | **26/26 pass**（#428 の既存ケース含む） | **PASS** |
| 回帰 | dispatch 系 | `bun test tests/session/dispatch*.test.ts tests/action/` | 全 pass | **134/134 pass** | **PASS** |
| 回帰 | CI と同じテスト集合 | `bun test <ci.yml の 96 ファイル>` | 新規 fail なし | 1261 pass / 4 fail。4 件は `tests/scripts/` のシェルテストで、**単独実行では 67/67 pass**（負荷依存の 5s timeout）。うち 1 件は base でも fail | **PASS（新規 fail 0）** |
| 回帰 | 全体（`bun test`） | ベースと差分比較 | 新規 fail なし | branch 34 fail / base(`c421916`) 36 fail、**branch 固有の fail は 0**（base の真部分集合）。全体実行時の fail は `mock.module("child_process")` のプロセス汚染で、CI が別プロセスに分けている既知クラス | **PASS（新規 fail 0）** |

## 注意点

- **`/compact` 系も検証対象になる**。`/impl` だけ特別扱いすると分岐が増えるだけで、根拠（実測）は全 slash に等しく効くため一律にした。`compactSession` / `compactClaudeHubExit` / `executeAction` はいずれも throw を上位に伝播して user に見せる作りなので、失敗はサイレントにならず**エラーとして表面化する**（従来はサイレントに消えていた）。
- `RelayResult` に `sendFailed?: boolean` を 1 フィールド追加した。`error` だけでは「配達失敗」と「応答が返らなかった」を区別できず、後者を失敗と報告すると長時間 dispatch を軒並み誤報するため。
- `skipped-slash` verdict と `SendToPaneOptions.verify` を削除した（slash carve-out を表すためだけに存在していたもので、本 PR でその carve-out 自体が無くなるため）。
- **スコープ外**: Enter 取りこぼし（#263 / #357）。

## レビュー対応（`96a49a9`）

独立レビュー（must なし / should 4 / question 2 / nit 3）に対応しました。詳細は [対応コメント](https://github.com/miyashita337/claude-hub/pull/434#issuecomment-5276052030) を参照。

- **should-1**: `manager.ts` の dead-session 早期 return に `sendFailed` を追加（同じサイレント停止クラスの残り穴）
- **should-3**: `/compact テスト用の意図` と bare `/compact` を実 TUI で実測し、外挿を実測に置換（結果は `/impl` と同じ＝入力行は照合可能）
- **should-4**: inject 失敗時にセッションを停止して枠を返す。停止に失敗したら `sessionStopped: false` で文面を切り替える
- **question-1**: bot.ts 側の配線をテスト 2 種（統合シミュレーション + ソース検査）で検証し、AC を PASS へ
- **should-2**: スコープ外（レビュアーも「#428 からの盲点で回帰ではない」と明記）。実態とズレていたコメントのみ修正し、別 Issue 化を提案
- **nit 1/2/3**: 定数改名（`DELIVERY_MAX_VERIFY_ROUNDS`）、`stage` の型統一、verdict を実質固定していなかったテストの是正

### 既知の制約（question-2）

本 PR の失敗通知は **Discord スレッドへの投稿**であり、corp 台帳への機械可読な伝達はありません。corp#107 / #108 の failed 再投入は「誰かがこの投稿に気付くこと」を前提とします。したがって **AC-3 は本 PR では満たされません**（follow-up Issue で追跡）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GzoXfTLSh56CjXpM3sza8p
