### PR TITLE
feat(relay): AskUserQuestion の複数質問に質問ごとのボタン/セレクトを表示する (#443)

### DIFF
--- a/supervisor/hooks/ask-user-relay.sh
+++ b/supervisor/hooks/ask-user-relay.sh
@@ -66,9 +66,15 @@ ASK_URL=$(printf '%s' "$SUPERVISOR_RELAY_URL" | sed 's|/relay/|/ask/|')
 #   { "questions": [ { "question", "header", "multiSelect",
 #                      "options": [ { "label", "description" } ] } ] }
 # Single question: forward its text + options flattened to "label — description"
-# strings so Discord can list the choices. Multiple questions: forward all
-# question texts joined by newlines; per-question option mapping over one
-# free-text reply is ambiguous, so options are omitted.
+# strings so Discord can list the choices. Multiple questions (#443): forward
+# the joined text as `question` (unchanged, used for the deny-envelope wording
+# and the expiry notice) PLUS a structured `questions[]` array carrying each
+# sub-question's own text + flattened options, so relay-server / bot.ts can
+# post one tappable ActionRow per question instead of flattening every option
+# away. Before #443 this branch dropped `options` entirely — the only way to
+# answer 2+ questions was one free-text reply for the whole batch, which is
+# what let an unrelated message get read as the answer to every question at
+# once (see Issue #443's incident writeup).
 QUESTION_COUNT=$(echo "$INPUT" | jq -r '(.tool_input.questions // []) | length' 2>/dev/null)
 if [ -z "$QUESTION_COUNT" ] || [ "$QUESTION_COUNT" -eq 0 ] 2>/dev/null; then
   # Unknown / legacy shape — let the regular TUI dialog handle it.
@@ -81,15 +87,21 @@ if [ -z "$QUESTION_TEXT" ]; then
 fi
 
 PAYLOAD=$(echo "$INPUT" | jq -c '
+  def flatten_options: [ .[]?
+    | (.label // "")
+      + (if (.description // "") != "" then " — " + .description else "" end) ];
   (.tool_input.questions // []) as $qs
   | if ($qs | length) == 1 then
       { question: ($qs[0].question // ""),
-        options: [ $qs[0].options[]?
-          | (.label // "")
-            + (if (.description // "") != "" then " — " + .description else "" end) ] }
+        options: ($qs[0].options // [] | flatten_options) }
       | if (.options | length) == 0 then del(.options) else . end
     else
-      { question: ($qs | map(.question // "") | join("\n")) }
+      { question: ($qs | map(.question // "") | join("\n")),
+        questions: [ $qs[] | {
+          question: (.question // ""),
+          multiSelect: (.multiSelect // false),
+          options: (.options // [] | flatten_options)
+        } | if (.options | length) == 0 then del(.options) else . end ] }
     end')
 
 # Forward to the supervisor and wait for the user's reply. The server enforces

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -32,8 +32,10 @@ import {
 } from "./commands/compact-button";
 import {
   createAskComponentHandler,
+  hasActiveMultiAsk,
   isAskComponentId,
   postAskUserPrompt,
+  postMultiAskUserPrompt,
 } from "./commands/ask-components";
 import { CHANNEL_MAP, MAX_SESSIONS } from "./config/channels";
 import { RELAY_ERROR_USER_MESSAGE, type AttachmentInfo } from "./session/relay";
@@ -549,12 +551,26 @@ export async function startBot(token: string): Promise<void> {
           // the wait budget has exactly one owner — the old hardcoded "約 5 分"
           // outlived two changes to the actual value.
           //
-          // multiSelect is read defensively: AskUserEvent does not carry the
-          // flag (the hook flattens options to `label — description` strings and
-          // drops it). Reading it now means the select path switches on by
-          // itself once the payload grows the field.
+          // multiSelect is read defensively: single-question AskUserEvents do
+          // not carry the flag (the hook flattens options to `label —
+          // description` strings and drops it). Reading it now means the
+          // select path switches on by itself once the payload grows the
+          // field.
           const multiSelect =
             (event as { multiSelect?: unknown }).multiSelect === true;
+          // Issue #443: 2+ questions arrive as `event.questions` (each with
+          // its own options) — post one ActionRow per question instead of the
+          // single flattened prompt below. The hook only populates this field
+          // for a genuinely multi-question ask, so a solo ask still takes the
+          // unchanged path.
+          if (event.questions && event.questions.length > 1) {
+            await postMultiAskUserPrompt(channel, {
+              threadId: event.threadId,
+              questions: event.questions,
+              timeoutMs: event.timeoutMs,
+            });
+            return;
+          }
           // Issue #436 V-2: build + send is `postAskUserPrompt` (not inlined
           // here) so an E2E test can drive this exact call with a fake channel
           // and assert on what actually reaches `send()`, not just on
@@ -1392,6 +1408,21 @@ export async function startBot(token: string): Promise<void> {
     // hook waiting on POST /ask — relaying the reply into tmux would type it
     // into a TUI that is not accepting input, so resolve the ask and stop.
     if (hasPendingAsk(threadId)) {
+      // Issue #443 AC-3: a multi-question ask is answered by tapping each
+      // question's own row, not by one free-text reply — resolveAskUser below
+      // would otherwise hand Claude a stray, unrelated message as "the answer
+      // to every question in the batch" (the #443 incident). The remaining
+      // questions stay live for tapping; nothing here resolves the ask.
+      if (hasActiveMultiAsk(threadId)) {
+        try {
+          await message.reply(
+            "この質問は複数あります。上のボタン/メニューからそれぞれタップして回答してください（テキストでの一括回答はできません）。"
+          );
+        } catch {
+          // Best-effort notice only; the ask itself stays pending either way.
+        }
+        return;
+      }
       resolveAskUser(threadId, messageText);
       // The session was parked for up to 5h with no activity recorded (#416), so
       // its idle age is stale by the whole wait. Answering IS activity — record

--- a/supervisor/src/commands/ask-components.ts
+++ b/supervisor/src/commands/ask-components.ts
@@ -217,16 +217,34 @@ export class AskPromptRegistry {
     // scan: falls through to evicting the oldest entry outright if every
     // candidate in the map is a live group member, so the map can never grow
     // unbounded even in that pathological case.
-    while (this.prompts.size > this.capacity) {
-      let victim: string | undefined;
-      for (const [tok, p] of this.prompts) {
-        const liveGroupMember = p.groupId !== undefined && p.state === "pending";
-        if (!liveGroupMember) {
-          victim = tok;
-          break;
+    if (this.prompts.size > this.capacity) {
+      // PR #444 review (CodeRabbit / Qodo): a group is "still open" as long as
+      // ANY sibling is pending — not just the pending ones individually. The
+      // original check only protected `state === "pending"` entries, so an
+      // ALREADY-ANSWERED sibling of a group that has not fully resolved yet
+      // was still evictable. Losing it would shrink `groupOf()`'s result,
+      // shifting the `Q<n>:` ordinals of the remaining siblings AND silently
+      // dropping that sibling's answer from the combined string sent back to
+      // Claude once the group does finish. Protecting the whole group (not
+      // just its pending members) closes that hole.
+      const openGroups = new Set<string>();
+      for (const p of this.prompts.values()) {
+        if (p.groupId !== undefined && p.state === "pending") {
+          openGroups.add(p.groupId);
         }
       }
-      this.prompts.delete(victim ?? this.prompts.keys().next().value!);
+      while (this.prompts.size > this.capacity) {
+        let victim: string | undefined;
+        for (const [tok, p] of this.prompts) {
+          const liveGroupMember =
+            p.groupId !== undefined && openGroups.has(p.groupId);
+          if (!liveGroupMember) {
+            victim = tok;
+            break;
+          }
+        }
+        this.prompts.delete(victim ?? this.prompts.keys().next().value!);
+      }
     }
     return token;
   }
@@ -265,14 +283,24 @@ export class AskPromptRegistry {
    */
   hasActiveMultiAsk(threadId: string): boolean {
     const counts = new Map<string, number>();
+    const hasPending = new Set<string>();
     for (const p of this.prompts.values()) {
       if (p.threadId !== threadId) continue;
       if (p.state === "superseded" || p.state === "expired") continue;
       if (p.groupId === undefined) continue;
       counts.set(p.groupId, (counts.get(p.groupId) ?? 0) + 1);
+      // PR #444 review (CodeRabbit / Qodo): a fully-answered group's entries
+      // stay in the registry as `"answered"` — they are never re-superseded
+      // (register()'s supersede loop deliberately skips `"answered"` prompts)
+      // — so without this, a group that finished answering would still count
+      // toward "active" here, and a LATER solo ask on the same thread would
+      // be wrongly told "this is a multi-question ask, tap the buttons"
+      // instead of accepting its plain-text reply. Only a group with at
+      // least one still-`"pending"` member is genuinely awaiting taps.
+      if (p.state === "pending") hasPending.add(p.groupId);
     }
-    for (const count of counts.values()) {
-      if (count > 1) return true;
+    for (const [groupId, count] of counts) {
+      if (count > 1 && hasPending.has(groupId)) return true;
     }
     return false;
   }
@@ -610,12 +638,27 @@ export function buildMultiAskPrompt(
   const canUseComponents =
     questions.length > 0 &&
     questions.length <= MAX_ASK_QUESTIONS_PER_MESSAGE &&
-    questions.every((q) => (q.options ?? []).length > 0);
+    questions.every((q) => {
+      const count = (q.options ?? []).length;
+      return count > 0 && count <= MAX_SELECT_OPTIONS;
+    });
 
   if (!canUseComponents) {
     if (questions.length > MAX_ASK_QUESTIONS_PER_MESSAGE) {
       console.warn(
         `[ask-components] ${questions.length} questions exceed the Discord ActionRow limit (${MAX_ASK_QUESTIONS_PER_MESSAGE}); posting without components (#443)`
+      );
+    }
+    // Review finding (PR #444): a per-question option count over
+    // MAX_SELECT_OPTIONS (25) would make buildSelectRow hand Discord a
+    // StringSelectMenu with more entries than its hard API ceiling — the
+    // send() call would fail outright, not degrade. Same whole-batch
+    // text fallback as the zero-options case: a free-text sub inside a
+    // tap-to-answer batch is the exact ambiguity buildAskPrompt's own
+    // over-limit branch already avoids for a solo ask.
+    if (questions.some((q) => (q.options ?? []).length > MAX_SELECT_OPTIONS)) {
+      console.warn(
+        `[ask-components] a question has more than ${MAX_SELECT_OPTIONS} options; posting the whole batch without components (#443)`
       );
     }
     const joined = questions.map((q) => q.question).join("\n");

--- a/supervisor/src/commands/ask-components.ts
+++ b/supervisor/src/commands/ask-components.ts
@@ -114,6 +114,14 @@ interface AskPrompt {
   state: AskPromptState;
   /** The answer sent to Claude, once answered through a component. */
   answer?: string;
+  /**
+   * Issue #443: shared by every sub-question of one multi-question ask, so
+   * they can be registered together without superseding each other (see
+   * {@link AskPromptRegistry.register}) and so the click handler can find its
+   * siblings ({@link AskPromptRegistry.groupOf}) to decide whether the whole
+   * ask is answered yet. `undefined` for a solo (single-question) ask.
+   */
+  groupId?: string;
 }
 
 /**
@@ -152,15 +160,29 @@ export class AskPromptRegistry {
    * then answer (#427 review must-2). The structural fix is to carry an ask id
    * through `hasPendingAsk` / `resolveAskUser`; that touches relay-server.ts,
    * which #416 is editing, so it is deferred there.
+   *
+   * `groupId` (Issue #443) opts a registration out of superseding its own
+   * siblings: every sub-question of one multi-question ask is registered with
+   * the SAME `groupId`, so posting Q2 does not immediately supersede Q1's
+   * still-unanswered buttons. A prompt belonging to a DIFFERENT group (or no
+   * group at all) is still superseded exactly as before — only a genuinely
+   * new ask, solo or multi, replaces the whole thread's pending question(s).
    */
   register(input: {
     threadId: string;
     kind: Exclude<AskComponentKind, "text">;
     options: AskOption[];
     multiSelect: boolean;
+    groupId?: string;
   }): string {
     for (const prompt of this.prompts.values()) {
-      if (prompt.threadId === input.threadId && prompt.state !== "answered") {
+      const sibling =
+        input.groupId !== undefined && prompt.groupId === input.groupId;
+      if (
+        prompt.threadId === input.threadId &&
+        prompt.state !== "answered" &&
+        !sibling
+      ) {
         prompt.state = "superseded";
       }
     }
@@ -173,6 +195,7 @@ export class AskPromptRegistry {
       options: input.options,
       multiSelect: input.multiSelect,
       state: "pending",
+      groupId: input.groupId,
     });
 
     // Answered prompts are kept so a repeat click can be told "already
@@ -181,14 +204,29 @@ export class AskPromptRegistry {
     // is accurate for one that old.
     //
     // Eviction is by insertion order and does NOT skip `pending` entries, so a
-    // live question can age out of the registry once ~50 asks have been posted
-    // since. That degrades safely: its buttons report "already finished" and the
-    // text-reply path still resolves the ask. It is not a correctness hole, but
-    // do not read the bound as "answered-only".
+    // solo live question can age out of the registry once ~50 asks have been
+    // posted since. That degrades safely: its buttons report "already
+    // finished" and the text-reply path still resolves the ask. It is not a
+    // correctness hole for a solo ask, but it WOULD be one for a multi-question
+    // group (Issue #443 review should-2): `groupOf()` only sees survivors, so
+    // evicting an unanswered sibling would let `allAnswered` in the click
+    // handler go true — and resolveAskUser fire — without that sibling ever
+    // being tapped. So a still-pending member of a multi-question group
+    // (`groupId` set) is skipped over here; only a solo prompt or an
+    // already-terminal (answered/superseded/expired) one is evicted. Bounded
+    // scan: falls through to evicting the oldest entry outright if every
+    // candidate in the map is a live group member, so the map can never grow
+    // unbounded even in that pathological case.
     while (this.prompts.size > this.capacity) {
-      const oldest = this.prompts.keys().next().value;
-      if (oldest === undefined) break;
-      this.prompts.delete(oldest);
+      let victim: string | undefined;
+      for (const [tok, p] of this.prompts) {
+        const liveGroupMember = p.groupId !== undefined && p.state === "pending";
+        if (!liveGroupMember) {
+          victim = tok;
+          break;
+        }
+      }
+      this.prompts.delete(victim ?? this.prompts.keys().next().value!);
     }
     return token;
   }
@@ -200,6 +238,44 @@ export class AskPromptRegistry {
   size(): number {
     return this.prompts.size;
   }
+
+  /**
+   * Every prompt sharing `token`'s `groupId`, including itself, in
+   * registration order (Issue #443). A solo prompt (`groupId` undefined)
+   * returns just itself — so callers can treat "is the whole ask answered
+   * yet" the same way for a solo click and a multi-question one: check
+   * whether every entry in the returned array is `answered`.
+   */
+  groupOf(token: string): AskPrompt[] {
+    const prompt = this.prompts.get(token);
+    if (!prompt) return [];
+    if (prompt.groupId === undefined) return [prompt];
+    const siblings: AskPrompt[] = [];
+    for (const p of this.prompts.values()) {
+      if (p.groupId === prompt.groupId) siblings.push(p);
+    }
+    return siblings;
+  }
+
+  /**
+   * True while this thread has a still-live multi-question ask (2+ siblings,
+   * none superseded/expired) registered. `bot.ts`'s plain-text reply path
+   * uses this to refuse answering an entire batch of taps with one stray
+   * message (#443 AC-3) while leaving single-question text answers untouched.
+   */
+  hasActiveMultiAsk(threadId: string): boolean {
+    const counts = new Map<string, number>();
+    for (const p of this.prompts.values()) {
+      if (p.threadId !== threadId) continue;
+      if (p.state === "superseded" || p.state === "expired") continue;
+      if (p.groupId === undefined) continue;
+      counts.set(p.groupId, (counts.get(p.groupId) ?? 0) + 1);
+    }
+    for (const count of counts.values()) {
+      if (count > 1) return true;
+    }
+    return false;
+  }
 }
 
 /** Registry used by the running bot. Tests build their own instance. */
@@ -208,6 +284,23 @@ export const askPrompts = new AskPromptRegistry();
 /** Whether a component interaction belongs to this module. */
 export function isAskComponentId(customId: string): boolean {
   return customId.startsWith(ASK_COMPONENT_PREFIX);
+}
+
+/**
+ * Issue #443 AC-3: whether `threadId` currently has a live multi-question ask
+ * (2+ tappable sub-questions, not yet fully answered). `bot.ts`'s
+ * `messageCreate` handler checks this before letting a plain-text reply
+ * resolve a pending ask — a stray message must not be read as the answer to
+ * every question in the batch, only a tap on a specific question's row does
+ * that. Delegates to {@link AskPromptRegistry.hasActiveMultiAsk}; the
+ * `registry` param exists so tests can build an isolated instance instead of
+ * the module singleton.
+ */
+export function hasActiveMultiAsk(
+  threadId: string,
+  registry: AskPromptRegistry = askPrompts
+): boolean {
+  return registry.hasActiveMultiAsk(threadId);
 }
 
 export function parseAskCustomId(
@@ -230,20 +323,16 @@ export function parseAskCustomId(
  * Buttons only when every option fits one ActionRow AND a single answer is
  * wanted; a select otherwise.
  *
- * DEAD PATH TODAY (#427 review should-3): in production this returns `true`
- * every time, so the select branch — and the >25 fallback in
- * {@link buildAskPrompt} — run only under unit tests. Two reasons:
+ * MOSTLY DEAD PATH for a single-question ask (#427 review should-3): in
+ * production `shouldUseButtons` still returns `true` for {@link buildAskPrompt}
+ * every time, because a solo question carries at most 4 options (+ Other) and
+ * hooks/ask-user-relay.sh still drops `multiSelect` when flattening ONE
+ * question's options. The select branch there runs only under unit tests.
  *
- *   1. AskUserQuestion carries at most 4 options (+ Other), i.e. never > 5
- *   2. `multiSelect` is dropped before it reaches us: hooks/ask-user-relay.sh
- *      flattens each option to a `label — description` string and AskUserEvent
- *      has no such field
- *
- * ENABLING CONDITION: the hook + `/ask` payload start carrying `multiSelect`
- * (and structured options). That work lands with the relay-server changes in
- * #416; bot.ts already reads the flag defensively, so the branch switches on by
- * itself. If that never happens, delete the select path rather than keeping it
- * as unexercised surface (agent-output-quality.md #4).
+ * REACHABLE for a multi-question ask (Issue #443): `hooks/ask-user-relay.sh`
+ * forwards each sub-question's `multiSelect` flag and structured options in
+ * `questions[]`, so {@link buildMultiAskPrompt} can and does hit the select
+ * branch in production when a question asks for multiple selections.
  */
 export function shouldUseButtons(
   optionCount: number,
@@ -352,6 +441,12 @@ export interface AskPromptMessage {
   kind: AskComponentKind;
   /** Registry token; absent when the message carries no components. */
   token?: string;
+  /**
+   * Issue #443: one registry token per question, in question order — set
+   * instead of `token` by {@link buildMultiAskPrompt}. `components` holds one
+   * row per entry at the same index.
+   */
+  tokens?: string[];
 }
 
 /**
@@ -463,6 +558,148 @@ export async function postAskUserPrompt(
   return prompt;
 }
 
+/** One sub-question of a multi-question ask, as `buildMultiAskPrompt` needs it. */
+export interface AskSubQuestionInput {
+  question: string;
+  options?: string[];
+  multiSelect?: boolean;
+}
+
+export interface MultiAskPromptInput {
+  threadId: string;
+  questions: AskSubQuestionInput[];
+  /** Same meaning as {@link AskPromptInput.timeoutMs}. */
+  timeoutMs?: number;
+}
+
+/** Discord's ActionRow-per-message ceiling (docs.discord.com/developers). */
+export const MAX_ASK_QUESTIONS_PER_MESSAGE = 5;
+
+/**
+ * Build the thread post for a multi-question AskUserQuestion (Issue #443).
+ *
+ * Before this, `hooks/ask-user-relay.sh` flattened every question in
+ * `questions[]` down to one joined text with no options the moment there was
+ * more than one — `buildAskPrompt` then had nothing to build components from
+ * and fell back to plain text, so the only way to answer was one free-text
+ * reply for the whole batch (the #443 incident: an unrelated message got read
+ * as the answer to every proposal at once).
+ *
+ * Each sub-question is registered as its OWN `AskPromptRegistry` entry — same
+ * registration, same customId scheme (`buildButtonRow` / `buildSelectRow`,
+ * unchanged), same click handling as a solo ask — so none of that machinery
+ * needed to change. What is new is `groupId`: every sub-question of one batch
+ * shares it, which (a) stops them superseding each other on registration (the
+ * "one live ask per thread" rule in {@link AskPromptRegistry.register} would
+ * otherwise disable Q1's buttons the instant Q2 registers) and (b) lets
+ * {@link createAskComponentHandler} tell "wait for the rest of the group"
+ * apart from "this alone is the whole answer" ({@link AskPromptRegistry.groupOf}).
+ *
+ * Falls back to the old flattened text-only post when any sub-question has no
+ * options, there are zero questions, or there are more questions than Discord
+ * allows rows for — a free-text sub inside a tap-to-answer batch is exactly
+ * the ambiguous-mapping problem `ask-user-relay.sh`'s own comment calls out,
+ * so it is not attempted; the whole batch degrades together, not
+ * question-by-question.
+ */
+export function buildMultiAskPrompt(
+  input: MultiAskPromptInput,
+  registry: AskPromptRegistry = askPrompts
+): AskPromptMessage {
+  const { threadId, questions, timeoutMs } = input;
+  const canUseComponents =
+    questions.length > 0 &&
+    questions.length <= MAX_ASK_QUESTIONS_PER_MESSAGE &&
+    questions.every((q) => (q.options ?? []).length > 0);
+
+  if (!canUseComponents) {
+    if (questions.length > MAX_ASK_QUESTIONS_PER_MESSAGE) {
+      console.warn(
+        `[ask-components] ${questions.length} questions exceed the Discord ActionRow limit (${MAX_ASK_QUESTIONS_PER_MESSAGE}); posting without components (#443)`
+      );
+    }
+    const joined = questions.map((q) => q.question).join("\n");
+    return {
+      content: joinContent(
+        [`❓ **Claude からの質問**`, joined],
+        [],
+        askFooter("text", timeoutMs)
+      ),
+      components: [],
+      kind: "text",
+    };
+  }
+
+  const groupId = `${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`;
+  const tokens: string[] = [];
+  const rows: AskComponentRow[] = [];
+  const kinds: Exclude<AskComponentKind, "text">[] = [];
+  const blocks: string[] = [];
+
+  questions.forEach((q, i) => {
+    const rawOptions = q.options ?? [];
+    const multiSelect = q.multiSelect ?? false;
+    const options = rawOptions.map(toAskOption);
+    const kind = shouldUseButtons(options.length, multiSelect)
+      ? "buttons"
+      : "select";
+    const token = registry.register({
+      threadId,
+      kind,
+      options,
+      multiSelect,
+      groupId,
+    });
+    tokens.push(token);
+    kinds.push(kind);
+    rows.push(
+      kind === "buttons"
+        ? buildButtonRow(token, options, false)
+        : buildSelectRow(token, options, multiSelect, false)
+    );
+    const list = rawOptions.map((option, j) => `${j + 1}. ${option}`);
+    blocks.push([`**Q${i + 1}.** ${q.question}`, ...list].join("\n"));
+  });
+
+  const footer =
+    "各質問のボタン/メニューからそれぞれ回答してください（すべてに回答すると再開します）。\n" +
+    askWaitNotice(timeoutMs);
+  const head = `❓ **Claude からの質問（${questions.length}件）**`;
+  const body = [head, ...blocks].join("\n\n");
+  const budget = CONTENT_LIMIT - footer.length - 2;
+  const trimmedBody = body.length > budget ? truncate(body, budget) : body;
+
+  return {
+    content: `${trimmedBody}\n\n${footer}`,
+    components: rows,
+    // Best-effort summary: a batch can mix buttons and selects per question,
+    // but AskPromptMessage.kind has no "mixed" value. "select" whenever at
+    // least one row is one, since that is the row a caller most needs to know
+    // about (it is the branch that is otherwise unreachable in production —
+    // see shouldUseButtons).
+    kind: kinds.includes("select") ? "select" : "buttons",
+    tokens,
+  };
+}
+
+/**
+ * Build the multi-question post and deliver it (mirrors `postAskUserPrompt`,
+ * #436 V-2's rationale: an E2E test can drive this exact call with a fake
+ * channel and assert on what actually reaches `send()`).
+ */
+export async function postMultiAskUserPrompt(
+  channel: AskPostChannel,
+  input: MultiAskPromptInput,
+  registry: AskPromptRegistry = askPrompts
+): Promise<AskPromptMessage> {
+  const prompt = buildMultiAskPrompt(input, registry);
+  await channel.send({
+    content: prompt.content,
+    ...(prompt.components.length ? { components: prompt.components } : {}),
+  });
+  return prompt;
+}
+
 /**
  * Closing lines of the post: how to answer, then the relay's own wait notice.
  *
@@ -501,11 +738,23 @@ function joinContent(
   return `${trimmedBody}\n\n${footer}`;
 }
 
+/**
+ * Rebuild a prompt's row, enabled or disabled. Used both for the
+ * single-answered-row case (disabled) and, for a multi-question ask (#443),
+ * to rebuild every sibling row on each click — the still-pending ones stay
+ * enabled, the just-answered one (and any answered earlier) come back
+ * disabled, so `interaction.update()` can replace the whole `components` list
+ * at once (Discord has no partial-row patch).
+ */
+function buildRowForPrompt(prompt: AskPrompt, disabled: boolean): AskComponentRow {
+  return prompt.kind === "buttons"
+    ? buildButtonRow(prompt.token, prompt.options, disabled)
+    : buildSelectRow(prompt.token, prompt.options, prompt.multiSelect, disabled);
+}
+
 /** Rebuild the row in its disabled form (answer recorded, no further clicks). */
 function buildDisabledRow(prompt: AskPrompt): AskComponentRow {
-  return prompt.kind === "buttons"
-    ? buildButtonRow(prompt.token, prompt.options, true)
-    : buildSelectRow(prompt.token, prompt.options, prompt.multiSelect, true);
+  return buildRowForPrompt(prompt, true);
 }
 
 /**
@@ -515,11 +764,19 @@ function buildDisabledRow(prompt: AskPrompt): AskComponentRow {
  */
 async function disableStaleMessage(
   interaction: ButtonInteraction | StringSelectMenuInteraction,
-  prompt: AskPrompt
+  prompt: AskPrompt,
+  registry: AskPromptRegistry
 ): Promise<void> {
   try {
+    // Issue #443 review must-1: rebuild EVERY sibling row, not just the one
+    // clicked. `.edit({components})` replaces the whole array — for a
+    // multi-question ask the message carries N rows, and every call site here
+    // means the whole ask is dead (expired / superseded / no longer pending),
+    // so all siblings go disabled together, not just the row that was tapped.
+    // A solo ask's group is just itself, so this is unchanged there.
+    const group = registry.groupOf(prompt.token);
     await interaction.message?.edit({
-      components: [buildDisabledRow(prompt)],
+      components: group.map((p) => buildRowForPrompt(p, true)),
     });
   } catch (err) {
     console.warn(
@@ -675,7 +932,7 @@ export function createAskComponentHandler(deps: AskComponentHandlerDeps) {
           "⌛ この質問は回答期限が切れています（セッションは TUI ダイアログに戻っています）。",
         ephemeral: true,
       });
-      await disableStaleMessage(interaction, prompt);
+      await disableStaleMessage(interaction, prompt, registry);
       return;
     }
     if (prompt.state === "superseded") {
@@ -684,7 +941,7 @@ export function createAskComponentHandler(deps: AskComponentHandlerDeps) {
           "ℹ️ この質問は新しい質問に置き換えられています。最新のメッセージから回答してください。",
         ephemeral: true,
       });
-      await disableStaleMessage(interaction, prompt);
+      await disableStaleMessage(interaction, prompt, registry);
       return;
     }
 
@@ -719,7 +976,7 @@ export function createAskComponentHandler(deps: AskComponentHandlerDeps) {
           "⌛ この質問は回答期限が切れています（セッションは TUI ダイアログに戻っています）。",
         ephemeral: true,
       });
-      await disableStaleMessage(interaction, prompt);
+      await disableStaleMessage(interaction, prompt, registry);
       return;
     }
 
@@ -735,7 +992,24 @@ export function createAskComponentHandler(deps: AskComponentHandlerDeps) {
     const answer = chosen.map((option) => option.answer).join(", ");
     prompt.state = "answered";
     prompt.answer = answer;
-    deps.resolveAskUser(prompt.threadId, answer);
+
+    // Issue #443: a multi-question ask registers each sub-question as its own
+    // prompt sharing one groupId. `group` is every sibling (a solo ask's group
+    // is just itself, so this whole block behaves exactly as it did before
+    // #443 for a solo ask — see AskPromptRegistry.groupOf). resolveAskUser
+    // fires the ONE underlying /ask response, so it must fire once, only once
+    // ALL siblings are answered — resolving on the first tap would hand Claude
+    // an answer for questions nobody tapped yet.
+    const group = registry.groupOf(prompt.token);
+    const ordinal = group.indexOf(prompt) + 1;
+    const allAnswered = group.every((p) => p.state === "answered");
+    if (allAnswered) {
+      const combinedAnswer =
+        group.length > 1
+          ? group.map((p, i) => `Q${i + 1}: ${p.answer ?? ""}`).join("\n")
+          : answer;
+      deps.resolveAskUser(prompt.threadId, combinedAnswer);
+    }
 
     // The decision trail (#427 review should-1). This is the 会長's input point:
     // when someone later says "I tapped it and nothing happened", this line is
@@ -746,7 +1020,10 @@ export function createAskComponentHandler(deps: AskComponentHandlerDeps) {
     );
 
     const base = interaction.message?.content ?? "";
-    const chosenLine = truncate(`✅ 選択: ${answer}`, CONTENT_LIMIT);
+    const chosenLine = truncate(
+      group.length > 1 ? `✅ Q${ordinal} 選択: ${answer}` : `✅ 選択: ${answer}`,
+      CONTENT_LIMIT
+    );
     // Trim the QUESTION, never the choice (#427 review should-4). Appending and
     // truncating the whole thing drops the tail first, which is exactly the line
     // that records what was decided.
@@ -757,7 +1034,11 @@ export function createAskComponentHandler(deps: AskComponentHandlerDeps) {
     try {
       await interaction.update({
         content,
-        components: [buildDisabledRow(prompt)],
+        // Rebuild every sibling row (not just this one) — a multi-question ask
+        // posts them all in ONE message, and Discord has no way to patch a
+        // single ActionRow without resending the rest. Still-pending siblings
+        // stay tappable; this is a no-op array-of-one for a solo ask.
+        components: group.map((p) => buildRowForPrompt(p, p.state === "answered")),
       });
     } catch (err) {
       // The answer is already delivered; only the message update failed. Log it

--- a/supervisor/src/session/relay-server.ts
+++ b/supervisor/src/session/relay-server.ts
@@ -40,6 +40,13 @@ export interface LateResponseEvent {
 // Discord thread, and resolves the request with `resolveAskUser(threadId, ans)`
 // once the user replies. The hook then injects `answer` back into Claude's
 // `tool_input` via the `updatedInput` PreToolUse contract.
+/** One sub-question of a multi-question ask (Issue #443). */
+export interface AskSubQuestionEvent {
+  question: string;
+  options?: string[];
+  multiSelect?: boolean;
+}
+
 export interface AskUserEvent {
   threadId: string;
   question: string;
@@ -47,6 +54,48 @@ export interface AskUserEvent {
   /** Effective wait budget for this ask, so the thread notice can state the
    *  real deadline instead of a second hardcoded copy of it (Issue #416). */
   timeoutMs: number;
+  /**
+   * Issue #443: present only when the ask carries 2+ questions with their own
+   * option sets. `question`/`options` above stay the flattened, joined form
+   * (unchanged — the deny envelope and the expiry notice still quote that),
+   * this is the structured form bot.ts uses to post one tappable ActionRow
+   * per question instead of falling back to a single free-text prompt.
+   */
+  questions?: AskSubQuestionEvent[];
+}
+
+/**
+ * Validate the `questions` field of an `/ask/:threadId` POST body (Issue
+ * #443). Any shape mismatch — not an array, an entry missing a non-empty
+ * `question`, an `options` entry that is not all strings — returns
+ * `undefined` rather than throwing, so a malformed or older-hook payload
+ * degrades to the flattened `question`/`options` fields instead of 400ing the
+ * whole request.
+ */
+function parseAskSubQuestions(value: unknown): AskSubQuestionEvent[] | undefined {
+  if (!Array.isArray(value) || value.length === 0) return undefined;
+  const parsed: AskSubQuestionEvent[] = [];
+  for (const entry of value) {
+    if (typeof entry !== "object" || entry === null) return undefined;
+    const record = entry as Record<string, unknown>;
+    const question =
+      typeof record.question === "string" ? record.question.trim() : "";
+    if (!question) return undefined;
+    const options =
+      record.options === undefined
+        ? undefined
+        : Array.isArray(record.options) &&
+            record.options.every((o) => typeof o === "string")
+          ? (record.options as string[])
+          : null;
+    if (options === null) return undefined;
+    parsed.push({
+      question,
+      ...(options ? { options } : {}),
+      ...(record.multiSelect === true ? { multiSelect: true } : {}),
+    });
+  }
+  return parsed;
 }
 
 /**
@@ -651,6 +700,13 @@ export function startRelayServer(): void {
             ? (body.options as string[])
             : undefined;
 
+        // Issue #443: structured per-question data for a multi-question ask.
+        // Malformed entries degrade to `undefined` (falls back to the
+        // flattened `question` above) rather than a 400 — a hook running an
+        // older/newer build than the server must not break the whole ask over
+        // a field it does not understand.
+        const questions = parseAskSubQuestions(body.questions);
+
         const requested =
           typeof body.timeout_ms === "number" && body.timeout_ms > 0
             ? body.timeout_ms
@@ -717,7 +773,7 @@ export function startRelayServer(): void {
           // request. Wrap in try/catch so a buggy callback can't leave the
           // request hanging.
           try {
-            callback({ threadId, question, options, timeoutMs });
+            callback({ threadId, question, options, timeoutMs, questions });
           } catch (err) {
             console.error("[relay-server] askUserCallback error:", err);
             const pending = pendingAsks.get(threadId);

--- a/supervisor/tests/commands/ask-components.test.ts
+++ b/supervisor/tests/commands/ask-components.test.ts
@@ -10,15 +10,19 @@ import {
   AskPromptRegistry,
   BUTTON_LABEL_LIMIT,
   CUSTOM_ID_LIMIT,
+  MAX_ASK_QUESTIONS_PER_MESSAGE,
   MAX_BUTTON_OPTIONS,
   MAX_SELECT_OPTIONS,
   OPTION_SEPARATOR,
   SELECT_DESCRIPTION_LIMIT,
   buildAskPrompt,
+  buildMultiAskPrompt,
   createAskComponentHandler,
+  hasActiveMultiAsk,
   isAskComponentId,
   parseAskCustomId,
   postAskUserPrompt,
+  postMultiAskUserPrompt,
   shouldUseButtons,
   splitOption,
   type AskComponentKind,
@@ -815,6 +819,12 @@ describe("coupled contracts (#412)", () => {
     expect(bot).toMatch(/postAskUserPrompt\(channel,\s*{/);
     // And the interaction dispatcher must route both component kinds.
     expect(bot).toMatch(/isAskComponentId\(interaction\.customId\)/);
+    // #443: a multi-question event must reach postMultiAskUserPrompt, and a
+    // plain-text reply must be gated by hasActiveMultiAsk before it can
+    // resolve a pending ask (AC-3) — same failure class as #370, one hop
+    // earlier: the branch existing but never being taken.
+    expect(bot).toMatch(/postMultiAskUserPrompt\(channel,\s*{/);
+    expect(bot).toMatch(/hasActiveMultiAsk\(threadId\)/);
   });
 });
 
@@ -915,5 +925,487 @@ describe("postAskUserPrompt (Issue #436 V-2)", () => {
     expect(sent).toHaveLength(1);
     expect(sent[0]!.components).toBeUndefined();
     expect(sent[0]!.content).toContain("自由記述でお願いします");
+  });
+});
+
+// --- multi-question ask (Issue #443) ----------------------------------------
+
+describe("buildMultiAskPrompt (#443)", () => {
+  test("one ActionRow per question, each with its own token/customIds", () => {
+    const registry = new AskPromptRegistry();
+    const prompt = buildMultiAskPrompt(
+      {
+        threadId: "thread-1",
+        questions: [
+          { question: "Q1 はどうしますか？", options: ["案A", "案B"] },
+          { question: "Q2 はどうしますか？", options: ["案C"] },
+        ],
+      },
+      registry
+    );
+
+    expect(prompt.kind).not.toBe("text");
+    expect(prompt.components).toHaveLength(2);
+    expect(prompt.tokens).toHaveLength(2);
+    expect(prompt.token).toBeUndefined();
+
+    const row0 = customIds(prompt.components[0]);
+    const row1 = customIds(prompt.components[1]);
+    expect(row0).toEqual([
+      `${ASK_COMPONENT_PREFIX}${prompt.tokens![0]}:0`,
+      `${ASK_COMPONENT_PREFIX}${prompt.tokens![0]}:1`,
+    ]);
+    expect(row1).toEqual([`${ASK_COMPONENT_PREFIX}${prompt.tokens![1]}:0`]);
+    // Different tokens: each question is its own independent registry entry.
+    expect(prompt.tokens![0]).not.toBe(prompt.tokens![1]);
+
+    expect(prompt.content).toContain("Q1 はどうしますか？");
+    expect(prompt.content).toContain("Q2 はどうしますか？");
+    expect(prompt.content).toContain("再開します");
+  });
+
+  test("registering siblings does not supersede each other (unlike two unrelated asks)", () => {
+    const registry = new AskPromptRegistry();
+    const prompt = buildMultiAskPrompt(
+      {
+        threadId: "thread-1",
+        questions: [
+          { question: "Q1", options: ["案A"] },
+          { question: "Q2", options: ["案B"] },
+        ],
+      },
+      registry
+    );
+
+    // Both siblings are still pending — registering Q2 must not have disabled
+    // Q1's row the way a second unrelated buildAskPrompt call would.
+    const first = registry.get(prompt.tokens![0]!);
+    const second = registry.get(prompt.tokens![1]!);
+    expect(first?.state).toBe("pending");
+    expect(second?.state).toBe("pending");
+  });
+
+  test("a genuinely new ask still supersedes an unanswered multi-question batch", () => {
+    const registry = new AskPromptRegistry();
+    const multi = buildMultiAskPrompt(
+      {
+        threadId: "thread-1",
+        questions: [
+          { question: "Q1", options: ["案A"] },
+          { question: "Q2", options: ["案B"] },
+        ],
+      },
+      registry
+    );
+
+    // A later solo ask on the same thread replaces the whole pending batch.
+    buildAskPrompt({ threadId: "thread-1", question: "Q3", options: ["案C"] }, registry);
+
+    expect(registry.get(multi.tokens![0]!)?.state).toBe("superseded");
+    expect(registry.get(multi.tokens![1]!)?.state).toBe("superseded");
+  });
+
+  test("falls back to the flattened text-only post when a sub-question has no options", () => {
+    const registry = new AskPromptRegistry();
+    const prompt = buildMultiAskPrompt(
+      {
+        threadId: "thread-1",
+        questions: [
+          { question: "Q1 はどうしますか？", options: ["案A"] },
+          { question: "Q2 は自由記述です" }, // no options
+        ],
+      },
+      registry
+    );
+
+    expect(prompt.kind).toBe("text");
+    expect(prompt.components).toHaveLength(0);
+    expect(prompt.tokens).toBeUndefined();
+    expect(registry.size()).toBe(0);
+    expect(prompt.content).toContain("Q1 はどうしますか？");
+    expect(prompt.content).toContain("Q2 は自由記述です");
+  });
+
+  test("falls back to text when there are more questions than Discord has rows for", () => {
+    const registry = new AskPromptRegistry();
+    const questions = Array.from({ length: MAX_ASK_QUESTIONS_PER_MESSAGE + 1 }, (_, i) => ({
+      question: `Q${i + 1}`,
+      options: ["A"],
+    }));
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const prompt = buildMultiAskPrompt({ threadId: "thread-1", questions }, registry);
+      expect(prompt.kind).toBe("text");
+      expect(prompt.components).toHaveLength(0);
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  test("falls back to text for zero questions", () => {
+    const registry = new AskPromptRegistry();
+    const prompt = buildMultiAskPrompt({ threadId: "thread-1", questions: [] }, registry);
+    expect(prompt.kind).toBe("text");
+    expect(prompt.components).toHaveLength(0);
+  });
+
+  test("a question needing multiSelect gets a select row even below the button limit", () => {
+    const registry = new AskPromptRegistry();
+    const prompt = buildMultiAskPrompt(
+      {
+        threadId: "thread-1",
+        questions: [
+          { question: "Q1", options: ["案A", "案B"] },
+          { question: "Q2（複数選択可）", options: ["x", "y"], multiSelect: true },
+        ],
+      },
+      registry
+    );
+
+    expect(prompt.components).toHaveLength(2);
+    const menu = rowJson(prompt.components[1]).components[0] as {
+      max_values?: number;
+    };
+    expect(menu.max_values).toBe(2);
+  });
+});
+
+describe("postMultiAskUserPrompt (#443)", () => {
+  function makeChannel() {
+    const sent: { content: string; components?: unknown[] }[] = [];
+    const channel: AskPostChannel = {
+      send: async (options) => {
+        sent.push(options);
+        return { id: "message-1" };
+      },
+    };
+    return { channel, sent };
+  }
+
+  test("delivers all rows in a single send()", async () => {
+    const registry = new AskPromptRegistry();
+    const { channel, sent } = makeChannel();
+
+    const prompt = await postMultiAskUserPrompt(
+      channel,
+      {
+        threadId: "thread-1",
+        questions: [
+          { question: "Q1", options: ["案A", "案B"] },
+          { question: "Q2", options: ["案C"] },
+          { question: "Q3", options: ["案D"] },
+        ],
+        timeoutMs: 5 * 60 * 60 * 1000,
+      },
+      registry
+    );
+
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.components).toHaveLength(3);
+    expect(prompt.tokens).toHaveLength(3);
+  });
+});
+
+describe("multi-question click resolution (#443 AC-1/AC-2)", () => {
+  test("tapping one of two questions does not resolve; the other stays live", async () => {
+    const registry = new AskPromptRegistry();
+    const prompt = buildMultiAskPrompt(
+      {
+        threadId: "thread-1",
+        questions: [
+          { question: "Q1", options: ["案A", "案B"] },
+          { question: "Q2", options: ["案C"] },
+        ],
+      },
+      registry
+    );
+    const { handler, resolved } = makeHandler({ registry });
+    const { interaction, replies } = makeInteraction({
+      customId: `${ASK_COMPONENT_PREFIX}${prompt.tokens![0]}:1`, // Q1 -> 案B
+      messageContent: prompt.content,
+    });
+
+    await handler(interaction as never);
+
+    // The underlying /ask has not been resolved — Q2 was never tapped.
+    expect(resolved).toHaveLength(0);
+    const update = replies.find((r) => r.kind === "update");
+    expect(update?.content).toContain("✅ Q1 選択: 案B");
+    const rows = (update?.components ?? []) as unknown[];
+    expect(rows).toHaveLength(2);
+    // Q1's row is now disabled...
+    const row0 = rowJson(rows[0]).components as { disabled?: boolean }[];
+    expect(row0.every((c) => c.disabled === true)).toBe(true);
+    // ...Q2's row is untouched and still tappable.
+    const row1 = rowJson(rows[1]).components as { disabled?: boolean }[];
+    expect(row1.every((c) => c.disabled !== true)).toBe(true);
+  });
+
+  test("answering every question resolves the ask exactly once, combining all answers", async () => {
+    const registry = new AskPromptRegistry();
+    const prompt = buildMultiAskPrompt(
+      {
+        threadId: "thread-1",
+        questions: [
+          { question: "Q1", options: ["案A", "案B"] },
+          { question: "Q2", options: ["案C"] },
+        ],
+      },
+      registry
+    );
+    const { handler, resolved } = makeHandler({ registry });
+
+    const first = makeInteraction({
+      customId: `${ASK_COMPONENT_PREFIX}${prompt.tokens![0]}:1`,
+      messageContent: prompt.content,
+    });
+    await handler(first.interaction as never);
+    expect(resolved).toHaveLength(0);
+
+    const second = makeInteraction({
+      customId: `${ASK_COMPONENT_PREFIX}${prompt.tokens![1]}:0`,
+      // The message content by now already carries Q1's confirmation line —
+      // mirrors what interaction.update() actually left behind.
+      messageContent: `${prompt.content}\n\n✅ Q1 選択: 案B`,
+    });
+    await handler(second.interaction as never);
+
+    // Resolves exactly once, with both answers — never twice, never with
+    // just the second tap's answer.
+    expect(resolved).toEqual([
+      { threadId: "thread-1", answer: "Q1: 案B\nQ2: 案C" },
+    ]);
+
+    const update = second.replies.find((r) => r.kind === "update");
+    expect(update?.content).toContain("✅ Q1 選択: 案B");
+    expect(update?.content).toContain("✅ Q2 選択: 案C");
+    const rows = (update?.components ?? []) as unknown[];
+    for (const row of rows) {
+      const buttons = rowJson(row).components as { disabled?: boolean }[];
+      expect(buttons.every((c) => c.disabled === true)).toBe(true);
+    }
+  });
+
+  test("re-tapping an already-answered question in the batch is refused, not a second resolve", async () => {
+    const registry = new AskPromptRegistry();
+    const prompt = buildMultiAskPrompt(
+      {
+        threadId: "thread-1",
+        questions: [
+          { question: "Q1", options: ["案A"] },
+          { question: "Q2", options: ["案B"] },
+        ],
+      },
+      registry
+    );
+    const { handler, resolved } = makeHandler({ registry });
+
+    const first = makeInteraction({
+      customId: `${ASK_COMPONENT_PREFIX}${prompt.tokens![0]}:0`,
+    });
+    await handler(first.interaction as never);
+
+    const again = makeInteraction({
+      customId: `${ASK_COMPONENT_PREFIX}${prompt.tokens![0]}:0`,
+    });
+    await handler(again.interaction as never);
+
+    expect(resolved).toHaveLength(0); // Q2 never answered
+    const reply = again.replies.find((r) => r.kind === "reply");
+    expect(reply?.content).toContain("回答済み");
+  });
+
+  test("a solo ask still resolves on the first tap (group of one, unchanged behaviour)", async () => {
+    const registry = new AskPromptRegistry();
+    const prompt = buildAskPrompt(
+      { threadId: "thread-1", question: "方針は？", options: ["案A", "案B"] },
+      registry
+    );
+    const { handler, resolved } = makeHandler({ registry });
+    const { interaction } = makeInteraction({
+      customId: `${ASK_COMPONENT_PREFIX}${prompt.token}:1`,
+    });
+
+    await handler(interaction as never);
+
+    // Exactly the old solo format — no "Q1:" label, no group join.
+    expect(resolved).toEqual([{ threadId: "thread-1", answer: "案B" }]);
+  });
+
+  test("a click on a dead multi-question ask (relay timed out) disables EVERY sibling row, not just the one tapped (#443 review must-1)", async () => {
+    const registry = new AskPromptRegistry();
+    const prompt = buildMultiAskPrompt(
+      {
+        threadId: "thread-1",
+        questions: [
+          { question: "Q1", options: ["案A"] },
+          { question: "Q2", options: ["案B"] },
+          { question: "Q3", options: ["案C"] },
+        ],
+      },
+      registry
+    );
+    // pending: false -> the relay already gave up waiting on this thread.
+    const { handler } = makeHandler({ registry, pending: false });
+    const { interaction, replies } = makeInteraction({
+      customId: `${ASK_COMPONENT_PREFIX}${prompt.tokens![1]}:0`, // taps Q2 only
+    });
+
+    await handler(interaction as never);
+
+    const edit = replies.find((r) => r.kind === "messageEdit");
+    const rows = (edit?.components ?? []) as unknown[];
+    // A naive fix that only rebuilds the clicked row would drop Q1 and Q3
+    // from the message entirely (Discord replaces the whole array). All
+    // three must still be present, all disabled — the whole batch is dead,
+    // not just the tapped question.
+    expect(rows).toHaveLength(3);
+    for (const row of rows) {
+      const buttons = rowJson(row).components as { disabled?: boolean }[];
+      expect(buttons.every((c) => c.disabled === true)).toBe(true);
+    }
+  });
+
+  test("a superseded multi-question ask also disables every sibling row on a stale click", async () => {
+    const registry = new AskPromptRegistry();
+    const first = buildMultiAskPrompt(
+      {
+        threadId: "thread-1",
+        questions: [
+          { question: "Q1", options: ["案A"] },
+          { question: "Q2", options: ["案B"] },
+        ],
+      },
+      registry
+    );
+    buildAskPrompt({ threadId: "thread-1", question: "Q3", options: ["案C"] }, registry);
+
+    const { handler } = makeHandler({ registry });
+    const { interaction, replies } = makeInteraction({
+      customId: `${ASK_COMPONENT_PREFIX}${first.tokens![0]}:0`,
+    });
+    await handler(interaction as never);
+
+    const edit = replies.find((r) => r.kind === "messageEdit");
+    const rows = (edit?.components ?? []) as unknown[];
+    expect(rows).toHaveLength(2); // Q1 + Q2, not just Q1
+  });
+});
+
+describe("AskPromptRegistry eviction (#443 review should-2)", () => {
+  test("a still-pending member of an open multi-question group is skipped in favour of a stale entry", () => {
+    const registry = new AskPromptRegistry(3);
+    // Two solo asks on an unrelated thread: the second immediately supersedes
+    // the first, so the registry already holds one terminal (evictable) entry
+    // before the group below is registered.
+    buildAskPrompt({ threadId: "thread-a", question: "old-1", options: ["x"] }, registry);
+    buildAskPrompt({ threadId: "thread-a", question: "old-2", options: ["x"] }, registry);
+
+    // Registering this 2-member group pushes size from 2 -> 4, one over
+    // capacity, forcing exactly one eviction.
+    const prompt = buildMultiAskPrompt(
+      {
+        threadId: "thread-b",
+        questions: [
+          { question: "Q1", options: ["案A"] },
+          { question: "Q2", options: ["案B"] },
+        ],
+      },
+      registry
+    );
+
+    // Both siblings must survive — the eviction should have taken the stale
+    // superseded entry instead. Evicting either sibling would let groupOf()
+    // see only the other one and resolve the ask as if the evicted question
+    // had been answered.
+    expect(registry.get(prompt.tokens![0]!)).toBeDefined();
+    expect(registry.get(prompt.tokens![1]!)).toBeDefined();
+    expect(registry.size()).toBe(3);
+  });
+
+  test("bounds the map even in the pathological case where every live entry is a group member", () => {
+    // Capacity 1 with a 2-member group: there is no stale entry to sacrifice,
+    // so the safety net (never grow past capacity) must win over "never evict
+    // a live group member" — the map stays bounded even though it means one
+    // sibling goes down. This is the documented fallback, not the common case.
+    const registry = new AskPromptRegistry(1);
+    buildMultiAskPrompt(
+      {
+        threadId: "thread-1",
+        questions: [
+          { question: "Q1", options: ["案A"] },
+          { question: "Q2", options: ["案B"] },
+        ],
+      },
+      registry
+    );
+
+    expect(registry.size()).toBeLessThanOrEqual(1);
+  });
+
+  test("an answered or solo prompt is still evicted normally once capacity is exceeded", () => {
+    const registry = new AskPromptRegistry(1);
+    const solo = buildAskPrompt(
+      { threadId: "thread-1", question: "Q0", options: ["案Z"] },
+      registry
+    );
+    // A second, unrelated solo ask forces eviction pressure. The first one
+    // (superseded, i.e. terminal) is a safe eviction target.
+    buildAskPrompt({ threadId: "thread-1", question: "Q1", options: ["案A"] }, registry);
+
+    expect(registry.get(solo.token!)).toBeUndefined();
+  });
+});
+
+describe("hasActiveMultiAsk (#443 AC-3)", () => {
+  test("true while a multi-question batch has any unanswered sibling", () => {
+    const registry = new AskPromptRegistry();
+    buildMultiAskPrompt(
+      {
+        threadId: "thread-1",
+        questions: [
+          { question: "Q1", options: ["A"] },
+          { question: "Q2", options: ["B"] },
+        ],
+      },
+      registry
+    );
+
+    expect(hasActiveMultiAsk("thread-1", registry)).toBe(true);
+    expect(hasActiveMultiAsk("thread-other", registry)).toBe(false);
+  });
+
+  test("false for a solo (single-question) ask", () => {
+    const registry = new AskPromptRegistry();
+    buildAskPrompt(
+      { threadId: "thread-1", question: "方針は？", options: ["A", "B"] },
+      registry
+    );
+
+    expect(hasActiveMultiAsk("thread-1", registry)).toBe(false);
+  });
+
+  test("false once a newer ask has superseded the batch", () => {
+    const registry = new AskPromptRegistry();
+    buildMultiAskPrompt(
+      {
+        threadId: "thread-1",
+        questions: [
+          { question: "Q1", options: ["A"] },
+          { question: "Q2", options: ["B"] },
+        ],
+      },
+      registry
+    );
+    buildAskPrompt({ threadId: "thread-1", question: "Q3", options: ["C"] }, registry);
+
+    expect(hasActiveMultiAsk("thread-1", registry)).toBe(false);
+  });
+
+  test("defaults to the module-level registry when none is passed", () => {
+    // Smoke test only: proves the wrapper is callable without an explicit
+    // registry (bot.ts calls it this way).
+    expect(hasActiveMultiAsk("thread-that-has-never-asked-anything")).toBe(false);
   });
 });

--- a/supervisor/tests/commands/ask-components.test.ts
+++ b/supervisor/tests/commands/ask-components.test.ts
@@ -1043,6 +1043,36 @@ describe("buildMultiAskPrompt (#443)", () => {
     }
   });
 
+  test("falls back to text (whole batch) when one question has more options than Discord's select ceiling (PR #444 review)", () => {
+    // Without this guard buildSelectRow would hand Discord a StringSelectMenu
+    // with > MAX_SELECT_OPTIONS entries — the actual send() call would fail
+    // outright rather than degrade, unlike the solo-ask path (buildAskPrompt)
+    // which already guards this.
+    const registry = new AskPromptRegistry();
+    const tooMany = Array.from({ length: MAX_SELECT_OPTIONS + 1 }, (_, i) => `選択肢${i + 1}`);
+    const warn = spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      const prompt = buildMultiAskPrompt(
+        {
+          threadId: "thread-1",
+          questions: [
+            { question: "Q1", options: ["A", "B"] },
+            { question: "Q2（選択肢が多すぎる）", options: tooMany },
+          ],
+        },
+        registry
+      );
+      expect(prompt.kind).toBe("text");
+      expect(prompt.components).toHaveLength(0);
+      expect(registry.size()).toBe(0); // neither question got registered
+      expect(prompt.content).toContain("Q1");
+      expect(prompt.content).toContain("Q2（選択肢が多すぎる）");
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
   test("falls back to text for zero questions", () => {
     const registry = new AskPromptRegistry();
     const prompt = buildMultiAskPrompt({ threadId: "thread-1", questions: [] }, registry);
@@ -1356,6 +1386,46 @@ describe("AskPromptRegistry eviction (#443 review should-2)", () => {
 
     expect(registry.get(solo.token!)).toBeUndefined();
   });
+
+  test("an ALREADY-ANSWERED sibling of a still-open group is protected too, not just pending ones (PR #444 review, must)", async () => {
+    const registry = new AskPromptRegistry(3);
+    // Two stale solo asks to absorb the evictions this test forces.
+    buildAskPrompt({ threadId: "thread-a", question: "old-1", options: ["x"] }, registry);
+    buildAskPrompt({ threadId: "thread-a", question: "old-2", options: ["x"] }, registry);
+
+    // Registered under "thread-1" — makeInteraction()'s default channelId —
+    // so the click below isn't rejected as cross-thread; the eviction pool
+    // (old-1/old-2) lives on the separate "thread-a" and is never clicked.
+    const prompt = buildMultiAskPrompt(
+      {
+        threadId: "thread-1",
+        questions: [
+          { question: "Q1", options: ["案A"] },
+          { question: "Q2", options: ["案B"] },
+        ],
+      },
+      registry
+    );
+    // size is now 4 (over capacity 3); registering already evicted once
+    // (see the sibling-preference test above) — answer Q1 so it becomes
+    // "answered" while Q2 is still pending, i.e. the group is NOT resolved.
+    const { handler } = makeHandler({ registry });
+    await handler(
+      makeInteraction({ customId: `${ASK_COMPONENT_PREFIX}${prompt.tokens![0]}:0` })
+        .interaction as never
+    );
+    expect(registry.get(prompt.tokens![0]!)?.state).toBe("answered");
+
+    // Force more eviction pressure without touching this group: register
+    // another unrelated solo ask that immediately supersedes old-2.
+    buildAskPrompt({ threadId: "thread-a", question: "old-3", options: ["x"] }, registry);
+
+    // A naive "protect pending members only" check would have evicted Q1
+    // (answered, not pending) the moment capacity pressure hit — losing its
+    // answer from the eventual combined response. It must still be here.
+    expect(registry.get(prompt.tokens![0]!)).toBeDefined();
+    expect(registry.get(prompt.tokens![1]!)).toBeDefined();
+  });
 });
 
 describe("hasActiveMultiAsk (#443 AC-3)", () => {
@@ -1407,5 +1477,38 @@ describe("hasActiveMultiAsk (#443 AC-3)", () => {
     // Smoke test only: proves the wrapper is callable without an explicit
     // registry (bot.ts calls it this way).
     expect(hasActiveMultiAsk("thread-that-has-never-asked-anything")).toBe(false);
+  });
+
+  test("false once a multi-question batch is FULLY answered, even though its entries stay in the registry (PR #444 review, must)", async () => {
+    // A completed group's members end up `"answered"`, which register()'s
+    // supersede loop deliberately never touches — they just sit there. A
+    // naive count-only check would still see 2+ entries for that groupId and
+    // report "active", wrongly blocking a LATER solo ask's plain-text reply.
+    const registry = new AskPromptRegistry();
+    const prompt = buildMultiAskPrompt(
+      {
+        threadId: "thread-1",
+        questions: [
+          { question: "Q1", options: ["A"] },
+          { question: "Q2", options: ["B"] },
+        ],
+      },
+      registry
+    );
+    const { handler } = makeHandler({ registry });
+    await handler(
+      makeInteraction({ customId: `${ASK_COMPONENT_PREFIX}${prompt.tokens![0]}:0` })
+        .interaction as never
+    );
+    await handler(
+      makeInteraction({ customId: `${ASK_COMPONENT_PREFIX}${prompt.tokens![1]}:0` })
+        .interaction as never
+    );
+
+    expect(hasActiveMultiAsk("thread-1", registry)).toBe(false);
+
+    // A subsequent solo ask on the same thread must not be treated as multi.
+    buildAskPrompt({ threadId: "thread-1", question: "Q3", options: ["C"] }, registry);
+    expect(hasActiveMultiAsk("thread-1", registry)).toBe(false);
   });
 });

--- a/supervisor/tests/e2e/ask-user-selector.test.ts
+++ b/supervisor/tests/e2e/ask-user-selector.test.ts
@@ -251,6 +251,12 @@ describe("AskUserQuestion selector end-to-end (Issue #436 V-2)", () => {
         await askComponentHandler(
           makeTap(`${ASK_COMPONENT_PREFIX}${tokens[1]}:1`, threadId) as never,
         );
+      }).catch((err) => {
+        // CodeRabbit review (#444): an exception here would otherwise leave
+        // resolveAskUser uncalled — the hook's HTTP request would then hang
+        // for the full ASK_TIMEOUT_MS (5h default) and the test would time
+        // out with no useful message instead of failing fast on an assertion.
+        resolveAskUser(threadId, `E2E setup failed: ${err}`);
       });
     });
 

--- a/supervisor/tests/e2e/ask-user-selector.test.ts
+++ b/supervisor/tests/e2e/ask-user-selector.test.ts
@@ -33,7 +33,11 @@ import {
   type AskUserEvent,
 } from "../../src/session/relay-server";
 import {
+  ASK_COMPONENT_PREFIX,
+  AskPromptRegistry,
+  createAskComponentHandler,
   postAskUserPrompt,
+  postMultiAskUserPrompt,
   type AskPostChannel,
 } from "../../src/commands/ask-components";
 
@@ -90,6 +94,40 @@ function makeHookInput(cwd: string, question: string, options: string[]) {
     },
     cwd,
   });
+}
+
+function makeMultiHookInput(
+  cwd: string,
+  questions: { question: string; options: string[] }[]
+) {
+  return JSON.stringify({
+    tool_name: "AskUserQuestion",
+    tool_input: {
+      questions: questions.map((q) => ({
+        question: q.question,
+        header: "test",
+        multiSelect: false,
+        options: q.options.map((label) => ({ label, description: "" })),
+      })),
+    },
+    cwd,
+  });
+}
+
+/** Minimal fake ButtonInteraction — just enough for createAskComponentHandler. */
+function makeTap(customId: string, threadId: string) {
+  return {
+    customId,
+    values: [],
+    channelId: threadId,
+    channel: { id: threadId, isThread: () => true, parentId: threadId },
+    user: { id: "user-owner" },
+    isStringSelectMenu: () => false,
+    message: { content: "", edit: async () => {} },
+    async reply() {},
+    async editReply() {},
+    async update() {},
+  };
 }
 
 async function runHook(env: TestEnv, input: string) {
@@ -175,5 +213,65 @@ describe("AskUserQuestion selector end-to-end (Issue #436 V-2)", () => {
 
     expect(exitCode).toBe(0);
     expect(stdout.trim()).toBe("");
+  });
+
+  test("multi-question round trip: hook -> relay -> per-question rows -> two taps -> hook answer (Issue #443)", async () => {
+    startRelayServer();
+    const port = getRelayPort();
+    const threadId = "thread-e2e-443";
+    env = setupEnv(`http://localhost:${port}/relay/${threadId}`);
+
+    const { channel, sent } = makeFakeChannel();
+    const registry = new AskPromptRegistry();
+    const askComponentHandler = createAskComponentHandler({
+      hasPendingAsk: () => true,
+      resolveAskUser,
+      registry,
+      // Bypass the Discord allowlist gate — this test drives the click
+      // handler directly, with no access.json configured for the fake
+      // thread, and access policy itself is covered elsewhere
+      // (ask-components.test.ts "tap authorization").
+      checkAccess: () => ({ allowed: true, reason: "allowed" }),
+    });
+
+    // Mirrors bot.ts's handleAskUser branch for event.questions (#443): post
+    // one ActionRow per question, then simulate the 会長 tapping each one in
+    // turn through the REAL click handler (not a shortcut resolveAskUser
+    // call) — this is what actually proves AC-1/AC-2 end to end.
+    onAskUser((event: AskUserEvent) => {
+      void postMultiAskUserPrompt(channel, {
+        threadId: event.threadId,
+        questions: event.questions ?? [],
+        timeoutMs: event.timeoutMs,
+      }, registry).then(async (prompt) => {
+        const tokens = prompt.tokens!;
+        await askComponentHandler(
+          makeTap(`${ASK_COMPONENT_PREFIX}${tokens[0]}:0`, threadId) as never,
+        );
+        await askComponentHandler(
+          makeTap(`${ASK_COMPONENT_PREFIX}${tokens[1]}:1`, threadId) as never,
+        );
+      });
+    });
+
+    const input = makeMultiHookInput(env.cwd, [
+      { question: "Q1: 承認しますか？", options: ["承認", "却下"] },
+      { question: "Q2: 優先度は？", options: ["高", "低"] },
+    ]);
+    const { stdout, exitCode } = await runHook(env, input);
+
+    expect(exitCode).toBe(0);
+
+    // 期待1 (AC-1): both questions reached Discord as their own tappable row,
+    // not flattened away.
+    expect(sent).toHaveLength(1);
+    expect(sent[0]!.components).toHaveLength(2);
+
+    // 期待2 (AC-2): the combined answer (both taps) travels all the way back
+    // through the hook's deny envelope.
+    const out = JSON.parse(stdout);
+    expect(out.hookSpecificOutput.permissionDecision).toBe("deny");
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain("承認");
+    expect(out.hookSpecificOutput.permissionDecisionReason).toContain("低");
   });
 });

--- a/supervisor/tests/hooks/ask-user-relay.test.ts
+++ b/supervisor/tests/hooks/ask-user-relay.test.ts
@@ -173,12 +173,12 @@ describe("ask-user-relay.sh — supervisor session active", () => {
     );
   });
 
-  test("multiple questions: all question texts are forwarded, options omitted", async () => {
+  test("multiple questions: the joined question text AND a structured questions[] (with options) are both forwarded (#443)", async () => {
     const input = makeInput(
       {
         questions: [
           { question: "Q1 はどうしますか？", header: "Q1", multiSelect: false, options: [{ label: "a", description: "d1" }] },
-          { question: "Q2 はどうしますか？", header: "Q2", multiSelect: false, options: [{ label: "b", description: "d2" }] },
+          { question: "Q2 はどうしますか？", header: "Q2", multiSelect: true, options: [{ label: "b", description: "d2" }] },
         ],
       },
       env.dir,
@@ -188,11 +188,45 @@ describe("ask-user-relay.sh — supervisor session active", () => {
     expect(exitCode).toBe(0);
 
     const sent = JSON.parse(readFileSync(env.curlStdinFile, "utf8"));
-    // Both questions must reach Discord in one message; per-question option
-    // mapping is ambiguous over a free-text reply, so options are omitted.
+    // `question` stays the flattened, joined form — unchanged, still used for
+    // the deny-envelope wording and the expiry notice.
     expect(sent.question).toContain("Q1 はどうしますか？");
     expect(sent.question).toContain("Q2 はどうしますか？");
     expect(sent.options).toBeUndefined();
+    // Issue #443: `questions[]` carries each sub-question's own text +
+    // flattened options, so Discord can post a tappable row per question
+    // instead of falling back to one free-text reply for the whole batch.
+    expect(sent.questions).toEqual([
+      { question: "Q1 はどうしますか？", multiSelect: false, options: ["a — d1"] },
+      { question: "Q2 はどうしますか？", multiSelect: true, options: ["b — d2"] },
+    ]);
+  });
+
+  test("multiple questions where one has no options: that question's options key is omitted, not an empty array", async () => {
+    const input = makeInput(
+      {
+        questions: [
+          { question: "Q1 はどうしますか？", header: "Q1", multiSelect: false, options: [{ label: "a", description: "" }] },
+          { question: "Q2 は自由記述です", header: "Q2", multiSelect: false, options: [] },
+        ],
+      },
+      env.dir,
+    );
+
+    const { exitCode } = await runHook(env, input);
+    expect(exitCode).toBe(0);
+
+    const sent = JSON.parse(readFileSync(env.curlStdinFile, "utf8"));
+    expect(sent.questions[0]).toEqual({
+      question: "Q1 はどうしますか？",
+      multiSelect: false,
+      options: ["a"],
+    });
+    expect(sent.questions[1]).toEqual({
+      question: "Q2 は自由記述です",
+      multiSelect: false,
+    });
+    expect(sent.questions[1].options).toBeUndefined();
   });
 });
 

--- a/supervisor/tests/session/relay-server.test.ts
+++ b/supervisor/tests/session/relay-server.test.ts
@@ -602,6 +602,72 @@ describe("ask timeout (Issue #416, 5 hours)", () => {
     expect(hasRecentAsk("thread-recent", 0)).toBe(false);
     expect(hasRecentAsk("never-asked")).toBe(false);
   });
+
+  test("/ask forwards a structured questions[] to the subscriber (Issue #443)", async () => {
+    startRelayServer();
+    const port = getRelayPort();
+    const events: unknown[] = [];
+    onAskUser((event) => {
+      events.push(event);
+      resolveAskUser(event.threadId, "ok");
+    });
+
+    const res = await fetch(`http://localhost:${port}/ask/thread-multi`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        question: "Q1\nQ2",
+        questions: [
+          { question: "Q1", options: ["a", "b"], multiSelect: false },
+          { question: "Q2", options: ["c"] },
+        ],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    // `multiSelect: false` is the implicit default, so it is dropped rather
+    // than round-tripped — matches how the rest of the ask payload treats
+    // falsy optional fields (AskOption's description, etc).
+    expect(events).toEqual([
+      {
+        threadId: "thread-multi",
+        question: "Q1\nQ2",
+        options: undefined,
+        timeoutMs: DEFAULT_ASK_TIMEOUT_MS,
+        questions: [
+          { question: "Q1", options: ["a", "b"] },
+          { question: "Q2", options: ["c"] },
+        ],
+      },
+    ]);
+  });
+
+  test("/ask degrades a malformed questions[] to undefined rather than 400ing the request", async () => {
+    startRelayServer();
+    const port = getRelayPort();
+    const events: unknown[] = [];
+    onAskUser((event) => {
+      events.push(event);
+      resolveAskUser(event.threadId, "ok");
+    });
+
+    // A question entry with no `question` text is malformed — the whole
+    // structured array must be dropped, not just that one entry, so the hook
+    // (or an older server) never gets a half-built per-question mapping.
+    const res = await fetch(`http://localhost:${port}/ask/thread-malformed`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        question: "Q1\nQ2",
+        questions: [{ question: "Q1", options: ["a"] }, { options: ["b"] }],
+      }),
+    });
+
+    expect(res.status).toBe(200);
+    expect((events[0] as { questions?: unknown }).questions).toBeUndefined();
+    // The flattened fields still carried the ask through.
+    expect((events[0] as { question: string }).question).toBe("Q1\nQ2");
+  });
 });
 
 /**


### PR DESCRIPTION
## 概要

AskUserQuestion で `questions[]` が2件以上（複数質問をまとめて聞く形）のとき、Discord中継はボタン/セレクトのコンポーネントを表示せず、質問文だけを平文で投稿し「次の返信がそのまま回答」というテキストフォールバックになっていた不具合を修正する。

2026-08-20 に本社CEOセッションから corp の朝レポ CEO提案(D1〜D4)を4問まとめて提示した際、無関係なテキスト送信が全問の回答として誤って確定しうる設計になっていた（実害は回避できたが危険な状態だった）。

Closes #443

## 採用した方式（Issue の案A）

1メッセージに質問ごとの ActionRow を複数積む方式を採用。AskUserQuestion は最大4問のため Discord のメッセージあたり ActionRow 上限（5）内に収まる。

## 主な変更点

- `hooks/ask-user-relay.sh`: 複数質問時も `questions[]` に各質問の options を含めて relay-server へ転送する（`question` の joined text は互換のため維持し、deny envelope の文言・期限切れ通知はそのまま使う）
- `relay-server.ts`: `/ask/:threadId` が `questions[]` を受け取り `AskUserEvent.questions` へ forward。不正な形（`question` 欠落・`options` が文字列配列でない等）は `questions` を `undefined` へフェイルクローズし、リクエスト自体は 400 にしない
- `ask-components.ts`:
  - 質問ごとに**独立した** `AskPromptRegistry` エントリを登録（既存の customId スキーム・`buildButtonRow`/`buildSelectRow` は変更なし）、新設した `groupId` で束ねることで登録時の相互supersede（1スレッド1質問の既存不変条件）を回避
  - `buildMultiAskPrompt` / `postMultiAskUserPrompt`: 1メッセージに質問ごとの行を複数積んで投稿。いずれかの質問に options が無い・0問・Discordの行数上限超過の場合は旧来のテキストのみフォールバックに縮退
  - `createAskComponentHandler`: クリック解決をグループ対応に変更。**全問タップされるまで `resolveAskUser` を呼ばない**集約ロジックを追加。単一質問（グループサイズ1）は完全に従来どおりの挙動・出力フォーマット
  - レビュー指摘で発見した2件を追加修正: `disableStaleMessage` が全同胞行を再構築するよう修正（従来はタップされた1行のみ残し他の質問行を消してしまうバグ）、`AskPromptRegistry` の evict がまだ回答されていないマルチ質問グループのメンバーを優先的に温存するよう修正
- `bot.ts`: `event.questions` が2件以上のとき `postMultiAskUserPrompt` を使用。`messageCreate` はマルチ質問 pending 中はテキスト一括回答を拒否する（`hasActiveMultiAsk`、AC-3 の直接対応）

## 統合ジャーニーAC 検証結果

1. **PASS**: `questions[]` に2〜4件を含む AskUserQuestion 発行時、Discordスレッドに各質問ごとのボタン/セレクトが表示される
   - unit test: `buildMultiAskPrompt` が質問数分のActionRow・独立トークンを生成することを検証
   - e2e test: hook→relay-server→`postMultiAskUserPrompt` の実際の `send()` 呼び出しで2行のコンポーネントが渡ることを検証
2. **PASS**: いずれかの質問のボタンをタップすると該当質問のみ確定し、残りの質問は引き続きタップ待ちになる。全問回答後にセッションへまとめて返る
   - unit test: 1問タップ→`resolveAskUser` 未呼び出し・他の行は enabled のまま／全問タップ→ちょうど1回だけ `resolveAskUser` が呼ばれ回答を結合
   - e2e test: 実際の `createAskComponentHandler` で2回タップし、hookのPreToolUse deny envelopeに両方の回答が含まれることを確認
3. **PASS**: 一部タップ・残り無関係テキスト送信時、誤ったテキストが全問の回答として解釈されない
   - `bot.ts` の `messageCreate` に `hasActiveMultiAsk` ガードを追加し、マルチ質問 pending 中はテキスト一括回答を拒否（ガイダンス返信のみ）することを保証

## テスト結果サマリー

- `bunx tsc --noEmit`: エラーなし
- `bun test`（ask関連5ファイル: ask-components / ask-user-relay hook / ask-user-relay session / relay-server / e2e selector + bot起動配線）: **126 pass / 0 fail**
- `bun test`（supervisor全体）: 1387 pass / 33 fail — 失敗は全て本PRと無関係の既知の不安定要素（並列実行時の real-tmux アダプタの exec タイムアウト系 / `src/infra/db.ts` の shell-exec injection guard、いずれも未変更ファイル）。単体ファイル隔離実行で無関係を確認済み
- self-review（code-review-orchestrator）: must 1件（`disableStaleMessage` の同胞行破棄）・should 1件（registry eviction の未回答グループメンバー除外）を検出、いずれも本PRで対応済み。再レビュー相当のリグレッションテストを追加

## 破壊的変更

なし。単一質問（`questions.length === 1`）の経路・customId形式・`resolveAskUser` の回答フォーマットは完全に従来どおり。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 複数の質問をDiscord上で質問ごとに表示し、ボタンや選択メニューから個別に回答できるようになりました。
  * すべての質問に回答すると、まとめて結果が送信されます。
  * 複数質問の内容や選択方式を構造化して連携できるようになりました。
* **改善**
  * 質問数が多すぎる場合や選択肢がない場合は、従来のテキスト形式に自動で切り替わります。
  * 回答済みの選択肢を無効化し、未回答の質問を継続して操作できます。
  * 回答途中の複数質問にテキストで返信した場合、案内メッセージを表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->