### PR TITLE
feat(session): 履歴ありスレッドへの着信メッセージで自動 resume する（#456）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -206,6 +206,7 @@ jobs:
                    tests/session/manager-input-ready.test.ts \
                    tests/session/progress-buffer.test.ts \
                    tests/session/salvage-reply.test.ts \
+                   tests/session/auto-resume.test.ts \
                    tests/session/slash-prefix.test.ts \
                    tests/session/thread-title.test.ts \
                    tests/session/worktree.test.ts \

--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -55,6 +55,21 @@ claude-hub プロジェクトで運用している Discord Bot の役割分担�
 
 > 制約: セッション付与は人間の `/session start` が起点であることは変わらない。bot 作成スレッドへの**自動**起動（人間の最初の発言でセッションを立てる）は Issue #454 で別途検討する。
 
+### 停止したセッションを着信メッセージで自動復帰する（Issue #456）
+
+セッションは放置で終了する（supervisor 再起動 = `supervisor_restart`、DispatchHealthReaper、idle reaper）。**セッション履歴が残るスレッドに次のメッセージが着信したら、supervisor がそのセッションを同じスレッドへ自動 resume して応答する**（message-triggered wake）。数時間〜数日単位で断続するラリー（corp の決裁フィードバックスレッド等）で、毎回手動 `/session resume <id>` を打つ必要がなくなる。
+
+- 対象: `sessions.db` に thread → session の行があり、`claude_session_id` が記録されていて、権威的 liveness 判定（#168）が `dead` のスレッド
+- 復帰先は**そのスレッド自身**（新スレッドを作らない）。復帰後、wake の契機になったメッセージはそのままセッションへ中継される
+- 復帰時はスレッドに `♻️ セッションが停止していたため自動で復帰しました` を post する（supervisor ログには `[AutoResume]` 行が残る）
+- **履歴のないスレッドでは何もしない**: 従来どおり案内のみで、セッションを勝手に新規起動しない
+- **失敗は fail-loud**: MAX_SESSIONS 満杯 / worktree 消失 / チャンネル未登録などで復帰できない場合、`⚠️ 自動復帰できませんでした` + 手動 resume コマンドをスレッドへ返す（黙って落とさない）
+- **プロセス生存中で Supervisor が追跡を見失っただけ**のセッションは resume しない（同一 cwd での二重 `claude --resume` は transcript を壊す。RW-046）。従来どおり salvage 案内を返す
+- 何度でも発動する（1 回きりではない）。復帰したセッションが再び終了すれば、次の着信でまた復帰する
+- アクセス制御は不変: `evaluateAccess` を通過したメッセージだけが wake の契機になるため、`requireMention=true` のチャンネルではメンション時のみ発動する
+
+実装: `supervisor/src/session/auto-resume.ts`（判定 + 実行）、`supervisor/src/bot.ts` の `messageCreate`（`sessionManager.has(threadId)` が false の分岐）。
+
 ### claude-hub 自体の修正
 1. Discord DM の `claudeHubExit` Bot を使用
 2. `--channels plugin:discord` 直結モードで Claude Code が動作

--- a/docs/bot-operations.md
+++ b/docs/bot-operations.md
@@ -67,8 +67,15 @@ claude-hub プロジェクトで運用している Discord Bot の役割分担�
 - **プロセス生存中で Supervisor が追跡を見失っただけ**のセッションは resume しない（同一 cwd での二重 `claude --resume` は transcript を壊す。RW-046）。従来どおり salvage 案内を返す
 - 何度でも発動する（1 回きりではない）。復帰したセッションが再び終了すれば、次の着信でまた復帰する
 - アクセス制御は不変: `evaluateAccess` を通過したメッセージだけが wake の契機になるため、`requireMention=true` のチャンネルではメンション時のみ発動する
+- 失敗理由のうち **Discord に出るのは定型文だけ**。`resumeSession` の生エラーは worktree 再生成失敗時に `projectDir` の絶対パスを含むため、生原因は supervisor ログにのみ残す（#236 / `RELAY_ERROR_USER_MESSAGE` と同じ契約）
+
+**kill-switch**: `AUTO_RESUME_DISABLED` を `0` 以外の値で設定するとこの経路だけを止められる（`CORP_BRIEF_WINDOW_DISABLED` と対称）。止めると #456 以前の挙動（salvage 案内のみ）に戻り、セッションは起動しない。誤 wake や連続失敗を bot 全体の停止なしに退避するための手段。
+
+> **運用上の制約（同一 `projectDir` の同時 wake）**: supervisor 再起動直後は多数のスレッドが同時に dead になるため、着信のたびにこの経路へ来る。同一チャンネルの**非 worktree**セッションは `projectDir` を共有するので、短時間に複数スレッドが復帰すると既知の relay-url 衝突（応答が別スレッドへ出る）を手動 resume より起こしやすい。多数の dead スレッドが一斉に動きそうな場面では、`AUTO_RESUME_DISABLED=1` で止めて順に手動 resume するか、worktree 運用のチャンネルを使うこと。
 
 実装: `supervisor/src/session/auto-resume.ts`（判定 + 実行）、`supervisor/src/bot.ts` の `messageCreate`（`sessionManager.has(threadId)` が false の分岐）。
+
+> 同じ分岐にある **#454 の朝レポ窓口の遅延再起動が先に走る**。窓口スレッド（`朝レポ窓口 <日付>`）は `/brief-window` を再注入して起動し直す専用経路を持ち、引き金の発言は中継せず「もう一度送ってください」と案内する（起動直後の TUI への入力取りこぼし対策。RW-025 / RW-047）。窓口以外のスレッドはスレッド名判定で素通りし、本節の自動 resume に落ちる。
 
 ### claude-hub 自体の修正
 1. Discord DM の `claudeHubExit` Bot を使用

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -48,7 +48,10 @@ import {
   buildSalvageReply,
   buildStatusReply,
 } from "./session/status-reply";
-import { autoResumeThread } from "./session/auto-resume";
+import {
+  autoResumeThread,
+  resolveWakeReply,
+} from "./session/auto-resume";
 import {
   onProgress,
   onLateResponse,
@@ -1665,61 +1668,36 @@ export async function startBot(token: string): Promise<void> {
     // policy sets requireMention still only wakes on a mention.
     if (!sessionManager.has(threadId)) {
       const wake = await autoResumeThread(sessionManager, threadId);
+      const botUserId = client.user?.id;
+      const { relay, reply } = await resolveWakeReply(wake, {
+        mentioned: botUserId ? message.mentions.users.has(botUserId) : false,
+        buildSalvage: (verdict) =>
+          buildSalvageReply(sessionManager, threadId, verdict),
+      });
 
-      if (wake.kind === "resumed") {
-        // notice === null when this message merely joined a resume another
-        // message in the same thread already started and announced.
-        if (wake.notice) {
-          try {
-            await (message.channel as ThreadChannel).send(wake.notice);
-          } catch (err) {
-            // The session IS live; losing the courtesy notice must not cost the
-            // user their message, so fall through to the relay either way.
-            console.warn(
-              `[Bot] Failed to post auto-resume notice in thread ${threadId}:`,
-              err
-            );
-          }
-        }
-        // Fall through: the relay below now finds the resumed session.
-      } else {
-        const botUserId = client.user?.id;
-        const mentioned = botUserId
-          ? message.mentions.users.has(botUserId)
-          : false;
-        // A failure is loud regardless of mention (#456 AC-3): the thread has a
-        // session the user is trying to reach, and silence here is exactly the
-        // dead-thread experience #456 exists to remove.
-        let reply: string | null = null;
-        if (wake.kind === "failed") {
-          reply = wake.notice;
-        } else if (mentioned) {
-          // The verdict is already resolved: "no-history" means unknown, and
-          // "not-resumable" carries the verdict it decided on. Passing it keeps
-          // this path to ONE liveness evaluation instead of a second tmux call
-          // that costs up to 2s on timeout (#238, same reason as #364).
-          reply = await buildSalvageReply(
-            sessionManager,
-            threadId,
-            wake.kind === "not-resumable" ? wake.verdict : "unknown"
-          );
-        }
-        if (!reply) {
-          console.debug(
-            `[Bot] Ignoring message in thread ${threadId} (no active session, kind=${wake.kind})`
-          );
-          return;
-        }
+      if (reply) {
         try {
           await (message.channel as ThreadChannel).send(reply);
         } catch (err) {
+          // On the resume path the session IS live, so losing the courtesy
+          // notice must not cost the user their message — fall through to the
+          // relay either way.
           console.error(
-            `[Bot] Failed to send salvage reply in thread ${threadId}:`,
+            `[Bot] Failed to reply in thread ${threadId}:`,
             err
+          );
+        }
+      }
+
+      if (!relay) {
+        if (!reply) {
+          console.debug(
+            `[Bot] Ignoring message in thread ${threadId} (no active session, wake=${wake.kind})`
           );
         }
         return;
       }
+      // Fall through: the relay below now finds the resumed session.
     }
 
     const thread = message.channel as ThreadChannel;

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -48,6 +48,7 @@ import {
   buildSalvageReply,
   buildStatusReply,
 } from "./session/status-reply";
+import { autoResumeThread } from "./session/auto-resume";
 import {
   onProgress,
   onLateResponse,
@@ -1653,27 +1654,72 @@ export async function startBot(token: string): Promise<void> {
     // claude_session_id and resume command so the session can be salvaged
     // (Issue #169). Non-mention messages keep the quiet debug log to avoid
     // spamming a dead thread on every line.
+    //
+    // Issue #456: before falling back to that guidance, treat the message
+    // itself as a wake trigger. A thread whose session was stopped (supervisor
+    // restart, dispatch-health reap, idle reap) still owns its history in
+    // sessions.db, so resume it INTO THIS THREAD and relay the message that
+    // woke it. Only threads with history do this — an unknown thread must never
+    // auto-start a session (AC-2) — and a failed resume is reported, not
+    // swallowed (AC-3). Access was already enforced above, so a channel whose
+    // policy sets requireMention still only wakes on a mention.
     if (!sessionManager.has(threadId)) {
-      const botUserId = client.user?.id;
-      const mentioned = botUserId
-        ? message.mentions.users.has(botUserId)
-        : false;
-      if (!mentioned) {
-        console.debug(
-          `[Bot] Ignoring message in thread ${threadId} (no active session)`
-        );
+      const wake = await autoResumeThread(sessionManager, threadId);
+
+      if (wake.kind === "resumed") {
+        // notice === null when this message merely joined a resume another
+        // message in the same thread already started and announced.
+        if (wake.notice) {
+          try {
+            await (message.channel as ThreadChannel).send(wake.notice);
+          } catch (err) {
+            // The session IS live; losing the courtesy notice must not cost the
+            // user their message, so fall through to the relay either way.
+            console.warn(
+              `[Bot] Failed to post auto-resume notice in thread ${threadId}:`,
+              err
+            );
+          }
+        }
+        // Fall through: the relay below now finds the resumed session.
+      } else {
+        const botUserId = client.user?.id;
+        const mentioned = botUserId
+          ? message.mentions.users.has(botUserId)
+          : false;
+        // A failure is loud regardless of mention (#456 AC-3): the thread has a
+        // session the user is trying to reach, and silence here is exactly the
+        // dead-thread experience #456 exists to remove.
+        let reply: string | null = null;
+        if (wake.kind === "failed") {
+          reply = wake.notice;
+        } else if (mentioned) {
+          // The verdict is already resolved: "no-history" means unknown, and
+          // "not-resumable" carries the verdict it decided on. Passing it keeps
+          // this path to ONE liveness evaluation instead of a second tmux call
+          // that costs up to 2s on timeout (#238, same reason as #364).
+          reply = await buildSalvageReply(
+            sessionManager,
+            threadId,
+            wake.kind === "not-resumable" ? wake.verdict : "unknown"
+          );
+        }
+        if (!reply) {
+          console.debug(
+            `[Bot] Ignoring message in thread ${threadId} (no active session, kind=${wake.kind})`
+          );
+          return;
+        }
+        try {
+          await (message.channel as ThreadChannel).send(reply);
+        } catch (err) {
+          console.error(
+            `[Bot] Failed to send salvage reply in thread ${threadId}:`,
+            err
+          );
+        }
         return;
       }
-      const salvage = await buildSalvageReply(sessionManager, threadId);
-      try {
-        await (message.channel as ThreadChannel).send(salvage);
-      } catch (err) {
-        console.error(
-          `[Bot] Failed to send salvage reply in thread ${threadId}:`,
-          err
-        );
-      }
-      return;
     }
 
     const thread = message.channel as ThreadChannel;

--- a/supervisor/src/session/auto-resume.ts
+++ b/supervisor/src/session/auto-resume.ts
@@ -126,26 +126,37 @@ async function attempt(
   threadId: string,
   deps: AutoResumeDeps,
 ): Promise<AutoResumeOutcome> {
-  const lookupSession = deps.lookupSession ?? getSessionByThreadId;
-  const channelMap = deps.channelMap ?? CHANNEL_MAP;
-
-  let row: SessionRow | undefined;
   try {
-    row = lookupSession(threadId);
+    return await decide(sessions, threadId, deps);
   } catch (err) {
-    // A DB read failure must not be reported as "no history" — that would let
-    // the caller answer "このスレッドにはセッション履歴がありません" for a thread
-    // that has one.
+    // The "never throws" contract, enforced in one place. bot.ts awaits this
+    // straight from the messageCreate handler, so a rejection escaping here is
+    // an unhandled rejection AND leaves the user with nothing back — exactly
+    // the silence #456 exists to remove. Anything unexpected (a locked DB in
+    // the history lookup, a liveness probe that blew up) becomes a loud outcome
+    // instead. Note this must NOT swallow it into "no-history": that would let
+    // the caller answer "セッション履歴がありません" for a thread that has one.
     const reason = err instanceof Error ? err.message : String(err);
-    console.error(`${LOG} DB lookup failed for thread ${threadId}: ${reason}`);
+    console.error(`${LOG} thread ${threadId} failed unexpectedly: ${reason}`);
     return {
       kind: "failed",
       reason,
       notice:
-        `⚠️ このスレッドのセッション履歴を読み出せませんでした: ${reason}\n` +
+        `⚠️ このスレッドのセッションを自動復帰できませんでした: ${reason}\n` +
         "supervisor のログを確認してください。",
     };
   }
+}
+
+async function decide(
+  sessions: AutoResumeSessions,
+  threadId: string,
+  deps: AutoResumeDeps,
+): Promise<AutoResumeOutcome> {
+  const lookupSession = deps.lookupSession ?? getSessionByThreadId;
+  const channelMap = deps.channelMap ?? CHANNEL_MAP;
+
+  const row: SessionRow | undefined = lookupSession(threadId);
   if (!row) return { kind: "no-history" };
 
   // Authoritative liveness (#168), not the DB status column: a supervisor that

--- a/supervisor/src/session/auto-resume.ts
+++ b/supervisor/src/session/auto-resume.ts
@@ -31,6 +31,27 @@ import type { Liveness } from "./manager";
 const LOG = "[AutoResume]";
 
 /**
+ * kill-switch の env 名。`CORP_BRIEF_WINDOW_DISABLED` と対称で、この経路だけを止める。
+ */
+export const AUTO_RESUME_DISABLED_ENV = "AUTO_RESUME_DISABLED";
+
+/**
+ * この経路を止める kill-switch。空文字 / `0` 以外なら停止。
+ *
+ * 着信メッセージのたびに走り、成功すればセッション枠を 1 つ埋める経路なので、
+ * 誤 wake や連発失敗を bot 全体の停止なしに退避できる手段を用意しておく
+ * （`isBriefDisabled` / `CORP_DISPATCH_DISABLED` と同じ形）。止まると `no-history`
+ * を返すため、呼び出し側は #456 以前の salvage 案内に戻るだけで、勝手にセッションを
+ * 起動することはない。
+ */
+export function isAutoResumeDisabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const raw = (env[AUTO_RESUME_DISABLED_ENV] ?? "").trim();
+  return raw.length > 0 && raw !== "0";
+}
+
+/**
  * The slice of {@link import("./manager").SessionManager} this module needs.
  * Structural, so the real manager satisfies it without a cast while tests can
  * drive the decision path with a stub.
@@ -87,6 +108,8 @@ export type AutoResumeOutcome =
 export interface AutoResumeDeps {
   channelMap?: ReadonlyMap<string, ChannelConfig>;
   lookupSession?: (threadId: string) => SessionRow | undefined;
+  /** Overridable for tests; defaults to `process.env` at the point of use. */
+  env?: Record<string, string | undefined>;
 }
 
 /**
@@ -136,14 +159,20 @@ async function attempt(
     // the history lookup, a liveness probe that blew up) becomes a loud outcome
     // instead. Note this must NOT swallow it into "no-history": that would let
     // the caller answer "セッション履歴がありません" for a thread that has one.
+    //
+    // The raw cause goes to the log ONLY (#236). `err` here is whatever the DB
+    // or the liveness probe threw, so `err.message` can be
+    // `ENOENT ... open '/Users/<name>/...'` and `String(err)` can be anything
+    // at all — posting it would put a home path in a thread that may have
+    // non-owner readers. `reason` stays raw for the log and for callers/tests.
     const reason = err instanceof Error ? err.message : String(err);
     console.error(`${LOG} thread ${threadId} failed unexpectedly: ${reason}`);
     return {
       kind: "failed",
       reason,
       notice:
-        `⚠️ このスレッドのセッションを自動復帰できませんでした: ${reason}\n` +
-        "supervisor のログを確認してください。",
+        "⚠️ このスレッドのセッションを自動復帰できませんでした（内部エラー）。\n" +
+        "詳細は Supervisor のログに記録されています。",
     };
   }
 }
@@ -153,6 +182,15 @@ async function decide(
   threadId: string,
   deps: AutoResumeDeps,
 ): Promise<AutoResumeOutcome> {
+  // kill-switch first: the cheapest possible early-out, and it must land before
+  // the DB read so a disabled route touches nothing. `no-history` (rather than a
+  // `failed` notice) is deliberate — disabling this feature should restore the
+  // pre-#456 experience exactly, not announce its own absence on every message.
+  if (isAutoResumeDisabled(deps.env)) {
+    console.debug(`${LOG} thread ${threadId}: disabled by ${AUTO_RESUME_DISABLED_ENV}`);
+    return { kind: "no-history" };
+  }
+
   const lookupSession = deps.lookupSession ?? getSessionByThreadId;
   const channelMap = deps.channelMap ?? CHANNEL_MAP;
 
@@ -178,7 +216,18 @@ async function decide(
     // ran. Resume needs its dir / flags, so there is nothing to launch.
     const reason = `チャンネル ${row.channel_name} は CHANNEL_MAP に未登録です`;
     console.warn(`${LOG} thread ${threadId}: ${reason}`);
-    return { kind: "failed", reason, notice: failureNotice(reason, claudeSessionId) };
+    // Authored here from a Discord channel name, so it carries no filesystem
+    // path and can be shown as-is — but it is passed explicitly rather than
+    // reusing `reason`, keeping "the notice never interpolates a raw reason"
+    // true by inspection at every call site.
+    return {
+      kind: "failed",
+      reason,
+      notice: failureNotice(
+        `チャンネル ${row.channel_name} は現在の設定に存在しません`,
+        claudeSessionId,
+      ),
+    };
   }
 
   console.log(
@@ -193,9 +242,15 @@ async function decide(
       row.branch,
     );
   } catch (err) {
+    // `resumeSession`'s worktree recovery interpolates `projectDir` into its
+    // error, so the notice gets the classified cause, never `reason` (#236).
     const reason = err instanceof Error ? err.message : String(err);
     console.warn(`${LOG} thread ${threadId} failed: ${reason}`);
-    return { kind: "failed", reason, notice: failureNotice(reason, claudeSessionId) };
+    return {
+      kind: "failed",
+      reason,
+      notice: failureNotice(classifyResumeFailure(reason), claudeSessionId),
+    };
   }
 
   console.log(
@@ -278,9 +333,55 @@ function withoutNotice(outcome: AutoResumeOutcome): AutoResumeOutcome {
   return outcome;
 }
 
-function failureNotice(reason: string, claudeSessionId: string): string {
+/**
+ * Build the AC-3 failure notice.
+ *
+ * `cause` MUST already be safe to show: either authored at the call site, or
+ * put through {@link classifyResumeFailure}. Never pass a raw `err.message` —
+ * that is the #236 vulnerability, and the parameter is named `cause` rather
+ * than `reason` so the outcome's raw `reason` field cannot be handed over by
+ * habit.
+ */
+function failureNotice(cause: string, claudeSessionId: string): string {
   return (
-    `⚠️ このスレッドのセッションを自動復帰できませんでした: ${reason}\n` +
+    `⚠️ このスレッドのセッションを自動復帰できませんでした: ${cause}\n` +
     `▶️ 手動で復帰する場合: \`/session resume ${claudeSessionId}\``
+  );
+}
+
+/**
+ * Known, path-free failure causes that may be shown in a thread.
+ *
+ * `resumeSession` throws two very different kinds of message. Its own guards
+ * are curated Japanese strings with no filesystem in them, but the worktree
+ * recovery path interpolates `projectDir`
+ * (`プロジェクトディレクトリが見つかりません: /Users/<name>/...`), and anything
+ * fs/child-process throws underneath carries `ENOENT ... open '/Users/<name>/…'`.
+ * Posting `err.message` verbatim is therefore the exact shape #236 removed from
+ * the relay path (see `RELAY_ERROR_USER_MESSAGE`): raw cause to the log, canned
+ * actionable text to the user.
+ *
+ * Matching is on a stable fragment of the manager's own wording, and it
+ * fails SAFE: a marker that stops matching falls through to
+ * {@link GENERIC_RESUME_FAILURE}, so drift costs diagnostic detail — never a
+ * leak. The returned text is written here rather than echoed from the match,
+ * so the thread never shows a string this module did not author.
+ */
+const KNOWN_RESUME_FAILURES: ReadonlyArray<{ marker: string; cause: string }> = [
+  // AC-3's motivating case; `manager.ts` throws `最大セッション数 (N) に達しています`.
+  { marker: "最大セッション数", cause: "最大セッション数に達しています" },
+  { marker: "resume 処理中", cause: "この session は現在 resume 処理中です" },
+  { marker: "既に稼働中", cause: "この session は既に稼働中です" },
+];
+
+/** Shown when the cause is not on the allowlist — assume it can carry a path. */
+const GENERIC_RESUME_FAILURE =
+  "内部エラー（詳細は Supervisor のログに記録されています）";
+
+/** Map a raw resume failure onto text that is safe to post in a thread. */
+export function classifyResumeFailure(reason: string): string {
+  return (
+    KNOWN_RESUME_FAILURES.find((known) => reason.includes(known.marker))?.cause ??
+    GENERIC_RESUME_FAILURE
   );
 }

--- a/supervisor/src/session/auto-resume.ts
+++ b/supervisor/src/session/auto-resume.ts
@@ -1,0 +1,215 @@
+import { CHANNEL_MAP, type ChannelConfig } from "../config/channels";
+import { getSessionByThreadId } from "../infra/db";
+import type { SessionRow } from "../infra/db";
+import type { Liveness } from "./manager";
+
+/**
+ * Message-triggered wake (Issue #456).
+ *
+ * A thread keeps its session history in sessions.db forever, but the session
+ * itself does not survive: a supervisor restart stops every session with
+ * `supervisor_restart`, the DispatchHealthReaper reaps quiet dispatch sessions,
+ * and the idle reaper eventually takes the rest. Before this module the next
+ * message in such a thread only ever produced resume *guidance*
+ * (session/status-reply.ts), so a conversation that rallies over hours or days
+ * — corp's decision-feedback threads are the motivating case — needed a manual
+ * `/session resume <id>` every single time.
+ *
+ * This turns an inbound message into the wake trigger: if the thread has
+ * history we resume THAT session INTO THAT SAME thread and let the caller relay
+ * the triggering message into it. Threads with no history are deliberately left
+ * alone — an unknown thread must never auto-start a session (#456 AC-2).
+ *
+ * Failures are loud (#456 AC-3): a full MAX_SESSIONS table or a deleted
+ * worktree returns a notice for the caller to post, never silence.
+ *
+ * The logic lives here rather than in bot.ts so it is unit-testable against the
+ * fake adapters, and so bot.ts's messageCreate path stays a thin dispatcher.
+ */
+
+/** Log prefix — AC-1 asserts the supervisor log records the auto-resume. */
+const LOG = "[AutoResume]";
+
+/**
+ * The slice of {@link import("./manager").SessionManager} this module needs.
+ * Structural, so the real manager satisfies it without a cast while tests can
+ * drive the decision path with a stub.
+ */
+export interface AutoResumeSessions {
+  livenessOf(threadId: string): Promise<Liveness>;
+  resumeSession(
+    config: ChannelConfig,
+    threadId: string,
+    claudeSessionId: string,
+    projectDir: string,
+    branch?: string | null,
+  ): Promise<unknown>;
+}
+
+export type AutoResumeOutcome =
+  /**
+   * Resumed into this thread; the caller relays the triggering message.
+   *
+   * `notice` is null for a caller that merely JOINED an in-flight attempt (see
+   * {@link inFlight}) — the resume was already announced for the message that
+   * started it, and repeating it would post the same banner once per line the
+   * user typed.
+   */
+  | { kind: "resumed"; claudeSessionId: string; notice: string | null }
+  /** Never-seen thread (#456 AC-2): the caller keeps its pre-#456 behaviour. */
+  | { kind: "no-history" }
+  /**
+   * History exists but resume must not be attempted. `alive` means the process
+   * is up while the Supervisor lost tracking — resuming a live claude session
+   * in the same cwd corrupts its transcript (RW-046) — and
+   * `no-claude-session-id` is a pre-#167 row with nothing to resume from. Both
+   * are exactly what the salvage reply already explains, so the caller falls
+   * back to it instead of inventing a second wording.
+   */
+  | {
+      kind: "not-resumable";
+      reason: "alive" | "no-claude-session-id";
+      /**
+       * The verdict this decision was made on. Handed to the caller so
+       * `buildSalvageReply` reuses it instead of re-deriving it — `livenessOf`
+       * runs a tmux call with a 2s timeout, and on timeout waits the full 2s
+       * (#238), so re-deriving costs the user real latency on every message in
+       * a dead thread (same reason #364 resolves it once).
+       */
+      verdict: Liveness;
+    }
+  /**
+   * Resume was attempted (or blocked) and failed: post `notice` (#456 AC-3).
+   * `notice` is null for a joined in-flight attempt, as for `resumed`.
+   */
+  | { kind: "failed"; reason: string; notice: string | null };
+
+export interface AutoResumeDeps {
+  channelMap?: ReadonlyMap<string, ChannelConfig>;
+  lookupSession?: (threadId: string) => SessionRow | undefined;
+}
+
+/**
+ * In-flight attempts, keyed by thread. A resume takes seconds (tmux spawn plus
+ * the "Resume from summary" confirm), and a user typing two lines in a row
+ * would otherwise start a second resume that `resumeSession` rejects — turning
+ * a normal double-post into a spurious failure notice. Sharing the promise
+ * makes the second message wait for the first attempt and observe its outcome.
+ */
+const inFlight = new Map<string, Promise<AutoResumeOutcome>>();
+
+/**
+ * Resume the thread's last session into the thread itself, if it has one.
+ *
+ * Never throws: every failure is reported as a `failed` outcome carrying the
+ * notice to post, so a caller in Discord's messageCreate path cannot be taken
+ * down by this (agent-output-quality #1 — no silent fallback, and no crash).
+ */
+export function autoResumeThread(
+  sessions: AutoResumeSessions,
+  threadId: string,
+  deps: AutoResumeDeps = {},
+): Promise<AutoResumeOutcome> {
+  const existing = inFlight.get(threadId);
+  // A joiner observes the initiator's outcome but must not repeat its notice.
+  if (existing) return existing.then(withoutNotice);
+
+  const run = attempt(sessions, threadId, deps).finally(() => {
+    inFlight.delete(threadId);
+  });
+  inFlight.set(threadId, run);
+  return run;
+}
+
+async function attempt(
+  sessions: AutoResumeSessions,
+  threadId: string,
+  deps: AutoResumeDeps,
+): Promise<AutoResumeOutcome> {
+  const lookupSession = deps.lookupSession ?? getSessionByThreadId;
+  const channelMap = deps.channelMap ?? CHANNEL_MAP;
+
+  let row: SessionRow | undefined;
+  try {
+    row = lookupSession(threadId);
+  } catch (err) {
+    // A DB read failure must not be reported as "no history" — that would let
+    // the caller answer "このスレッドにはセッション履歴がありません" for a thread
+    // that has one.
+    const reason = err instanceof Error ? err.message : String(err);
+    console.error(`${LOG} DB lookup failed for thread ${threadId}: ${reason}`);
+    return {
+      kind: "failed",
+      reason,
+      notice:
+        `⚠️ このスレッドのセッション履歴を読み出せませんでした: ${reason}\n` +
+        "supervisor のログを確認してください。",
+    };
+  }
+  if (!row) return { kind: "no-history" };
+
+  // Authoritative liveness (#168), not the DB status column: a supervisor that
+  // was SIGKILLed leaves `status='running'` behind on a process that is gone.
+  const verdict = await sessions.livenessOf(threadId);
+  if (verdict === "unknown") return { kind: "no-history" };
+  if (verdict === "alive") {
+    return { kind: "not-resumable", reason: "alive", verdict };
+  }
+
+  const claudeSessionId = row.claude_session_id;
+  if (!claudeSessionId) {
+    return { kind: "not-resumable", reason: "no-claude-session-id", verdict };
+  }
+
+  const config = channelMap.get(row.channel_name);
+  if (!config) {
+    // The channel was renamed or removed from CHANNEL_MAP since the session
+    // ran. Resume needs its dir / flags, so there is nothing to launch.
+    const reason = `チャンネル ${row.channel_name} は CHANNEL_MAP に未登録です`;
+    console.warn(`${LOG} thread ${threadId}: ${reason}`);
+    return { kind: "failed", reason, notice: failureNotice(reason, claudeSessionId) };
+  }
+
+  console.log(
+    `${LOG} resuming thread ${threadId} (channel ${config.channelName}, claude session ${claudeSessionId})`,
+  );
+  try {
+    await sessions.resumeSession(
+      config,
+      threadId,
+      claudeSessionId,
+      row.project_dir,
+      row.branch,
+    );
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    console.warn(`${LOG} thread ${threadId} failed: ${reason}`);
+    return { kind: "failed", reason, notice: failureNotice(reason, claudeSessionId) };
+  }
+
+  console.log(
+    `${LOG} resumed thread ${threadId} (claude session ${claudeSessionId})`,
+  );
+  return {
+    kind: "resumed",
+    claudeSessionId,
+    notice:
+      "♻️ セッションが停止していたため自動で復帰しました。前回の会話を引き継いで応答します。\n" +
+      `🔑 claude_session_id: \`${claudeSessionId}\``,
+  };
+}
+
+/** Strip the announcement from an outcome handed to a joined-in-flight caller. */
+function withoutNotice(outcome: AutoResumeOutcome): AutoResumeOutcome {
+  if (outcome.kind === "resumed" || outcome.kind === "failed") {
+    return { ...outcome, notice: null };
+  }
+  return outcome;
+}
+
+function failureNotice(reason: string, claudeSessionId: string): string {
+  return (
+    `⚠️ このスレッドのセッションを自動復帰できませんでした: ${reason}\n` +
+    `▶️ 手動で復帰する場合: \`/session resume ${claudeSessionId}\``
+  );
+}

--- a/supervisor/src/session/auto-resume.ts
+++ b/supervisor/src/session/auto-resume.ts
@@ -210,6 +210,66 @@ async function decide(
   };
 }
 
+/**
+ * What the caller should do with a wake outcome: what (if anything) to post in
+ * the thread, and whether the triggering message should still be relayed.
+ */
+export interface WakeReply {
+  /** True only after a successful resume — the session can receive the message. */
+  relay: boolean;
+  /** Text to post in the thread, or null to stay quiet. */
+  reply: string | null;
+}
+
+/**
+ * Map an {@link AutoResumeOutcome} onto the caller's two decisions.
+ *
+ * Split out of bot.ts (rather than inlined at the call site) for the same
+ * reason access-policy / slash-prefix / status-reply were: the branching is
+ * real logic with a spec attached (#456 AC-2 and AC-3 both live here), and
+ * inside bot.ts's messageCreate handler it is unreachable from a unit test.
+ *
+ * `buildSalvage` is injected because the salvage wording belongs to
+ * status-reply.ts and needs a live SessionManager; it is only awaited on the
+ * paths that actually use it.
+ */
+export async function resolveWakeReply(
+  outcome: AutoResumeOutcome,
+  opts: {
+    /** Whether the triggering message @-mentioned the bot. */
+    mentioned: boolean;
+    buildSalvage: (verdict: Liveness) => Promise<string>;
+  },
+): Promise<WakeReply> {
+  switch (outcome.kind) {
+    case "resumed":
+      // notice is null when this message joined a resume another message in the
+      // same thread already announced — relay it, but do not repeat the banner.
+      return { relay: true, reply: outcome.notice };
+    case "failed":
+      // Loud regardless of mention (#456 AC-3): the thread has a session the
+      // user is trying to reach, and silence here is the dead-thread experience
+      // #456 exists to remove. null only for a joined attempt, already reported.
+      return { relay: false, reply: outcome.notice };
+    case "not-resumable":
+      // Pass the verdict the decision was made on so the salvage path does not
+      // re-run livenessOf — a tmux call that waits the full 2s on timeout
+      // (#238, same reason as #364).
+      return {
+        relay: false,
+        reply: opts.mentioned ? await opts.buildSalvage(outcome.verdict) : null,
+      };
+    case "no-history":
+      // #456 AC-2: never auto-start here. Pre-#456 behaviour is preserved —
+      // guidance on a mention, silence otherwise so an unrelated thread is not
+      // spammed on every line.
+      return {
+        relay: false,
+        reply: opts.mentioned ? await opts.buildSalvage("unknown") : null,
+      };
+  }
+}
+
 /** Strip the announcement from an outcome handed to a joined-in-flight caller. */
 function withoutNotice(outcome: AutoResumeOutcome): AutoResumeOutcome {
   if (outcome.kind === "resumed" || outcome.kind === "failed") {

--- a/supervisor/tests/session/auto-resume.test.ts
+++ b/supervisor/tests/session/auto-resume.test.ts
@@ -1,0 +1,272 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+// Isolate DB writes from the real sessions.db (mirrors salvage-reply.test.ts).
+// Must precede any module that transitively loads infra/db, hence the dynamic
+// imports below.
+process.env.SUPERVISOR_DB_PATH = ":memory:";
+
+const { insertSession, updateSessionStatus, getDb, getSessionByThreadId } =
+  await import("../../src/infra/db");
+const { autoResumeThread } = await import("../../src/session/auto-resume");
+const { SessionManager } = await import("../../src/session/manager");
+const { createFakeEffects } = await import("../../src/session/adapters-fake");
+const { MAX_SESSIONS } = await import("../../src/config/channels");
+
+import type { ChannelConfig } from "../../src/config/channels";
+import type { FakeSessionEffects } from "../../src/session/adapters-fake";
+
+/**
+ * Message-triggered wake (Issue #456): an inbound message on a thread that has
+ * session history resumes that session INTO THAT THREAD instead of answering
+ * with manual `/session resume` guidance.
+ *
+ * The AC numbering below is the Issue's 統合ジャーニーAC list. Fake adapters
+ * stand in for tmux / iTerm2 / relay, so these run hermetically; AC-1's
+ * Discord-side half (the reply the user sees) is asserted through the returned
+ * notice, which bot.ts posts verbatim.
+ */
+
+const CHANNEL = "agent-base";
+
+/** Distinct ids per row — resume's single-flight guard is keyed by claude id. */
+function uuid(n: number): string {
+  const tail = String(n).padStart(12, "0");
+  return `11111111-1111-4111-8111-${tail}`;
+}
+
+describe("autoResumeThread (#456)", () => {
+  let manager: InstanceType<typeof SessionManager>;
+  let effects: FakeSessionEffects;
+  let projectDir: string;
+  let channelMap: Map<string, ChannelConfig>;
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    getDb().run("DELETE FROM sessions");
+    effects = createFakeEffects();
+    // resumePromptPollAttempts: 0 keeps the "Resume from summary" poll out of
+    // these tests (manager-resume.test.ts covers it).
+    manager = new SessionManager({
+      effects,
+      gracefulKillTimeoutMs: 0,
+      resumePromptPollAttempts: 0,
+    });
+    tmpRoot = mkdtempSync(join(tmpdir(), "auto-resume-"));
+    projectDir = join(tmpRoot, "project");
+    mkdirSync(projectDir, { recursive: true });
+    channelMap = new Map<string, ChannelConfig>([
+      [CHANNEL, { channelName: CHANNEL, dir: projectDir, displayName: "Agent Base" }],
+    ]);
+  });
+
+  afterEach(async () => {
+    await manager?.shutdownAll();
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  /** Insert a row for `threadId` and mark it stopped, as a real stop would. */
+  function seedStoppedSession(
+    threadId: string,
+    opts: { id?: string; claudeSessionId?: string | null; branch?: string | null } = {},
+  ): string | null {
+    const id = opts.id ?? `row-${threadId}`;
+    const claudeSessionId =
+      opts.claudeSessionId === undefined ? uuid(1) : opts.claudeSessionId;
+    const now = new Date().toISOString();
+    insertSession({
+      id,
+      channel_name: CHANNEL,
+      thread_id: threadId,
+      project_dir: projectDir,
+      pid: 4242,
+      claude_session_id: claudeSessionId,
+      started_at: now,
+      last_activity_at: now,
+      status: "running",
+      branch: opts.branch ?? null,
+    });
+    updateSessionStatus(id, "stopped", "supervisor_restart");
+    return claudeSessionId;
+  }
+
+  test("AC-1: a stopped thread is resumed into that same thread", async () => {
+    const threadId = "thread-ac1";
+    const claudeSessionId = seedStoppedSession(threadId)!;
+
+    const outcome = await autoResumeThread(manager, threadId, { channelMap });
+
+    expect(outcome.kind).toBe("resumed");
+    if (outcome.kind !== "resumed") throw new Error("unreachable");
+    expect(outcome.claudeSessionId).toBe(claudeSessionId);
+    // The reply the user sees is an actual answer path, not resume guidance.
+    expect(outcome.notice).toContain("自動で復帰");
+    expect(outcome.notice).not.toContain("セッション履歴がありません");
+
+    // Resumed in-place: the session is tracked under the SAME thread id, so the
+    // caller's relay finds it and the triggering message reaches Claude.
+    expect(manager.has(threadId)).toBe(true);
+    const cmd = effects.tmux.getCommand(`claude-${threadId.slice(0, 12)}`) ?? "";
+    expect(cmd).toContain(`--resume ${claudeSessionId}`);
+    expect(cmd).toContain(`cd "${projectDir}"`);
+  });
+
+  test("AC-2: a thread with no history never starts a session", async () => {
+    const outcome = await autoResumeThread(manager, "thread-never-seen", {
+      channelMap,
+    });
+
+    expect(outcome.kind).toBe("no-history");
+    expect(manager.count()).toBe(0);
+    expect(manager.has("thread-never-seen")).toBe(false);
+    expect(effects.tmux.list()).toEqual([]);
+  });
+
+  test("AC-3: a full session table fails loudly instead of silently", async () => {
+    // Saturate the manager with live sessions so resume hits the guard.
+    for (let i = 0; i < MAX_SESSIONS; i++) {
+      await manager.resumeSession(
+        channelMap.get(CHANNEL)!,
+        `filler-thread-${i}`,
+        uuid(100 + i),
+        projectDir,
+      );
+    }
+    expect(manager.count()).toBe(MAX_SESSIONS);
+
+    const threadId = "thread-ac3";
+    const claudeSessionId = seedStoppedSession(threadId, { id: "row-ac3" })!;
+
+    const outcome = await autoResumeThread(manager, threadId, { channelMap });
+
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") throw new Error("unreachable");
+    expect(outcome.reason).toContain("最大セッション数");
+    expect(outcome.notice).toContain("最大セッション数");
+    // Still actionable: the user can free a slot and resume by hand.
+    expect(outcome.notice).toContain(`/session resume ${claudeSessionId}`);
+    expect(manager.has(threadId)).toBe(false);
+  });
+
+  test("AC-4: wake is repeatable, not once-per-thread", async () => {
+    const threadId = "thread-ac4";
+    const claudeSessionId = seedStoppedSession(threadId)!;
+
+    const first = await autoResumeThread(manager, threadId, { channelMap });
+    expect(first.kind).toBe("resumed");
+
+    // The resumed session dies again (supervisor restart / reaper).
+    await manager.stop(threadId, "supervisor_restart");
+    expect(manager.has(threadId)).toBe(false);
+    // Resume wrote a fresh row for the same thread; that row is what the second
+    // wake reads, so the history the thread carries survives the round trip.
+    expect(getSessionByThreadId(threadId)?.claude_session_id).toBe(claudeSessionId);
+
+    const second = await autoResumeThread(manager, threadId, { channelMap });
+    expect(second.kind).toBe("resumed");
+    if (second.kind !== "resumed") throw new Error("unreachable");
+    expect(second.claudeSessionId).toBe(claudeSessionId);
+    expect(manager.has(threadId)).toBe(true);
+  });
+
+  test("a session the Supervisor merely lost track of is not resumed", async () => {
+    const threadId = "thread-alive";
+    insertSession({
+      id: "row-alive",
+      channel_name: CHANNEL,
+      thread_id: threadId,
+      project_dir: projectDir,
+      pid: 4242,
+      claude_session_id: uuid(2),
+      started_at: new Date().toISOString(),
+      last_activity_at: new Date().toISOString(),
+      status: "running",
+    });
+    // Reality agrees the process is up: the recorded pid answers, and a tmux
+    // session exists under the deterministic `claude-<threadId12>` name.
+    effects.process.alivePids.add(4242);
+    await effects.tmux.newSession(`claude-${threadId.slice(0, 12)}`, "claude");
+
+    const outcome = await autoResumeThread(manager, threadId, { channelMap });
+
+    // Resuming a live claude session in the same cwd corrupts its transcript
+    // (RW-046), so the caller falls back to the salvage wording instead.
+    expect(outcome).toEqual({
+      kind: "not-resumable",
+      reason: "alive",
+      // Handed to the caller so buildSalvageReply reuses it (#364 pattern).
+      verdict: "alive",
+    });
+    expect(manager.has(threadId)).toBe(false);
+  });
+
+  test("a pre-#167 row with no claude_session_id is not resumable", async () => {
+    const threadId = "thread-legacy";
+    seedStoppedSession(threadId, { claudeSessionId: null });
+
+    const outcome = await autoResumeThread(manager, threadId, { channelMap });
+
+    expect(outcome).toEqual({
+      kind: "not-resumable",
+      reason: "no-claude-session-id",
+      verdict: "dead",
+    });
+    expect(manager.has(threadId)).toBe(false);
+  });
+
+  test("an unregistered channel fails loudly rather than silently skipping", async () => {
+    const threadId = "thread-unknown-channel";
+    const claudeSessionId = seedStoppedSession(threadId)!;
+
+    const outcome = await autoResumeThread(manager, threadId, {
+      channelMap: new Map(),
+    });
+
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") throw new Error("unreachable");
+    expect(outcome.reason).toContain(CHANNEL);
+    expect(outcome.notice).toContain(`/session resume ${claudeSessionId}`);
+  });
+
+  test("concurrent messages on one thread share a single resume attempt", async () => {
+    const threadId = "thread-concurrent";
+    seedStoppedSession(threadId);
+
+    // Two messages arriving back-to-back must not race into a second
+    // `claude --resume` (which resumeSession would reject, turning a normal
+    // double-post into a spurious failure notice).
+    const [a, b] = await Promise.all([
+      autoResumeThread(manager, threadId, { channelMap }),
+      autoResumeThread(manager, threadId, { channelMap }),
+    ]);
+
+    expect(a.kind).toBe("resumed");
+    expect(b.kind).toBe("resumed");
+    // Exactly one resume ran...
+    expect(manager.count()).toBe(1);
+    expect(effects.tmux.list()).toEqual([`claude-${threadId.slice(0, 12)}`]);
+    // ...and only the message that started it announces the wake, so a user
+    // typing two lines does not get the banner twice.
+    if (a.kind !== "resumed" || b.kind !== "resumed") {
+      throw new Error("unreachable");
+    }
+    expect(a.notice).toContain("自動で復帰");
+    expect(b.notice).toBeNull();
+  });
+
+  test("a DB read failure is reported, never mistaken for 'no history'", async () => {
+    const outcome = await autoResumeThread(manager, "thread-db-broken", {
+      channelMap,
+      lookupSession: () => {
+        throw new Error("database is locked");
+      },
+    });
+
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") throw new Error("unreachable");
+    expect(outcome.reason).toContain("database is locked");
+    expect(outcome.notice).not.toContain("セッション履歴がありません");
+  });
+});

--- a/supervisor/tests/session/auto-resume.test.ts
+++ b/supervisor/tests/session/auto-resume.test.ts
@@ -10,9 +10,13 @@ process.env.SUPERVISOR_DB_PATH = ":memory:";
 
 const { insertSession, updateSessionStatus, getDb, getSessionByThreadId } =
   await import("../../src/infra/db");
-const { autoResumeThread, resolveWakeReply } = await import(
-  "../../src/session/auto-resume"
-);
+const {
+  autoResumeThread,
+  resolveWakeReply,
+  classifyResumeFailure,
+  isAutoResumeDisabled,
+  AUTO_RESUME_DISABLED_ENV,
+} = await import("../../src/session/auto-resume");
 const { SessionManager } = await import("../../src/session/manager");
 const { createFakeEffects } = await import("../../src/session/adapters-fake");
 const { MAX_SESSIONS } = await import("../../src/config/channels");
@@ -321,6 +325,92 @@ describe("autoResumeThread (#456)", () => {
     if (outcome.kind !== "failed") throw new Error("unreachable");
     expect(outcome.reason).toContain("tmux control channel exploded");
     expect(outcome.notice).toContain("自動復帰できませんでした");
+  });
+
+  // PR #457 review (must ×3, and CodeRabbit CLI minor): `resumeSession`'s
+  // worktree recovery interpolates `projectDir` into its error, so posting
+  // `err.message` puts an absolute home path in a thread that may have
+  // non-owner readers. Same contract as RELAY_ERROR_USER_MESSAGE (#236): raw
+  // cause to the log, canned actionable text to the user.
+  test("a resume failure carrying an absolute path never posts it to the thread", async () => {
+    const threadId = "thread-path-leak";
+    const claudeSessionId = seedStoppedSession(threadId)!;
+    const leaky = {
+      livenessOf: async () => "dead" as const,
+      resumeSession: async () => {
+        throw new Error(
+          `プロジェクトディレクトリが見つかりません: ${projectDir}（worktree が削除された可能性があります）`,
+        );
+      },
+    };
+
+    const outcome = await autoResumeThread(leaky, threadId, { channelMap });
+
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") throw new Error("unreachable");
+    // The raw cause survives for the log and for callers.
+    expect(outcome.reason).toContain(projectDir);
+    // …but never reaches Discord. Assert on the path itself, not on a wording,
+    // so the test keeps meaning if the canned text is reworded.
+    expect(outcome.notice).not.toContain(projectDir);
+    // The `/session resume` hint is the only slash that belongs here; anything
+    // rooted at a real filesystem prefix is the leak this test exists to catch.
+    expect(outcome.notice).not.toMatch(/\/(Users|home|var|tmp|private)\//);
+    // Still fail-loud and actionable (AC-3).
+    expect(outcome.notice).toContain("自動復帰できませんでした");
+    expect(outcome.notice).toContain("Supervisor のログ");
+  });
+
+  test("an unexpected exception carrying an absolute path is logged, not posted", async () => {
+    const threadId = "thread-unexpected-path";
+    const outcome = await autoResumeThread(manager, threadId, {
+      channelMap,
+      lookupSession: () => {
+        throw new Error(`ENOENT: no such file or directory, open '${projectDir}/sessions.db'`);
+      },
+    });
+
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") throw new Error("unreachable");
+    expect(outcome.reason).toContain(projectDir);
+    expect(outcome.notice).not.toContain(projectDir);
+    expect(outcome.notice).toContain("自動復帰できませんでした");
+  });
+
+  // PR #457 review (should ×2): a route that fires on every inbound message and
+  // consumes a session slot needs an escape hatch short of stopping the bot.
+  test("the kill-switch disables the route without auto-starting anything", async () => {
+    const threadId = "thread-killswitch";
+    seedStoppedSession(threadId);
+
+    const outcome = await autoResumeThread(manager, threadId, {
+      channelMap,
+      env: { [AUTO_RESUME_DISABLED_ENV]: "1" },
+    });
+
+    // `no-history`, so bot.ts falls back to the pre-#456 salvage guidance
+    // rather than announcing the feature's absence on every message.
+    expect(outcome).toEqual({ kind: "no-history" });
+    expect(manager.has(threadId)).toBe(false);
+    expect(manager.count()).toBe(0);
+  });
+
+  test("the kill-switch is off for an unset or '0' value", async () => {
+    expect(isAutoResumeDisabled({})).toBe(false);
+    expect(isAutoResumeDisabled({ [AUTO_RESUME_DISABLED_ENV]: "" })).toBe(false);
+    expect(isAutoResumeDisabled({ [AUTO_RESUME_DISABLED_ENV]: "0" })).toBe(false);
+    expect(isAutoResumeDisabled({ [AUTO_RESUME_DISABLED_ENV]: "1" })).toBe(true);
+    expect(isAutoResumeDisabled({ [AUTO_RESUME_DISABLED_ENV]: "true" })).toBe(true);
+  });
+
+  test("classifyResumeFailure keeps known causes and buries unknown ones", () => {
+    expect(classifyResumeFailure("最大セッション数 (10) に達しています")).toContain(
+      "最大セッション数",
+    );
+    // Unknown → generic, and specifically NOT an echo of the input.
+    const leaked = classifyResumeFailure(`ENOENT ... open '${projectDir}'`);
+    expect(leaked).not.toContain(projectDir);
+    expect(leaked).toContain("Supervisor のログ");
   });
 });
 

--- a/supervisor/tests/session/auto-resume.test.ts
+++ b/supervisor/tests/session/auto-resume.test.ts
@@ -10,7 +10,9 @@ process.env.SUPERVISOR_DB_PATH = ":memory:";
 
 const { insertSession, updateSessionStatus, getDb, getSessionByThreadId } =
   await import("../../src/infra/db");
-const { autoResumeThread } = await import("../../src/session/auto-resume");
+const { autoResumeThread, resolveWakeReply } = await import(
+  "../../src/session/auto-resume"
+);
 const { SessionManager } = await import("../../src/session/manager");
 const { createFakeEffects } = await import("../../src/session/adapters-fake");
 const { MAX_SESSIONS } = await import("../../src/config/channels");
@@ -256,6 +258,34 @@ describe("autoResumeThread (#456)", () => {
     expect(b.notice).toBeNull();
   });
 
+  test("a joined attempt on a non-resumable thread sees the same verdict", async () => {
+    // The joiner path strips the notice from resumed/failed outcomes; verdict
+    // outcomes carry no notice, so they must pass through untouched.
+    const threadId = "thread-joined-alive";
+    seedStoppedSession(threadId);
+    let release: (() => void) | undefined;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const slow = {
+      livenessOf: async () => {
+        await gate;
+        return "alive" as const;
+      },
+      resumeSession: async () => {
+        throw new Error("must not be reached");
+      },
+    };
+
+    const first = autoResumeThread(slow, threadId, { channelMap });
+    const joined = autoResumeThread(slow, threadId, { channelMap });
+    release!();
+    const [a, b] = await Promise.all([first, joined]);
+
+    expect(a).toEqual({ kind: "not-resumable", reason: "alive", verdict: "alive" });
+    expect(b).toEqual(a);
+  });
+
   test("a DB read failure is reported, never mistaken for 'no history'", async () => {
     const outcome = await autoResumeThread(manager, "thread-db-broken", {
       channelMap,
@@ -291,5 +321,104 @@ describe("autoResumeThread (#456)", () => {
     if (outcome.kind !== "failed") throw new Error("unreachable");
     expect(outcome.reason).toContain("tmux control channel exploded");
     expect(outcome.notice).toContain("自動復帰できませんでした");
+  });
+});
+
+/**
+ * The caller-side half of the decision: given an outcome, what does bot.ts post
+ * and does the triggering message still get relayed? bot.ts's messageCreate
+ * handler is unreachable from a unit test, so this mapping lives here (same
+ * split as access-policy / slash-prefix / status-reply).
+ */
+describe("resolveWakeReply (#456)", () => {
+  const SALVAGE = "salvage-text";
+  /** Records what verdict, if any, the salvage builder was asked for. */
+  function salvageSpy() {
+    const asked: string[] = [];
+    return {
+      asked,
+      buildSalvage: async (verdict: string) => {
+        asked.push(verdict);
+        return SALVAGE;
+      },
+    };
+  }
+
+  test("resumed → relays the message and posts the wake notice", async () => {
+    const spy = salvageSpy();
+    expect(
+      await resolveWakeReply(
+        { kind: "resumed", claudeSessionId: "id", notice: "♻️ notice" },
+        { mentioned: false, buildSalvage: spy.buildSalvage }
+      )
+    ).toEqual({ relay: true, reply: "♻️ notice" });
+    expect(spy.asked).toEqual([]);
+  });
+
+  test("resumed by a joined attempt → relays without repeating the notice", async () => {
+    const spy = salvageSpy();
+    expect(
+      await resolveWakeReply(
+        { kind: "resumed", claudeSessionId: "id", notice: null },
+        { mentioned: true, buildSalvage: spy.buildSalvage }
+      )
+    ).toEqual({ relay: true, reply: null });
+  });
+
+  test("AC-3: failed → posts the reason even without a mention, and stops", async () => {
+    const spy = salvageSpy();
+    expect(
+      await resolveWakeReply(
+        { kind: "failed", reason: "満杯", notice: "⚠️ notice" },
+        { mentioned: false, buildSalvage: spy.buildSalvage }
+      )
+    ).toEqual({ relay: false, reply: "⚠️ notice" });
+    // The failure wording is authoritative here — no salvage second-guessing.
+    expect(spy.asked).toEqual([]);
+  });
+
+  test("not-resumable → salvage on a mention, reusing the resolved verdict", async () => {
+    const spy = salvageSpy();
+    expect(
+      await resolveWakeReply(
+        { kind: "not-resumable", reason: "alive", verdict: "alive" },
+        { mentioned: true, buildSalvage: spy.buildSalvage }
+      )
+    ).toEqual({ relay: false, reply: SALVAGE });
+    // Reused, not re-derived: livenessOf waits the full 2s on timeout (#238).
+    expect(spy.asked).toEqual(["alive"]);
+  });
+
+  test("not-resumable without a mention → stays quiet", async () => {
+    const spy = salvageSpy();
+    expect(
+      await resolveWakeReply(
+        { kind: "not-resumable", reason: "no-claude-session-id", verdict: "dead" },
+        { mentioned: false, buildSalvage: spy.buildSalvage }
+      )
+    ).toEqual({ relay: false, reply: null });
+    expect(spy.asked).toEqual([]);
+  });
+
+  test("AC-2: no-history → guidance on a mention, never a relay", async () => {
+    const spy = salvageSpy();
+    expect(
+      await resolveWakeReply(
+        { kind: "no-history" },
+        { mentioned: true, buildSalvage: spy.buildSalvage }
+      )
+    ).toEqual({ relay: false, reply: SALVAGE });
+    expect(spy.asked).toEqual(["unknown"]);
+  });
+
+  test("AC-2: no-history without a mention → silence, no session started", async () => {
+    const spy = salvageSpy();
+    expect(
+      await resolveWakeReply(
+        { kind: "no-history" },
+        { mentioned: false, buildSalvage: spy.buildSalvage }
+      )
+    ).toEqual({ relay: false, reply: null });
+    expect(spy.asked).toEqual([]);
   });
 });

--- a/supervisor/tests/session/auto-resume.test.ts
+++ b/supervisor/tests/session/auto-resume.test.ts
@@ -269,4 +269,27 @@ describe("autoResumeThread (#456)", () => {
     expect(outcome.reason).toContain("database is locked");
     expect(outcome.notice).not.toContain("セッション履歴がありません");
   });
+
+  test("a liveness probe that throws is reported, not left as a rejection", async () => {
+    // bot.ts awaits this straight from the messageCreate handler, so a
+    // rejection would be an unhandled rejection AND leave the user with no
+    // reply at all (PR #457 review, CodeRabbit major).
+    const threadId = "thread-liveness-broken";
+    seedStoppedSession(threadId);
+    const exploding = {
+      livenessOf: async () => {
+        throw new Error("tmux control channel exploded");
+      },
+      resumeSession: async () => {
+        throw new Error("must not be reached");
+      },
+    };
+
+    const outcome = await autoResumeThread(exploding, threadId, { channelMap });
+
+    expect(outcome.kind).toBe("failed");
+    if (outcome.kind !== "failed") throw new Error("unreachable");
+    expect(outcome.reason).toContain("tmux control channel exploded");
+    expect(outcome.notice).toContain("自動復帰できませんでした");
+  });
 });


### PR DESCRIPTION
Closes #456

## 背景

セッションは数時間の放置で終了する（supervisor 再起動 = `supervisor_restart` / DispatchHealthReaper / idle reaper）。終了後にスレッドへ書き込むと「このスレッドのセッションは停止しています → `/session resume <id>`」で止まり、毎回手動 resume が要る。corp の決裁フィードバックスレッドのように数時間〜数日単位で断続するラリーでは、これが実質的な会話の断絶になっていた（corp#128 の「ループ外配置」状態）。

## 変更内容

**セッション履歴が残るスレッドへの着信メッセージを wake の契機にする**（message-triggered wake）。

| ファイル | 内容 |
|---|---|
| `supervisor/src/session/auto-resume.ts` (新規) | wake の判定と実行。DB 履歴 → 権威的 liveness 判定（#168） → `resumeSession` を**同じスレッドへ**。同時着信の単一化つき |
| `supervisor/src/bot.ts` | `messageCreate` の「in-memory セッション無し」分岐で `autoResumeThread` を呼び、成功時は通知 post → そのまま relay へ fall through |
| `supervisor/tests/session/auto-resume.test.ts` (新規) | AC-1〜4 + 非 resume 経路の単体テスト（9 件） |
| `.github/workflows/ci.yml` | 新テストを gating リストへ追加（`lint-gating-coverage` 要件） |
| `docs/bot-operations.md` | 運用挙動を追記 |

### 設計上のポイント

- **履歴のないスレッドでは何もしない**（#456 AC-2）。従来どおり案内のみで、勝手に新規セッションを起動しない
- **fail-loud**（AC-3）。MAX_SESSIONS 満杯 / worktree 消失 / チャンネル未登録は `⚠️ 自動復帰できませんでした` + 手動 resume コマンドをスレッドへ返す。メンション有無に関わらず出す（silent が #456 の直したい体験そのもののため）
- **プロセス生存中で追跡だけ失ったセッションは resume しない**。同一 cwd での二重 `claude --resume` は transcript を壊す（RW-046）。従来の salvage 案内へ委ねる
- **永続化は追加不要**。thread → session の対応は `sessions.db` の `sessions` 行（`thread_id` / `claude_session_id` / `project_dir` / `branch`）に既にあり、プロセス再起動を跨いで残る。resume は毎回新しい行を書くので、AC-4 の「何度でも」も自然に満たす
- **同一スレッドの同時着信は 1 回の resume を共有**する。resume は数秒かかるため、ユーザーが 2 行続けて打つと 2 本目が `resumeSession` に弾かれて偽の失敗通知になる。in-flight promise を共有し、通知は契機側だけが出す
- **liveness は 1 回しか評価しない**。`not-resumable` は判定に使った verdict を持ち回り、`buildSalvageReply` に渡す（`livenessOf` は tmux 呼び出しで timeout 時に最大 2s 待つ。#238 / #364 と同じ理由）
- **アクセス制御は不変**。`evaluateAccess` を通過したメッセージだけが契機になるため、`requireMention=true` のチャンネルはメンション時のみ wake する（claudeHubExit の非 primary チャンネル方針を維持）
- ロジックを bot.ts ではなく独立モジュールに置いたのは、fake adapters で単体検証できるようにするため

## 統合ジャーニーAC の検証状況

| AC | 内容 | 検証 | 結果 |
|---|---|---|---|
| AC-1 | 停止済みスレッドへの投稿で自動 resume され応答が返る | `AC-1: a stopped thread is resumed into that same thread` — 同一 thread id でセッションが tracked になり、tmux コマンドが `--resume <id>` + 記録済み `cd <projectDir>`。応答文が resume 案内でないことも assert | PASS |
| AC-2 | 履歴のないスレッドでは自動起動しない | `AC-2: a thread with no history never starts a session` — `no-history` を返し、session 数 0 / tmux セッション 0 | PASS |
| AC-3 | MAX_SESSIONS 満杯時に silent 失敗せず理由が返る | `AC-3: a full session table fails loudly instead of silently` — 実際に MAX_SESSIONS まで埋めてから wake。notice に「最大セッション数」と手動 resume コマンド、ログに理由 | PASS |
| AC-4 | 1 回きりでなく何度でも復帰する | `AC-4: wake is repeatable, not once-per-thread` — resume → stop → 再 wake で 2 回とも `resumed`、履歴も維持 | PASS |

補助（AC 外だが回帰を止めるもの）:

- 追跡喪失（alive）セッションは resume せず verdict を持ち回る
- `claude_session_id` 未記録の #167 以前の行は resume しない
- チャンネル未登録は fail-loud
- 同時着信は resume 1 回 + 通知 1 回
- DB 読み出し失敗を「履歴なし」と誤報しない

> 実機（Discord + 実 supervisor 再起動）での通し確認は merge 後に行う。CI ではまず tmux / Discord を fake に差し替えた決定的検証で AC を固定している。

## テスト結果

```
# CI curated list (107 files)
1482 pass / 3 skip / 0 fail  (3747 expect)

# mock-isolated suites (CI と同じく個別プロセス)
tests/session/adapters-hassession.test.ts  exit=0
tests/session/adapters.test.ts             exit=0
tests/session/tmux.test.ts                 exit=0
tests/session/relay-nonblocking.test.ts    exit=0

# typecheck / lint
bunx tsc --noEmit                    OK
lint-blocking-in-timers              OK
lint-no-sync-exec                    OK
lint-gating-coverage                 116 files — 114 gated, 2 excluded, 0 ungated
check-access-policy --ci             in sync
```

## 関連

- #453 / PR #455（スレッド内 `/session start` bind — 本 PR はその follow-up）
- corp#127（決裁後フィードバック通知設計）/ corp#128（自前ポーリング watcher の恒久代替）


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - 停止済みセッションの履歴があるスレッドにメッセージが届くと、同じスレッドで自動的にセッションを再開します。
  - 再開成功時は通知後にメッセージを中継し、再開できない場合は状況と手動対応手順を案内します。
  - 同時に複数メッセージが届いた場合も、重複した再開処理を防止します。
  - `/brief` 実行時に、再開に対応した会話用スレッドを開けるようになりました。

- **ドキュメント**
  - 自動再開の対象条件、通知内容、例外時の運用手順を追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->