### PR TITLE
feat(brief): 決裁を CEO セッション不要で #corp 直下のタップボタンにする（#449）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -190,6 +190,7 @@ jobs:
                    tests/session/dispatch-headless.test.ts \
                    tests/session/dispatch-report.test.ts \
                    tests/session/corp-brief.test.ts \
+                   tests/session/brief-decision.test.ts \
                    tests/session/artifact-probe.test.ts \
                    tests/session/orchestrate.test.ts \
                    tests/session/adapters-executor.test.ts \

--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -240,9 +240,11 @@ access.json は毎メッセージ読み込まれるため、編集は即反映�
 | group | 用途 |
 |---|---|
 | 各部署チャンネル（team-salary / convert-service / agent-base） | corp dispatch bot からの `/dispatch`（corp `registry.yaml` の `dispatchChannelId` と対応） |
-| corp | corp dispatch bot からの `/brief`（朝レポ配信を契機に CEO セッションを起こす。#426 / #445） |
+| corp | corp dispatch bot からの `/brief`（朝レポ配信を契機に #corp 直下へタップ決裁ボタンを post する。#426 / #445 / #449） |
 
 新しいチャンネルへ `/dispatch` / `/brief` を通すときは、その group に corp dispatch bot の user id を `dispatchFrom` として追加する。**corp の entry を忘れると `/brief` が silent に denied になり朝レポの決裁 UI が出ない**（#445 の実事故）。
+
+`/brief` は #449 以降セッションを介さない: supervisor が `ChannelConfig.brief`（`config/channels.ts`）の proposals CLI を実行して未決提案を取得し、チャンネル直下に承認/却下/保留ボタンを post する。**ボタンを押せる（= 決裁を確定できる）のは group の `allowFrom` に列挙されたユーザーのみ**（`brief-decision.ts`、ask-components と同じゲート）。`brief` 設定の無いチャンネルでは `/brief` は「実行設定がありません」で fail-closed になる。
 
 ## Permission Mode (claudeHubExit)
 

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -98,6 +98,14 @@ import {
   type RecentBrief,
 } from "./session/corp-brief";
 import {
+  buildAllDecidedMessage,
+  buildBriefDecisionMessages,
+  createBriefDecisionHandler,
+  isBriefDecisionComponentId,
+  parseProposalsOutput,
+  runBriefCli,
+} from "./session/brief-decision";
+import {
   ORCHESTRATE_PREFIX,
   parseOrchestrateCommand,
   runOrchestrate,
@@ -491,6 +499,20 @@ export async function startBot(token: string): Promise<void> {
   const askComponentHandler = createAskComponentHandler({
     hasPendingAsk,
     resolveAskUser,
+  });
+  // Issue #449: `/brief` のタップ決裁ボタン。押した人は access.json（allowFrom）で
+  // 認可され、実行コマンドは CHANNEL_MAP の `brief` 設定を持つチャンネルに限る
+  // （fail-closed）。
+  const briefDecisionHandler = createBriefDecisionHandler({
+    resolveChannel: (_channelId, channelName) => {
+      const config = CHANNEL_MAP.get(channelName);
+      if (!config?.brief) return null;
+      return {
+        channelName: config.channelName,
+        cwd: config.dir,
+        decideArgs: config.brief.decideArgs,
+      };
+    },
   });
 
   // Per-thread progress buffer (Issue #119): coalesce PostToolUse events
@@ -945,6 +967,15 @@ export async function startBot(token: string): Promise<void> {
         return;
       }
     }
+    // #449: `/brief` タップ決裁ボタン。ask 系と同じく customId prefix で振り分け、
+    // 認可・実行はハンドラ側が持つ。
+    if (interaction.isButton() && isBriefDecisionComponentId(interaction.customId)) {
+      briefDecisionHandler(interaction).catch(async (err) => {
+        console.error("[Bot] Brief decision component error:", err);
+        await safeReplyError(interaction, err);
+      });
+      return;
+    }
     // #364: the one-click compact button. Component interactions are routed by
     // customId to the app that sent the message, so unlike a top-level
     // `/compact` slash command this can never be captured by another bot.
@@ -1384,23 +1415,24 @@ export async function startBot(token: string): Promise<void> {
   // is the safer failure direction than persisting a stale "already delivered".
   const recentBriefByChannel = new Map<string, RecentBrief>();
 
-  // Issue #426: handle a `/brief <YYYY-MM-DD>` message from an allowed external
-  // source (corp's dispatch bot) — wake the channel's ALREADY RUNNING session so
-  // it puts the morning brief's proposals to the chairman (corp#112 AC-1).
-  // Returns true when the message was a brief attempt and was fully handled
-  // (caller must stop), false when it is not a brief and normal processing
-  // should continue.
+  // Issue #426 → #449: handle a `/brief <YYYY-MM-DD>` message from an allowed
+  // external source (corp's dispatch bot) — fetch the day's pending proposals
+  // via the channel's configured CLI and post tap-to-decide buttons DIRECTLY in
+  // the channel (corp#112 AC-1, session-less since #449). Returns true when the
+  // message was a brief attempt and was fully handled (caller must stop), false
+  // when it is not a brief and normal processing should continue.
   //
   // This is the second exception to the blanket `message.author.bot` drop, and
   // it is deliberately the SAME shape and the SAME authorization as
   // handleDispatchMessage (`isDispatchSourceAllowed`, fail-closed) — a new
   // authorization model would be a new way to get it wrong. Two things make it
   // strictly weaker than dispatch, by design:
-  //   - it starts no session (it only injects into one that is already running);
+  //   - it starts no session and injects into none (#449 removed the injection
+  //     capability entirely — the decision runs through a deterministic CLI);
   //   - it accepts no caller text. The single external input is a `YYYY-MM-DD`
-  //     token; the injected sentence is a fixed template built in corp-brief.ts.
-  //     That is what stops this path from becoming a way to hand the HQ session
-  //     arbitrary instructions and bypass the approval gate.
+  //     token; what gets executed is fixed argv from CHANNEL_MAP's `brief`
+  //     config. That is what stops this path from becoming a way to hand the
+  //     HQ arbitrary instructions and bypass the approval gate.
   async function handleBriefMessage(message: Message): Promise<boolean> {
     // Same entry shape as dispatch: a non-thread message in a known channel
     // whose text starts with the trigger token.
@@ -1427,13 +1459,6 @@ export async function startBot(token: string): Promise<void> {
       channelId: message.channel.id,
       sourceId: message.author.id,
       policy: loadAccessPolicy(),
-      sessions: sessionManager.listRunningByChannel(channelName),
-      // `hasRecentAsk`, not `hasPendingAsk`: the TUI dialog the ask hook falls
-      // back to appears AFTER the ask settles, so `hasPendingAsk` alone is false
-      // at exactly the moment a dangerous dialog is on screen
-      // (relay-server.ts). This path types into the pane — and `sendToPane`
-      // leads with Escape — so it takes the wider of the two windows.
-      askPending: hasRecentAsk,
       recentBrief: recentBriefByChannel.get(channelName),
     });
 
@@ -1497,132 +1522,99 @@ export async function startBot(token: string): Promise<void> {
         );
         return true;
 
-      case "deferred":
-        // The one capability /dispatch and /orchestrate do not have: this types
-        // into a session that was ALREADY running, whose state we do not own.
-        // While an AskUserQuestion is outstanding the chairman may be mid-decision,
-        // and `sendToPane` leads with Escape — injecting here could discard a
-        // pending decision (or worse, answer it) with the chairman not present.
-        // The human relay path refuses the same way (#370), so this does too.
-        console.warn(
-          `[Bot] Brief deferred in channel ${channelName} (date=${decision.date}, thread=${decision.threadId}): an AskUserQuestion is outstanding; not injected`
-        );
-        await postToChannel(
-          `⏸️ 朝レポ（${decision.date}）の決裁依頼を見送りました。**${config.displayName}** が会長の回答待ち（AskUserQuestion）のため、` +
-            `割り込むと保留中の決裁を壊すおそれがあります。\n` +
-            `先に保留中の質問へ回答してください。回答後、朝レポの決裁が必要なら会長がスレッドで指示してください` +
-            `（corp は自動で再送しません）。`
-        );
-        notifyPushover(
-          "朝レポの決裁依頼を見送り",
-          `#${channelName} が回答待ちのため ${decision.date} の朝レポ決裁を投入しませんでした。保留中の質問に回答してください。`
-        ).catch((err) =>
-          console.warn("[Bot] brief deferred pushover failed:", err)
-        );
-        return true;
-
-      case "no_session":
-        // AC-3: must not fail silently. The brief arrived but there was nobody
-        // to hand it to — say so on the channel and page, so a stopped CEO
-        // session is noticed the same morning instead of days later.
-        console.warn(
-          `[Bot] Brief undeliverable in channel ${channelName} (date=${decision.date}): no running session`
-        );
-        // Addressed to the chairman, not to corp: corp posted this trigger and
-        // will not post it again on its own, so "resend it" would be an
-        // instruction with nobody to carry it out. Say what a human can do.
-        await postToChannel(
-          `⚠️ 朝レポ（${decision.date}）の着信を受けましたが、**${config.displayName}** の稼働中セッションがありません（決裁は未実行）。\n` +
-            `\`/session start <branch>\` で起動したうえで、スレッドで朝レポの決裁を指示してください。` +
-            `corp は自動で再送しません。`
-        );
-        notifyPushover(
-          "朝レポの決裁依頼が未達",
-          `#${channelName} に稼働中セッションが無いため ${decision.date} の朝レポ決裁を依頼できませんでした。`
-        ).catch((err) =>
-          console.warn("[Bot] brief no-session pushover failed:", err)
-        );
-        return true;
-
-      case "ambiguous":
-        // Two or more candidate sessions remain after the orchestrator filter:
-        // which one is "the CEO" is not decidable from here, and guessing would
-        // inject HQ instructions into the wrong session. Refuse and report
-        // (AC-3 applies equally — this must not fail silently either).
-        console.warn(
-          `[Bot] Brief ambiguous in channel ${channelName} (date=${decision.date}, candidates=${decision.count}); not injected`
-        );
-        await postToChannel(
-          `⚠️ 朝レポ（${decision.date}）の着信を受けましたが、**${config.displayName}** で投入先候補が ${decision.count} 件あるため特定できません（決裁は未実行）。\n` +
-            `不要なセッションを停止したうえで、スレッドで朝レポの決裁を指示してください。corp は自動で再送しません。`
-        );
-        notifyPushover(
-          "朝レポの決裁依頼が未達",
-          `#${channelName} で投入先候補が ${decision.count} 件あるため ${decision.date} の朝レポ決裁を投入できませんでした。`
-        ).catch((err) =>
-          console.warn("[Bot] brief ambiguous pushover failed:", err)
-        );
-        return true;
-
-      case "inject": {
+      case "decide": {
+        // #449: セッションに触れず、ここで未決提案を取得してチャンネル直下に
+        // 決裁ボタンを post する（会長決裁・案 A）。セッション不在 / 複数 /
+        // 回答待ちという #426 の失敗クラス（no_session / ambiguous / deferred）
+        // はこの経路には存在しない。
+        if (!config.brief) {
+          // CHANNEL_MAP に brief CLI が未設定のチャンネル。fail-closed だが
+          // silent にしない（corp 側からは post が消えたように見えるため）。
+          console.warn(
+            `[Bot] Brief received but channel ${channelName} has no brief CLI config; not executed`
+          );
+          await postToChannel(
+            `⚠️ 朝レポ（${decision.date}）の着信を受けましたが、このチャンネルには brief 決裁の実行設定がありません（決裁は未実行）。`
+          );
+          return true;
+        }
         console.log(
-          `[Bot] Brief accepted in channel ${channelName} (date=${decision.date}, thread=${decision.threadId})`
+          `[Bot] Brief accepted in channel ${channelName} (date=${decision.date}); fetching pending proposals`
         );
-        // Recorded at DECISION time, not after the relay resolves: the relay
-        // takes minutes, and a retry arriving in that window is exactly the
-        // double-interruption this guards against. Only the `inject` branch
-        // records, so a brief that ended as deferred / no_session stays
-        // re-triggerable.
+        // AC-3 相当（#426 から継承）: 取得失敗を silent にしない。corp は自動で
+        // 再送しないので、チャンネルへの報告 + Pushover で同じ朝に気付けるようにする。
+        const reportFetchFailure = async (detail: string): Promise<void> => {
+          console.error(
+            `[Bot] Brief proposals fetch failed in channel ${channelName} (date=${decision.date}): ${detail}`
+          );
+          await postToChannel(
+            `⚠️ 朝レポ（${decision.date}）の未決提案を取得できませんでした（決裁は未実行）。\n` +
+              `\`\`\`\n${detail.slice(0, 500)}\n\`\`\``
+          );
+          notifyPushover(
+            "朝レポの決裁依頼が未達",
+            `#${channelName} で未決提案の取得に失敗し ${decision.date} の朝レポ決裁を提示できませんでした。`
+          ).catch((err) =>
+            console.warn("[Bot] brief fetch-failure pushover failed:", err)
+          );
+        };
+        const cliResult = await runBriefCli(
+          config.brief.proposalsArgs,
+          config.dir
+        );
+        if (cliResult.code !== 0) {
+          await reportFetchFailure(
+            `exit ${cliResult.code ?? "signal/timeout"}: ${cliResult.stderr.trim()}`
+          );
+          return true;
+        }
+        const proposals = parseProposalsOutput(cliResult.stdout);
+        if (proposals.kind === "error") {
+          await reportFetchFailure(proposals.reason);
+          return true;
+        }
+        if (proposals.pending.length === 0 && proposals.skipped === 0) {
+          await postToChannel(
+            buildAllDecidedMessage(decision.date, proposals.total)
+          );
+          recentBriefByChannel.set(channelName, {
+            date: decision.date,
+            atMs: Date.now(),
+          });
+          return true;
+        }
+        try {
+          for (const msg of buildBriefDecisionMessages(
+            decision.date,
+            proposals.pending
+          )) {
+            await textChannel.send({
+              content: msg.content,
+              components: msg.components,
+            });
+          }
+        } catch (err) {
+          // post 失敗時は dedup を記録しない（同じ日付の再送で回復できる余地を
+          // 残す — corp-brief.ts の duplicate 契約）。
+          console.error(
+            `[Bot] Brief decision post failed in channel ${channelName}:`,
+            err
+          );
+          return true;
+        }
+        if (proposals.skipped > 0) {
+          // id がボタン化できない提案を黙って落とさない（silent truncation 禁止）。
+          console.warn(
+            `[Bot] Brief: ${proposals.skipped} pending proposal(s) skipped (id not button-safe) in channel ${channelName}`
+          );
+          await postToChannel(
+            `⚠️ 未決提案のうち ${proposals.skipped} 件は id をボタン化できず表示していません。` +
+              `作業ディレクトリで proposals コマンドを直接確認してください。`
+          );
+        }
         recentBriefByChannel.set(channelName, {
           date: decision.date,
           atMs: Date.now(),
-        });
-        // Non-blocking on purpose: sendMessage waits for the session's Stop hook
-        // (minutes), so awaiting it inside the gateway handler would stall
-        // MessageCreate — the same reason dispatch hands off to its queue rather
-        // than awaiting runDispatch. enqueueForThread also keeps this ordered
-        // against a concurrent user message in that thread (one relay at a time).
-        enqueueForThread(decision.threadId, async () => {
-          // Discord I/O is best-effort here and never aborts the injection: a
-          // failed post must not cost us the wake-up itself (the whole point of
-          // the trigger). Failures are logged, never swallowed.
-          const channel = await client.channels
-            .fetch(decision.threadId)
-            .catch((err: unknown) => {
-              console.error(
-                `[Bot] Brief thread fetch failed for ${decision.threadId}:`,
-                err
-              );
-              return null;
-            });
-          const send = async (text: string): Promise<void> => {
-            if (!channel?.isThread()) return;
-            try {
-              await channel.send(text);
-            } catch (err) {
-              console.error(
-                `[Bot] Brief post failed in thread ${decision.threadId}:`,
-                err
-              );
-            }
-          };
-          // Marker first: the wake-up is observable in the thread even if the
-          // session answers slowly (or the relay later errors).
-          await send(
-            `📣 朝レポ（${decision.date}）の着信を受け、CEO セッションへ決裁の確認を依頼します。`
-          );
-          const result = await sessionManager.sendMessage(
-            decision.threadId,
-            decision.text
-          );
-          if (result.error) {
-            console.error(
-              `[Bot] Brief relay error in thread ${decision.threadId}: ${result.error}`
-            );
-          }
-          for (const chunk of result.chunks) {
-            if (chunk.trim()) await send(chunk);
-          }
         });
         return true;
       }

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -98,12 +98,9 @@ import {
   type RecentBrief,
 } from "./session/corp-brief";
 import {
-  buildAllDecidedMessage,
-  buildBriefDecisionMessages,
   createBriefDecisionHandler,
   isBriefDecisionComponentId,
-  parseProposalsOutput,
-  runBriefCli,
+  runBriefDecideFlow,
 } from "./session/brief-decision";
 import {
   ORCHESTRATE_PREFIX,
@@ -1541,81 +1538,31 @@ export async function startBot(token: string): Promise<void> {
         console.log(
           `[Bot] Brief accepted in channel ${channelName} (date=${decision.date}); fetching pending proposals`
         );
-        // AC-3 相当（#426 から継承）: 取得失敗を silent にしない。corp は自動で
-        // 再送しないので、チャンネルへの報告 + Pushover で同じ朝に気付けるようにする。
-        const reportFetchFailure = async (detail: string): Promise<void> => {
-          console.error(
-            `[Bot] Brief proposals fetch failed in channel ${channelName} (date=${decision.date}): ${detail}`
-          );
-          await postToChannel(
-            `⚠️ 朝レポ（${decision.date}）の未決提案を取得できませんでした（決裁は未実行）。\n` +
-              `\`\`\`\n${detail.slice(0, 500)}\n\`\`\``
-          );
-          notifyPushover(
-            "朝レポの決裁依頼が未達",
-            `#${channelName} で未決提案の取得に失敗し ${decision.date} の朝レポ決裁を提示できませんでした。`
-          ).catch((err) =>
-            console.warn("[Bot] brief fetch-failure pushover failed:", err)
-          );
-        };
-        const cliResult = await runBriefCli(
-          config.brief.proposalsArgs,
-          config.dir
-        );
-        if (cliResult.code !== 0) {
-          await reportFetchFailure(
-            `exit ${cliResult.code ?? "signal/timeout"}: ${cliResult.stderr.trim()}`
-          );
-          return true;
-        }
-        const proposals = parseProposalsOutput(cliResult.stdout);
-        if (proposals.kind === "error") {
-          await reportFetchFailure(proposals.reason);
-          return true;
-        }
-        if (proposals.pending.length === 0 && proposals.skipped === 0) {
-          await postToChannel(
-            buildAllDecidedMessage(decision.date, proposals.total)
-          );
-          recentBriefByChannel.set(channelName, {
-            date: decision.date,
-            atMs: Date.now(),
-          });
-          return true;
-        }
-        try {
-          for (const msg of buildBriefDecisionMessages(
-            decision.date,
-            proposals.pending
-          )) {
+        // 一連（取得 → パース → post）は runBriefDecideFlow が持ち、失敗報告の
+        // 義務ごと単体テストで固定されている。delivered のときだけ同日 dedup を
+        // 記録する（失敗時は記録せず、同じ日付の再送で回復できる余地を残す）。
+        const delivered = await runBriefDecideFlow({
+          date: decision.date,
+          channelName,
+          cwd: config.dir,
+          proposalsArgs: config.brief.proposalsArgs,
+          postToChannel,
+          postDecisionMessage: async (msg) => {
             await textChannel.send({
               content: msg.content,
               components: msg.components,
             });
-          }
-        } catch (err) {
-          // post 失敗時は dedup を記録しない（同じ日付の再送で回復できる余地を
-          // 残す — corp-brief.ts の duplicate 契約）。
-          console.error(
-            `[Bot] Brief decision post failed in channel ${channelName}:`,
-            err
-          );
-          return true;
-        }
-        if (proposals.skipped > 0) {
-          // id がボタン化できない提案を黙って落とさない（silent truncation 禁止）。
-          console.warn(
-            `[Bot] Brief: ${proposals.skipped} pending proposal(s) skipped (id not button-safe) in channel ${channelName}`
-          );
-          await postToChannel(
-            `⚠️ 未決提案のうち ${proposals.skipped} 件は id をボタン化できず表示していません。` +
-              `作業ディレクトリで proposals コマンドを直接確認してください。`
-          );
-        }
-        recentBriefByChannel.set(channelName, {
-          date: decision.date,
-          atMs: Date.now(),
+          },
+          notifyFailure: async (title, body) => {
+            await notifyPushover(title, body);
+          },
         });
+        if (delivered) {
+          recentBriefByChannel.set(channelName, {
+            date: decision.date,
+            atMs: Date.now(),
+          });
+        }
         return true;
       }
     }

--- a/supervisor/src/config/channels.ts
+++ b/supervisor/src/config/channels.ts
@@ -27,6 +27,18 @@ export interface ChannelConfig {
    * enable for channels that drive a browser via `mcp__claude-in-chrome__*`.
    */
   chromeEnabled?: boolean;
+  /**
+   * Issue #449: `/brief <date>` のタップ決裁で claude-hub が実行する CLI。
+   * 未設定チャンネルでは brief 決裁経路全体が fail-closed で動かない。
+   * どちらも argv 配列（shell を通さない）で、cwd は `dir`。corp 固有の
+   * コマンドを supervisor 側へハードコードしないための注入点。
+   */
+  brief?: {
+    /** 未決提案の取得。stdout に `{ date, proposals: [...] }` の JSON を出すこと。 */
+    proposalsArgs: string[];
+    /** 決裁確定。末尾に `<proposalId> <approved|rejected|deferred>` が追加される。 */
+    decideArgs: string[];
+  };
 }
 
 const home = homedir();
@@ -42,6 +54,28 @@ export const CHANNEL_MAP = new Map<string, ChannelConfig>([
       channelName: "corp",
       dir: resolve(home, "corp"),
       displayName: "Corp CEO",
+      // #449: 朝レポのタップ決裁。コマンドの契約は corp src/cli.ts
+      // （runProposalsCmd / runDecideProposalCmd）。--silent で npm の run
+      // banner を stdout から除き、JSON だけを受け取る。
+      brief: {
+        proposalsArgs: [
+          "npm",
+          "run",
+          "--silent",
+          "secretary",
+          "--",
+          "proposals",
+          "--json",
+        ],
+        decideArgs: [
+          "npm",
+          "run",
+          "--silent",
+          "secretary",
+          "--",
+          "decide-proposal",
+        ],
+      },
     },
   ],
   [

--- a/supervisor/src/session/brief-decision.ts
+++ b/supervisor/src/session/brief-decision.ts
@@ -1,0 +1,482 @@
+/**
+ * 朝レポ決裁のチャンネル直下ボタン UI と、タップによる決裁確定（Issue #449）。
+ *
+ * #426 の「稼働中 CEO セッションへ注入して AskUserQuestion を出させる」経路は、
+ * セッション不在（no_session）で決裁ジャーニーが止まる（2026-08-23 朝の実機観測）。
+ * 会長決裁（案 A）により、`/brief <date>` 受信時に claude-hub 自身が:
+ *
+ *   1. 対象チャンネルの作業ディレクトリで proposals CLI（corp なら
+ *      `npm run secretary -- proposals --json`）を実行して未決提案を取得し、
+ *   2. **チャンネル直下**に提案ごとの承認/却下/保留ボタンを post し、
+ *   3. 会長のタップで decide CLI（`decide-proposal <id> <decision>`）を実行する。
+ *
+ * セッションも LLM も介在しない決定的な経路であり、決裁の**判断**は変わらず
+ * 会長のタップのみが行う（#423 の自動回答禁止と同じ線。CLI は corp 側で
+ * 同一決裁の再実行が no-op になる冪等設計）。
+ *
+ * セキュリティ境界:
+ *   - **タップの認可**: ask-components.ts と同じく `evaluateAccess`（access.json の
+ *     `allowFrom`）で「押した人」を検証する。ボタンが誰にでも見えても、許可
+ *     ユーザー以外の押下は decide を実行しない。
+ *   - **customId は閉じたトークンのみ**: `briefdec:<proposalId>:<decision>`。
+ *     proposalId は {@link PROPOSAL_ID_RE} を通過したものだけがボタンになり、
+ *     decision は 3 値 enum。自由文が CLI 引数に到達する経路が無い。
+ *   - **CLI は argv 配列 + shell なし**（execFile）。文字列連結の shell を通さない。
+ *   - registry を持たない stateless 設計: customId が全情報を運ぶため、supervisor
+ *     再起動をまたいでもボタンは機能する（ask-components の token registry が
+ *     再起動で失効するのと対照的。決裁は「後から押しても正しい」冪等操作なので
+ *     失効させる理由がない）。
+ *
+ * corp 固有のコマンドはここにハードコードしない。何を実行するかは
+ * `ChannelConfig.brief`（config/channels.ts）が持ち、未設定チャンネルでは
+ * この経路全体が fail-closed で動かない。
+ */
+
+import { execFile } from "child_process";
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonStyle,
+  type ButtonInteraction,
+} from "discord.js";
+import {
+  evaluateAccess,
+  type AccessDecision,
+  type AccessQuery,
+} from "../config/access-policy";
+import { safeRespond } from "../commands/safe-respond";
+
+/** customId 名前空間。`briefdec:<proposalId>:<decision>`。 */
+export const BRIEF_DECISION_PREFIX = "briefdec:";
+
+/** corp CLI `decide-proposal` が受け付ける決裁 3 値（corp src/cli.ts）。 */
+export const PROPOSAL_DECISIONS = ["approved", "rejected", "deferred"] as const;
+export type ProposalDecision = (typeof PROPOSAL_DECISIONS)[number];
+
+/**
+ * ボタンに載せてよい提案 id の形。corp の提案 id（`dispatch-<dept>-<slug>`）を
+ * 十分に覆いつつ、`:`（customId の区切り）や空白・shell メタ文字を含む id を
+ * 構造的に排除する。80 文字上限は customId 全体（Discord 上限 100）に
+ * `briefdec:` (9) + `:approved` (9) を足しても収まる長さ（= 98）。
+ */
+export const PROPOSAL_ID_RE = /^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$/;
+
+/** Discord の 1 メッセージあたり ActionRow 上限 = 決裁ボタンを並べられる提案数。 */
+export const MAX_PROPOSALS_PER_MESSAGE = 5;
+
+/** Discord のメッセージ本文上限は 2000。余裕を残す（ask-components と同じ値）。 */
+const CONTENT_LIMIT = 1900;
+
+/** 決裁ラベル（ボタン表示と決裁済み行の両方で使う）。 */
+export const DECISION_LABELS: Record<ProposalDecision, string> = {
+  approved: "承認",
+  rejected: "却下",
+  deferred: "保留",
+};
+
+/** proposals CLI 出力のうち、この UI が必要とする最小面。 */
+export interface PendingProposal {
+  id: string;
+  title: string;
+  priority: number | null;
+  targetDept: string | null;
+  pendingDays: number | null;
+}
+
+export type ParsedProposals =
+  | {
+      kind: "ok";
+      /** CLI が報告した業務日（`/brief` の日付と異なることがある）。 */
+      date: string;
+      /** 提案の総数（決裁済み含む）。 */
+      total: number;
+      /** 未決（decision === null）のうちボタン化できたもの。 */
+      pending: PendingProposal[];
+      /** id が {@link PROPOSAL_ID_RE} を通らず除外した未決の件数。 */
+      skipped: number;
+    }
+  | { kind: "error"; reason: string };
+
+/**
+ * `proposals --json` の stdout をパースする（出典: corp src/cli.ts
+ * runProposalsCmd — stdout は `{ date, pending, proposals: [...] }` の JSON 1 本、
+ * ログは stderr）。npm の run banner が stdout に混ざる環境に備えて最初の `{`
+ * から読む。未決 = `decision === null`。id が customId に載せられない形の
+ * 提案は**その 1 件だけ**除外して数を報告する（1 件の異常で朝の決裁全体を
+ * 落とさない。ただし黙って落とさず skipped で数える）。
+ */
+export function parseProposalsOutput(stdout: string): ParsedProposals {
+  const start = stdout.indexOf("{");
+  if (start < 0) {
+    return { kind: "error", reason: "proposals 出力に JSON がありません" };
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(stdout.slice(start));
+  } catch {
+    return { kind: "error", reason: "proposals 出力の JSON を解析できません" };
+  }
+  if (parsed === null || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { kind: "error", reason: "proposals 出力が object ではありません" };
+  }
+  const obj = parsed as Record<string, unknown>;
+  const date = typeof obj.date === "string" ? obj.date : "";
+  const rows = Array.isArray(obj.proposals) ? obj.proposals : null;
+  if (!date || !rows) {
+    return {
+      kind: "error",
+      reason: "proposals 出力に date / proposals がありません",
+    };
+  }
+
+  const pending: PendingProposal[] = [];
+  let skipped = 0;
+  for (const row of rows) {
+    if (row === null || typeof row !== "object") continue;
+    const r = row as Record<string, unknown>;
+    if (r.decision !== null) continue; // 決裁済みはボタン対象外
+    const id = typeof r.id === "string" ? r.id : "";
+    if (!PROPOSAL_ID_RE.test(id)) {
+      skipped += 1;
+      continue;
+    }
+    pending.push({
+      id,
+      title: typeof r.title === "string" ? r.title : id,
+      priority: typeof r.priority === "number" ? r.priority : null,
+      targetDept: typeof r.targetDept === "string" ? r.targetDept : null,
+      pendingDays: typeof r.pendingDays === "number" ? r.pendingDays : null,
+    });
+  }
+  return { kind: "ok", date, total: rows.length, pending, skipped };
+}
+
+export function buildBriefDecisionCustomId(
+  proposalId: string,
+  decision: ProposalDecision,
+): string {
+  return `${BRIEF_DECISION_PREFIX}${proposalId}:${decision}`;
+}
+
+/** このモジュール宛の component interaction か。 */
+export function isBriefDecisionComponentId(customId: string): boolean {
+  return customId.startsWith(BRIEF_DECISION_PREFIX);
+}
+
+export function parseBriefDecisionCustomId(
+  customId: string,
+): { proposalId: string; decision: ProposalDecision } | null {
+  if (!isBriefDecisionComponentId(customId)) return null;
+  const parts = customId.slice(BRIEF_DECISION_PREFIX.length).split(":");
+  if (parts.length !== 2) return null;
+  const [proposalId, decision] = parts as [string, string];
+  if (!PROPOSAL_ID_RE.test(proposalId)) return null;
+  if (!PROPOSAL_DECISIONS.includes(decision as ProposalDecision)) return null;
+  return { proposalId, decision: decision as ProposalDecision };
+}
+
+export type BriefDecisionRow = ActionRowBuilder<ButtonBuilder>;
+
+export interface BriefDecisionMessage {
+  content: string;
+  components: BriefDecisionRow[];
+}
+
+function truncate(text: string, limit: number): string {
+  return text.length <= limit ? text : `${text.slice(0, limit - 1)}…`;
+}
+
+function buildProposalRow(
+  proposal: PendingProposal,
+  ordinal: number,
+): BriefDecisionRow {
+  return new ActionRowBuilder<ButtonBuilder>().addComponents(
+    new ButtonBuilder()
+      .setCustomId(buildBriefDecisionCustomId(proposal.id, "approved"))
+      .setLabel(`✅ 承認 ${ordinal}`)
+      .setStyle(ButtonStyle.Success),
+    new ButtonBuilder()
+      .setCustomId(buildBriefDecisionCustomId(proposal.id, "rejected"))
+      .setLabel(`⛔ 却下 ${ordinal}`)
+      .setStyle(ButtonStyle.Danger),
+    new ButtonBuilder()
+      .setCustomId(buildBriefDecisionCustomId(proposal.id, "deferred"))
+      .setLabel(`⏸ 保留 ${ordinal}`)
+      .setStyle(ButtonStyle.Secondary),
+  );
+}
+
+/**
+ * 未決提案の決裁メッセージ群を組み立てる。ActionRow は 1 メッセージ 5 行が
+ * Discord の上限なので、6 件以上は複数メッセージに分ける（silent truncation を
+ * しない — 上限で切り捨てると「表に出なかった提案が永遠に未決のまま」になる）。
+ * 通し番号（ordinal）はメッセージをまたいで連番にし、本文の行とボタンの
+ * ラベルが同じ番号で対応する。
+ */
+export function buildBriefDecisionMessages(
+  date: string,
+  pending: PendingProposal[],
+): BriefDecisionMessage[] {
+  const messages: BriefDecisionMessage[] = [];
+  for (let i = 0; i < pending.length; i += MAX_PROPOSALS_PER_MESSAGE) {
+    const chunk = pending.slice(i, i + MAX_PROPOSALS_PER_MESSAGE);
+    const head =
+      i === 0
+        ? `📋 **朝レポ（${date}）の未決提案 ${pending.length} 件** — ボタンで決裁してください（承認は次の dispatch 周期で部署へ投入されます）`
+        : `📋 朝レポ（${date}）未決提案のつづき`;
+    const lines = chunk.map((p, j) => {
+      const ordinal = i + j + 1;
+      const pri = p.priority !== null ? `[D${p.priority}] ` : "";
+      const dept = p.targetDept ? `**${p.targetDept}** ` : "";
+      const days =
+        p.pendingDays !== null && p.pendingDays > 1
+          ? `（未決 ${p.pendingDays} 日目)`
+          : "";
+      return `${ordinal}. ${pri}${dept}${truncate(p.title, 160)}${days}\n   id: \`${p.id}\``;
+    });
+    messages.push({
+      content: truncate([head, ...lines].join("\n"), CONTENT_LIMIT),
+      components: chunk.map((p, j) => buildProposalRow(p, i + j + 1)),
+    });
+  }
+  return messages;
+}
+
+/** 未決 0 件のときの 1 行報告（ボタンなし）。 */
+export function buildAllDecidedMessage(date: string, total: number): string {
+  return total > 0
+    ? `✅ 朝レポ（${date}）の提案 ${total} 件はすべて決裁済みです（未決 0 件）。`
+    : `ℹ️ 朝レポ（${date}）に CEO 提案はありません。`;
+}
+
+/** CLI 実行結果。`code === null` はシグナル/タイムアウトによる異常終了。 */
+export interface CliResult {
+  code: number | null;
+  stdout: string;
+  stderr: string;
+}
+
+/**
+ * CLI 実行の注入点。実体は {@link runBriefCli}、テストは fake を渡す。
+ * args は argv 配列（shell を通さない）。
+ */
+export type BriefCliRunner = (args: string[], cwd: string) => Promise<CliResult>;
+
+/**
+ * 既定の CLI runner。`execFile`（shell なし）+ タイムアウトで、corp CLI の
+ * 実行が刺さってもゲートウェイ側のハンドラが永久に待たないようにする。
+ * npm 経由（`npm run secretary -- ...`）は tsx 起動込みで数秒かかるため、
+ * 余裕を持って 2 分。
+ */
+export const runBriefCli: BriefCliRunner = (args, cwd) =>
+  new Promise((resolvePromise) => {
+    const [cmd, ...rest] = args;
+    if (!cmd) {
+      resolvePromise({ code: null, stdout: "", stderr: "empty command" });
+      return;
+    }
+    execFile(
+      cmd,
+      rest,
+      { cwd, timeout: 120_000, maxBuffer: 4 * 1024 * 1024 },
+      (err, stdout, stderr) => {
+        const code =
+          err === null
+            ? 0
+            : typeof (err as NodeJS.ErrnoException & { code?: unknown }).code ===
+                "number"
+              ? ((err as unknown as { code: number }).code ?? null)
+              : null;
+        resolvePromise({ code, stdout: String(stdout), stderr: String(stderr) });
+      },
+    );
+  });
+
+/** 決裁ボタンが押されたチャンネルに対する実行設定（config/channels.ts 由来）。 */
+export interface BriefDecisionChannelConfig {
+  channelName: string;
+  /** CLI の作業ディレクトリ（`ChannelConfig.dir`）。 */
+  cwd: string;
+  /** 決裁確定コマンド（argv）。末尾に `<proposalId> <decision>` を追加して実行。 */
+  decideArgs: string[];
+}
+
+export interface BriefDecisionHandlerDeps {
+  /**
+   * interaction の発生チャンネルを実行設定へ解決する。`null` = このチャンネルは
+   * brief 決裁の対象外（fail-closed: ボタンだけが何らかの経路で存在しても
+   * 実行しない）。
+   */
+  resolveChannel: (
+    channelId: string,
+    channelName: string,
+  ) => BriefDecisionChannelConfig | null;
+  runCli?: BriefCliRunner;
+  /** access.json gate。既定は実 policy 評価。テストで注入する。 */
+  checkAccess?: (query: AccessQuery) => AccessDecision;
+}
+
+/**
+ * 決裁ボタンの interaction handler。ask-components.ts の handler と同じ流儀:
+ * bot.ts の dispatcher が customId prefix で振り分け、それ以降はここが持つ。
+ * 応答しない失敗経路を作らない（押して無反応が最悪の UX）。
+ *
+ * 認可はタップした**ユーザー**に対して行う（`allowFrom`）。ask-components の
+ * must-1 と同じ理屈で、テキスト返信と同じゲートをタップにも課す — これが
+ * 「会長のタップのみが決裁を確定できる」の実装点。`isMention: true` は
+ * ask-components と同じ意図（component interaction は常に bot 宛て）。
+ *
+ * 二重タップは 2 段で守る: in-flight ガード（同じ提案の実行が終わるまで後続を
+ * 断る）+ corp CLI 自体の冪等性（同一決裁の再実行は no-op、変更は上書き記録）。
+ */
+export function createBriefDecisionHandler(deps: BriefDecisionHandlerDeps) {
+  const runCli = deps.runCli ?? runBriefCli;
+  const checkAccess = deps.checkAccess ?? ((query) => evaluateAccess(query));
+  const inFlight = new Set<string>();
+
+  return async (interaction: ButtonInteraction): Promise<void> => {
+    const parsed = parseBriefDecisionCustomId(interaction.customId);
+    if (!parsed) {
+      await safeRespond(interaction, {
+        content: "ℹ️ この操作は認識できませんでした。",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const channel = interaction.channel;
+    const channelName =
+      channel && "name" in channel && typeof channel.name === "string"
+        ? channel.name
+        : "";
+    const config = deps.resolveChannel(interaction.channelId ?? "", channelName);
+    if (!config) {
+      console.warn(
+        `[brief-decision] tap on unconfigured channel (${channelName || "unknown"}); not executed`,
+      );
+      await safeRespond(interaction, {
+        content: "⚠️ このチャンネルには brief 決裁の実行設定がありません。",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    // 押した人の認可（ask-components must-1 の双子）。decision の内容以前に、
+    // 実行可否をここで確定する。
+    const userId = interaction.user?.id ?? "";
+    const decision: AccessDecision = userId
+      ? checkAccess({
+          channelKey: interaction.channelId ?? "",
+          userId,
+          isMention: true,
+        })
+      : { allowed: false, reason: "sender_not_allowlisted" };
+    if (!decision.allowed) {
+      console.warn(
+        `[brief-decision] tap denied (reason=${decision.reason}) in channel ${config.channelName}; not executed`,
+      );
+      await safeRespond(interaction, {
+        content:
+          "🚫 決裁する権限がありません（このチャンネルの許可リストに登録されたユーザーのみ決裁できます）。",
+        ephemeral: true,
+      });
+      return;
+    }
+
+    const flightKey = `${config.channelName}:${parsed.proposalId}`;
+    if (inFlight.has(flightKey)) {
+      await safeRespond(interaction, {
+        content: `⏳ ${parsed.proposalId} は処理中です。完了メッセージをお待ちください。`,
+        ephemeral: true,
+      });
+      return;
+    }
+    inFlight.add(flightKey);
+
+    try {
+      // decide CLI は npm + tsx 起動で数秒かかる。Discord の 3 秒 ack 期限を
+      // 超えるため先に defer する（以降は editReply が応答面になる）。
+      // flags: 64 = ephemeral（compact-button.ts と同じ流儀）。
+      await interaction.deferReply({ flags: 64 });
+
+      const args = [...config.decideArgs, parsed.proposalId, parsed.decision];
+      const result = await runCli(args, config.cwd);
+      const label = DECISION_LABELS[parsed.decision];
+
+      if (result.code !== 0) {
+        // 失敗は会長にそのまま見せる（silent fallback 禁止）。stderr には
+        // corp CLI の使い方エラー / snapshot 不在などの実因が載る。
+        console.error(
+          `[brief-decision] decide failed (channel=${config.channelName}, proposal=${parsed.proposalId}, decision=${parsed.decision}, code=${result.code}): ${result.stderr.trim()}`,
+        );
+        await interaction.editReply({
+          content: `⚠️ 決裁コマンドが失敗しました（exit ${result.code ?? "signal/timeout"}）。\n\`\`\`\n${truncate(result.stderr.trim() || result.stdout.trim() || "(出力なし)", 500)}\n\`\`\``,
+        });
+        return;
+      }
+
+      // corp CLI は同一決裁の再実行を no-op として stderr に「既に ... 済み」を
+      // 出す（exit 0）。成功として扱いつつ、その旨は会長に伝える。
+      const noop = result.stderr.includes("既に");
+      console.log(
+        `[brief-decision] decided (channel=${config.channelName}, proposal=${parsed.proposalId}, decision=${parsed.decision}${noop ? ", no-op" : ""})`,
+      );
+      await interaction.editReply({
+        content: noop
+          ? `ℹ️ ${parsed.proposalId} は既に ${label} 済みでした（変更なし）。`
+          : `✅ ${parsed.proposalId} を **${label}** として確定しました。${
+              parsed.decision === "approved"
+                ? "次の dispatch 周期で部署へ投入されます。"
+                : ""
+            }`,
+      });
+
+      await markRowDecided(interaction, parsed.proposalId, parsed.decision);
+    } finally {
+      inFlight.delete(flightKey);
+    }
+  };
+}
+
+/**
+ * 決裁済みの提案の行（ボタン 3 つ）を disable し、本文に決裁結果を追記する。
+ * best-effort: 決裁自体は既に確定しているので、メッセージ更新の失敗は log のみ
+ * （ask-components の disableStaleMessage と同じ扱い）。
+ *
+ * stateless 設計のため元の提案リストを持っていない。行の特定は「その行の
+ * ボタンの customId が同じ proposalId を指すか」で行い、対象行だけ disabled で
+ * 再構築、他の行は現状のまま `ActionRowBuilder.from` で写す。
+ */
+async function markRowDecided(
+  interaction: ButtonInteraction,
+  proposalId: string,
+  decision: ProposalDecision,
+): Promise<void> {
+  try {
+    const message = interaction.message;
+    if (!message) return;
+    const rows = message.components.map((row) => {
+      const builder = ActionRowBuilder.from(
+        row as never,
+      ) as ActionRowBuilder<ButtonBuilder>;
+      const belongs = builder.components.some((c) => {
+        const id = (c.data as { custom_id?: string }).custom_id ?? "";
+        return parseBriefDecisionCustomId(id)?.proposalId === proposalId;
+      });
+      if (belongs) {
+        for (const c of builder.components) c.setDisabled(true);
+      }
+      return builder;
+    });
+    const stamp = `✅ \`${proposalId}\`: ${DECISION_LABELS[decision]}（会長決裁）`;
+    const base = message.content ?? "";
+    const budget = CONTENT_LIMIT - stamp.length - 2;
+    const content = `${base.length > budget ? truncate(base, budget) : base}\n\n${stamp}`;
+    await message.edit({ content, components: rows });
+  } catch (err) {
+    console.warn(
+      `[brief-decision] decided but message update failed (proposal=${proposalId}):`,
+      err,
+    );
+  }
+}

--- a/supervisor/src/session/brief-decision.ts
+++ b/supervisor/src/session/brief-decision.ts
@@ -292,6 +292,105 @@ export const runBriefCli: BriefCliRunner = (args, cwd) =>
     );
   });
 
+/**
+ * `/brief` の decide verdict 後の一連（取得 → パース → post）。bot.ts から
+ * Discord I/O と通知を注入して呼ぶ。ここに抽出してあるのは、失敗経路
+ * （CLI 失敗 / パース失敗 / post 失敗 / skipped）の報告義務を bot.ts の
+ * 配線コード（カバレッジ対象外に近い）ではなく単体テストで固定するため。
+ */
+export interface BriefDecideFlowInput {
+  /** `/brief` が運んだ日付（表示用。CLI は常に当日の業務日を返す）。 */
+  date: string;
+  /** ログ用のチャンネル名。 */
+  channelName: string;
+  /** proposals CLI の作業ディレクトリ。 */
+  cwd: string;
+  /** 未決提案の取得コマンド（argv）。 */
+  proposalsArgs: string[];
+  runCli?: BriefCliRunner;
+  /** チャンネル直下へのテキスト post（報告・警告用）。 */
+  postToChannel: (text: string) => Promise<void>;
+  /** 決裁ボタン付きメッセージの post。失敗は throw してよい（flow が受ける）。 */
+  postDecisionMessage: (msg: BriefDecisionMessage) => Promise<void>;
+  /** 取得失敗時のページング（Pushover 等）。失敗しても flow は落ちない。 */
+  notifyFailure: (title: string, body: string) => Promise<void>;
+}
+
+/**
+ * @returns true = 決裁 UI（または「未決なし」報告）の post まで成功し、呼び出し元が
+ * 同日 dedup を記録してよい。false = 失敗（dedup を記録せず、同じ日付の再送で
+ * 回復できる余地を残す — corp-brief.ts の duplicate 契約）。
+ */
+export async function runBriefDecideFlow(
+  input: BriefDecideFlowInput,
+): Promise<boolean> {
+  const runCli = input.runCli ?? runBriefCli;
+
+  // AC-3 相当（#426 から継承）: 取得失敗を silent にしない。corp は自動で
+  // 再送しないので、チャンネルへの報告 + ページで同じ朝に気付けるようにする。
+  const reportFetchFailure = async (detail: string): Promise<void> => {
+    console.error(
+      `[brief-decision] proposals fetch failed in channel ${input.channelName} (date=${input.date}): ${detail}`,
+    );
+    await input.postToChannel(
+      `⚠️ 朝レポ（${input.date}）の未決提案を取得できませんでした（決裁は未実行）。\n` +
+        `\`\`\`\n${truncate(detail, 500)}\n\`\`\``,
+    );
+    await input
+      .notifyFailure(
+        "朝レポの決裁依頼が未達",
+        `#${input.channelName} で未決提案の取得に失敗し ${input.date} の朝レポ決裁を提示できませんでした。`,
+      )
+      .catch((err) =>
+        console.warn("[brief-decision] fetch-failure notify failed:", err),
+      );
+  };
+
+  const cliResult = await runCli(input.proposalsArgs, input.cwd);
+  if (cliResult.code !== 0) {
+    await reportFetchFailure(
+      `exit ${cliResult.code ?? "signal/timeout"}: ${cliResult.stderr.trim()}`,
+    );
+    return false;
+  }
+  const proposals = parseProposalsOutput(cliResult.stdout);
+  if (proposals.kind === "error") {
+    await reportFetchFailure(proposals.reason);
+    return false;
+  }
+
+  if (proposals.pending.length === 0 && proposals.skipped === 0) {
+    await input.postToChannel(
+      buildAllDecidedMessage(input.date, proposals.total),
+    );
+    return true;
+  }
+
+  try {
+    for (const msg of buildBriefDecisionMessages(input.date, proposals.pending)) {
+      await input.postDecisionMessage(msg);
+    }
+  } catch (err) {
+    console.error(
+      `[brief-decision] decision post failed in channel ${input.channelName}:`,
+      err,
+    );
+    return false;
+  }
+
+  if (proposals.skipped > 0) {
+    // id がボタン化できない提案を黙って落とさない（silent truncation 禁止）。
+    console.warn(
+      `[brief-decision] ${proposals.skipped} pending proposal(s) skipped (id not button-safe) in channel ${input.channelName}`,
+    );
+    await input.postToChannel(
+      `⚠️ 未決提案のうち ${proposals.skipped} 件は id をボタン化できず表示していません。` +
+        `作業ディレクトリで proposals コマンドを直接確認してください。`,
+    );
+  }
+  return true;
+}
+
 /** 決裁ボタンが押されたチャンネルに対する実行設定（config/channels.ts 由来）。 */
 export interface BriefDecisionChannelConfig {
   channelName: string;

--- a/supervisor/src/session/corp-brief.ts
+++ b/supervisor/src/session/corp-brief.ts
@@ -1,14 +1,14 @@
 /**
- * 朝レポ契機の CEO セッション起こし（#426 / corp#112 の AC-1）。
+ * 朝レポ契機のタップ決裁トリガー（#426 → #449 / corp#112 の AC-1）。
  *
  * corp が朝レポ（CEO 提案 `[D1]..[Dn]`）を #corp へ配信しても、`bot.ts` の
  * `if (message.author.bot) return;` が bot / webhook のメッセージを一律 drop する
- * ため、corp スレッドで稼働中の CEO セッションは「朝レポが来た」ことを知れない。
- * その結果「朝レポ → CEO が決裁を問う → 会長がタップ → 決裁実行」というジャーニーが
- * 起点で成立しない（#412 のボタン UI / #416 の回答待ちが揃っても、質問を発生させる
- * 主体が居ない）。
+ * ため、「朝レポが来た」ことを起点に決裁ジャーニーを始める主体が居ない。
  *
- * 本モジュールはその受け口を、**既存 `/dispatch` と同じ認可・同じ入口形状**で用意する:
+ * #426 は「稼働中の CEO セッションへ注入して AskUserQuestion を出させる」設計だったが、
+ * Mac / supervisor 再起動のたびに `/session start` の手動再実行が前提になり、
+ * 2026-08-23 朝の実機観測でセッション不在（no_session）により決裁が止まった。
+ * #449（会長決裁・案 A）で **セッション非依存** に置き換える:
  *
  *   1. トリガーは既知チャンネルの**非スレッド**メッセージ `/brief <YYYY-MM-DD>`。
  *      corp の朝レポ配信 webhook ではなく、corp の **dispatch bot**（別 identity）が
@@ -18,28 +18,22 @@
  *   2. 認可は {@link isDispatchSourceAllowed} を**そのまま**再利用する。policy 不在 /
  *      channel 未登録 / `dispatchFrom` 未列挙 の 3 つの deny がそのまま効く
  *      （fail-closed）。新しい認可モデルを書かない = 新しい抜け道を作らない。
- *   3. **セッションへ注入する文字列は claude-hub が組み立て、自由文を一切受け取らない**。
- *      外部から受け取るのは `YYYY-MM-DD` という閉じたトークン 1 個だけで、
- *      `/dispatch <branch> <N>` → `/impl <N>` を claude-hub 側で構築するのと同型。
- *      これが「本社セッションへ任意の指示を注入して承認ゲートを迂回する」ことに対する
- *      主防御になる。レポート本文は CEO セッションが自分で `~/corp` から読む。
- *   4. 投入先スレッドは `listRunningByChannel(<channel>)` で**決定的に**解決する。
- *      オーケストレーター（branch が `orchestrate-` 始まり）だけは機械的な印で
- *      候補から除き（{@link selectBriefTargets}）、残りがちょうど 1 件のときだけ
- *      注入する。0 件 / 2 件以上は注入せず通知する（推測で選ばない）。
- *   5. **稼働中セッションへ打鍵する唯一の外部トリガー**なので、割り込みの安全弁を 2 つ持つ:
- *      対象スレッドが AskUserQuestion の回答待ちなら注入しない（`askPending`）、
- *      同じ日付を直近に注入済みなら二度割り込まない（{@link BRIEF_DEDUP_WINDOW_MS}）。
- *      dispatch / orchestrate は**自分が起こしたばかりのセッション**にしか打鍵しないため
- *      この論点を持たない。ここだけは brief のほうが強い能力を持つ。
+ *   3. **外部から受け取るのは `YYYY-MM-DD` という閉じたトークン 1 個だけ**。
+ *      提案の実体（id / タイトル / 未決状態）は claude-hub 自身が対象チャンネルの
+ *      作業ディレクトリで `proposals --json`（corp CLI）を実行して取得する
+ *      （brief-decision.ts）。自由文を一切受け取らない性質は #426 と同じ。
+ *   4. 決裁の実行者は**会長のボタンタップのみ**（brief-decision.ts が access.json の
+ *      `allowFrom` で検証する）。この評価器はどのセッションにも触れない —
+ *      セッションへの打鍵という能力自体を持たないため、#426 が持っていた
+ *      askPending / no_session / ambiguous / deferred の各安全弁は不要になった。
  *
  * *誰が* トリガーできるかは access policy 側の設定であり、本モジュールは corp 固有の
  * 送信元を一切ハードコードしない（`dispatch.ts` と同じ方針）。#corp が最初の利用者
- * というだけで、機構としては CHANNEL_MAP に載っている任意のチャンネルで動く。
+ * というだけで、機構としては CHANNEL_MAP + `ChannelConfig.brief` が設定された任意の
+ * チャンネルで動く。
  *
- * 判断はすべて純関数 {@link evaluateBriefTrigger} に閉じており、Discord ゲートウェイも
- * 実 SessionManager も無しで単体テストできる。副作用（注入・通知・投稿）は呼び出し元
- * （bot.ts）が持つ。
+ * 判断はすべて純関数 {@link evaluateBriefTrigger} に閉じており、Discord ゲートウェイ
+ * 無しで単体テストできる。副作用（CLI 実行・投稿）は呼び出し元（bot.ts）が持つ。
  */
 
 import {
@@ -48,7 +42,6 @@ import {
   type AccessPolicy,
   type DispatchDecisionReason,
 } from "../config/access-policy";
-import { ORCHESTRATE_BRANCH_PREFIX } from "./orchestrate";
 
 /** リテラルのトリガートークン。corp 側が同じ文字列を post する。 */
 export const BRIEF_PREFIX = "/brief";
@@ -138,62 +131,18 @@ export function parseBriefCommand(content: string): ParsedBrief {
 }
 
 /**
- * セッションへ注入する文字列を組み立てる。**外部入力は検証済みの `date` だけ**で、
- * 残りは固定リテラル。`date` は {@link BRIEF_DATE_RE} を通過した数字とハイフンのみ
- * なので、テンプレートへ埋めても指示文を注入できない。
- *
- * relay は `tmux send-keys -l` の途中送信を避けるため改行を空白へ潰す
- * （`relay.ts` flattenForSendKeys）。潰される前提に依存しないよう最初から 1 行で作る。
- */
-export function buildBriefInjection(date: string): string {
-  return (
-    `【朝レポ着信 ${date}】corp の朝レポ配信を claude-hub が検知しました。` +
-    `~/corp の ${date} 分の朝レポ（CEO 提案 [D1]..[Dn]）を読み、` +
-    `どの提案を承認するかを AskUserQuestion で会長に問うてください。` +
-    `会長の回答を得るまで、dispatch など承認を要する操作は実行しないこと。`
-  );
-}
-
-/** 投入先候補セッションの最小面（実 SessionInfo が構造的に満たす）。 */
-export interface BriefSessionRef {
-  threadId: string;
-  branch?: string;
-}
-
-/**
- * 投入先の候補から、CEO セッションでないと**決定的に**判る行を除く。
- *
- * `listRunningByChannel` は channelName と status でしか絞らないため、#corp では
- * `/orchestrate` で起動したオーケストレーター（branch が
- * {@link ORCHESTRATE_BRANCH_PREFIX} 始まり）も同じ候補集合に入る。これを残すと
- * CEO セッションとの同時稼働で毎回 `ambiguous`（＝朝レポ未達）になる。
- *
- * 除外の根拠は `orchestrateBranchName()` が付ける固定 prefix という**機械的な印**
- * だけに限る（推測でセッションを選り分けない）。それ以外の候補が複数残る場合は
- * 従来どおり `ambiguous` に倒す。hub work セッションは channelName が
- * `claude-hub-work` なので、そもそも #corp の候補に入らない。
- */
-export function selectBriefTargets(
-  sessions: readonly BriefSessionRef[],
-): BriefSessionRef[] {
-  return sessions.filter(
-    (s) => !(s.branch ?? "").startsWith(ORCHESTRATE_BRANCH_PREFIX),
-  );
-}
-
-/**
- * 同じ日付の brief を再び受けても投入しない時間窓（冪等性）。
+ * 同じ日付の brief を再び受けても決裁メッセージを出し直さない時間窓（冪等性）。
  *
  * corp 側の配信リトライや手動 re-post で同じ `(channel, date)` が二度来ると、
- * **稼働中の会話に二度割り込む**（`enqueueForThread` が直列化するので状態は壊れないが、
- * 会長との対話は二度中断される）。corp の dispatch スケジューラが 30 分周期なので、
- * その 1 サイクル分をまたいで吸収できる 60 分を既定にする。窓を無期限にしないのは、
- * 初回の注入がセッション側で活きなかったときに**同じ日付で意図的に再投入する**余地を
- * 残すため（無期限だと当日中は二度と起こせなくなる）。
+ * 同じ未決提案のボタンがチャンネルに二重に並ぶ（decide-proposal 自体は corp 側で
+ * 冪等だが、どちらのメッセージが生きているか会長には判別できない）。corp の
+ * dispatch スケジューラが 30 分周期なので、その 1 サイクル分をまたいで吸収できる
+ * 60 分を既定にする。窓を無期限にしないのは、決裁メッセージの post に失敗した
+ * とき**同じ日付で意図的に再投入する**余地を残すため。
  */
 export const BRIEF_DEDUP_WINDOW_MS = 60 * 60_000;
 
-/** 直近に注入済みの brief（冪等性判定の入力）。 */
+/** 直近に処理済みの brief（冪等性判定の入力）。 */
 export interface RecentBrief {
   date: string;
   atMs: number;
@@ -208,21 +157,9 @@ export interface BriefTriggerInput {
   sourceId: string;
   /** 読み込み済み access policy。`null` = 読めなかった（fail-closed で deny）。 */
   policy: AccessPolicy | null;
-  /** 当該チャンネルで running のセッション（`listRunningByChannel` の結果）。 */
-  sessions: BriefSessionRef[];
   /**
-   * 対象スレッドで AskUserQuestion が保留中（またはその直後の猶予窓）か。
-   *
-   * **必須**（省略可にしない）。この経路は「既に走っていて状態の分からないセッション」へ
-   * 打鍵する唯一の外部トリガーで、`sendToPane` は毎回先頭に `Escape` を送る。会長が
-   * 回答を検討している最中に打てば、保留中の決裁が本人不在で消えるか、最悪 fallback
-   * dialog の既定が選ばれる（#412 / #416 / #423 が閉じた失敗クラスそのもの）。
-   * 呼び出し側は `hasRecentAsk`（= 保留中 + settle 直後の猶予）を渡すこと。
-   */
-  askPending: (threadId: string) => boolean;
-  /**
-   * 同じチャンネルで直近に注入した brief。`undefined` = 記録なし。
-   * {@link BRIEF_DEDUP_WINDOW_MS} 以内に同じ日付が来たら投入しない。
+   * 同じチャンネルで直近に処理した brief。`undefined` = 記録なし。
+   * {@link BRIEF_DEDUP_WINDOW_MS} 以内に同じ日付が来たら再処理しない。
    */
   recentBrief?: RecentBrief;
   /** 冪等性判定の基準時刻。省略時 `Date.now()`。 */
@@ -246,32 +183,24 @@ export type BriefDecision =
   | { action: "denied"; reason: DispatchDecisionReason }
   /** 認可済みだがコマンドが不正。 */
   | { action: "rejected"; reason: string }
-  /** 注入する（対象スレッドがちょうど 1 件）。 */
-  | { action: "inject"; date: string; threadId: string; text: string }
-  /** 同じ日付を直近に注入済み → 二度割り込まない（冪等性）。 */
-  | { action: "duplicate"; date: string; elapsedMs: number }
-  /** 対象セッションが会長の回答待ち → 注入せず通知（割り込まない）。 */
-  | { action: "deferred"; date: string; threadId: string }
-  /** 稼働中セッションが無い → 注入せず通知（サイレントに落とさない）。 */
-  | { action: "no_session"; date: string }
-  /** 稼働中セッションが複数 → 曖昧なので注入せず通知（推測で選ばない）。 */
-  | { action: "ambiguous"; date: string; count: number };
+  /** 未決提案を取得して決裁メッセージをチャンネル直下へ post する（#449）。 */
+  | { action: "decide"; date: string }
+  /** 同じ日付を直近に処理済み → 決裁メッセージを二重に出さない（冪等性）。 */
+  | { action: "duplicate"; date: string; elapsedMs: number };
 
 /**
- * トリガーの可否と投入先を決める純関数。評価順は次で固定する:
+ * トリガーの可否を決める純関数。評価順は次で固定する:
  *
  *   1. `/brief` か（安価な形式判定。違えば policy を読まない）
  *   2. kill-switch
  *   3. **認可**（fail-closed。ここを通らなければパースもしない）
  *   4. コマンドのパース（自由文を拒否）
- *   5. 冪等性（同じ日付を直近に注入済みなら二度割り込まない）
- *   6. 投入先スレッドの決定（1 件のときだけ先へ進む）
- *   7. **回答待ちの割り込み回避**（保留中なら注入しない）
+ *   5. 冪等性（同じ日付を直近に処理済みなら決裁メッセージを出し直さない）
  *
  * 3 が 4 より先なのは既存 `handleDispatchMessage` と同じ順序で、認可されない送信元の
  * 入力を一切解釈しないため（`tests/guards/access-enforcement-wired.test.ts` が
- * dispatch と同様にこの順序を固定する）。7 が最後なのは、対象スレッドが確定して
- * 初めて「そのスレッドが回答待ちか」を問えるため。
+ * dispatch と同様にこの順序を固定する）。#426 にあった投入先セッションの決定
+ * （6）と回答待ちの割り込み回避（7）は、セッションへ触れない #449 では存在しない。
  */
 export function evaluateBriefTrigger(input: BriefTriggerInput): BriefDecision {
   if (!isBriefCommand(input.content)) return { action: "ignore" };
@@ -302,9 +231,9 @@ export function evaluateBriefTrigger(input: BriefTriggerInput): BriefDecision {
 
   const { date } = parsed;
 
-  // 冪等性: 同じ日付を直近に注入済みなら、稼働中の会話へ二度割り込まない。
-  // 記録は inject したときだけ残す契約なので、no_session / deferred で終わった
-  // brief の再送はここで止まらない（止めると回復手段が消える）。
+  // 冪等性: 同じ日付を直近に処理済みなら、決裁メッセージを二重に出さない。
+  // 記録は decide 側の post 成功時だけ残す契約なので、CLI 失敗 / post 失敗で
+  // 終わった brief の再送はここで止まらない（止めると回復手段が消える）。
   const now = input.nowMs ?? Date.now();
   const recent = input.recentBrief;
   if (recent && recent.date === date) {
@@ -314,29 +243,5 @@ export function evaluateBriefTrigger(input: BriefTriggerInput): BriefDecision {
     }
   }
 
-  const sessions = selectBriefTargets(input.sessions);
-  if (sessions.length === 0) {
-    return { action: "no_session", date };
-  }
-  if (sessions.length > 1) {
-    return { action: "ambiguous", date, count: sessions.length };
-  }
-
-  const threadId = (sessions[0] as BriefSessionRef).threadId;
-
-  // 会長が AskUserQuestion に回答している最中（およびその直後の猶予窓）には
-  // 打鍵しない。人間の relay 経路は同じ状況で tmux へ流さず resolveAskUser へ
-  // 回している（bot.ts / #370）。こちらは Discord の返信ではなく生の打鍵で、
-  // しかも `sendToPane` は先頭に Escape を送るため、割り込みの害はより大きい。
-  // no_session / ambiguous と同じ「推測で触らない」方針の延長。
-  if (input.askPending(threadId)) {
-    return { action: "deferred", date, threadId };
-  }
-
-  return {
-    action: "inject",
-    date,
-    threadId,
-    text: buildBriefInjection(date),
-  };
+  return { action: "decide", date };
 }

--- a/supervisor/tests/guards/access-enforcement-wired.test.ts
+++ b/supervisor/tests/guards/access-enforcement-wired.test.ts
@@ -149,25 +149,29 @@ describe("brief trigger is wired fail-closed (#426)", () => {
     expect(src).toContain("decision.allowed");
   });
 
-  test("bot.ts only injects on the evaluator's inject verdict", async () => {
+  test("bot.ts runs the proposals CLI only after the evaluator's decide verdict (#449)", async () => {
     const src = await read("src/bot.ts");
     const evalIdx = src.indexOf("evaluateBriefTrigger({");
-    // `decision.text` is the injected sentence and exists only on the `inject`
-    // verdict, so its presence after the evaluator pins the order.
-    const injectIdx = src.indexOf("decision.text");
+    // `config.brief.proposalsArgs` is consumed only inside the `decide` case,
+    // so its position after the evaluator pins the order: no CLI execution
+    // before the fail-closed authorization verdict.
+    const cliIdx = src.indexOf("config.brief.proposalsArgs");
     expect(evalIdx).toBeGreaterThan(-1);
-    expect(injectIdx).toBeGreaterThan(-1);
-    expect(evalIdx).toBeLessThan(injectIdx);
+    expect(cliIdx).toBeGreaterThan(-1);
+    expect(evalIdx).toBeLessThan(cliIdx);
   });
 
-  test("bot.ts feeds the real ask guard into the evaluator (#432 must-1)", async () => {
-    // The evaluator requires `askPending`, so it cannot be forgotten — but it
-    // CAN be defeated by passing a constant. This pins the live predicate:
-    // `hasRecentAsk` (pending + the post-settle grace window), not
-    // `hasPendingAsk`, because the TUI dialog the ask hook falls back to appears
-    // after the ask settles. This path types into the pane, Escape first.
+  test("the brief path no longer types into any session (#449: session-less by design)", async () => {
+    // #426's injection capability (typing into an already-running session,
+    // Escape first) was the reason the path needed the ask guard / no_session /
+    // ambiguous safety valves. #449 removed the capability itself: the brief
+    // path must build tap-to-decide buttons, never a session injection. A
+    // refactor that reintroduces an injected sentence would bring back the
+    // whole failure class — pin its absence.
+    const brief = await read("src/session/corp-brief.ts");
+    expect(brief).not.toContain("buildBriefInjection");
     const src = await read("src/bot.ts");
-    expect(src).toContain("askPending: hasRecentAsk");
+    expect(src).toContain("buildBriefDecisionMessages(");
   });
 
   test("brief denial logs do not interpolate raw source/channel ids or body", async () => {

--- a/supervisor/tests/guards/access-enforcement-wired.test.ts
+++ b/supervisor/tests/guards/access-enforcement-wired.test.ts
@@ -171,7 +171,7 @@ describe("brief trigger is wired fail-closed (#426)", () => {
     const brief = await read("src/session/corp-brief.ts");
     expect(brief).not.toContain("buildBriefInjection");
     const src = await read("src/bot.ts");
-    expect(src).toContain("buildBriefDecisionMessages(");
+    expect(src).toContain("runBriefDecideFlow(");
   });
 
   test("brief denial logs do not interpolate raw source/channel ids or body", async () => {

--- a/supervisor/tests/session/brief-decision.test.ts
+++ b/supervisor/tests/session/brief-decision.test.ts
@@ -342,3 +342,125 @@ describe("createBriefDecisionHandler", () => {
     expect(calls.length).toBe(2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// runBriefDecideFlow（bot.ts の decide case から抽出された一連）
+// ---------------------------------------------------------------------------
+
+import { runBriefDecideFlow } from "../../src/session/brief-decision";
+
+interface FlowCapture {
+  channelPosts: string[];
+  decisionPosts: number;
+  notifications: string[];
+}
+
+function flowDeps(
+  cli: CliResult,
+  over: {
+    postDecisionMessage?: () => Promise<void>;
+  } = {},
+): { capture: FlowCapture; input: Parameters<typeof runBriefDecideFlow>[0] } {
+  const capture: FlowCapture = { channelPosts: [], decisionPosts: 0, notifications: [] };
+  return {
+    capture,
+    input: {
+      date: "2026-08-23",
+      channelName: "corp",
+      cwd: "/tmp/corp",
+      proposalsArgs: ["npm", "run", "secretary", "--", "proposals", "--json"],
+      runCli: async () => cli,
+      postToChannel: async (text) => {
+        capture.channelPosts.push(text);
+      },
+      postDecisionMessage:
+        over.postDecisionMessage ??
+        (async () => {
+          capture.decisionPosts += 1;
+        }),
+      notifyFailure: async (title) => {
+        capture.notifications.push(title);
+      },
+    },
+  };
+}
+
+describe("runBriefDecideFlow", () => {
+  test("pending ありなら決裁メッセージを post して true（dedup 記録可）", async () => {
+    const { capture, input } = flowDeps({
+      code: 0,
+      stdout: proposalsJson([{ id: "a-1", title: "A", decision: null }]),
+      stderr: "",
+    });
+    await expect(runBriefDecideFlow(input)).resolves.toBe(true);
+    expect(capture.decisionPosts).toBe(1);
+    expect(capture.notifications.length).toBe(0);
+  });
+
+  test("未決 0 件は「すべて決裁済み」1 行のみで true", async () => {
+    const { capture, input } = flowDeps({
+      code: 0,
+      stdout: proposalsJson([{ id: "a-1", title: "A", decision: "approved" }]),
+      stderr: "",
+    });
+    await expect(runBriefDecideFlow(input)).resolves.toBe(true);
+    expect(capture.decisionPosts).toBe(0);
+    expect(capture.channelPosts.join("\n")).toContain("すべて決裁済み");
+  });
+
+  test("CLI 失敗はチャンネル報告 + ページで false（silent にしない・dedup 記録不可）", async () => {
+    const { capture, input } = flowDeps({
+      code: 1,
+      stdout: "",
+      stderr: "当日の snapshot がありません",
+    });
+    await expect(runBriefDecideFlow(input)).resolves.toBe(false);
+    expect(capture.channelPosts.join("\n")).toContain("取得できませんでした");
+    expect(capture.channelPosts.join("\n")).toContain("snapshot");
+    expect(capture.notifications).toEqual(["朝レポの決裁依頼が未達"]);
+  });
+
+  test("パース不能な出力も同じ失敗報告で false", async () => {
+    const { capture, input } = flowDeps({ code: 0, stdout: "not json", stderr: "" });
+    await expect(runBriefDecideFlow(input)).resolves.toBe(false);
+    expect(capture.notifications.length).toBe(1);
+  });
+
+  test("決裁メッセージの post 失敗は false（同日再送で回復できる余地を残す）", async () => {
+    const { input } = flowDeps(
+      {
+        code: 0,
+        stdout: proposalsJson([{ id: "a-1", title: "A", decision: null }]),
+        stderr: "",
+      },
+      {
+        postDecisionMessage: async () => {
+          throw new Error("50013 Missing Permissions");
+        },
+      },
+    );
+    await expect(runBriefDecideFlow(input)).resolves.toBe(false);
+  });
+
+  test("ボタン化できない id は skipped として警告される（silent truncation 禁止）", async () => {
+    const { capture, input } = flowDeps({
+      code: 0,
+      stdout: proposalsJson([
+        { id: "a-1", title: "A", decision: null },
+        { id: "bad id", title: "B", decision: null },
+      ]),
+      stderr: "",
+    });
+    await expect(runBriefDecideFlow(input)).resolves.toBe(true);
+    expect(capture.decisionPosts).toBe(1);
+    expect(capture.channelPosts.join("\n")).toContain("1 件は id をボタン化できず");
+  });
+
+  test("notify 自体の失敗で flow は落ちない", async () => {
+    const { input } = flowDeps({ code: 1, stdout: "", stderr: "boom" });
+    input.notifyFailure = async () => {
+      throw new Error("pushover down");
+    };
+    await expect(runBriefDecideFlow(input)).resolves.toBe(false);
+  });
+});

--- a/supervisor/tests/session/brief-decision.test.ts
+++ b/supervisor/tests/session/brief-decision.test.ts
@@ -1,0 +1,344 @@
+import { describe, test, expect } from "bun:test";
+import type { ButtonInteraction } from "discord.js";
+import {
+  BRIEF_DECISION_PREFIX,
+  MAX_PROPOSALS_PER_MESSAGE,
+  buildAllDecidedMessage,
+  buildBriefDecisionCustomId,
+  buildBriefDecisionMessages,
+  createBriefDecisionHandler,
+  isBriefDecisionComponentId,
+  parseBriefDecisionCustomId,
+  parseProposalsOutput,
+  type CliResult,
+  type PendingProposal,
+} from "../../src/session/brief-decision";
+
+/**
+ * Issue #449: `/brief` のタップ決裁。セッションを介さず、supervisor が
+ * proposals CLI の出力からチャンネル直下の決裁ボタンを組み立て、会長のタップで
+ * decide CLI を実行する。テストが固定する性質:
+ *
+ *   1. customId は閉じたトークンのみ（提案 id の形を通過したものだけがボタンになる）
+ *   2. タップの認可は access.json ゲートを通る（deny なら CLI は実行されない）
+ *   3. 未決 6 件以上は複数メッセージに分かれ、silent truncation しない
+ *   4. CLI 失敗は会長へ報告される（silent fallback 禁止）
+ */
+
+function proposal(over: Partial<PendingProposal> = {}): PendingProposal {
+  return {
+    id: "dispatch-social-436",
+    title: "[social] 着手検討: #436",
+    priority: 3,
+    targetDept: "social",
+    pendingDays: 1,
+    ...over,
+  };
+}
+
+/** corp CLI `proposals --json` 相当の stdout を組み立てる。 */
+function proposalsJson(rows: unknown[]): string {
+  return JSON.stringify({ date: "2026-08-23", pending: { count: 1, maxDays: 1 }, proposals: rows });
+}
+
+describe("parseProposalsOutput", () => {
+  test("parses pending proposals and drops decided ones", () => {
+    const out = parseProposalsOutput(
+      proposalsJson([
+        { id: "a-1", title: "A", priority: 1, targetDept: "x", decision: null, pendingDays: 2 },
+        { id: "b-2", title: "B", priority: 2, targetDept: "y", decision: "approved", pendingDays: null },
+      ]),
+    );
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.date).toBe("2026-08-23");
+      expect(out.total).toBe(2);
+      expect(out.pending.map((p) => p.id)).toEqual(["a-1"]);
+      expect(out.skipped).toBe(0);
+    }
+  });
+
+  test("tolerates an npm run banner before the JSON (reads from the first brace)", () => {
+    const out = parseProposalsOutput(`> secretary\n> tsx src/cli.ts proposals --json\n${proposalsJson([])}`);
+    expect(out.kind).toBe("ok");
+  });
+
+  test("skips (and counts) a pending proposal whose id cannot ride a customId", () => {
+    const out = parseProposalsOutput(
+      proposalsJson([
+        { id: "ok-id", title: "OK", decision: null },
+        { id: "bad id with spaces", title: "NG", decision: null },
+        { id: "colon:id", title: "NG", decision: null },
+      ]),
+    );
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.pending.map((p) => p.id)).toEqual(["ok-id"]);
+      expect(out.skipped).toBe(2);
+    }
+  });
+
+  test("errors on output without JSON / with broken JSON / without proposals", () => {
+    expect(parseProposalsOutput("no json here").kind).toBe("error");
+    expect(parseProposalsOutput("{broken").kind).toBe("error");
+    expect(parseProposalsOutput(JSON.stringify({ date: "2026-08-23" })).kind).toBe("error");
+    expect(parseProposalsOutput(JSON.stringify({ proposals: [] })).kind).toBe("error");
+  });
+});
+
+describe("customId scheme", () => {
+  test("builds and parses a round trip", () => {
+    const id = buildBriefDecisionCustomId("dispatch-social-436", "approved");
+    expect(isBriefDecisionComponentId(id)).toBe(true);
+    expect(parseBriefDecisionCustomId(id)).toEqual({
+      proposalId: "dispatch-social-436",
+      decision: "approved",
+    });
+  });
+
+  test("stays within Discord's 100-char customId limit at the max id length", () => {
+    const longId = `a${"b".repeat(79)}`; // PROPOSAL_ID_RE の上限 80 文字
+    const customId = buildBriefDecisionCustomId(longId, "approved");
+    expect(customId.length).toBeLessThanOrEqual(100);
+    expect(parseBriefDecisionCustomId(customId)?.proposalId).toBe(longId);
+  });
+
+  test("rejects foreign prefixes, unknown decisions, and malformed ids", () => {
+    expect(parseBriefDecisionCustomId("ask:tok:1")).toBeNull();
+    expect(parseBriefDecisionCustomId(`${BRIEF_DECISION_PREFIX}id-1:destroy`)).toBeNull();
+    expect(parseBriefDecisionCustomId(`${BRIEF_DECISION_PREFIX}id-1`)).toBeNull();
+    expect(parseBriefDecisionCustomId(`${BRIEF_DECISION_PREFIX}:approved`)).toBeNull();
+    expect(parseBriefDecisionCustomId(`${BRIEF_DECISION_PREFIX}a:b:approved`)).toBeNull();
+  });
+});
+
+describe("buildBriefDecisionMessages", () => {
+  test("one message with one row of 3 buttons per proposal", () => {
+    const msgs = buildBriefDecisionMessages("2026-08-23", [proposal()]);
+    expect(msgs.length).toBe(1);
+    const msg = msgs[0]!;
+    expect(msg.content).toContain("2026-08-23");
+    expect(msg.content).toContain("dispatch-social-436");
+    expect(msg.components.length).toBe(1);
+    const ids = msg.components[0]!.components.map(
+      (c) => (c.data as { custom_id?: string }).custom_id,
+    );
+    expect(ids).toEqual([
+      `${BRIEF_DECISION_PREFIX}dispatch-social-436:approved`,
+      `${BRIEF_DECISION_PREFIX}dispatch-social-436:rejected`,
+      `${BRIEF_DECISION_PREFIX}dispatch-social-436:deferred`,
+    ]);
+  });
+
+  test("splits 7 proposals across 2 messages with continuous ordinals (no silent truncation)", () => {
+    const pending = Array.from({ length: 7 }, (_, i) =>
+      proposal({ id: `p-${i + 1}`, title: `提案 ${i + 1}` }),
+    );
+    const msgs = buildBriefDecisionMessages("2026-08-23", pending);
+    expect(msgs.length).toBe(2);
+    expect(msgs[0]!.components.length).toBe(MAX_PROPOSALS_PER_MESSAGE);
+    expect(msgs[1]!.components.length).toBe(2);
+    // 通し番号: 2 通目は 6. から始まる
+    expect(msgs[1]!.content).toContain("6. ");
+    expect(msgs[1]!.content).toContain("p-6");
+  });
+
+  test("all-decided / no-proposal one-liners", () => {
+    expect(buildAllDecidedMessage("2026-08-23", 4)).toContain("すべて決裁済み");
+    expect(buildAllDecidedMessage("2026-08-23", 0)).toContain("提案はありません");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// handler
+// ---------------------------------------------------------------------------
+
+interface FakeInteraction {
+  customId: string;
+  channelId: string;
+  channel: { name: string; isThread: () => boolean };
+  user: { id: string };
+  deferred: boolean;
+  replied: boolean;
+  replies: unknown[];
+  edits: unknown[];
+  message: {
+    content: string;
+    components: unknown[];
+    edits: unknown[];
+    edit: (opts: unknown) => Promise<void>;
+  };
+  reply: (opts: unknown) => Promise<void>;
+  deferReply: (opts?: unknown) => Promise<void>;
+  editReply: (opts: unknown) => Promise<void>;
+}
+
+function fakeInteraction(over: Partial<FakeInteraction> = {}): FakeInteraction {
+  const it: FakeInteraction = {
+    customId: buildBriefDecisionCustomId("dispatch-social-436", "approved"),
+    channelId: "999",
+    channel: { name: "corp", isThread: () => false },
+    user: { id: "chairman" },
+    deferred: false,
+    replied: false,
+    replies: [],
+    edits: [],
+    message: {
+      content: "📋 未決提案",
+      components: [],
+      edits: [],
+      async edit(opts: unknown) {
+        this.edits.push(opts);
+      },
+    },
+    async reply(opts: unknown) {
+      this.replied = true;
+      this.replies.push(opts);
+    },
+    async deferReply() {
+      this.deferred = true;
+    },
+    async editReply(opts: unknown) {
+      this.edits.push(opts);
+    },
+    ...over,
+  };
+  return it;
+}
+
+function asButton(it: FakeInteraction): ButtonInteraction {
+  return it as unknown as ButtonInteraction;
+}
+
+const CORP_CHANNEL = {
+  channelName: "corp",
+  cwd: "/tmp/corp",
+  decideArgs: ["npm", "run", "secretary", "--", "decide-proposal"],
+};
+
+function okCli(calls: string[][]): (args: string[], cwd: string) => Promise<CliResult> {
+  return async (args) => {
+    calls.push(args);
+    return { code: 0, stdout: "", stderr: "" };
+  };
+}
+
+describe("createBriefDecisionHandler", () => {
+  test("runs the decide CLI with proposalId + decision appended (allowed tap)", async () => {
+    const calls: string[][] = [];
+    const handler = createBriefDecisionHandler({
+      resolveChannel: () => CORP_CHANNEL,
+      runCli: okCli(calls),
+      checkAccess: () => ({ allowed: true, reason: "allowed" }),
+    });
+    const it = fakeInteraction();
+    await handler(asButton(it));
+    expect(calls).toEqual([
+      ["npm", "run", "secretary", "--", "decide-proposal", "dispatch-social-436", "approved"],
+    ]);
+    expect(it.deferred).toBe(true);
+    expect(JSON.stringify(it.edits)).toContain("承認");
+    // 決裁済み表示への message 更新も走る
+    expect(it.message.edits.length).toBe(1);
+    expect(JSON.stringify(it.message.edits[0])).toContain("dispatch-social-436");
+  });
+
+  test("denied tap never reaches the CLI (access gate)", async () => {
+    const calls: string[][] = [];
+    const handler = createBriefDecisionHandler({
+      resolveChannel: () => CORP_CHANNEL,
+      runCli: okCli(calls),
+      checkAccess: () => ({ allowed: false, reason: "sender_not_allowlisted" }),
+    });
+    const it = fakeInteraction();
+    await handler(asButton(it));
+    expect(calls.length).toBe(0);
+    expect(it.deferred).toBe(false);
+    expect(JSON.stringify(it.replies)).toContain("権限がありません");
+  });
+
+  test("unconfigured channel is fail-closed (no CLI, explicit reply)", async () => {
+    const calls: string[][] = [];
+    const handler = createBriefDecisionHandler({
+      resolveChannel: () => null,
+      runCli: okCli(calls),
+      checkAccess: () => ({ allowed: true, reason: "allowed" }),
+    });
+    const it = fakeInteraction();
+    await handler(asButton(it));
+    expect(calls.length).toBe(0);
+    expect(JSON.stringify(it.replies)).toContain("実行設定がありません");
+  });
+
+  test("a foreign customId is answered, not executed", async () => {
+    const calls: string[][] = [];
+    const handler = createBriefDecisionHandler({
+      resolveChannel: () => CORP_CHANNEL,
+      runCli: okCli(calls),
+      checkAccess: () => ({ allowed: true, reason: "allowed" }),
+    });
+    const it = fakeInteraction({ customId: "briefdec:not enough" });
+    await handler(asButton(it));
+    expect(calls.length).toBe(0);
+    expect(JSON.stringify(it.replies)).toContain("認識できません");
+  });
+
+  test("CLI failure is reported to the chairman (never silent)", async () => {
+    const handler = createBriefDecisionHandler({
+      resolveChannel: () => CORP_CHANNEL,
+      runCli: async () => ({ code: 1, stdout: "", stderr: "当日の snapshot がありません" }),
+      checkAccess: () => ({ allowed: true, reason: "allowed" }),
+    });
+    const it = fakeInteraction();
+    await handler(asButton(it));
+    const edits = JSON.stringify(it.edits);
+    expect(edits).toContain("失敗");
+    expect(edits).toContain("snapshot");
+    // 失敗時は決裁済み表示にしない
+    expect(it.message.edits.length).toBe(0);
+  });
+
+  test("an already-decided no-op (corp CLI exit 0 + 既に…済み) is reported as unchanged", async () => {
+    const handler = createBriefDecisionHandler({
+      resolveChannel: () => CORP_CHANNEL,
+      runCli: async () => ({
+        code: 0,
+        stdout: "",
+        stderr: "既に approved 済みです: dispatch-social-436 — 変更なし",
+      }),
+      checkAccess: () => ({ allowed: true, reason: "allowed" }),
+    });
+    const it = fakeInteraction();
+    await handler(asButton(it));
+    expect(JSON.stringify(it.edits)).toContain("既に");
+  });
+
+  test("a double tap while the first is in flight is refused (in-flight guard)", async () => {
+    let release: (r: CliResult) => void = () => {};
+    const gate = new Promise<CliResult>((res) => {
+      release = res;
+    });
+    const calls: string[][] = [];
+    const handler = createBriefDecisionHandler({
+      resolveChannel: () => CORP_CHANNEL,
+      runCli: async (args) => {
+        calls.push(args);
+        return gate;
+      },
+      checkAccess: () => ({ allowed: true, reason: "allowed" }),
+    });
+    const first = fakeInteraction();
+    const second = fakeInteraction();
+    const p1 = handler(asButton(first));
+    // 1 タップ目が CLI 待ちの間に同じ提案をもう一度タップ
+    await handler(asButton(second));
+    expect(JSON.stringify(second.replies)).toContain("処理中");
+    expect(calls.length).toBe(1);
+    release({ code: 0, stdout: "", stderr: "" });
+    await p1;
+    // 完了後は再びタップできる（corp CLI 側の冪等 no-op が受け止める）
+    const third = fakeInteraction();
+    await handler(asButton(third));
+    expect(calls.length).toBe(2);
+  });
+});

--- a/supervisor/tests/session/corp-brief.test.ts
+++ b/supervisor/tests/session/corp-brief.test.ts
@@ -3,32 +3,29 @@ import {
   BRIEF_DEDUP_WINDOW_MS,
   BRIEF_DISABLED_ENV,
   BRIEF_PREFIX,
-  buildBriefInjection,
   evaluateBriefTrigger,
   isBriefCommand,
   isBriefDisabled,
   parseBriefCommand,
-  selectBriefTargets,
-  type BriefSessionRef,
   type BriefTriggerInput,
 } from "../../src/session/corp-brief";
 import type { AccessPolicy } from "../../src/config/access-policy";
-import { ORCHESTRATE_BRANCH_PREFIX } from "../../src/session/orchestrate";
 
 /**
- * Issue #426: corp posts `/brief <YYYY-MM-DD>` to a known channel and the
- * channel's already-running session is asked to put the morning brief's
- * proposals to the chairman (corp#112 AC-1).
+ * Issue #426 → #449: corp posts `/brief <YYYY-MM-DD>` to a known channel and
+ * the supervisor fetches the day's pending proposals and posts tap-to-decide
+ * buttons directly in the channel (corp#112 AC-1, session-less).
  *
- * This path can hand instructions to the HQ session, so the tests below fix the
- * two properties that keep it from becoming an approval-gate bypass:
+ * This path triggers CLI execution in the channel's working directory, so the
+ * tests below fix the two properties that keep it from becoming an
+ * approval-gate bypass:
  *
  *   1. **fail-closed authorization** — the same `dispatchFrom` gate as
  *      `/dispatch`, denying on missing policy / unconfigured channel / empty
  *      list / unlisted source;
- *   2. **no free text** — the only external input is a `YYYY-MM-DD` token and
- *      the injected sentence is built here, so extra tokens are rejected rather
- *      than forwarded.
+ *   2. **no free text** — the only external input is a `YYYY-MM-DD` token; what
+ *      gets executed is fixed argv from CHANNEL_MAP, so extra tokens are
+ *      rejected rather than interpreted.
  */
 
 const CHANNEL_ID = "111111111111111111";
@@ -48,13 +45,10 @@ function allowingPolicy(): AccessPolicy {
   };
 }
 
-const ONE_SESSION: BriefSessionRef[] = [{ threadId: "thread-1" }];
-
 /**
  * Base input for the evaluator. `env` / `envAllowedSourceIds` are always passed
  * explicitly so a stray `CORP_BRIEF_DISABLED` / `DISPATCH_ALLOWED_SOURCE_IDS`
- * in the developer's shell cannot change the verdict under test. `askPending`
- * defaults to "nothing outstanding" so only the tests that care set it.
+ * in the developer's shell cannot change the verdict under test.
  */
 function input(over: Partial<BriefTriggerInput> = {}): BriefTriggerInput {
   return {
@@ -62,8 +56,6 @@ function input(over: Partial<BriefTriggerInput> = {}): BriefTriggerInput {
     channelId: CHANNEL_ID,
     sourceId: CORP_BOT_ID,
     policy: allowingPolicy(),
-    sessions: ONE_SESSION,
-    askPending: () => false,
     env: {},
     envAllowedSourceIds: [],
     ...over,
@@ -106,7 +98,7 @@ describe("isBriefCommand / parseBriefCommand", () => {
 
   test("rejects extra tokens (no free text may ride along)", () => {
     // The whole point of the closed token: anything beyond the date is refused,
-    // never silently dropped and never forwarded into the session.
+    // never silently dropped and never interpreted.
     const r = parseBriefCommand("/brief 2026-08-13 rm -rf ~");
     expect(r.kind).toBe("error");
   });
@@ -116,7 +108,7 @@ describe("isBriefCommand / parseBriefCommand", () => {
     // the likeliest way free text would try to ride along. It is refused today
     // because the split is `/\s+/` (newlines are whitespace) — pin it, so a
     // future line-oriented rewrite ("look at the first line only", `split(" ")`)
-    // fails here instead of quietly forwarding the rest into the HQ session.
+    // fails here instead of quietly accepting the rest.
     for (const sep of ["\n", "\r\n", "\r"]) {
       const r = parseBriefCommand(`/brief 2026-08-13${sep}rm -rf ~`);
       expect(r.kind).toBe("error");
@@ -126,7 +118,7 @@ describe("isBriefCommand / parseBriefCommand", () => {
   test("rejects control characters riding on the date token", () => {
     // NUL / ESC / RTL-override attached to an otherwise valid date. None of
     // these are whitespace, so they stay part of the token and the anchored
-    // date regex refuses them rather than trimming them off. Written as \\u
+    // date regex refuses them rather than trimming them off. Written as \u
     // escapes on purpose — an invisible byte in a test file is unreviewable.
     for (const bad of [
       "/brief 2026-08-13\u0000",
@@ -156,18 +148,6 @@ describe("isBriefCommand / parseBriefCommand", () => {
   });
 });
 
-describe("buildBriefInjection", () => {
-  test("embeds the date and asks for AskUserQuestion", () => {
-    const text = buildBriefInjection("2026-08-13");
-    expect(text).toContain("2026-08-13");
-    expect(text).toContain("AskUserQuestion");
-  });
-
-  test("is a single line (relay flattens newlines for tmux send-keys)", () => {
-    expect(buildBriefInjection("2026-08-13")).not.toContain("\n");
-  });
-});
-
 describe("isBriefDisabled (kill-switch)", () => {
   test("off by default", () => {
     expect(isBriefDisabled({})).toBe(false);
@@ -189,8 +169,6 @@ describe("evaluateBriefTrigger — authorization is fail-closed", () => {
   });
 
   test("denies when the channel is not configured in groups", () => {
-    // The live access.json has no group for #corp today, so this is the current
-    // real-world state: the trigger is refused until the group is added.
     const d = evaluateBriefTrigger(input({ policy: { groups: {} } }));
     expect(d.action).toBe("denied");
     if (d.action === "denied") expect(d.reason).toBe("channel_not_configured");
@@ -229,16 +207,16 @@ describe("evaluateBriefTrigger — authorization is fail-closed", () => {
     expect(d.action).toBe("denied");
   });
 
-  test("a denied source never reaches inject, even with exactly one session", () => {
-    const d = evaluateBriefTrigger(input({ policy: null, sessions: ONE_SESSION }));
-    expect(d.action).not.toBe("inject");
+  test("a denied source never reaches decide", () => {
+    const d = evaluateBriefTrigger(input({ policy: null }));
+    expect(d.action).not.toBe("decide");
   });
 
   test("allows the source listed in the env allowlist (shared with /dispatch)", () => {
     const d = evaluateBriefTrigger(
       input({ sourceId: OTHER_ID, envAllowedSourceIds: [OTHER_ID] }),
     );
-    expect(d.action).toBe("inject");
+    expect(d.action).toBe("decide");
   });
 
   test("the env allowlist does not bypass the 'channel must be configured' gate", () => {
@@ -268,103 +246,30 @@ describe("evaluateBriefTrigger — trigger handling", () => {
     if (d.action === "rejected") expect(d.reason.length).toBeGreaterThan(0);
   });
 
-  test("injects into the single running session", () => {
+  test("an authorized, well-formed trigger resolves to decide (#449: no session involved)", () => {
     const d = evaluateBriefTrigger(input());
-    expect(d.action).toBe("inject");
-    if (d.action === "inject") {
-      expect(d.threadId).toBe("thread-1");
-      expect(d.date).toBe("2026-08-13");
-      expect(d.text).toBe(buildBriefInjection("2026-08-13"));
-    }
+    expect(d.action).toBe("decide");
+    if (d.action === "decide") expect(d.date).toBe("2026-08-13");
   });
 
-  test("reports no_session when nothing is running (AC-3: never silent)", () => {
-    const d = evaluateBriefTrigger(input({ sessions: [] }));
-    expect(d.action).toBe("no_session");
-    if (d.action === "no_session") expect(d.date).toBe("2026-08-13");
-  });
-
-  test("refuses to guess when several candidate sessions are running", () => {
-    const d = evaluateBriefTrigger(
-      input({ sessions: [{ threadId: "thread-1" }, { threadId: "thread-2" }] }),
-    );
-    expect(d.action).toBe("ambiguous");
-    if (d.action === "ambiguous") expect(d.count).toBe(2);
+  test("the decision carries no caller-supplied text", () => {
+    // A rejected command cannot contribute text, and an accepted one only ever
+    // contributes the date — so nothing from the wire can appear verbatim.
+    const marker = "IGNORE-PREVIOUS-INSTRUCTIONS";
+    const d = evaluateBriefTrigger(input({ content: `/brief 2026-08-13 ${marker}` }));
+    expect(d.action).toBe("rejected");
+    expect(JSON.stringify(d)).not.toContain(marker);
   });
 });
 
 /**
- * PR #432 review, must-1. This is the one capability `/dispatch` and
- * `/orchestrate` do not have: they only ever type into a session they just
- * started, while `/brief` types into a session that was ALREADY running and
- * whose state it does not own. `sendToPane` leads every send with `Escape`, so
- * injecting while the chairman has an AskUserQuestion open could discard the
- * pending decision — or, if Escape picks a fallback dialog's default, answer it
- * on their behalf. That is the failure class #412 / #416 / #423 just closed.
+ * PR #432 review, should-1（#449 でも維持）. corp retrying a failed delivery
+ * (or a manual re-post) must not repost the same day's decision buttons twice.
  */
-describe("evaluateBriefTrigger — never interrupts a pending decision (#432 must-1)", () => {
-  test("defers instead of injecting when the target thread is awaiting an answer", () => {
-    const d = evaluateBriefTrigger(input({ askPending: () => true }));
-    expect(d.action).toBe("deferred");
-    if (d.action === "deferred") {
-      expect(d.threadId).toBe("thread-1");
-      expect(d.date).toBe("2026-08-13");
-    }
-  });
-
-  test("the guard is asked about the RESOLVED target thread, not any thread", () => {
-    // A pending ask on some other thread must not block this channel's brief,
-    // and a pending ask on the target must block it — so the predicate has to
-    // receive the thread the injection would actually go to.
-    const asked: string[] = [];
-    const d = evaluateBriefTrigger(
-      input({
-        sessions: [{ threadId: "thread-target" }],
-        askPending: (threadId) => {
-          asked.push(threadId);
-          return threadId === "someone-else";
-        },
-      }),
-    );
-    expect(asked).toEqual(["thread-target"]);
-    expect(d.action).toBe("inject");
-  });
-
-  test("the ask guard runs even for an otherwise perfect trigger", () => {
-    // Guards against a refactor that checks askPending only on some branch:
-    // authorized, well-formed, exactly one target — and still deferred.
-    const d = evaluateBriefTrigger(
-      input({ policy: allowingPolicy(), askPending: () => true }),
-    );
-    expect(d.action).not.toBe("inject");
-  });
-
-  test("no target session means no ask question to answer (no_session wins)", () => {
-    // Ordering check: with zero candidates there is no thread to ask about, so
-    // the predicate must not be consulted with a bogus id.
-    let called = false;
-    const d = evaluateBriefTrigger(
-      input({
-        sessions: [],
-        askPending: () => {
-          called = true;
-          return true;
-        },
-      }),
-    );
-    expect(d.action).toBe("no_session");
-    expect(called).toBe(false);
-  });
-});
-
-/**
- * PR #432 review, should-1. corp retrying a failed delivery (or a manual
- * re-post) must not interrupt the running conversation twice for the same day.
- */
-describe("evaluateBriefTrigger — same-day idempotency (#432 should-1)", () => {
+describe("evaluateBriefTrigger — same-day idempotency", () => {
   const NOW = 1_760_000_000_000;
 
-  test("a repeat of the same date inside the window is not injected again", () => {
+  test("a repeat of the same date inside the window is a duplicate", () => {
     const d = evaluateBriefTrigger(
       input({
         nowMs: NOW,
@@ -382,7 +287,7 @@ describe("evaluateBriefTrigger — same-day idempotency (#432 should-1)", () => 
         recentBrief: { date: "2026-08-13", atMs: NOW - BRIEF_DEDUP_WINDOW_MS - 1 },
       }),
     );
-    expect(d.action).toBe("inject");
+    expect(d.action).toBe("decide");
   });
 
   test("a different date is never a duplicate", () => {
@@ -393,81 +298,14 @@ describe("evaluateBriefTrigger — same-day idempotency (#432 should-1)", () => 
         recentBrief: { date: "2026-08-13", atMs: NOW - 60_000 },
       }),
     );
-    expect(d.action).toBe("inject");
+    expect(d.action).toBe("decide");
   });
 
-  test("de-dup does not mask a deferred/no_session retry", () => {
-    // The caller records only on `inject`, so a brief that ended as deferred
-    // leaves no record — this pins the evaluator side of that contract: with no
-    // record, the retry is evaluated normally rather than swallowed.
-    const d = evaluateBriefTrigger(
-      input({ nowMs: NOW, recentBrief: undefined, askPending: () => false }),
-    );
-    expect(d.action).toBe("inject");
-  });
-});
-
-describe("selectBriefTargets — orchestrator sessions are not candidates", () => {
-  test("drops orchestrator sessions, keeps the rest", () => {
-    const kept = selectBriefTargets([
-      { threadId: "ceo" },
-      { threadId: "orc", branch: `${ORCHESTRATE_BRANCH_PREFIX}20260813-0700` },
-      { threadId: "worktree", branch: "corp-brief-work" },
-    ]);
-    expect(kept.map((s) => s.threadId)).toEqual(["ceo", "worktree"]);
-  });
-
-  test("an orchestrator running alongside the CEO session does not block the brief", () => {
-    // Regression for the failure mode CodeRabbit flagged on PR #432: without
-    // the filter this pair is `ambiguous`, so the morning brief silently never
-    // reaches the CEO whenever an orchestrator happens to be up.
-    const d = evaluateBriefTrigger(
-      input({
-        sessions: [
-          { threadId: "thread-1", branch: "corp" },
-          {
-            threadId: "thread-orc",
-            branch: `${ORCHESTRATE_BRANCH_PREFIX}20260813-0700`,
-          },
-        ],
-      }),
-    );
-    expect(d.action).toBe("inject");
-    if (d.action === "inject") expect(d.threadId).toBe("thread-1");
-  });
-
-  test("an orchestrator alone is not a target (no CEO session to ask)", () => {
-    const d = evaluateBriefTrigger(
-      input({
-        sessions: [
-          {
-            threadId: "thread-orc",
-            branch: `${ORCHESTRATE_BRANCH_PREFIX}20260813-0700`,
-          },
-        ],
-      }),
-    );
-    expect(d.action).toBe("no_session");
-  });
-
-  test("two non-orchestrator sessions still refuse (the filter narrows, it does not guess)", () => {
-    const d = evaluateBriefTrigger(
-      input({
-        sessions: [
-          { threadId: "thread-1", branch: "corp" },
-          { threadId: "thread-2", branch: "corp-dispatch-99" },
-        ],
-      }),
-    );
-    expect(d.action).toBe("ambiguous");
-  });
-
-  test("the injected text carries no caller-supplied text", () => {
-    // A rejected command cannot contribute text, and an accepted one only ever
-    // contributes the date — so nothing from the wire can appear verbatim.
-    const marker = "IGNORE-PREVIOUS-INSTRUCTIONS";
-    const d = evaluateBriefTrigger(input({ content: `/brief 2026-08-13 ${marker}` }));
-    expect(d.action).toBe("rejected");
-    expect(JSON.stringify(d)).not.toContain(marker);
+  test("no record means the retry is evaluated normally (failed posts stay recoverable)", () => {
+    // The caller records only after the decision message was posted, so a brief
+    // that failed at the CLI / post stage leaves no record — this pins the
+    // evaluator side of that contract.
+    const d = evaluateBriefTrigger(input({ nowMs: NOW, recentBrief: undefined }));
+    expect(d.action).toBe("decide");
   });
 });


### PR DESCRIPTION
Closes #449

## 目的

2026-08-23 朝の実機観測で `/brief 2026-08-23` が `no_session` に落ち、朝レポの決裁が未実行になった（#426 は「#corp で稼働中の CEO セッションがちょうど 1 件」を前提にセッションへ注入する設計で、Mac / supervisor 再起動のたびに手動 `/session start` が必要だった）。

会長決裁（2026-08-23・案 A）に基づき、**セッション注入を廃止**して supervisor が決裁ジャーニーを直接完結させる:

1. `/brief <date>` 受信 → corp CLI `proposals --json` を実行して未決提案を取得
2. **#corp チャンネル直下**に提案ごとの承認/却下/保留ボタンを post
3. 会長のタップで `decide-proposal <id> <decision>` を実行して確定

会長要件 ①セッション不要 ②#corp 直下で決裁タップ の両方を満たす。#447（直下へのリンク通知）はこの直下ボタンで置き換えられる。

## 主な変更

| ファイル | 変更 |
|---|---|
| `supervisor/src/session/corp-brief.ts` | 評価器から session 依存（inject / no_session / ambiguous / deferred、askPending、buildBriefInjection）を除去。認可 + パース + 冪等のみで `decide` verdict を返す純関数に縮小 |
| `supervisor/src/session/brief-decision.ts`（新規） | proposals JSON のパース、決裁ボタン UI の組み立て（5 件/メッセージで分割・silent truncation なし）、タップハンドラ（認可 → in-flight ガード → decide CLI 実行 → メッセージ更新） |
| `supervisor/src/config/channels.ts` | `ChannelConfig.brief`（proposalsArgs / decideArgs）を追加し corp に設定。未設定チャンネルは fail-closed |
| `supervisor/src/bot.ts` | `decide` verdict の実装（CLI 実行 → ボタン post。取得失敗は channel 報告 + Pushover）。interaction dispatcher に `briefdec:` 分岐を追加 |
| `supervisor/tests/**` | corp-brief テストを新契約に更新、brief-decision テスト新規（48 tests）、wired-guard を「verdict 前に CLI を実行しない」「brief 経路はセッションへ打鍵しない」に更新 |
| `.github/workflows/ci.yml` | `tests/session/brief-decision.test.ts` をゲートに登録 |
| `docs/bot-operations.md` | #449 のセッションレス化とタップ認可（allowFrom）を追記 |

## セキュリティ設計（#426 の防御を維持・強化）

- トリガー認可は `isDispatchSourceAllowed`（dispatchFrom、fail-closed 3 分岐）をそのまま再利用
- 外部入力は `YYYY-MM-DD` の閉じたトークン 1 個のみ（自由文拒否は従来どおり）
- **タップの認可**: access.json `allowFrom` で「押した人」を検証（ask-components の must-1 と同じゲート）。許可ユーザー以外の押下は CLI を実行しない
- customId は `briefdec:<proposalId>:<decision>` の閉じたトークンのみ（id は `^[A-Za-z0-9][A-Za-z0-9._-]{0,79}$` を通過したものだけがボタン化される）
- CLI は argv 配列 + `execFile`（shell を通さない）+ 120s タイムアウト
- 二重タップ: in-flight ガード + corp CLI 側の同一決裁冪等 no-op の二段
- kill-switch `CORP_BRIEF_DISABLED`、同日 60 分 dedup は従来どおり
- セッションへの打鍵能力そのものを削除したため、#426 の askPending / no_session / ambiguous の安全弁は構造的に不要化（guard テストで再導入を pin）

## テスト

- `bun test`（対象 5 ファイル）: 82 pass / 0 fail
- `bunx tsc --noEmit`: clean
- フルスイート: worktree 36 fail vs main チェックアウト 38 fail — ローカル環境依存（実 tmux 系）の既存 fail のみで、本変更由来の新規 fail は CI ゲート未登録（本 PR で登録済み）を除きゼロ

## マージ後の残作業

- supervisor 再起動（新コード反映）→ 実機で `/brief` 再送し、#corp 直下にボタン（未決 0 件なら「すべて決裁済み」1 行）が出ることを確認
- 翌朝 07:00 の実機ジャーニー観測（セッション不在のまま決裁ボタンが出ること）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NpPc7m5VV5KgCc6q5gjFwk


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `/brief` で未決提案を取得し、チャンネル上のボタンから承認・却下・保留を選択できるようになりました。
  * 決裁結果を反映し、処理済みの提案は再実行を防止します。
  * 許可されたユーザーのみ決裁操作を実行できます。
  * 設定不備、実行失敗、不正な提案には安全にエラーを通知します。

* **テスト**
  * 提案表示、権限確認、重複操作防止、エラー処理のテストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->