### PR TITLE
test(relay): AskUserQuestion selector を hook→relay→Discord投稿までE2Eで検証する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -430,7 +430,13 @@ jobs:
         env:
           SUPERVISOR_DB_PATH: ":memory:"
           TMUX_PATH: /usr/bin/tmux
-        run: bun test tests/e2e/ac-verification.test.ts tests/session/relay.test.ts tests/e2e/dialog-stall.test.ts
+        # tests/e2e/ask-user-selector.test.ts (Issue #436): drives the real
+        # relay-server + a real `hooks/ask-user-relay.sh` child process + real
+        # curl, so the hook->relay->Discord-post chain for the AskUserQuestion
+        # selector (buttons/select, #412/#416/#423) is exercised on every PR
+        # instead of only by a human clicking a button in Discord after each
+        # supervisor restart.
+        run: bun test tests/e2e/ac-verification.test.ts tests/session/relay.test.ts tests/e2e/dialog-stall.test.ts tests/e2e/ask-user-selector.test.ts
         working-directory: supervisor
 
       # Supervisor ↔ tmux session lifecycle E2E (Issue #144 / #273). Runs as its

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -31,9 +31,9 @@ import {
   withCompactButton,
 } from "./commands/compact-button";
 import {
-  buildAskPrompt,
   createAskComponentHandler,
   isAskComponentId,
+  postAskUserPrompt,
 } from "./commands/ask-components";
 import { CHANNEL_MAP, MAX_SESSIONS } from "./config/channels";
 import { RELAY_ERROR_USER_MESSAGE, type AttachmentInfo } from "./session/relay";
@@ -555,18 +555,16 @@ export async function startBot(token: string): Promise<void> {
           // itself once the payload grows the field.
           const multiSelect =
             (event as { multiSelect?: unknown }).multiSelect === true;
-          const prompt = buildAskPrompt({
+          // Issue #436 V-2: build + send is `postAskUserPrompt` (not inlined
+          // here) so an E2E test can drive this exact call with a fake channel
+          // and assert on what actually reaches `send()`, not just on
+          // `buildAskPrompt`'s return value.
+          await postAskUserPrompt(channel, {
             threadId: event.threadId,
             question: event.question,
             options: event.options,
             multiSelect,
             timeoutMs: event.timeoutMs,
-          });
-          await channel.send({
-            content: prompt.content,
-            ...(prompt.components.length
-              ? { components: prompt.components }
-              : {}),
           });
         } catch (err) {
           console.error(

--- a/supervisor/src/commands/ask-components.ts
+++ b/supervisor/src/commands/ask-components.ts
@@ -425,6 +425,45 @@ export function buildAskPrompt(
 }
 
 /**
+ * Minimal Discord channel surface `postAskUserPrompt` needs to deliver a post.
+ * Deliberately narrower than discord.js's `Channel` union (which not every
+ * member satisfies — only text-based / thread channels have `.send()`) so a
+ * caller can pass an already-narrowed `ThreadChannel` (bot.ts, after its own
+ * `isThread()` check) or a hermetic fake (tests) without a cast.
+ */
+export interface AskPostChannel {
+  send(options: {
+    content: string;
+    components?: AskComponentRow[];
+  }): Promise<unknown>;
+}
+
+/**
+ * Build the AskUserQuestion post and actually deliver it (Issue #436 V-2).
+ *
+ * Split out from `buildAskPrompt` so "does this reach Discord in the right
+ * shape" is answerable without a live bot token: tests can pass a fake
+ * `AskPostChannel` and assert on the captured `send()` call. Previously
+ * nothing fed `buildAskPrompt`'s output into an actual send in any test —
+ * bot-wiring tests only checked that the handler was registered, never that
+ * it produced a correct post. Kept side-effect-free otherwise: callers own
+ * channel resolution (`client.channels.fetch` + `isThread()`) and error
+ * handling, same as before this was extracted.
+ */
+export async function postAskUserPrompt(
+  channel: AskPostChannel,
+  input: AskPromptInput,
+  registry: AskPromptRegistry = askPrompts
+): Promise<AskPromptMessage> {
+  const prompt = buildAskPrompt(input, registry);
+  await channel.send({
+    content: prompt.content,
+    ...(prompt.components.length ? { components: prompt.components } : {}),
+  });
+  return prompt;
+}
+
+/**
  * Closing lines of the post: how to answer, then the relay's own wait notice.
  *
  * `askWaitNotice` (relay-server.ts, #416) already says both "a text reply in

--- a/supervisor/tests/commands/ask-components.test.ts
+++ b/supervisor/tests/commands/ask-components.test.ts
@@ -18,9 +18,11 @@ import {
   createAskComponentHandler,
   isAskComponentId,
   parseAskCustomId,
+  postAskUserPrompt,
   shouldUseButtons,
   splitOption,
   type AskComponentKind,
+  type AskPostChannel,
 } from "../../src/commands/ask-components";
 
 /**
@@ -801,18 +803,117 @@ describe("coupled contracts (#412)", () => {
     expect(hook).toContain(`"${OPTION_SEPARATOR}"`);
   });
 
-  test("bot.ts sends the built components, not just the text", () => {
-    // #370's failure class: a relay path that exists but is not wired. The
-    // components only reach Discord if handleAskUser passes them to send() —
-    // assert the call site so a future edit cannot drop them back to text-only
-    // while every unit test above still passes.
+  test("bot.ts wires handleAskUser through postAskUserPrompt", () => {
+    // #370's failure class: a relay path that exists but is not wired. Text
+    // matching can only prove bot.ts calls the right function, not that the
+    // function actually produces a correct post — that gap is closed by the
+    // postAskUserPrompt describe block below, which drives the real send().
     const bot = readFileSync(
       resolve(import.meta.dir, "../../src/bot.ts"),
       "utf8"
     );
-    expect(bot).toContain("buildAskPrompt({");
-    expect(bot).toMatch(/components:\s*prompt\.components/);
+    expect(bot).toMatch(/postAskUserPrompt\(channel,\s*{/);
     // And the interaction dispatcher must route both component kinds.
     expect(bot).toMatch(/isAskComponentId\(interaction\.customId\)/);
+  });
+});
+
+describe("postAskUserPrompt (Issue #436 V-2)", () => {
+  // Nothing before this point fed buildAskPrompt's output into an actual
+  // send(): ask-components.test.ts covers buildAskPrompt in isolation, and
+  // startup-wiring.test.ts only proves handleAskUser is registered — neither
+  // ever executes it. These tests drive the exact call bot.ts makes, with a
+  // fake channel standing in for the live Discord send that could not be
+  // verified for two days after #427/#431 shipped (Issue #436).
+  function makeChannel() {
+    const sent: {
+      content: string;
+      components?: unknown[];
+    }[] = [];
+    const channel: AskPostChannel = {
+      send: async (options) => {
+        sent.push(options);
+        return { id: "message-1" };
+      },
+    };
+    return { channel, sent };
+  }
+
+  test("delivers buttons for a 2-option question, with the real deadline and no-auto-select notice", async () => {
+    const registry = new AskPromptRegistry();
+    const { channel, sent } = makeChannel();
+
+    const prompt = await postAskUserPrompt(
+      channel,
+      {
+        threadId: "thread-1",
+        question: "A か B か？",
+        options: ["A", "B"],
+        timeoutMs: 5 * 60 * 60 * 1000,
+      },
+      registry
+    );
+
+    expect(sent).toHaveLength(1);
+    expect(prompt.kind).toBe("buttons");
+    // 期待2: the wait notice states the real deadline, not a stale hardcode.
+    expect(sent[0]!.content).toContain("約 5 時間");
+    // 期待3: the no-auto-select line (Issue #423) is present verbatim.
+    expect(sent[0]!.content).toContain(
+      "選択肢が自動で選ばれることはありません（Issue #423）"
+    );
+    // 期待1: components reach send(), not just the text.
+    expect(sent[0]!.components).toBeDefined();
+    expect(sent[0]!.components).toHaveLength(1);
+    const ids = customIds(sent[0]!.components![0]);
+    expect(ids).toHaveLength(2);
+  });
+
+  test("delivers a select menu once options exceed the button limit", async () => {
+    const registry = new AskPromptRegistry();
+    const { channel, sent } = makeChannel();
+
+    await postAskUserPrompt(
+      channel,
+      {
+        threadId: "thread-1",
+        question: "方針は？",
+        options: ["A", "B", "C", "D", "E", "F"],
+        timeoutMs: 30 * 60 * 1000,
+      },
+      registry
+    );
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.content).toContain("約 30 分");
+    const menu = rowJson(sent[0]!.components![0]).components[0] as {
+      options: { label: string }[];
+    };
+    expect(menu.options.map((o) => o.label)).toEqual([
+      "A",
+      "B",
+      "C",
+      "D",
+      "E",
+      "F",
+    ]);
+  });
+
+  test("sends text-only (no components key) when the ask carries no options", async () => {
+    // Multi-question asks flatten to a bare question with no options — the
+    // send() call must omit `components` entirely rather than send `[]`,
+    // matching what buildAskPrompt already guarantees for this shape.
+    const registry = new AskPromptRegistry();
+    const { channel, sent } = makeChannel();
+
+    await postAskUserPrompt(
+      channel,
+      { threadId: "thread-1", question: "自由記述でお願いします" },
+      registry
+    );
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.components).toBeUndefined();
+    expect(sent[0]!.content).toContain("自由記述でお願いします");
   });
 });

--- a/supervisor/tests/e2e/ask-user-selector.test.ts
+++ b/supervisor/tests/e2e/ask-user-selector.test.ts
@@ -1,0 +1,179 @@
+// End-to-end coverage for the AskUserQuestion selector path (Issue #436 V-2).
+//
+// Issue #436 asked for a manual Discord check ("does a real button appear")
+// after every supervisor restart. Two days running it never completed — not
+// because the feature was broken, but because nothing in CI drove the full
+// chain: hooks/ask-user-relay.sh -> relay-server /ask/:threadId -> onAskUser
+// -> the Discord post. Every existing test covers one hop in isolation
+// (tests/hooks/ask-user-relay.test.ts mocks curl and never touches a live
+// server; tests/session/ask-user-relay.test.ts drives the server but never
+// the hook process; tests/commands/ask-components.test.ts drives
+// postAskUserPrompt directly but never through the hook or the server;
+// tests/bot/startup-wiring.test.ts proves handleAskUser is registered but
+// never executes it). This file wires all of them together with a real
+// relay-server, a real `bash hooks/ask-user-relay.sh` child process, real
+// curl, and a fake Discord channel standing in for the one hop that
+// genuinely requires a live bot token (channel.send against the Gateway).
+//
+// A green run here is the automated equivalent of Issue #436's V-2 checklist
+// (期待 1-4): components reach the post, the real deadline is quoted, the
+// no-auto-select notice (#423) is present, and the user's tap/reply resolves
+// back to the hook's PreToolUse deny envelope.
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { $ } from "bun";
+import { resolve } from "path";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import {
+  startRelayServer,
+  stopRelayServer,
+  getRelayPort,
+  onAskUser,
+  resolveAskUser,
+  type AskUserEvent,
+} from "../../src/session/relay-server";
+import {
+  postAskUserPrompt,
+  type AskPostChannel,
+} from "../../src/commands/ask-components";
+
+const HOOK_PATH = resolve(import.meta.dir, "../../hooks/ask-user-relay.sh");
+
+interface SentMessage {
+  content: string;
+  components?: unknown[];
+}
+
+function makeFakeChannel() {
+  const sent: SentMessage[] = [];
+  const channel: AskPostChannel = {
+    send: async (options) => {
+      sent.push(options);
+      return { id: "message-1" };
+    },
+  };
+  return { channel, sent };
+}
+
+interface TestEnv {
+  cwd: string;
+  runtimeDir: string;
+}
+
+function setupEnv(relayUrl: string): TestEnv {
+  const cwd = mkdtempSync(resolve(tmpdir(), "ask-user-selector-e2e-"));
+  const runtimeDir = mkdtempSync(resolve(tmpdir(), "ask-user-selector-runtime-"));
+  const sanitisedCwd = cwd.replace(/^\/+/, "").replace(/\//g, "_");
+  const relayDir = resolve(runtimeDir, "claude-hub-supervisor");
+  mkdirSync(relayDir, { recursive: true });
+  writeFileSync(resolve(relayDir, `${sanitisedCwd}.relay-url`), relayUrl, "utf8");
+  return { cwd, runtimeDir };
+}
+
+function cleanupEnv(env: TestEnv) {
+  rmSync(env.cwd, { recursive: true, force: true });
+  rmSync(env.runtimeDir, { recursive: true, force: true });
+}
+
+function makeHookInput(cwd: string, question: string, options: string[]) {
+  return JSON.stringify({
+    tool_name: "AskUserQuestion",
+    tool_input: {
+      questions: [
+        {
+          question,
+          header: "test",
+          multiSelect: false,
+          options: options.map((label) => ({ label, description: "" })),
+        },
+      ],
+    },
+    cwd,
+  });
+}
+
+async function runHook(env: TestEnv, input: string) {
+  const result = await $`echo ${input} | XDG_RUNTIME_DIR=${env.runtimeDir} bash ${HOOK_PATH}`
+    .quiet()
+    .nothrow();
+  return {
+    stdout: result.stdout.toString(),
+    exitCode: result.exitCode,
+  };
+}
+
+describe("AskUserQuestion selector end-to-end (Issue #436 V-2)", () => {
+  let env: TestEnv;
+
+  afterEach(() => {
+    stopRelayServer();
+    if (env) cleanupEnv(env);
+  });
+
+  test("hook -> relay-server -> Discord post -> user tap -> hook answer, full round trip", async () => {
+    startRelayServer();
+    const port = getRelayPort();
+    const threadId = "thread-e2e-436";
+    env = setupEnv(`http://localhost:${port}/relay/${threadId}`);
+
+    const { channel, sent } = makeFakeChannel();
+
+    // Mirrors bot.ts's handleAskUser exactly (Issue #370 / #412 / #416):
+    // build + deliver the post the moment the hook's question arrives, then
+    // simulate the user tapping a button by resolving with an answer.
+    onAskUser((event: AskUserEvent) => {
+      void postAskUserPrompt(channel, {
+        threadId: event.threadId,
+        question: event.question,
+        options: event.options,
+        timeoutMs: event.timeoutMs,
+      }).then(() => {
+        resolveAskUser(event.threadId, "A（テストOK）");
+      });
+    });
+
+    const input = makeHookInput(env.cwd, "V-2検証テスト: AでもBでも選んでください", [
+      "A（テストOK）",
+      "B（テストOK・別選択）",
+    ]);
+    const { stdout, exitCode } = await runHook(env, input);
+
+    expect(exitCode).toBe(0);
+
+    // 期待1: the post actually reached a send() call, with buttons attached
+    // (not a text-only fallback).
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.components).toBeDefined();
+    expect(sent[0]!.components).toHaveLength(1);
+
+    // 期待2/3: the real deadline and the no-auto-select notice (#423) are in
+    // the text that would have rendered in Discord.
+    expect(sent[0]!.content).toMatch(/約 \d+(\.\d+)? (時間|分)/);
+    expect(sent[0]!.content).toContain(
+      "選択肢が自動で選ばれることはありません（Issue #423）",
+    );
+
+    // 期待4: the user's tap resolves the hook, which hands the answer back
+    // to Claude via the PreToolUse deny envelope (same contract as the
+    // hardcoded-curl hook tests, but this time the answer traveled through a
+    // real relay-server round trip instead of a mocked one).
+    const out = JSON.parse(stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain(
+      "A（テストOK）",
+    );
+  });
+
+  test("hook falls back to TUI behaviour (no relay-url) without touching Discord", async () => {
+    // No relay-url file written: mirrors a non-supervisor session. Nothing
+    // should be posted anywhere, and the hook must exit silently (0, no
+    // stdout) so Claude Code opens its native dialog.
+    env = { cwd: mkdtempSync(resolve(tmpdir(), "ask-user-selector-e2e-")), runtimeDir: mkdtempSync(resolve(tmpdir(), "ask-user-selector-runtime-")) };
+
+    const input = makeHookInput(env.cwd, "no relay configured", ["A", "B"]);
+    const { stdout, exitCode } = await runHook(env, input);
+
+    expect(exitCode).toBe(0);
+    expect(stdout.trim()).toBe("");
+  });
+});


### PR DESCRIPTION
## 概要

Issue #436 の V-2（Discordで実際にボタン/セレクトが表示されるか）は、supervisor 再起動のたびに人手で確認する運用だったが、2日間一度も実施できなかった。

原因は偶然ではなく、**そのパスを検証するテストが元々存在しなかった**ため:
- `ask-components.test.ts` は `buildAskPrompt`（テキスト生成部分）を単体テストするのみ
- `startup-wiring.test.ts` は `handleAskUser` が正しいイベントに配線されているかを見るだけで、ハンドラの中身（実際に `channel.send()` へ渡す処理）は一度も実行しない

結果として「Discordに実際に送る `content`/`components` が正しい形か」を保証するテストがゼロだった。

## 変更内容

- `src/commands/ask-components.ts`: `buildAskPrompt` + 送信処理を `postAskUserPrompt` として抽出。フェイクの Discord チャンネルを渡して送信内容を検証できるようにした
- `src/bot.ts`: `handleAskUser` を `postAskUserPrompt` 呼び出しに置き換え（挙動は不変、fetch + isThread の narrowing は呼び出し元に残したまま）
- `tests/commands/ask-components.test.ts`: `postAskUserPrompt` が実際の期限表示（例: 「約 5 時間」）・#423 の自動選択なし文言・components を正しく送信することを検証する3件を追加
- `tests/e2e/ask-user-selector.test.ts`（新規）: **実際の** relay-server + **実際の** `hooks/ask-user-relay.sh` 子プロセス + **実際の** curl を使い、hook → relay-server → Discord投稿 → ユーザー回答 → hookの応答（PreToolUse deny envelope）までを一気通貫で検証
- `.github/workflows/ci.yml`: 新規E2Eテストを `e2e-tests` ジョブに組み込み

## テスト方法

```bash
cd supervisor
bunx tsc --noEmit
bun test tests/commands/ask-components.test.ts tests/e2e/ask-user-selector.test.ts tests/bot/startup-wiring.test.ts
bun scripts/lint-gating-coverage.ts
```

- [x] 型チェック PASS
- [x] 関連テスト全106件 PASS（ローカル実行済み）
- [x] `lint-gating-coverage.ts`（新規テストがCI未組み込みだと落ちるlint）PASS
- [x] pre-commit hook PASS

## 関連

- Issue #436


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * AskUserQuestion の質問投稿処理を改善し、ボタンや選択メニューなどの選択肢をより確実に表示できるようになりました。
  * 選択肢がない場合は、不要な操作コンポーネントを表示せず、テキストのみで通知します。
  * 質問の期限や自動選択されない場合の通知が、Discord上で適切に表示されます。

* **品質向上**
  * 質問の送信から回答処理までの一連の動作を検証するテストを追加しました。
  * 接続情報がない場合、Discordへの送信を行わず安全にTUIへ切り替えます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->