### PR TITLE
feat(session): スレッド内の /session start をそのスレッドに bind する（#453）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,6 +166,7 @@ jobs:
                    tests/session/manager-compact-concurrency.test.ts \
                    tests/commands/session-start-access.test.ts \
                    tests/commands/session-start-branch.test.ts \
+                   tests/commands/session-start-in-thread.test.ts \
                    tests/commands/session-thread-title.test.ts \
                    tests/commands/session-stop.test.ts \
                    tests/commands/session-list.test.ts \

--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -42,6 +42,19 @@ claude-hub プロジェクトで運用している Discord Bot の役割分担�
 2. 作成されたスレッドにメッセージを送信 → Channel-Supervisor が Claude Code に中継
 3. 終了時は `/session stop`（worktree は削除されるが branch は repo に保持される）
 
+### 既存スレッドにセッションを常駐させる（Issue #453）
+
+`/session start <branch>` を**スレッド内**で実行すると、新しいスレッドを作らず**そのスレッドに**セッションを bind する。
+
+- 対象: 稼働中セッションを持たないスレッド（bot が API で作ったスレッドを含む。例: corp の決裁フィードバックスレッド #449 / corp#127）
+- bind 後は通常のセッションスレッドと同じ挙動（発言が中継され、`/session status` `/session stop` `/session compact` が効く）
+- アーカイブ済みスレッドは bind 時に自動でアーカイブ解除する（ロック済みスレッドは失敗を返す）
+- **既に稼働中セッションを持つスレッド**で実行した場合は従来どおり親チャンネルに新スレッドを作る（同一スレッドから 2 本目のセッションを開始する動線は不変）
+- チャンネル直下での実行も従来どおり新スレッド作成（挙動不変）
+- アクセス制御は不変: 親チャンネル id に対する `allowFrom` で判定するため、親チャンネルが未許可のスレッドには bind できない
+
+> 制約: セッション付与は人間の `/session start` が起点であることは変わらない。bot 作成スレッドへの**自動**起動（人間の最初の発言でセッションを立てる）は Issue #454 で別途検討する。
+
 ### claude-hub 自体の修正
 1. Discord DM の `claudeHubExit` Bot を使用
 2. `--channels plugin:discord` 直結モードで Claude Code が動作

--- a/supervisor/src/commands/session.ts
+++ b/supervisor/src/commands/session.ts
@@ -413,40 +413,64 @@ async function handleStart(
   let createdThread: ThreadChannel | null = null;
 
   try {
-    // Issue #175: title by branch, with a sequence suffix only when another
-    // session is already live on the *same* branch (RW-046: same-branch
-    // multi-session is allowed). Counting same-branch (not channel-wide) keeps
-    // distinct branches at "(1)" so they read cleanly.
-    const sameBranchCount = sessionManager
-      .listRunningByChannel(channelName)
-      .filter((s) => s.branch === branch).length;
-    const sessionNum = sameBranchCount + 1;
-    const threadName = buildThreadTitle(
-      "running",
-      branch,
-      config.displayName,
-      sessionNum
-    );
+    // Issue #453: `/session start` invoked INSIDE a thread that has no live
+    // session binds the session to *that* thread instead of creating a sibling
+    // one. This is exactly what the dead-thread guidance already tells the user
+    // to do (status-reply.ts), and it is the only way a thread the Supervisor
+    // did not create — e.g. a decision thread opened by the corp bot (#449 /
+    // corp#127) — can get a resident session. A thread that already has a live
+    // session keeps the previous behaviour (create a sibling thread), so
+    // starting a second session from inside a working thread still works.
+    const bindTarget =
+      channel.isThread() && !sessionManager.has(channel.id)
+        ? (channel as ThreadChannel)
+        : null;
 
-    // Create a thread in the channel
-    // Get the text channel to create thread in
-    const parentChannel = channel.isThread() && channel.parent
-      ? channel.parent
-      : channel;
+    let thread: ThreadChannel;
+    if (bindTarget) {
+      // `createdThread` deliberately stays null here: the catch below deletes
+      // the thread it created, and deleting a thread we merely bound to would
+      // destroy a conversation the Supervisor does not own.
+      thread = bindTarget;
+      // An archived thread rejects sends, so unarchive before the session's
+      // first message. A locked thread throws here and the catch reports it.
+      if (thread.archived) await thread.setArchived(false);
+    } else {
+      // Issue #175: title by branch, with a sequence suffix only when another
+      // session is already live on the *same* branch (RW-046: same-branch
+      // multi-session is allowed). Counting same-branch (not channel-wide) keeps
+      // distinct branches at "(1)" so they read cleanly.
+      const sameBranchCount = sessionManager
+        .listRunningByChannel(channelName)
+        .filter((s) => s.branch === branch).length;
+      const sessionNum = sameBranchCount + 1;
+      const threadName = buildThreadTitle(
+        "running",
+        branch,
+        config.displayName,
+        sessionNum
+      );
 
-    if (!parentChannel.isTextBased() || parentChannel.isDMBased() || !("threads" in parentChannel)) {
-      await interaction.editReply({
-        content: "❌ このチャンネルではスレッドを作成できません。",
+      // Create a thread in the channel
+      // Get the text channel to create thread in
+      const parentChannel = channel.isThread() && channel.parent
+        ? channel.parent
+        : channel;
+
+      if (!parentChannel.isTextBased() || parentChannel.isDMBased() || !("threads" in parentChannel)) {
+        await interaction.editReply({
+          content: "❌ このチャンネルではスレッドを作成できません。",
+        });
+        return;
+      }
+
+      const textChannel = parentChannel as import("discord.js").TextChannel;
+      thread = await textChannel.threads.create({
+        name: threadName,
+        autoArchiveDuration: 10080, // 7 days
       });
-      return;
+      createdThread = thread;
     }
-
-    const textChannel = parentChannel as import("discord.js").TextChannel;
-    const thread = await textChannel.threads.create({
-      name: threadName,
-      autoArchiveDuration: 10080, // 7 days
-    });
-    createdThread = thread;
 
     // Start the session with the thread ID — runs claude in a per-branch
     // worktree (Issue #154).
@@ -459,8 +483,13 @@ async function handleStart(
     // #303: surface the model override so the user can confirm what was pinned
     // (omitted → recommended/environment default, so no line is shown).
     const modelLine = model ? `\n🤖 モデル: \`${model}\`` : "";
+    // #453: say which of the two things happened — a new thread was opened, or
+    // this existing thread just gained a session.
+    const header = bindTarget
+      ? `✅ **${config.displayName}** のセッションをこのスレッドに接続しました`
+      : `✅ **${config.displayName}** のセッションを開始しました`;
     await thread.send(
-      `✅ **${config.displayName}** のセッションを開始しました\n\n` +
+      `${header}\n\n` +
         `${locationLine}${modelLine}\n` +
         `📊 稼働中セッション: ${sessionManager.count()}/${MAX_SESSIONS}\n\n` +
         `このスレッドにメッセージを送信すると、Claude Code に中継されます。\n` +
@@ -468,7 +497,9 @@ async function handleStart(
     );
 
     await interaction.editReply({
-      content: `✅ セッションをスレッドで起動しました → ${thread}`,
+      content: bindTarget
+        ? "✅ このスレッドにセッションを接続しました。以降このスレッドの発言が中継されます。"
+        : `✅ セッションをスレッドで起動しました → ${thread}`,
     });
   } catch (err) {
     // Best-effort: drop the orphan thread so a failed start doesn't leave a
@@ -696,9 +727,13 @@ async function handleStop(
     // Update thread name to show stopped. markTitleStopped swaps a leading 🟢
     // (start) or ♻️ (resume) to 🔴 — shared with the reaper so both paths stay
     // consistent (Issue #175).
+    // #453: a thread the Supervisor merely bound to (not created) has no
+    // status emoji, so markTitleStopped returns the name unchanged. Renaming to
+    // the identical value would still spend one of Discord's scarce thread-
+    // rename slots and can stall the stop behind a rate limit — skip it.
     const thread = channel as ThreadChannel;
     const stoppedName = markTitleStopped(thread.name);
-    await thread.setName(stoppedName);
+    if (stoppedName !== thread.name) await thread.setName(stoppedName);
 
     // Archive and lock the thread
     await thread.setArchived(true);

--- a/supervisor/src/session/reaper.ts
+++ b/supervisor/src/session/reaper.ts
@@ -166,8 +166,10 @@ export class Reaper {
         await thread.send(Reaper.buildIdleNotice(idleMs, info));
         // Rename and archive. markTitleStopped also handles ♻️ resume threads,
         // which the old `.replace("🟢", ...)` skipped (Issue #175).
+        // #453: skip a no-op rename on a bound (Supervisor-not-created) thread,
+        // whose title carries no status emoji — see handleStop for the rationale.
         const stoppedName = markTitleStopped(thread.name);
-        await thread.setName(stoppedName);
+        if (stoppedName !== thread.name) await thread.setName(stoppedName);
         await thread.setArchived(true);
       }
     } catch (err) {

--- a/supervisor/src/session/status-reply.ts
+++ b/supervisor/src/session/status-reply.ts
@@ -12,6 +12,17 @@ import { getSessionByThreadId } from "../infra/db";
  */
 
 /**
+ * Reply for a thread with no session history.
+ *
+ * Issue #453: `/session start <branch>` run inside a thread now binds the
+ * session to THAT thread (commands/session.ts handleStart) instead of opening a
+ * sibling one, so this guidance is literally actionable where it is read — the
+ * previous wording sent the user to a command that used to move them elsewhere.
+ */
+const UNKNOWN_THREAD_REPLY =
+  "ℹ️ このスレッドにはセッション履歴がありません。`/session start <branch>` でこのスレッドにセッションを開始できます。";
+
+/**
  * Salvage reply for a thread whose Supervisor session is no longer active in
  * memory (Issue #169). Gives the claude_session_id and a ready-to-paste resume
  * command instead of silence.
@@ -33,13 +44,13 @@ export async function buildSalvageReply(
 ): Promise<string> {
   const verdict = knownVerdict ?? (await sessionManager.livenessOf(threadId));
   if (verdict === "unknown") {
-    return "ℹ️ このスレッドにはセッション履歴がありません。`/session start` で開始してください。";
+    return UNKNOWN_THREAD_REPLY;
   }
 
   const row = getSessionByThreadId(threadId);
   // verdict !== "unknown" guarantees a row exists, but guard defensively.
   if (!row) {
-    return "ℹ️ このスレッドにはセッション履歴がありません。`/session start` で開始してください。";
+    return UNKNOWN_THREAD_REPLY;
   }
 
   if (verdict === "alive") {
@@ -70,7 +81,7 @@ export async function buildSalvageReply(
   }
   return (
     `💀 このスレッドのセッションは停止しています${reason}。\n` +
-    "🔑 claude_session_id は未記録です（#167 導入前に開始されたセッション）。`/session start` で新規起動してください。"
+    "🔑 claude_session_id は未記録です（#167 導入前に開始されたセッション）。`/session start <branch>` でこのスレッドに新規セッションを開始してください。"
   );
 }
 

--- a/supervisor/tests/commands/session-start-in-thread.test.ts
+++ b/supervisor/tests/commands/session-start-in-thread.test.ts
@@ -1,0 +1,244 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { createSessionHandler } from "../../src/commands/session";
+
+/**
+ * Handler-level tests for Issue #453: `/session start <branch>` run INSIDE a
+ * thread binds the session to that thread instead of opening a sibling one.
+ *
+ * The motivating case is a thread the Supervisor did not create — a corp
+ * decision thread opened by a bot (#449) — which previously had no way to gain
+ * a resident session, so `@Supervisor` there only ever answered "このスレッドには
+ * セッション履歴がありません".
+ *
+ * Access is enforced before any of this (Issue #32), so these tests point the
+ * policy loader at a temp file that allows the fixture user on the fixture
+ * PARENT channel id (threads inherit their parent's opt-in).
+ */
+
+const FIXTURE_PARENT_CHANNEL_ID = "fixture-parent-channel";
+const FIXTURE_USER_ID = "fixture-user";
+const EXISTING_THREAD_ID = "existing-bot-thread";
+
+let accessDir: string;
+const prevAccessPath = process.env.SUPERVISOR_ACCESS_JSON_PATH;
+
+beforeEach(() => {
+  accessDir = mkdtempSync(join(tmpdir(), "session-start-in-thread-access-"));
+  const accessPath = join(accessDir, "access.json");
+  writeFileSync(
+    accessPath,
+    JSON.stringify({
+      groups: {
+        [FIXTURE_PARENT_CHANNEL_ID]: {
+          requireMention: true,
+          allowFrom: [FIXTURE_USER_ID],
+        },
+      },
+    }),
+  );
+  process.env.SUPERVISOR_ACCESS_JSON_PATH = accessPath;
+});
+
+afterEach(() => {
+  if (prevAccessPath === undefined)
+    delete process.env.SUPERVISOR_ACCESS_JSON_PATH;
+  else process.env.SUPERVISOR_ACCESS_JSON_PATH = prevAccessPath;
+  rmSync(accessDir, { recursive: true, force: true });
+});
+
+interface ReplyRecord {
+  kind: "reply" | "editReply";
+  content?: string;
+}
+
+function makeInteraction(opts: {
+  /** Invoke from inside a thread (default) or from the parent channel. */
+  inThread?: boolean;
+  /** Whether the invoking thread already has a live tracked session. */
+  hasSession?: boolean;
+  /** Whether the invoking thread is archived. */
+  archived?: boolean;
+  /** Make SessionManager.start fail, to exercise the cleanup path. */
+  startFails?: boolean;
+}) {
+  const inThread = opts.inThread ?? true;
+  const replies: ReplyRecord[] = [];
+  const startCalls: unknown[][] = [];
+  const setArchivedCalls: boolean[] = [];
+  const existingThreadSends: string[] = [];
+  const newThreadSends: string[] = [];
+  let threadCreated = false;
+  let createdThreadDeleted = false;
+  let existingThreadDeleted = false;
+
+  const newThread = {
+    id: "newly-created-thread",
+    send: async (m: string) => {
+      newThreadSends.push(m);
+    },
+    delete: async () => {
+      createdThreadDeleted = true;
+    },
+  };
+
+  const parentChannel = {
+    id: FIXTURE_PARENT_CHANNEL_ID,
+    name: "agent-base",
+    isThread: () => false,
+    isTextBased: () => true,
+    isDMBased: () => false,
+    threads: {
+      create: async () => {
+        threadCreated = true;
+        return newThread;
+      },
+    },
+  };
+
+  const threadChannel = {
+    id: EXISTING_THREAD_ID,
+    parentId: FIXTURE_PARENT_CHANNEL_ID,
+    parent: parentChannel,
+    isThread: () => true,
+    archived: opts.archived ?? false,
+    setArchived: async (value: boolean) => {
+      setArchivedCalls.push(value);
+    },
+    send: async (m: string) => {
+      existingThreadSends.push(m);
+    },
+    delete: async () => {
+      existingThreadDeleted = true;
+    },
+  };
+
+  const channel = inThread ? threadChannel : parentChannel;
+
+  const interaction = {
+    user: { id: FIXTURE_USER_ID },
+    options: {
+      getSubcommand: () => "start",
+      getString: (name: string) => (name === "branch" ? "feature-foo" : null),
+    },
+    channel,
+    deferred: false,
+    replied: false,
+    async reply(msg: { content?: string }) {
+      this.replied = true;
+      replies.push({ kind: "reply", content: msg.content });
+    },
+    async deferReply() {
+      this.deferred = true;
+    },
+    async editReply(msg: { content?: string }) {
+      replies.push({ kind: "editReply", content: msg.content });
+    },
+  };
+
+  const sessionManager = {
+    count: () => 0,
+    listRunning: () => [],
+    listRunningByChannel: () => [],
+    has: (threadId: string) =>
+      (opts.hasSession ?? false) && threadId === EXISTING_THREAD_ID,
+    start: (...args: unknown[]) => {
+      startCalls.push(args);
+      if (opts.startFails) throw new Error("worktree 作成に失敗");
+      return {
+        worktree: {
+          mainRepoDir: "/Users/x/agent-base",
+          path: "/Users/x/agent-base/.claude/worktrees/feature-foo",
+          branch: "feature-foo",
+        },
+      };
+    },
+  };
+
+  return {
+    run: () =>
+      createSessionHandler(sessionManager as never)(interaction as never),
+    replies,
+    startCalls,
+    setArchivedCalls,
+    existingThreadSends,
+    newThreadSends,
+    get threadCreated() {
+      return threadCreated;
+    },
+    get createdThreadDeleted() {
+      return createdThreadDeleted;
+    },
+    get existingThreadDeleted() {
+      return existingThreadDeleted;
+    },
+  };
+}
+
+describe("/session start inside a thread (Issue #453)", () => {
+  test("AC-1: binds to the invoking thread instead of creating a new one", async () => {
+    const h = makeInteraction({ inThread: true, hasSession: false });
+    await h.run();
+
+    expect(h.threadCreated).toBe(false);
+    expect(h.startCalls.length).toBe(1);
+    // start(config, threadId, branch, model) — the thread we were invoked in.
+    expect(h.startCalls[0]![1]).toBe(EXISTING_THREAD_ID);
+    expect(h.startCalls[0]![2]).toBe("feature-foo");
+
+    // Welcome message lands in the same thread, and says it bound here.
+    expect(h.existingThreadSends.length).toBe(1);
+    expect(h.existingThreadSends[0]).toContain("このスレッドに接続しました");
+    expect(h.newThreadSends.length).toBe(0);
+
+    const last = h.replies.at(-1)!;
+    expect(last.kind).toBe("editReply");
+    expect(last.content).toContain("このスレッドにセッションを接続しました");
+  });
+
+  test("AC-3: from the parent channel it still creates a new thread", async () => {
+    const h = makeInteraction({ inThread: false });
+    await h.run();
+
+    expect(h.threadCreated).toBe(true);
+    expect(h.startCalls[0]![1]).toBe("newly-created-thread");
+    expect(h.newThreadSends[0]).toContain("セッションを開始しました");
+    expect(h.replies.at(-1)!.content).toContain("セッションをスレッドで起動しました");
+  });
+
+  test("a thread that already has a live session keeps creating a sibling thread", async () => {
+    const h = makeInteraction({ inThread: true, hasSession: true });
+    await h.run();
+
+    expect(h.threadCreated).toBe(true);
+    expect(h.startCalls[0]![1]).toBe("newly-created-thread");
+    expect(h.existingThreadSends.length).toBe(0);
+  });
+
+  test("an archived thread is unarchived before the session's first message", async () => {
+    const h = makeInteraction({ inThread: true, archived: true });
+    await h.run();
+
+    expect(h.setArchivedCalls).toEqual([false]);
+    expect(h.existingThreadSends.length).toBe(1);
+  });
+
+  test("a failed start never deletes the thread it merely bound to", async () => {
+    const h = makeInteraction({ inThread: true, startFails: true });
+    await h.run();
+
+    expect(h.existingThreadDeleted).toBe(false);
+    expect(h.createdThreadDeleted).toBe(false);
+    expect(h.replies.at(-1)!.content).toContain("セッション起動に失敗");
+  });
+
+  test("a failed start still deletes the thread it created (unchanged)", async () => {
+    const h = makeInteraction({ inThread: false, startFails: true });
+    await h.run();
+
+    expect(h.createdThreadDeleted).toBe(true);
+    expect(h.replies.at(-1)!.content).toContain("セッション起動に失敗");
+  });
+});

--- a/supervisor/tests/commands/session-stop.test.ts
+++ b/supervisor/tests/commands/session-stop.test.ts
@@ -24,6 +24,8 @@ function makeInteraction(opts: {
   isThread?: boolean;
   hasSession?: boolean;
   stopImpl?: (...args: unknown[]) => unknown;
+  /** Thread title; defaults to a Supervisor-created one (status emoji). */
+  threadName?: string;
 }) {
   const replies: ReplyRecord[] = [];
   const stopCalls: unknown[][] = [];
@@ -32,7 +34,7 @@ function makeInteraction(opts: {
 
   const channel = {
     id: "thread-stop-1",
-    name: "🟢 feature-foo | agent-base",
+    name: opts.threadName ?? "🟢 feature-foo | agent-base",
     isThread: () => opts.isThread ?? true,
     setName: async (name: string) => {
       setNameCalls.push(name);
@@ -113,6 +115,21 @@ describe("/session stop dispatch (#349)", () => {
     const editReplies = h.replies.filter((r) => r.kind === "editReply");
     expect(editReplies).toHaveLength(1);
     expect(editReplies[0]!.content).toContain("停止しました");
+  });
+
+  test("#453: a bound thread with no status emoji is archived but not renamed", async () => {
+    // A thread the Supervisor bound to (rather than created) keeps its own
+    // title, so markTitleStopped has nothing to swap. Renaming it to the same
+    // value would burn one of Discord's scarce thread-rename slots for nothing.
+    const h = makeInteraction({
+      isThread: true,
+      hasSession: true,
+      threadName: "決裁: 朝レポ 2026-08-24",
+    });
+    await h.run();
+
+    expect(h.setNameCalls).toHaveLength(0);
+    expect(h.setArchivedCalls).toEqual([true]);
   });
 
   test("stop() failure → error surfaced, thread not renamed/archived", async () => {


### PR DESCRIPTION
Closes #453

## 変更概要

スレッド内で `/session start <branch>` を実行した場合、親チャンネルに新しいスレッドを作らず、**実行したそのスレッドに**セッションを bind する（Issue #453 の提案 A）。

bot が Discord API で作成したスレッド（corp の決裁フィードバックスレッド #449 / corp#127）は、これまでセッションを紐づける経路が無く、@メンションしても `このスレッドにはセッション履歴がありません` で終わっていた。bind 後は通常のセッションスレッドと同じく発言が中継され、`/session status` `/session stop` `/session compact` も効く。

| 実行位置 | 変更前 | 変更後 |
|---|---|---|
| チャンネル直下 | 新スレッド作成 | 変更なし |
| スレッド内（セッション無し） | 親に新スレッド作成 | **このスレッドに bind** |
| スレッド内（セッション稼働中） | 親に新スレッド作成 | 変更なし |

### 実装上のポイント

- 判定は `sessionManager.has(threadId)`（同期・tmux を叩かない）。Discord の 3 秒応答期限に影響しない
- bind 経路では `createdThread` を null のままにし、起動失敗時の cleanup が**他人のスレッドを削除しない**ようにした
- アーカイブ済みスレッドは bind 時に自動でアーカイブ解除（ロック済みは例外として報告）
- bind 先スレッドは自前のタイトルを保つ（`🟢` を付けない）。そのため stop / reaper の rename が no-op になるケースが生まれるので、同値 rename を skip した（Discord のスレッド rename はレート制限が厳しく、無駄な PATCH が停止処理を待たせるため）
- アクセス制御は不変（親チャンネル id に対する `allowFrom` 判定）。未許可チャンネルのスレッドには bind できない

### 提案 B（自動 bind）は未実装

Issue #453 の提案 B（bot 作成スレッドへ人間の最初の発言で**自動**起動）は本 PR に含めない。人間の 1 発言で `--dangerously-skip-permissions` セッションが自動起動する副作用（権限・セッション枠・対象スレッドの識別）を先に決める必要があるため、#454 で追跡する。Issue 本文の通り、提案 A のみで要望（1 アクションで常駐）は満たせる。

## 統合ジャーニーAC 検証結果

| # | 操作 | 期待結果 | 判定 | 検証 |
|---|---|---|---|---|
| 1 | bot 作成スレッド内で `/session start <branch>` | そのスレッドに bind され、以降の発言に応答 | PASS | `tests/commands/session-start-in-thread.test.ts` AC-1（新スレッド未作成 + `start()` が当該 thread id で呼ばれる + welcome がそのスレッドへ）。中継自体は `bot.ts` の `sessionManager.has(threadId)` 経路なので bind 成立で成立 |
| 2 | （B 採用時）bot 作成スレッドへの発言で自動起動 | — | 対象外 | 提案 B は #454 へ分離 |
| 3 | 通常チャンネルでの `/session start` | 従来挙動（新スレッド作成）が退行しない | PASS | 同ファイル AC-3 + 既存 `session-start-branch` / `session-start-access` / `session-thread-title` |

> 実 Discord での slash command 実行は「Bot は他 Bot の slash command を実行できない」という Discord 制約のため自動 E2E 不可（`docs/e2e-orchestrate.md`）。本リポの既定どおり hermetic な handler テストで回帰を担保し、実機確認は deploy 後の手動操作（`.claude/commands/local-e2e-discord.md`）で行う。

## テスト結果

```
bun test tests/commands tests/session/salvage-reply.test.ts tests/session/reaper.test.ts
→ 156 pass / 0 fail

bun test <ci.yml Unit Tests の全 106 ファイル>
→ 1446 pass / 29 skip / 0 fail（連続 2 回）
```

- `bunx tsc --noEmit`: エラーなし
- `bun scripts/lint-gating-coverage.ts`: 115 files — 113 gated / 2 excluded / 0 ungated（新規テストを `.github/workflows/ci.yml` の Unit Tests に登録済み）
- 補足: フル実行の 1 回目のみ 2 件 fail したが、同一コマンドの再実行 2 回はいずれも 0 fail。失敗テスト名を捕捉できていないため原因は未特定（未検証）。本変更が触る start / stop / status-reply 系は個別実行でも安定して green。

## 新規テスト

`supervisor/tests/commands/session-start-in-thread.test.ts`（6 件）

- AC-1: スレッド内実行 → 新スレッドを作らず当該スレッドに bind
- AC-3: チャンネル直下実行 → 従来どおり新スレッド作成
- 稼働中セッションを持つスレッド → 従来どおり兄弟スレッド作成
- アーカイブ済みスレッド → 送信前にアーカイブ解除
- 起動失敗時: bind 先スレッドは削除しない / 自分が作ったスレッドは従来どおり削除

`supervisor/tests/commands/session-stop.test.ts`: 絵文字なしスレッドで rename を呼ばずアーカイブのみ行うケースを追加


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - スレッド内で `/session start <branch>` を実行すると、既存スレッドにセッションを接続できるようになりました。
  - アーカイブ済みスレッドは自動的に復元されます。
  - 稼働中セッションがある場合やチャンネル直下からの実行時は、従来どおり新しいスレッドを作成します。

- **改善**
  - 既存スレッドのタイトルが不要に変更されないようになりました。
  - セッション開始案内とエラーメッセージを更新しました。

- **テスト**
  - スレッド内でのセッション開始、復元、停止動作を追加検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->