### PR TITLE
fix(brief): 決裁済み提案もボタン化して押し直せるようにする（#458）

### DIFF
--- a/supervisor/src/session/brief-decision.ts
+++ b/supervisor/src/session/brief-decision.ts
@@ -53,6 +53,14 @@ export const BRIEF_DECISION_PREFIX = "briefdec:";
 export const PROPOSAL_DECISIONS = ["approved", "rejected", "deferred"] as const;
 export type ProposalDecision = (typeof PROPOSAL_DECISIONS)[number];
 
+/** 未知の値を決裁として通さないための型ガード（CLI 出力は外部入力として扱う）。 */
+export function isProposalDecision(v: unknown): v is ProposalDecision {
+  return (
+    typeof v === "string" &&
+    (PROPOSAL_DECISIONS as readonly string[]).includes(v)
+  );
+}
+
 /**
  * ボタンに載せてよい提案 id の形。corp の提案 id（`dispatch-<dept>-<slug>`）を
  * 十分に覆いつつ、`:`（customId の区切り）や空白・shell メタ文字を含む id を
@@ -74,13 +82,22 @@ export const DECISION_LABELS: Record<ProposalDecision, string> = {
   deferred: "保留",
 };
 
-/** proposals CLI 出力のうち、この UI が必要とする最小面。 */
-export interface PendingProposal {
+/**
+ * proposals CLI 出力のうち、この UI が必要とする最小面。
+ *
+ * Issue #132: 未決だけでなく**決裁済みも運ぶ**。決裁は corp 側で後勝ちの追記であり
+ * （`src/cli.ts` は同一決裁の再実行だけを no-op にする）、却下→承認のような押し直しは
+ * 元から CLI 側でサポートされている。ここで決裁済みを落としていたため、朝レポに 4 件並んでも
+ * 押せるのは未決 1 件だけ、という状態になっていた。
+ */
+export interface BriefProposal {
   id: string;
   title: string;
   priority: number | null;
   targetDept: string | null;
   pendingDays: number | null;
+  /** 現在の決裁。未決は null。決裁済みはそのボタンだけ disabled にする。 */
+  decision: ProposalDecision | null;
 }
 
 export type ParsedProposals =
@@ -90,9 +107,11 @@ export type ParsedProposals =
       date: string;
       /** 提案の総数（決裁済み含む）。 */
       total: number;
-      /** 未決（decision === null）のうちボタン化できたもの。 */
-      pending: PendingProposal[];
-      /** id が {@link PROPOSAL_ID_RE} を通らず除外した未決の件数。 */
+      /** ボタン化できた提案（未決・決裁済みの両方・#132）。 */
+      proposals: BriefProposal[];
+      /** うち未決（decision === null）の件数。見出しの「未決 N 件」に使う。 */
+      pendingCount: number;
+      /** id が {@link PROPOSAL_ID_RE} を通らず除外した件数。 */
       skipped: number;
     }
   | { kind: "error"; reason: string };
@@ -129,26 +148,38 @@ export function parseProposalsOutput(stdout: string): ParsedProposals {
     };
   }
 
-  const pending: PendingProposal[] = [];
+  const proposals: BriefProposal[] = [];
   let skipped = 0;
   for (const row of rows) {
     if (row === null || typeof row !== "object") continue;
     const r = row as Record<string, unknown>;
-    if (r.decision !== null) continue; // 決裁済みはボタン対象外
     const id = typeof r.id === "string" ? r.id : "";
     if (!PROPOSAL_ID_RE.test(id)) {
       skipped += 1;
       continue;
     }
-    pending.push({
+    // 未知の決裁値（CLI 側に 4 値目が増えた等）は null に倒さず除外する。null に倒すと
+    // 「決裁済みなのに未決として表示」という嘘になり、承認ゲートの見え方を誤らせる。
+    const raw = r.decision;
+    let decision: ProposalDecision | null = null;
+    if (raw !== null && raw !== undefined) {
+      if (!isProposalDecision(raw)) {
+        skipped += 1;
+        continue;
+      }
+      decision = raw;
+    }
+    proposals.push({
       id,
       title: typeof r.title === "string" ? r.title : id,
       priority: typeof r.priority === "number" ? r.priority : null,
       targetDept: typeof r.targetDept === "string" ? r.targetDept : null,
       pendingDays: typeof r.pendingDays === "number" ? r.pendingDays : null,
+      decision,
     });
   }
-  return { kind: "ok", date, total: rows.length, pending, skipped };
+  const pendingCount = proposals.filter((p) => p.decision === null).length;
+  return { kind: "ok", date, total: rows.length, proposals, pendingCount, skipped };
 }
 
 export function buildBriefDecisionCustomId(
@@ -186,23 +217,37 @@ function truncate(text: string, limit: number): string {
   return text.length <= limit ? text : `${text.slice(0, limit - 1)}…`;
 }
 
+/** 決裁ごとのボタン見た目（ラベル絵文字と style）。行の組み立てを 1 か所に寄せる。 */
+const DECISION_BUTTON: Record<
+  ProposalDecision,
+  { emoji: string; style: ButtonStyle }
+> = {
+  approved: { emoji: "✅", style: ButtonStyle.Success },
+  rejected: { emoji: "⛔", style: ButtonStyle.Danger },
+  deferred: { emoji: "⏸", style: ButtonStyle.Secondary },
+};
+
+/**
+ * 1 提案の決裁ボタン行を作る。
+ *
+ * Issue #132: `current` に現在の決裁を渡すと、**その決裁のボタンだけ disabled** になる。
+ * corp CLI が同一決裁の再実行を no-op にするため押しても何も起きず、押せると誤解させないため。
+ * 残る 2 つは押せる = 却下→承認のような押し直しがそのまま通る。未決（current=null）では 3 つとも押せる。
+ */
 function buildProposalRow(
-  proposal: PendingProposal,
+  proposal: BriefProposal,
   ordinal: number,
 ): BriefDecisionRow {
   return new ActionRowBuilder<ButtonBuilder>().addComponents(
-    new ButtonBuilder()
-      .setCustomId(buildBriefDecisionCustomId(proposal.id, "approved"))
-      .setLabel(`✅ 承認 ${ordinal}`)
-      .setStyle(ButtonStyle.Success),
-    new ButtonBuilder()
-      .setCustomId(buildBriefDecisionCustomId(proposal.id, "rejected"))
-      .setLabel(`⛔ 却下 ${ordinal}`)
-      .setStyle(ButtonStyle.Danger),
-    new ButtonBuilder()
-      .setCustomId(buildBriefDecisionCustomId(proposal.id, "deferred"))
-      .setLabel(`⏸ 保留 ${ordinal}`)
-      .setStyle(ButtonStyle.Secondary),
+    ...PROPOSAL_DECISIONS.map((decision) =>
+      new ButtonBuilder()
+        .setCustomId(buildBriefDecisionCustomId(proposal.id, decision))
+        .setLabel(
+          `${DECISION_BUTTON[decision].emoji} ${DECISION_LABELS[decision]} ${ordinal}`,
+        )
+        .setStyle(DECISION_BUTTON[decision].style)
+        .setDisabled(proposal.decision === decision),
+    ),
   );
 }
 
@@ -215,24 +260,28 @@ function buildProposalRow(
  */
 export function buildBriefDecisionMessages(
   date: string,
-  pending: PendingProposal[],
+  proposals: BriefProposal[],
 ): BriefDecisionMessage[] {
   const messages: BriefDecisionMessage[] = [];
-  for (let i = 0; i < pending.length; i += MAX_PROPOSALS_PER_MESSAGE) {
-    const chunk = pending.slice(i, i + MAX_PROPOSALS_PER_MESSAGE);
+  const pendingCount = proposals.filter((p) => p.decision === null).length;
+  for (let i = 0; i < proposals.length; i += MAX_PROPOSALS_PER_MESSAGE) {
+    const chunk = proposals.slice(i, i + MAX_PROPOSALS_PER_MESSAGE);
     const head =
       i === 0
-        ? `📋 **朝レポ（${date}）の未決提案 ${pending.length} 件** — ボタンで決裁してください（承認は次の dispatch 周期で部署へ投入されます）`
-        : `📋 朝レポ（${date}）未決提案のつづき`;
+        ? `📋 **朝レポ（${date}）の提案 ${proposals.length} 件（未決 ${pendingCount} 件）** — ボタンで決裁してください（承認は次の dispatch 周期で部署へ投入されます。決裁済みも押し直せます）`
+        : `📋 朝レポ（${date}）提案のつづき`;
     const lines = chunk.map((p, j) => {
       const ordinal = i + j + 1;
       const pri = p.priority !== null ? `[D${p.priority}] ` : "";
       const dept = p.targetDept ? `**${p.targetDept}** ` : "";
-      const days =
-        p.pendingDays !== null && p.pendingDays > 1
-          ? `（未決 ${p.pendingDays} 日目)`
-          : "";
-      return `${ordinal}. ${pri}${dept}${truncate(p.title, 160)}${days}\n   id: \`${p.id}\``;
+      // 決裁済みは現在の決裁を、未決は滞留日数を出す（どちらか一方しか意味を持たない）。
+      const state =
+        p.decision !== null
+          ? `（現在: ${DECISION_LABELS[p.decision]}）`
+          : p.pendingDays !== null && p.pendingDays > 1
+            ? `（未決 ${p.pendingDays} 日目)`
+            : "";
+      return `${ordinal}. ${pri}${dept}${truncate(p.title, 160)}${state}\n   id: \`${p.id}\``;
     });
     messages.push({
       content: truncate([head, ...lines].join("\n"), CONTENT_LIMIT),
@@ -359,7 +408,9 @@ export async function runBriefDecideFlow(
     return false;
   }
 
-  if (proposals.pending.length === 0 && proposals.skipped === 0) {
+  // #132: 決裁済みも押し直せるようボタン化するため、「ボタンを出さない」のは
+  // ボタン化できる提案が 1 件も無いときだけ（提案 0 件 / 全件 id 不正）。
+  if (proposals.proposals.length === 0 && proposals.skipped === 0) {
     await input.postToChannel(
       buildAllDecidedMessage(input.date, proposals.total),
     );
@@ -367,7 +418,7 @@ export async function runBriefDecideFlow(
   }
 
   try {
-    for (const msg of buildBriefDecisionMessages(input.date, proposals.pending)) {
+    for (const msg of buildBriefDecisionMessages(input.date, proposals.proposals)) {
       await input.postDecisionMessage(msg);
     }
   } catch (err) {
@@ -381,10 +432,10 @@ export async function runBriefDecideFlow(
   if (proposals.skipped > 0) {
     // id がボタン化できない提案を黙って落とさない（silent truncation 禁止）。
     console.warn(
-      `[brief-decision] ${proposals.skipped} pending proposal(s) skipped (id not button-safe) in channel ${input.channelName}`,
+      `[brief-decision] ${proposals.skipped} proposal(s) skipped (id or decision not button-safe) in channel ${input.channelName}`,
     );
     await input.postToChannel(
-      `⚠️ 未決提案のうち ${proposals.skipped} 件は id をボタン化できず表示していません。` +
+      `⚠️ 提案のうち ${proposals.skipped} 件は id または決裁値をボタン化できず表示していません。` +
         `作業ディレクトリで proposals コマンドを直接確認してください。`,
     );
   }
@@ -538,7 +589,7 @@ export function createBriefDecisionHandler(deps: BriefDecisionHandlerDeps) {
 }
 
 /**
- * 決裁済みの提案の行（ボタン 3 つ）を disable し、本文に決裁結果を追記する。
+ * 決裁した提案の行を「新しい決裁のボタンだけ disabled」に組み替え、本文に決裁結果を追記する。
  * best-effort: 決裁自体は既に確定しているので、メッセージ更新の失敗は log のみ
  * （ask-components の disableStaleMessage と同じ扱い）。
  *
@@ -563,7 +614,14 @@ async function markRowDecided(
         return parseBriefDecisionCustomId(id)?.proposalId === proposalId;
       });
       if (belongs) {
-        for (const c of builder.components) c.setDisabled(true);
+        // #132: 行全体を disable すると押し直しができなくなる。押した決裁のボタンだけを
+        // disable し（CLI が no-op にするため）、他の 2 つは押せるまま残す。
+        for (const c of builder.components) {
+          const id = (c.data as { custom_id?: string }).custom_id ?? "";
+          c.setDisabled(
+            parseBriefDecisionCustomId(id)?.decision === decision,
+          );
+        }
       }
       return builder;
     });

--- a/supervisor/tests/session/brief-decision.test.ts
+++ b/supervisor/tests/session/brief-decision.test.ts
@@ -11,7 +11,7 @@ import {
   parseBriefDecisionCustomId,
   parseProposalsOutput,
   type CliResult,
-  type PendingProposal,
+  type BriefProposal,
 } from "../../src/session/brief-decision";
 
 /**
@@ -25,13 +25,14 @@ import {
  *   4. CLI 失敗は会長へ報告される（silent fallback 禁止）
  */
 
-function proposal(over: Partial<PendingProposal> = {}): PendingProposal {
+function proposal(over: Partial<BriefProposal> = {}): BriefProposal {
   return {
     id: "dispatch-social-436",
     title: "[social] 着手検討: #436",
     priority: 3,
     targetDept: "social",
     pendingDays: 1,
+    decision: null,
     ...over,
   };
 }
@@ -42,7 +43,7 @@ function proposalsJson(rows: unknown[]): string {
 }
 
 describe("parseProposalsOutput", () => {
-  test("parses pending proposals and drops decided ones", () => {
+  test("keeps decided proposals too, and counts the pending ones (#132)", () => {
     const out = parseProposalsOutput(
       proposalsJson([
         { id: "a-1", title: "A", priority: 1, targetDept: "x", decision: null, pendingDays: 2 },
@@ -53,7 +54,9 @@ describe("parseProposalsOutput", () => {
     if (out.kind === "ok") {
       expect(out.date).toBe("2026-08-23");
       expect(out.total).toBe(2);
-      expect(out.pending.map((p) => p.id)).toEqual(["a-1"]);
+      expect(out.proposals.map((p: BriefProposal) => p.id)).toEqual(["a-1", "b-2"]);
+      expect(out.proposals.map((p: BriefProposal) => p.decision)).toEqual([null, "approved"]);
+      expect(out.pendingCount).toBe(1);
       expect(out.skipped).toBe(0);
     }
   });
@@ -63,7 +66,7 @@ describe("parseProposalsOutput", () => {
     expect(out.kind).toBe("ok");
   });
 
-  test("skips (and counts) a pending proposal whose id cannot ride a customId", () => {
+  test("skips (and counts) a proposal whose id cannot ride a customId", () => {
     const out = parseProposalsOutput(
       proposalsJson([
         { id: "ok-id", title: "OK", decision: null },
@@ -73,7 +76,7 @@ describe("parseProposalsOutput", () => {
     );
     expect(out.kind).toBe("ok");
     if (out.kind === "ok") {
-      expect(out.pending.map((p) => p.id)).toEqual(["ok-id"]);
+      expect(out.proposals.map((p: BriefProposal) => p.id)).toEqual(["ok-id"]);
       expect(out.skipped).toBe(2);
     }
   });
@@ -397,15 +400,26 @@ describe("runBriefDecideFlow", () => {
     expect(capture.notifications.length).toBe(0);
   });
 
-  test("未決 0 件は「すべて決裁済み」1 行のみで true", async () => {
+  test("未決 0 件でも決裁済みがあればボタンを出す（押し直せる・#132）", async () => {
     const { capture, input } = flowDeps({
       code: 0,
       stdout: proposalsJson([{ id: "a-1", title: "A", decision: "approved" }]),
       stderr: "",
     });
     await expect(runBriefDecideFlow(input)).resolves.toBe(true);
+    expect(capture.decisionPosts).toBe(1);
+    expect(capture.channelPosts.join("\n")).not.toContain("すべて決裁済み");
+  });
+
+  test("提案が 1 件も無ければ「すべて決裁済み」1 行のみで true", async () => {
+    const { capture, input } = flowDeps({
+      code: 0,
+      stdout: proposalsJson([]),
+      stderr: "",
+    });
+    await expect(runBriefDecideFlow(input)).resolves.toBe(true);
     expect(capture.decisionPosts).toBe(0);
-    expect(capture.channelPosts.join("\n")).toContain("すべて決裁済み");
+    expect(capture.channelPosts.join("\n")).toContain("提案はありません");
   });
 
   test("CLI 失敗はチャンネル報告 + ページで false（silent にしない・dedup 記録不可）", async () => {
@@ -453,7 +467,7 @@ describe("runBriefDecideFlow", () => {
     });
     await expect(runBriefDecideFlow(input)).resolves.toBe(true);
     expect(capture.decisionPosts).toBe(1);
-    expect(capture.channelPosts.join("\n")).toContain("1 件は id をボタン化できず");
+    expect(capture.channelPosts.join("\n")).toContain("1 件は id または決裁値をボタン化できず");
   });
 
   test("notify 自体の失敗で flow は落ちない", async () => {
@@ -462,5 +476,90 @@ describe("runBriefDecideFlow", () => {
       throw new Error("pushover down");
     };
     await expect(runBriefDecideFlow(input)).resolves.toBe(false);
+  });
+});
+
+/**
+ * Issue #132: 朝レポに提案が 4 件並んでも押せるのは未決 1 件だけ、という状態の修正。
+ * 決裁済みもボタン化し、現在の決裁ボタンだけ disabled にして押し直しを通す。
+ */
+describe("決裁済み提案の押し直し（#132）", () => {
+  test("未知の決裁値は null に倒さず skipped に数える（嘘の未決を作らない）", () => {
+    const out = parseProposalsOutput(
+      proposalsJson([
+        { id: "ok-1", title: "OK", decision: null },
+        { id: "weird-1", title: "NG", decision: "escalated" },
+      ]),
+    );
+    expect(out.kind).toBe("ok");
+    if (out.kind === "ok") {
+      expect(out.proposals.map((p: BriefProposal) => p.id)).toEqual(["ok-1"]);
+      expect(out.skipped).toBe(1);
+    }
+  });
+
+  test("未決の行は 3 ボタンとも押せる", () => {
+    const [msg] = buildBriefDecisionMessages("2026-08-25", [proposal()]);
+    const row = msg!.components[0]!.toJSON();
+    expect(row.components.map((c) => (c as { disabled?: boolean }).disabled ?? false)).toEqual([
+      false,
+      false,
+      false,
+    ]);
+  });
+
+  test("決裁済みの行は現在の決裁だけ disabled、他の 2 つは押せる", () => {
+    const [msg] = buildBriefDecisionMessages("2026-08-25", [
+      proposal({ decision: "rejected" }),
+    ]);
+    const row = msg!.components[0]!.toJSON();
+    const byId = row.components.map((c) => {
+      const b = c as { custom_id?: string; disabled?: boolean };
+      return [parseBriefDecisionCustomId(b.custom_id ?? "")?.decision, b.disabled ?? false];
+    });
+    expect(byId).toEqual([
+      ["approved", false],
+      ["rejected", true],
+      ["deferred", false],
+    ]);
+  });
+
+  test("決裁済みを含む全提案が行として並ぶ（未決だけに絞らない）", () => {
+    const msgs = buildBriefDecisionMessages("2026-08-25", [
+      proposal({ id: "p-1", decision: "approved" }),
+      proposal({ id: "p-2", decision: "rejected" }),
+      proposal({ id: "p-3", decision: null }),
+      proposal({ id: "p-4", decision: "approved" }),
+    ]);
+    expect(msgs).toHaveLength(1);
+    expect(msgs[0]!.components).toHaveLength(4);
+  });
+
+  test("見出しは総数と未決数の両方を出す", () => {
+    const [msg] = buildBriefDecisionMessages("2026-08-25", [
+      proposal({ id: "p-1", decision: "approved" }),
+      proposal({ id: "p-2", decision: null }),
+    ]);
+    expect(msg!.content).toContain("提案 2 件");
+    expect(msg!.content).toContain("未決 1 件");
+  });
+
+  test("決裁済みの行には現在の決裁が本文に出る", () => {
+    const [msg] = buildBriefDecisionMessages("2026-08-25", [
+      proposal({ decision: "rejected" }),
+    ]);
+    expect(msg!.content).toContain("現在: 却下");
+  });
+
+  test("5 件超は複数メッセージに分かれ、通し番号が連番になる（決裁済み込み）", () => {
+    const rows = Array.from({ length: 7 }, (_, i) =>
+      proposal({ id: `p-${i + 1}`, decision: i % 2 === 0 ? "approved" : null }),
+    );
+    const msgs = buildBriefDecisionMessages("2026-08-25", rows);
+    expect(msgs).toHaveLength(2);
+    expect(msgs[0]!.components).toHaveLength(MAX_PROPOSALS_PER_MESSAGE);
+    expect(msgs[1]!.components).toHaveLength(7 - MAX_PROPOSALS_PER_MESSAGE);
+    expect(msgs[1]!.content).toContain("6. ");
+    expect(msgs[1]!.content).toContain("7. ");
   });
 });


### PR DESCRIPTION
## 目的

朝レポに提案が 4 件並んでも**押せるのは未決 1 件だけ**、という状態を直す。
会長の指摘「複数質問に対して、回答が一つしか選択できないのはもどかしい」（2026-08-25）への対応。

Closes #458 / corp 側: miyashita337/corp#132

## 原因

`parseProposalsOutput` が `decision !== null` を落としていた。corp 側の決裁は `proposalId` 単位で
当月＋前月から引くため、一度決裁した提案は翌日以降も朝レポに載り続ける。結果、朝レポには
並ぶのに操作できない行が増えていく（2026-08-25 実測: 4 件中 3 件が 2026-08-20 の決裁）。

corp `src/cli.ts` の `runDecideProposalCmd` は「**同じ決裁の再実行だけ**」を no-op にしており、
却下→承認の押し直しは元から通る。塞いでいたのは claude-hub 側のこの 1 行だけ。

## 変更

| 項目 | 変更前 | 変更後 |
|---|---|---|
| 型 | `PendingProposal` | `BriefProposal`（`decision` を運ぶ） |
| パース結果 | `pending: PendingProposal[]` | `proposals: BriefProposal[]` + `pendingCount` |
| ボタン | 未決のみ 3 つ enabled | 全提案に 3 つ。**現在の決裁だけ disabled** |
| 見出し | 「未決 N 件」 | 「提案 M 件（未決 N 件）」 |
| 決裁済み行 | 出ない | 「（現在: 却下）」を表示 |
| タップ後 | 行全体を disable | 新しい決裁だけ disable（押し直しが続けられる） |
| 未知の決裁値 | （到達しない） | `null` に倒さず skipped に数える |
| 「すべて決裁済み」 | 未決 0 件で表示 | ボタン化できる提案が 0 件のときだけ |

## 設計上の判断

- **現在の決裁ボタンを disabled にする**のは、corp CLI が同一決裁を no-op にするため。
  押しても何も起きないボタンを押せるように見せない
- **未知の決裁値を `null` に倒さない**。倒すと「決裁済みなのに未決として表示」という嘘になり、
  承認ゲートの見え方を誤らせる。silent に落とさず skipped として警告に出す
- **承認ゲートは弱めない**。決裁の判断は従来どおり会長のタップのみ。押し直しは corp 側が
  元から許している操作で、新しい権限を作っていない

## テスト

```
bun test tests/session/brief-decision.test.ts   # 32 pass / 0 fail
bun test tests/session/corp-brief.test.ts       # 31 pass / 0 fail
npx tsc --noEmit                                 # エラーなし
```

新規 7 ケース（未知の決裁値の除外 / 未決行は 3 つとも押せる / 決裁済みは現在の決裁だけ disabled /
決裁済み込みで全件並ぶ / 見出しの総数と未決数 / 「現在: 却下」の表示 / 5 件超の分割と連番）。

## 統合ジャーニーAC

| # | 操作 | 期待結果 | 検証手段 | 判定 |
|---|---|---|---|---|
| 1 | 決裁済みを含む複数提案の決裁メッセージを受け取る | 提案の件数分の行が並び決裁済みに現在の決裁が出る | ユニットテスト（行数・本文） | PASS |
| 2 | 決裁済み（却下）の「承認」をタップ | 承認として確定し衛星に起票される | 実 Discord で確認（supervisor 再起動後） | 未実施 |
| 3 | 現在の決裁と同じボタン | disabled で押せない | ユニットテスト（disabled フラグ） | PASS |

AC-2 は supervisor 再起動後に corp の `scripts/rehearse-morning-loop.sh` で通し確認する（別途報告）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 決裁済みの提案も一覧に表示し、別の決裁へ変更できるようになりました。
  - 現在の決裁状態を提案ごとに表示します。
  - メッセージ見出しに未決裁の件数を表示します。

- **改善**
  - 不正な決裁情報を自動的に除外し、処理の安定性を向上しました。
  - 提案がある場合は、決裁済みを含めて決裁メッセージを表示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->