### PR TITLE
feat(brief): 朝レポ着信で #corp に窓口セッションを1本自動起動する（#454）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,6 +192,7 @@ jobs:
                    tests/session/dispatch-report.test.ts \
                    tests/session/corp-brief.test.ts \
                    tests/session/brief-decision.test.ts \
+                   tests/session/brief-window.test.ts \
                    tests/session/artifact-probe.test.ts \
                    tests/session/orchestrate.test.ts \
                    tests/session/adapters-executor.test.ts \

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -38,7 +38,11 @@ import {
   postAskUserPrompt,
   postMultiAskUserPrompt,
 } from "./commands/ask-components";
-import { CHANNEL_MAP, MAX_SESSIONS } from "./config/channels";
+import {
+  CHANNEL_MAP,
+  MAX_SESSIONS,
+  type ChannelConfig,
+} from "./config/channels";
 import { RELAY_ERROR_USER_MESSAGE, type AttachmentInfo } from "./session/relay";
 import { buildDialogStuckHandler } from "./session/dialog-stuck-handler";
 import { notifyPushover, warnIfPushoverUnconfigured } from "./session/notify-pushover";
@@ -102,6 +106,12 @@ import {
   isBriefDecisionComponentId,
   runBriefDecideFlow,
 } from "./session/brief-decision";
+import {
+  openBriefWindow,
+  parseBriefWindowThreadName,
+  restartBriefWindow,
+  type BriefWindowDeps,
+} from "./session/brief-window";
 import {
   ORCHESTRATE_PREFIX,
   parseOrchestrateCommand,
@@ -1412,6 +1422,127 @@ export async function startBot(token: string): Promise<void> {
   // is the safer failure direction than persisting a stale "already delivered".
   const recentBriefByChannel = new Map<string, RecentBrief>();
 
+  // Issue #454: side-effect adapters for the morning-brief conversation window.
+  // Shared by the eager path (opened when `/brief` lands) and the lazy path (a
+  // message in a window thread the idle reaper already closed), so both agree on
+  // what a window is. All decisions live in `session/brief-window.ts`; this only
+  // supplies Discord / SessionManager access.
+  const briefWindowDeps = (
+    config: ChannelConfig,
+    textChannel: TextChannel,
+  ): BriefWindowDeps => ({
+    // The idempotency key is the thread NAME, not an in-memory id: a Supervisor
+    // restart between two `/brief` posts must not produce a second window.
+    findThreadByName: async (name) => {
+      const active = await textChannel.threads.fetchActive();
+      const hit = active.threads.find((t) => t.name === name);
+      return hit ? { id: hit.id } : null;
+    },
+    hasSession: (threadId) => sessionManager.has(threadId),
+    createThread: async (name) => {
+      const created = await textChannel.threads.create({
+        name,
+        autoArchiveDuration: 10080, // 7 days, same as dispatch threads
+      });
+      return { id: created.id };
+    },
+    start: async (threadId, branch) => {
+      await sessionManager.start(config, threadId, branch);
+    },
+    waitForInputReady: (threadId) => sessionManager.waitForInputReady(threadId),
+    sendMessage: async (threadId, text) => {
+      await sessionManager.sendMessage(threadId, text);
+    },
+    postToThread: async (threadId, content) => {
+      const ch = await client.channels.fetch(threadId);
+      if (ch?.isThread()) await ch.send(content);
+    },
+    postToChannel: async (content) => {
+      await textChannel.send(content);
+    },
+    notifyFailure: async (title, body) => {
+      await notifyPushover(title, body);
+    },
+  });
+
+  // Issue #454 (lazy path): a message in a window thread whose session the idle
+  // reaper already stopped restarts it, instead of leaving the chairman with the
+  // salvage notice. Returns true when the message was consumed (restarted, or
+  // refused with a posted reason) and the caller must stop; false when this is
+  // not a window thread and normal salvage handling should continue.
+  async function tryRestartBriefWindow(
+    message: Message,
+    threadId: string,
+  ): Promise<boolean> {
+    const thread = message.channel as ThreadChannel;
+    // Cheap early-out so an ordinary dead thread never fetches config or channels.
+    if (parseBriefWindowThreadName(thread.name) === null) return false;
+
+    // thread.parent はキャッシュ依存のゲッターで、起動直後などキャッシュ外だと
+    // 実在する親でも null を返す（PR #340 gemini high）。parentId からの明示
+    // fetch にフォールバックしないと、supervisor 再起動直後の窓口だけ再起動できない。
+    let parent = thread.parent as TextChannel | null;
+    if (!parent && thread.parentId) {
+      const fetched = await client.channels.fetch(thread.parentId);
+      parent = fetched && !fetched.isThread() && fetched.isTextBased()
+        ? (fetched as TextChannel)
+        : null;
+    }
+    if (!parent) return false;
+
+    const parentName = "name" in parent ? (parent.name as string) : "";
+    const config = CHANNEL_MAP.get(parentName);
+    if (!config) return false;
+
+    const result = await restartBriefWindow(
+      {
+        threadName: thread.name,
+        hasBriefConfig: Boolean(config.brief),
+        // Reaching this call site means the thread has no live session.
+        hasSession: false,
+        sessionCount: sessionManager.count(),
+        maxSessions: MAX_SESSIONS,
+      },
+      threadId,
+      briefWindowDeps(config, parent),
+    );
+
+    if (result.ok) {
+      console.log(
+        `[Bot] Brief window restarted (thread=${threadId}, channel=${parentName})`,
+      );
+      // The message that woke the window is NOT relayed: the session is still
+      // booting and `/brief-window` is being injected, so racing a second write
+      // into the same pane is how RW-025-class input loss happens. Say so
+      // instead of dropping it silently.
+      try {
+        await thread.send(
+          "🔓 窓口セッションを再起動しました（前回は無操作で自動クローズされていました）。\n" +
+            "起動処理中のため、いまの発言は届いていません。**もう一度送ってください**。",
+        );
+      } catch (err) {
+        console.error(
+          `[Bot] Brief window restart notice failed for thread ${threadId}:`,
+          err,
+        );
+      }
+      return true;
+    }
+
+    if (result.stage === "skipped") {
+      // `capacity` was reported into the thread by restartBriefWindow; anything
+      // else (kill-switch off, channel without brief config) falls through to
+      // the existing salvage reply rather than going quiet.
+      return result.reason === "capacity";
+    }
+
+    // start / inject failures already posted their reason and paged.
+    console.warn(
+      `[Bot] Brief window restart failed (thread=${threadId}, stage=${result.stage})`,
+    );
+    return true;
+  }
+
   // Issue #426 → #449: handle a `/brief <YYYY-MM-DD>` message from an allowed
   // external source (corp's dispatch bot) — fetch the day's pending proposals
   // via the channel's configured CLI and post tap-to-decide buttons DIRECTLY in
@@ -1563,6 +1694,37 @@ export async function startBot(token: string): Promise<void> {
             atMs: Date.now(),
           });
         }
+
+        // Issue #454: open the day's conversation window ALONGSIDE the buttons.
+        // A channel-level message reaches no session (see the isThread guard in
+        // handleMessageCreate), so a thread is the only place the chairman can
+        // answer with anything other than approve / reject / hold. Deliberately
+        // not gated on `delivered`: the morning the decision post fails is
+        // exactly when a way to talk matters most. Failures here are reported by
+        // openBriefWindow and never propagate — the buttons must not go down
+        // with the window.
+        try {
+          const window = await openBriefWindow(
+            {
+              date: decision.date,
+              hasBriefConfig: true,
+              sessionCount: sessionManager.count(),
+              maxSessions: MAX_SESSIONS,
+            },
+            briefWindowDeps(config, textChannel),
+          );
+          if (window.ok) {
+            console.log(
+              `[Bot] Brief window ${window.reused ? "reused" : "opened"} in channel ${channelName} (thread=${window.threadId}, date=${decision.date})`,
+            );
+          } else {
+            console.warn(
+              `[Bot] Brief window not opened in channel ${channelName} (stage=${window.stage}, reason=${window.reason})`,
+            );
+          }
+        } catch (err) {
+          console.error("[Bot] Brief window handler error:", err);
+        }
         return true;
       }
     }
@@ -1654,6 +1816,18 @@ export async function startBot(token: string): Promise<void> {
     // (Issue #169). Non-mention messages keep the quiet debug log to avoid
     // spamming a dead thread on every line.
     if (!sessionManager.has(threadId)) {
+      // Issue #454: the morning window is meant to stay usable all day, but the
+      // interactive idle reaper (6h) legitimately stops it. Restart it on the
+      // chairman's next message instead of answering with a salvage notice —
+      // access was already enforced above, so this is the same privilege a
+      // `/session start` in this thread would take. Non-window threads fall
+      // through unchanged.
+      try {
+        if (await tryRestartBriefWindow(message, threadId)) return;
+      } catch (err) {
+        console.error("[Bot] Brief window restart error:", err);
+      }
+
       const botUserId = client.user?.id;
       const mentioned = botUserId
         ? message.mentions.users.has(botUserId)

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -107,9 +107,10 @@ import {
   runBriefDecideFlow,
 } from "./session/brief-decision";
 import {
-  openBriefWindow,
+  createBriefWindowDeps,
+  handleBriefWindowThreadMessage,
+  openBriefWindowForBrief,
   parseBriefWindowThreadName,
-  restartBriefWindow,
   type BriefWindowDeps,
 } from "./session/brief-window";
 import {
@@ -1422,54 +1423,39 @@ export async function startBot(token: string): Promise<void> {
   // is the safer failure direction than persisting a stale "already delivered".
   const recentBriefByChannel = new Map<string, RecentBrief>();
 
-  // Issue #454: side-effect adapters for the morning-brief conversation window.
-  // Shared by the eager path (opened when `/brief` lands) and the lazy path (a
-  // message in a window thread the idle reaper already closed), so both agree on
-  // what a window is. All decisions live in `session/brief-window.ts`; this only
-  // supplies Discord / SessionManager access.
+  // Issue #454: bind the real Discord channel / SessionManager into the window
+  // adapters. Everything else — decisions, notices, logging — lives in
+  // session/brief-window.ts so it stays under test; this is only the binding.
   const briefWindowDeps = (
     config: ChannelConfig,
     textChannel: TextChannel,
-  ): BriefWindowDeps => ({
-    // The idempotency key is the thread NAME, not an in-memory id: a Supervisor
-    // restart between two `/brief` posts must not produce a second window.
-    findThreadByName: async (name) => {
-      const active = await textChannel.threads.fetchActive();
-      const hit = active.threads.find((t) => t.name === name);
-      return hit ? { id: hit.id } : null;
-    },
-    hasSession: (threadId) => sessionManager.has(threadId),
-    createThread: async (name) => {
-      const created = await textChannel.threads.create({
-        name,
-        autoArchiveDuration: 10080, // 7 days, same as dispatch threads
-      });
-      return { id: created.id };
-    },
-    start: async (threadId, branch) => {
-      await sessionManager.start(config, threadId, branch);
-    },
-    waitForInputReady: (threadId) => sessionManager.waitForInputReady(threadId),
-    sendMessage: async (threadId, text) => {
-      await sessionManager.sendMessage(threadId, text);
-    },
-    postToThread: async (threadId, content) => {
-      const ch = await client.channels.fetch(threadId);
-      if (ch?.isThread()) await ch.send(content);
-    },
-    postToChannel: async (content) => {
-      await textChannel.send(content);
-    },
-    notifyFailure: async (title, body) => {
-      await notifyPushover(title, body);
-    },
-  });
+  ): BriefWindowDeps =>
+    createBriefWindowDeps({
+      channel: textChannel,
+      sessions: {
+        has: (threadId) => sessionManager.has(threadId),
+        start: async (threadId, branch) => {
+          await sessionManager.start(config, threadId, branch);
+        },
+        waitForInputReady: (threadId) =>
+          sessionManager.waitForInputReady(threadId),
+        sendMessage: async (threadId, text) => {
+          await sessionManager.sendMessage(threadId, text);
+        },
+      },
+      fetchThread: async (threadId) => {
+        const ch = await client.channels.fetch(threadId);
+        return ch?.isThread() ? ch : null;
+      },
+      notifyFailure: async (title, body) => {
+        await notifyPushover(title, body);
+      },
+    });
 
   // Issue #454 (lazy path): a message in a window thread whose session the idle
-  // reaper already stopped restarts it, instead of leaving the chairman with the
-  // salvage notice. Returns true when the message was consumed (restarted, or
-  // refused with a posted reason) and the caller must stop; false when this is
-  // not a window thread and normal salvage handling should continue.
+  // reaper already stopped restarts it instead of answering with the salvage
+  // notice. Returns true when the message was consumed and the caller must stop.
+  // Only the Discord-specific parent resolution lives here.
   async function tryRestartBriefWindow(
     message: Message,
     threadId: string,
@@ -1480,13 +1466,14 @@ export async function startBot(token: string): Promise<void> {
 
     // thread.parent はキャッシュ依存のゲッターで、起動直後などキャッシュ外だと
     // 実在する親でも null を返す（PR #340 gemini high）。parentId からの明示
-    // fetch にフォールバックしないと、supervisor 再起動直後の窓口だけ再起動できない。
+    // fetch にフォールバックしないと、supervisor 再起動直後の窓口だけ復帰しない。
     let parent = thread.parent as TextChannel | null;
     if (!parent && thread.parentId) {
       const fetched = await client.channels.fetch(thread.parentId);
-      parent = fetched && !fetched.isThread() && fetched.isTextBased()
-        ? (fetched as TextChannel)
-        : null;
+      parent =
+        fetched && !fetched.isThread() && fetched.isTextBased()
+          ? (fetched as TextChannel)
+          : null;
     }
     if (!parent) return false;
 
@@ -1494,53 +1481,14 @@ export async function startBot(token: string): Promise<void> {
     const config = CHANNEL_MAP.get(parentName);
     if (!config) return false;
 
-    const result = await restartBriefWindow(
-      {
-        threadName: thread.name,
-        hasBriefConfig: Boolean(config.brief),
-        // Reaching this call site means the thread has no live session.
-        hasSession: false,
-        sessionCount: sessionManager.count(),
-        maxSessions: MAX_SESSIONS,
-      },
+    return handleBriefWindowThreadMessage({
       threadId,
-      briefWindowDeps(config, parent),
-    );
-
-    if (result.ok) {
-      console.log(
-        `[Bot] Brief window restarted (thread=${threadId}, channel=${parentName})`,
-      );
-      // The message that woke the window is NOT relayed: the session is still
-      // booting and `/brief-window` is being injected, so racing a second write
-      // into the same pane is how RW-025-class input loss happens. Say so
-      // instead of dropping it silently.
-      try {
-        await thread.send(
-          "🔓 窓口セッションを再起動しました（前回は無操作で自動クローズされていました）。\n" +
-            "起動処理中のため、いまの発言は届いていません。**もう一度送ってください**。",
-        );
-      } catch (err) {
-        console.error(
-          `[Bot] Brief window restart notice failed for thread ${threadId}:`,
-          err,
-        );
-      }
-      return true;
-    }
-
-    if (result.stage === "skipped") {
-      // `capacity` was reported into the thread by restartBriefWindow; anything
-      // else (kill-switch off, channel without brief config) falls through to
-      // the existing salvage reply rather than going quiet.
-      return result.reason === "capacity";
-    }
-
-    // start / inject failures already posted their reason and paged.
-    console.warn(
-      `[Bot] Brief window restart failed (thread=${threadId}, stage=${result.stage})`,
-    );
-    return true;
+      threadName: thread.name,
+      hasBriefConfig: Boolean(config.brief),
+      sessionCount: sessionManager.count(),
+      maxSessions: MAX_SESSIONS,
+      deps: briefWindowDeps(config, parent),
+    });
   }
 
   // Issue #426 → #449: handle a `/brief <YYYY-MM-DD>` message from an allowed
@@ -1700,31 +1648,17 @@ export async function startBot(token: string): Promise<void> {
         // handleMessageCreate), so a thread is the only place the chairman can
         // answer with anything other than approve / reject / hold. Deliberately
         // not gated on `delivered`: the morning the decision post fails is
-        // exactly when a way to talk matters most. Failures here are reported by
-        // openBriefWindow and never propagate — the buttons must not go down
+        // exactly when a way to talk matters most. openBriefWindowForBrief
+        // reports and swallows its own failures so the buttons never go down
         // with the window.
-        try {
-          const window = await openBriefWindow(
-            {
-              date: decision.date,
-              hasBriefConfig: true,
-              sessionCount: sessionManager.count(),
-              maxSessions: MAX_SESSIONS,
-            },
-            briefWindowDeps(config, textChannel),
-          );
-          if (window.ok) {
-            console.log(
-              `[Bot] Brief window ${window.reused ? "reused" : "opened"} in channel ${channelName} (thread=${window.threadId}, date=${decision.date})`,
-            );
-          } else {
-            console.warn(
-              `[Bot] Brief window not opened in channel ${channelName} (stage=${window.stage}, reason=${window.reason})`,
-            );
-          }
-        } catch (err) {
-          console.error("[Bot] Brief window handler error:", err);
-        }
+        await openBriefWindowForBrief({
+          date: decision.date,
+          channelName,
+          sessionCount: sessionManager.count(),
+          maxSessions: MAX_SESSIONS,
+          deps: briefWindowDeps(config, textChannel),
+        });
+
         return true;
       }
     }

--- a/supervisor/src/session/brief-window.ts
+++ b/supervisor/src/session/brief-window.ts
@@ -398,3 +398,181 @@ async function startWindowSession(
 
   return { ok: true, threadId, reused };
 }
+
+/* --------------------------------------------------------------------------
+ * bot.ts を薄く保つためのアダプタ層。
+ *
+ * discord.js / SessionManager の型は構造的に受け取り、ここでは import しない。
+ * bot.ts 側に残すのは「実物をこの形に束ねる」数行だけにして、判断もログも
+ * 通知文もこのファイル（= テストのあるファイル）に置く。
+ * ------------------------------------------------------------------------ */
+
+/** 親チャンネル（スレッドを作れるテキストチャンネル）に必要な最小形。 */
+export interface BriefWindowChannelLike {
+  threads: {
+    fetchActive: () => Promise<{
+      threads: {
+        find: (
+          predicate: (t: { name: string; id: string }) => boolean,
+        ) => { id: string } | undefined;
+      };
+    }>;
+    create: (options: {
+      name: string;
+      autoArchiveDuration: number;
+    }) => Promise<{ id: string }>;
+  };
+  send: (content: string) => Promise<unknown>;
+}
+
+/** SessionManager に必要な最小形（config は呼び出し元で bind 済み）。 */
+export interface BriefWindowSessionsLike {
+  has: (threadId: string) => boolean;
+  start: (threadId: string, branch: string) => Promise<void>;
+  waitForInputReady: (threadId: string) => Promise<boolean>;
+  sendMessage: (threadId: string, text: string) => Promise<void>;
+}
+
+/** dispatch スレッドと同じ 7 日。窓口は idle reaper 側で先に閉じる。 */
+export const BRIEF_WINDOW_AUTO_ARCHIVE_MINUTES = 10080;
+
+/** Discord / SessionManager から {@link BriefWindowDeps} を組み立てる。 */
+export function createBriefWindowDeps(args: {
+  channel: BriefWindowChannelLike;
+  sessions: BriefWindowSessionsLike;
+  /** スレッド id から送信口を引く（見つからなければ null）。 */
+  fetchThread: (
+    threadId: string,
+  ) => Promise<{ send: (content: string) => Promise<unknown> } | null>;
+  notifyFailure: (title: string, body: string) => Promise<void>;
+}): BriefWindowDeps {
+  return {
+    findThreadByName: async (name) => {
+      const active = await args.channel.threads.fetchActive();
+      const hit = active.threads.find((t) => t.name === name);
+      return hit ? { id: hit.id } : null;
+    },
+    hasSession: (threadId) => args.sessions.has(threadId),
+    createThread: async (name) =>
+      args.channel.threads.create({
+        name,
+        autoArchiveDuration: BRIEF_WINDOW_AUTO_ARCHIVE_MINUTES,
+      }),
+    start: (threadId, branch) => args.sessions.start(threadId, branch),
+    waitForInputReady: (threadId) => args.sessions.waitForInputReady(threadId),
+    sendMessage: (threadId, text) => args.sessions.sendMessage(threadId, text),
+    postToThread: async (threadId, content) => {
+      const thread = await args.fetchThread(threadId);
+      if (thread) await thread.send(content);
+    },
+    postToChannel: async (content) => {
+      await args.channel.send(content);
+    },
+    notifyFailure: args.notifyFailure,
+  };
+}
+
+/**
+ * eager 経路のエントリ。`/brief` 受理後に呼ぶ。
+ *
+ * 窓口は決裁の付随機能なので、ここで throw して決裁経路を巻き添えにしない
+ * （失敗は結果型 + ログで返す）。
+ */
+export async function openBriefWindowForBrief(args: {
+  date: string;
+  channelName: string;
+  sessionCount: number;
+  maxSessions: number;
+  deps: BriefWindowDeps;
+  env?: Record<string, string | undefined>;
+}): Promise<BriefWindowResult> {
+  try {
+    const result = await openBriefWindow(
+      {
+        date: args.date,
+        hasBriefConfig: true,
+        sessionCount: args.sessionCount,
+        maxSessions: args.maxSessions,
+        env: args.env,
+      },
+      args.deps,
+    );
+    if (result.ok) {
+      console.log(
+        `[brief-window] ${result.reused ? "reused" : "opened"} in channel ${args.channelName} (thread=${result.threadId}, date=${args.date})`,
+      );
+    } else {
+      console.warn(
+        `[brief-window] not opened in channel ${args.channelName} (stage=${result.stage}, reason=${result.reason})`,
+      );
+    }
+    return result;
+  } catch (err) {
+    const reason = errMsg(err);
+    console.error(`[brief-window] unexpected error in ${args.channelName}: ${reason}`);
+    return { ok: false, stage: "skipped", reason };
+  }
+}
+
+/** 再起動時にスレッドへ出す案内。引き金になった発言は中継しないことを明示する。 */
+export const BRIEF_WINDOW_RESTART_NOTICE =
+  "🔓 窓口セッションを再起動しました（前回は無操作で自動クローズされていました）。\n" +
+  "起動処理中のため、いまの発言はまだ届いていません。**もう一度送ってください**。";
+
+/**
+ * lazy 経路のエントリ。セッション不在スレッドへの発言で呼ぶ。
+ *
+ * 戻り値 `true` = このメッセージを消費した（呼び出し元は以降の salvage 処理を
+ * 止める）。`false` = 窓口ではない等で、従来の salvage 返信に委ねる。
+ */
+export async function handleBriefWindowThreadMessage(args: {
+  threadId: string;
+  threadName: string;
+  hasBriefConfig: boolean;
+  sessionCount: number;
+  maxSessions: number;
+  deps: BriefWindowDeps;
+  env?: Record<string, string | undefined>;
+}): Promise<boolean> {
+  const result = await restartBriefWindow(
+    {
+      threadName: args.threadName,
+      hasBriefConfig: args.hasBriefConfig,
+      // ここに来ている時点でそのスレッドに稼働セッションは無い。
+      hasSession: false,
+      sessionCount: args.sessionCount,
+      maxSessions: args.maxSessions,
+      env: args.env,
+    },
+    args.threadId,
+    args.deps,
+  );
+
+  if (result.ok) {
+    console.log(`[brief-window] restarted (thread=${args.threadId})`);
+    // 引き金の発言は中継しない: 起動直後の TUI に `/brief-window` と会長の発言を
+    // 同時に打つと RW-025 / RW-047 と同じ入力取りこぼしを起こす。黙って捨てず、
+    // 「もう一度送って」と明示する。
+    await args.deps
+      .postToThread(args.threadId, BRIEF_WINDOW_RESTART_NOTICE)
+      .catch((err) =>
+        console.error(
+          `[brief-window] restart notice failed (thread=${args.threadId}):`,
+          err,
+        ),
+      );
+    return true;
+  }
+
+  if (result.stage === "skipped") {
+    // capacity は restartBriefWindow がスレッドへ通知済み。それ以外
+    // （kill-switch / brief 未設定 / 窓口でない）は従来の salvage に委ねる。
+    return result.reason === "capacity";
+  }
+
+  // start / inject の失敗は既に post + notify 済み。二重に salvage を出さない。
+  console.warn(
+    `[brief-window] restart failed (thread=${args.threadId}, stage=${result.stage})`,
+  );
+  return true;
+}

--- a/supervisor/src/session/brief-window.ts
+++ b/supervisor/src/session/brief-window.ts
@@ -1,0 +1,400 @@
+/**
+ * 朝レポ「窓口セッション」（#454）— ボタン決裁以外の返信を受ける会話口。
+ *
+ * #449 で朝レポの決裁はセッション非依存のボタンになった。堅牢さと引き換えに、
+ * 会長が「OK / NG 以外」を返す口が消えている。#corp のチャンネル直下に書いた
+ * メッセージはどのセッションにも中継されないため（`bot.ts` の
+ * `if (!message.channel.isThread()) return;`）、受け口はスレッドしか有り得ない。
+ *
+ * そこで `/brief <YYYY-MM-DD>` の着信を契機に、決裁ボタンと**並行して**
+ * 会話用スレッドを 1 本開き、corp の CEO セッションを起動する。
+ *
+ * 設計上の約束:
+ *
+ *   1. **自由文を受け取らない**（#449 の不変条件を継承）。注入するのは
+ *      検証済みの `YYYY-MM-DD` から組み立てた固定リテラル `/brief-window <date>`
+ *      だけで、送信者のテキストは 1 バイトも通らない。実際の振る舞いは corp 側の
+ *      `.claude/commands/brief-window.md`（corp#136）が持つ = 部署の playbook は
+ *      部署リポに置く（corp#49 の決定）。
+ *   2. **決裁経路と独立**。窓口の起動に失敗しても決裁ボタンは生きている。
+ *      逆に決裁の post に失敗した朝こそ窓口が要るので、`delivered` の真偽に
+ *      関わらず開こうとする。
+ *   3. **冪等**。窓口は同名スレッド（`朝レポ窓口 <date>`）で識別する。同じ業務日の
+ *      `/brief` が再送されても、生きている窓口があればそれを再利用する。
+ *      thread id を supervisor のメモリに持たないので、再起動を跨いでも壊れない。
+ *   4. **停止機構を足さない**。生存期間は interactive セッション共通の idle reaper
+ *      （`SESSION_IDLE_DEFAULT_MS`、既定 6h）に委ねる。閉じた後にそのスレッドへ
+ *      発言されたら {@link evaluateBriefWindowRestart} 経由で起動し直す。
+ *
+ * 判断はすべて純関数に閉じており、副作用は {@link BriefWindowDeps} として注入する
+ * （`corp-brief.ts` / `dispatch.ts` と同じ設計方針）。
+ */
+
+/** 窓口だけを止める kill-switch。決裁経路の `CORP_BRIEF_DISABLED` とは独立。 */
+export const BRIEF_WINDOW_DISABLED_ENV = "CORP_BRIEF_WINDOW_DISABLED";
+
+/** 窓口スレッド名の接頭辞。この文字列が窓口スレッドの識別子そのもの。 */
+export const BRIEF_WINDOW_THREAD_PREFIX = "朝レポ窓口";
+
+/** 注入するスラッシュコマンド名（定義は corp 側 `.claude/commands/brief-window.md`）。 */
+export const BRIEF_WINDOW_COMMAND = "brief-window";
+
+/** 窓口 worktree のブランチ接頭辞。dispatch の `corp-dispatch-<N>` と同じ命名思想。 */
+export const BRIEF_WINDOW_BRANCH_PREFIX = "corp-brief-window-";
+
+const DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * 日付トークンの再検証。呼び出し元（`parseBriefCommand`）が既に検証済みでも、
+ * ここを通らない限りスレッド名・ブランチ名・注入文字列のどれにも値が入らないようにする。
+ * 不正値は握りつぶさず throw する（silent fallback 禁止）。
+ */
+function assertDate(date: string): string {
+  if (!DATE_RE.test(date)) {
+    throw new Error(
+      `brief-window: 日付が YYYY-MM-DD ではありません（注入・命名に使えません）: ${date}`,
+    );
+  }
+  return date;
+}
+
+/** この経路を止める kill-switch。空文字 / `0` 以外なら停止（`isBriefDisabled` と同型）。 */
+export function isBriefWindowDisabled(
+  env: Record<string, string | undefined> = process.env,
+): boolean {
+  const raw = (env[BRIEF_WINDOW_DISABLED_ENV] ?? "").trim();
+  return raw.length > 0 && raw !== "0";
+}
+
+/** 窓口スレッド名。この名前が (channel, 業務日) に対する冪等キーになる。 */
+export function briefWindowThreadName(date: string): string {
+  return `${BRIEF_WINDOW_THREAD_PREFIX} ${assertDate(date)}`;
+}
+
+/** 窓口 worktree のブランチ名。branchless（`~/corp` 直）だと #150 の relay-url 衝突を踏む。 */
+export function briefWindowBranch(date: string): string {
+  return `${BRIEF_WINDOW_BRANCH_PREFIX}${assertDate(date)}`;
+}
+
+/** セッションへ注入する固定リテラル。送信者のテキストはここに一切入らない。 */
+export function briefWindowInitialCommand(date: string): string {
+  return `/${BRIEF_WINDOW_COMMAND} ${assertDate(date)}`;
+}
+
+/**
+ * スレッド名から窓口の業務日を取り出す。窓口でなければ `null`。
+ *
+ * 名前で識別するのは、この名前を付けたのが supervisor 自身だから（外部 UI の
+ * 表示文字列マッチ = RW-027 の anti-pattern ではない）。人が改名した窓口は
+ * 自動再起動の対象外に落ちるが、従来どおり salvage 返信が出るだけで壊れない。
+ */
+export function parseBriefWindowThreadName(
+  name: string | null | undefined,
+): string | null {
+  if (!name) return null;
+  const prefix = `${BRIEF_WINDOW_THREAD_PREFIX} `;
+  if (!name.startsWith(prefix)) return null;
+  const date = name.slice(prefix.length).trim();
+  return DATE_RE.test(date) ? date : null;
+}
+
+/** 窓口を開かない理由。すべて呼び出し元が観測・報告できるよう列挙する。 */
+export type BriefWindowSkipReason =
+  | "disabled"
+  | "no_brief_config"
+  | "invalid_date"
+  | "capacity"
+  | "not_window_thread"
+  | "session_alive";
+
+export type BriefWindowOpenDecision =
+  | {
+      kind: "open";
+      date: string;
+      threadName: string;
+      branch: string;
+      command: string;
+    }
+  | { kind: "skip"; reason: BriefWindowSkipReason };
+
+export interface BriefWindowOpenInput {
+  /** `parseBriefCommand` が検証済みの業務日。 */
+  date: string;
+  /** 対象チャンネルに `ChannelConfig.brief` があるか（無ければ窓口も対象外）。 */
+  hasBriefConfig: boolean;
+  /** 現在の稼働セッション数。 */
+  sessionCount: number;
+  /** `MAX_SESSIONS`。 */
+  maxSessions: number;
+  env?: Record<string, string | undefined>;
+}
+
+/**
+ * 窓口を開いてよいかの判定。決裁経路（`evaluateBriefTrigger`）とは独立に
+ * fail-closed で判断する — 認可自体は呼び出し元が既に通した `/brief` の
+ * `dispatchFrom` ゲートが担う（新しい認可モデルを作らない）。
+ */
+export function evaluateBriefWindowOpen(
+  input: BriefWindowOpenInput,
+): BriefWindowOpenDecision {
+  if (isBriefWindowDisabled(input.env ?? process.env)) {
+    return { kind: "skip", reason: "disabled" };
+  }
+  if (!input.hasBriefConfig) {
+    return { kind: "skip", reason: "no_brief_config" };
+  }
+  if (!DATE_RE.test(input.date)) {
+    return { kind: "skip", reason: "invalid_date" };
+  }
+  if (input.sessionCount >= input.maxSessions) {
+    return { kind: "skip", reason: "capacity" };
+  }
+  return {
+    kind: "open",
+    date: input.date,
+    threadName: briefWindowThreadName(input.date),
+    branch: briefWindowBranch(input.date),
+    command: briefWindowInitialCommand(input.date),
+  };
+}
+
+export type BriefWindowRestartDecision =
+  | { kind: "restart"; date: string; branch: string; command: string }
+  | { kind: "skip"; reason: BriefWindowSkipReason };
+
+export interface BriefWindowRestartInput {
+  /** 発言のあったスレッド名。 */
+  threadName: string | null | undefined;
+  hasBriefConfig: boolean;
+  /** そのスレッドに稼働セッションがあるか。 */
+  hasSession: boolean;
+  sessionCount: number;
+  maxSessions: number;
+  env?: Record<string, string | undefined>;
+}
+
+/**
+ * idle reaper に閉じられた窓口スレッドへの発言で、セッションを起動し直してよいかの判定。
+ * 窓口スレッド以外は従来どおり salvage 返信に任せる（`not_window_thread`）。
+ */
+export function evaluateBriefWindowRestart(
+  input: BriefWindowRestartInput,
+): BriefWindowRestartDecision {
+  const date = parseBriefWindowThreadName(input.threadName);
+  if (date === null) {
+    return { kind: "skip", reason: "not_window_thread" };
+  }
+  if (isBriefWindowDisabled(input.env ?? process.env)) {
+    return { kind: "skip", reason: "disabled" };
+  }
+  if (!input.hasBriefConfig) {
+    return { kind: "skip", reason: "no_brief_config" };
+  }
+  if (input.hasSession) {
+    return { kind: "skip", reason: "session_alive" };
+  }
+  if (input.sessionCount >= input.maxSessions) {
+    return { kind: "skip", reason: "capacity" };
+  }
+  return {
+    kind: "restart",
+    date,
+    branch: briefWindowBranch(date),
+    command: briefWindowInitialCommand(date),
+  };
+}
+
+/** 窓口を開くために必要な副作用。Discord / SessionManager を直接触らないための注入点。 */
+export interface BriefWindowDeps {
+  /** 同名の生存スレッドを探す（冪等キー）。見つからなければ null。 */
+  findThreadByName: (name: string) => Promise<{ id: string } | null>;
+  /** そのスレッドに稼働セッションがあるか。 */
+  hasSession: (threadId: string) => boolean;
+  createThread: (name: string) => Promise<{ id: string }>;
+  start: (threadId: string, branch: string) => Promise<void>;
+  waitForInputReady: (threadId: string) => Promise<boolean>;
+  sendMessage: (threadId: string, text: string) => Promise<void>;
+  postToThread: (threadId: string, content: string) => Promise<void>;
+  postToChannel: (content: string) => Promise<void>;
+  notifyFailure: (title: string, body: string) => Promise<void>;
+}
+
+export type BriefWindowResult =
+  | { ok: true; threadId: string; reused: boolean }
+  | {
+      ok: false;
+      stage: "skipped" | "thread" | "start" | "inject";
+      reason: string;
+    };
+
+function errMsg(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * 窓口を開く（朝レポ着信時の eager 経路）。
+ *
+ * 失敗は必ずチャンネルに出す。決裁ボタンは呼び出し元が別に post 済みなので、
+ * ここで throw して決裁ごと巻き添えにしない（結果型で返す）。
+ */
+export async function openBriefWindow(
+  input: BriefWindowOpenInput,
+  deps: BriefWindowDeps,
+): Promise<BriefWindowResult> {
+  const decision = evaluateBriefWindowOpen(input);
+  if (decision.kind === "skip") {
+    // 意図的な停止（kill-switch / 未設定チャンネル）は「失敗」ではないので黙る。
+    // 開けるはずが開けなかった理由（capacity / invalid_date）だけを可視化する。
+    if (decision.reason === "capacity" || decision.reason === "invalid_date") {
+      const detail =
+        decision.reason === "capacity"
+          ? `稼働セッションが上限（${input.maxSessions}）に達しているため起動できませんでした`
+          : `日付トークンが不正でした（${input.date}）`;
+      await deps
+        .postToChannel(
+          `⚠️ 朝レポ（${input.date}）の窓口スレッドを開けませんでした — ${detail}。\n` +
+            `決裁ボタンは通常どおり使えます。会話が必要なら \`/session start <branch>\` でスレッドを作ってください。`,
+        )
+        .catch((err) =>
+          console.warn("[brief-window] skip notice post failed:", err),
+        );
+    }
+    return { ok: false, stage: "skipped", reason: decision.reason };
+  }
+
+  // 冪等キー = スレッド名。生きている窓口があれば何もしない（同日 2 本作らない）。
+  let threadId: string;
+  let reused = false;
+  try {
+    const existing = await deps.findThreadByName(decision.threadName);
+    if (existing) {
+      if (deps.hasSession(existing.id)) {
+        return { ok: true, threadId: existing.id, reused: true };
+      }
+      // スレッドはあるがセッションが落ちている（reaper 後の再送）→ 貼り直す。
+      threadId = existing.id;
+    } else {
+      threadId = (await deps.createThread(decision.threadName)).id;
+    }
+  } catch (err) {
+    const reason = errMsg(err);
+    console.error(`[brief-window] thread resolution failed: ${reason}`);
+    await deps
+      .postToChannel(
+        `⚠️ 朝レポ（${decision.date}）の窓口スレッドを作成できませんでした（決裁ボタンは有効）。\n\`\`\`\n${reason}\n\`\`\``,
+      )
+      .catch(() => {});
+    await deps
+      .notifyFailure(
+        "朝レポ窓口の起動に失敗",
+        `${decision.date} の窓口スレッドを作成できませんでした: ${reason}`,
+      )
+      .catch(() => {});
+    return { ok: false, stage: "thread", reason };
+  }
+
+  return startWindowSession(decision.date, threadId, decision.branch, decision.command, deps, reused);
+}
+
+/**
+ * 閉じた窓口スレッドへの発言でセッションを起動し直す（lazy 経路）。
+ * スレッドは既にあるので、起動と注入だけを行う。
+ */
+export async function restartBriefWindow(
+  input: BriefWindowRestartInput,
+  threadId: string,
+  deps: BriefWindowDeps,
+): Promise<BriefWindowResult> {
+  const decision = evaluateBriefWindowRestart(input);
+  if (decision.kind === "skip") {
+    if (decision.reason === "capacity") {
+      await deps
+        .postToThread(
+          threadId,
+          `⚠️ 稼働セッションが上限に達しているため、この窓口を再開できませんでした。` +
+            `他のセッションを止めてからもう一度発言してください。`,
+        )
+        .catch((err) =>
+          console.warn("[brief-window] capacity notice post failed:", err),
+        );
+    }
+    return { ok: false, stage: "skipped", reason: decision.reason };
+  }
+
+  return startWindowSession(
+    decision.date,
+    threadId,
+    decision.branch,
+    decision.command,
+    deps,
+    false,
+  );
+}
+
+/** 起動 → input-ready 待ち → 固定コマンド注入。eager / lazy で共通。 */
+async function startWindowSession(
+  date: string,
+  threadId: string,
+  branch: string,
+  command: string,
+  deps: BriefWindowDeps,
+  reused: boolean,
+): Promise<BriefWindowResult> {
+  try {
+    await deps.start(threadId, branch);
+  } catch (err) {
+    const reason = errMsg(err);
+    console.error(`[brief-window] session start failed (${threadId}): ${reason}`);
+    await deps
+      .postToChannel(
+        `⚠️ 朝レポ（${date}）の窓口セッションを起動できませんでした（決裁ボタンは有効）。\n\`\`\`\n${reason}\n\`\`\``,
+      )
+      .catch(() => {});
+    await deps
+      .notifyFailure(
+        "朝レポ窓口の起動に失敗",
+        `${date} の窓口セッションを起動できませんでした: ${reason}`,
+      )
+      .catch(() => {});
+    return { ok: false, stage: "start", reason };
+  }
+
+  // start() は PID までしか待たない。起動直後の Ink TUI に打つと先頭の `/` を
+  // スラッシュピッカーが食って入力欄に取り残される（RW-025 / RW-047 と同じ
+  // タイミング事故）。marker を待ってから注入し、待てなくても best-effort で打つ。
+  try {
+    const ready = await deps.waitForInputReady(threadId);
+    if (!ready) {
+      console.warn(
+        `[brief-window] input-ready marker not seen for thread ${threadId}; injecting anyway`,
+      );
+    }
+  } catch (err) {
+    console.warn(
+      `[brief-window] waitForInputReady failed for thread ${threadId}: ${errMsg(err)}`,
+    );
+  }
+
+  try {
+    await deps.sendMessage(threadId, command);
+  } catch (err) {
+    const reason = errMsg(err);
+    console.error(`[brief-window] inject failed (${threadId}): ${reason}`);
+    await deps
+      .postToThread(
+        threadId,
+        `⚠️ 窓口セッションは起動しましたが初期コマンド \`${command}\` を注入できませんでした。\n` +
+          `このスレッドで直接話しかけるか、\`@Channel-Supervisor status\` で生死を確認してください。\n\`\`\`\n${reason}\n\`\`\``,
+      )
+      .catch(() => {});
+    await deps
+      .notifyFailure(
+        "朝レポ窓口の初期化に失敗",
+        `${date} の窓口へ ${command} を注入できませんでした: ${reason}`,
+      )
+      .catch(() => {});
+    return { ok: false, stage: "inject", reason };
+  }
+
+  return { ok: true, threadId, reused };
+}

--- a/supervisor/tests/session/brief-window.test.ts
+++ b/supervisor/tests/session/brief-window.test.ts
@@ -1,0 +1,330 @@
+import { describe, test, expect } from "bun:test";
+import {
+  BRIEF_WINDOW_DISABLED_ENV,
+  briefWindowBranch,
+  briefWindowInitialCommand,
+  briefWindowThreadName,
+  evaluateBriefWindowOpen,
+  evaluateBriefWindowRestart,
+  isBriefWindowDisabled,
+  openBriefWindow,
+  parseBriefWindowThreadName,
+  type BriefWindowDeps,
+} from "../../src/session/brief-window";
+
+/**
+ * Issue #454: the morning brief opens ONE conversation window (thread +
+ * session) in #corp so the chairman can reply with something other than the
+ * decision buttons.
+ *
+ * The properties fixed here are the ones that keep the window from becoming
+ * either a saturation source or an approval-gate bypass:
+ *
+ *   1. **no free text** — the injected command is built from the already
+ *      validated `YYYY-MM-DD` token and a fixed literal, never from caller text
+ *      (same invariant as #449);
+ *   2. **idempotent** — a second `/brief` for the same business day reuses the
+ *      existing window instead of opening a second one;
+ *   3. **never silent** — a capacity refusal or a start failure is reported,
+ *      and it never takes the decision buttons down with it.
+ */
+
+const DATE = "2026-08-26";
+
+function deps(over: Partial<BriefWindowDeps> = {}) {
+  const calls = {
+    created: [] as string[],
+    started: [] as Array<{ threadId: string; branch: string }>,
+    sent: [] as Array<{ threadId: string; text: string }>,
+    thread: [] as Array<{ threadId: string; content: string }>,
+    channel: [] as string[],
+    failures: [] as Array<{ title: string; body: string }>,
+  };
+  const base: BriefWindowDeps = {
+    findThreadByName: async () => null,
+    hasSession: () => false,
+    createThread: async (name) => {
+      calls.created.push(name);
+      return { id: "thread-new" };
+    },
+    start: async (threadId, branch) => {
+      calls.started.push({ threadId, branch });
+    },
+    waitForInputReady: async () => true,
+    sendMessage: async (threadId, text) => {
+      calls.sent.push({ threadId, text });
+    },
+    postToThread: async (threadId, content) => {
+      calls.thread.push({ threadId, content });
+    },
+    postToChannel: async (content) => {
+      calls.channel.push(content);
+    },
+    notifyFailure: async (title, body) => {
+      calls.failures.push({ title, body });
+    },
+  };
+  return { deps: { ...base, ...over }, calls };
+}
+
+describe("naming contract", () => {
+  test("thread name / branch / injected command are derived from the date alone", () => {
+    expect(briefWindowThreadName(DATE)).toBe(`朝レポ窓口 ${DATE}`);
+    expect(briefWindowBranch(DATE)).toBe(`corp-brief-window-${DATE}`);
+    expect(briefWindowInitialCommand(DATE)).toBe(`/brief-window ${DATE}`);
+  });
+
+  test("the injected command carries no caller text beyond the validated date", () => {
+    // A date that already failed validation upstream must not reach the pane.
+    expect(() => briefWindowInitialCommand("2026-08-26; rm -rf /")).toThrow();
+    expect(() => briefWindowThreadName("../evil")).toThrow();
+    expect(() => briefWindowBranch("$(whoami)")).toThrow();
+  });
+
+  test("a window thread is recognised by its name and yields back the date", () => {
+    expect(parseBriefWindowThreadName(`朝レポ窓口 ${DATE}`)).toBe(DATE);
+    expect(parseBriefWindowThreadName("朝レポ窓口")).toBeNull();
+    expect(parseBriefWindowThreadName("朝レポ窓口 not-a-date")).toBeNull();
+    expect(parseBriefWindowThreadName("corp-dispatch-12 Corp CEO 1")).toBeNull();
+    expect(parseBriefWindowThreadName(null)).toBeNull();
+  });
+});
+
+describe("kill-switch", () => {
+  test("is independent of the decision path's own switch", () => {
+    expect(BRIEF_WINDOW_DISABLED_ENV).toBe("CORP_BRIEF_WINDOW_DISABLED");
+    expect(isBriefWindowDisabled({})).toBe(false);
+    expect(isBriefWindowDisabled({ CORP_BRIEF_WINDOW_DISABLED: "" })).toBe(false);
+    expect(isBriefWindowDisabled({ CORP_BRIEF_WINDOW_DISABLED: "0" })).toBe(false);
+    expect(isBriefWindowDisabled({ CORP_BRIEF_WINDOW_DISABLED: "1" })).toBe(true);
+    // The decision path's switch must NOT take the window down with it.
+    expect(isBriefWindowDisabled({ CORP_BRIEF_DISABLED: "1" })).toBe(false);
+  });
+});
+
+describe("evaluateBriefWindowOpen", () => {
+  const ok = { date: DATE, hasBriefConfig: true, sessionCount: 3, maxSessions: 10 };
+
+  test("opens for a brief-configured channel with capacity", () => {
+    const d = evaluateBriefWindowOpen(ok);
+    expect(d.kind).toBe("open");
+    if (d.kind !== "open") return;
+    expect(d.threadName).toBe(`朝レポ窓口 ${DATE}`);
+    expect(d.branch).toBe(`corp-brief-window-${DATE}`);
+    expect(d.command).toBe(`/brief-window ${DATE}`);
+  });
+
+  test("skips when the kill-switch is set", () => {
+    const d = evaluateBriefWindowOpen({ ...ok, env: { CORP_BRIEF_WINDOW_DISABLED: "1" } });
+    expect(d).toEqual({ kind: "skip", reason: "disabled" });
+  });
+
+  test("skips a channel without brief config (fail-closed, same rule as the decision path)", () => {
+    expect(evaluateBriefWindowOpen({ ...ok, hasBriefConfig: false })).toEqual({
+      kind: "skip",
+      reason: "no_brief_config",
+    });
+  });
+
+  test("skips an invalid date rather than interpolating it", () => {
+    expect(evaluateBriefWindowOpen({ ...ok, date: "2026/08/26" })).toEqual({
+      kind: "skip",
+      reason: "invalid_date",
+    });
+  });
+
+  test("skips at the session cap", () => {
+    expect(evaluateBriefWindowOpen({ ...ok, sessionCount: 10 })).toEqual({
+      kind: "skip",
+      reason: "capacity",
+    });
+  });
+});
+
+describe("evaluateBriefWindowRestart", () => {
+  const ok = {
+    threadName: `朝レポ窓口 ${DATE}`,
+    hasBriefConfig: true,
+    hasSession: false,
+    sessionCount: 2,
+    maxSessions: 10,
+  };
+
+  test("restarts a reaped window thread", () => {
+    const d = evaluateBriefWindowRestart(ok);
+    expect(d.kind).toBe("restart");
+    if (d.kind !== "restart") return;
+    expect(d.date).toBe(DATE);
+    expect(d.branch).toBe(`corp-brief-window-${DATE}`);
+  });
+
+  test("leaves non-window threads to the existing salvage path", () => {
+    expect(evaluateBriefWindowRestart({ ...ok, threadName: "corp-dispatch-12" })).toEqual({
+      kind: "skip",
+      reason: "not_window_thread",
+    });
+  });
+
+  test("does nothing when the session is still alive", () => {
+    expect(evaluateBriefWindowRestart({ ...ok, hasSession: true })).toEqual({
+      kind: "skip",
+      reason: "session_alive",
+    });
+  });
+
+  test("is fail-closed on channel config, kill-switch and capacity", () => {
+    expect(evaluateBriefWindowRestart({ ...ok, hasBriefConfig: false })).toEqual({
+      kind: "skip",
+      reason: "no_brief_config",
+    });
+    expect(
+      evaluateBriefWindowRestart({ ...ok, env: { CORP_BRIEF_WINDOW_DISABLED: "1" } }),
+    ).toEqual({ kind: "skip", reason: "disabled" });
+    expect(evaluateBriefWindowRestart({ ...ok, sessionCount: 10 })).toEqual({
+      kind: "skip",
+      reason: "capacity",
+    });
+  });
+});
+
+describe("openBriefWindow", () => {
+  test("creates the thread, starts the session and injects the fixed command", async () => {
+    const { deps: d, calls } = deps();
+    const res = await openBriefWindow(
+      { date: DATE, hasBriefConfig: true, sessionCount: 1, maxSessions: 10 },
+      d,
+    );
+
+    expect(res).toEqual({ ok: true, threadId: "thread-new", reused: false });
+    expect(calls.created).toEqual([`朝レポ窓口 ${DATE}`]);
+    expect(calls.started).toEqual([
+      { threadId: "thread-new", branch: `corp-brief-window-${DATE}` },
+    ]);
+    expect(calls.sent).toEqual([
+      { threadId: "thread-new", text: `/brief-window ${DATE}` },
+    ]);
+    expect(calls.failures).toEqual([]);
+  });
+
+  test("AC-3: a second brief for the same day reuses the live window instead of opening a second one", async () => {
+    const { deps: d, calls } = deps({
+      findThreadByName: async (name) =>
+        name === `朝レポ窓口 ${DATE}` ? { id: "thread-existing" } : null,
+      hasSession: (id) => id === "thread-existing",
+    });
+
+    const res = await openBriefWindow(
+      { date: DATE, hasBriefConfig: true, sessionCount: 1, maxSessions: 10 },
+      d,
+    );
+
+    expect(res).toEqual({ ok: true, threadId: "thread-existing", reused: true });
+    expect(calls.created).toEqual([]);
+    expect(calls.started).toEqual([]);
+    expect(calls.sent).toEqual([]);
+  });
+
+  test("reattaches to an existing thread whose session was reaped (no duplicate thread)", async () => {
+    const { deps: d, calls } = deps({
+      findThreadByName: async () => ({ id: "thread-existing" }),
+      hasSession: () => false,
+    });
+
+    const res = await openBriefWindow(
+      { date: DATE, hasBriefConfig: true, sessionCount: 1, maxSessions: 10 },
+      d,
+    );
+
+    expect(res).toEqual({ ok: true, threadId: "thread-existing", reused: false });
+    expect(calls.created).toEqual([]);
+    expect(calls.started).toEqual([
+      { threadId: "thread-existing", branch: `corp-brief-window-${DATE}` },
+    ]);
+  });
+
+  test("AC-4: a capacity refusal is reported to the channel, not swallowed", async () => {
+    const { deps: d, calls } = deps();
+    const res = await openBriefWindow(
+      { date: DATE, hasBriefConfig: true, sessionCount: 10, maxSessions: 10 },
+      d,
+    );
+
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.stage).toBe("skipped");
+    expect(res.reason).toBe("capacity");
+    expect(calls.channel.length).toBe(1);
+    expect(calls.channel[0]).toContain("窓口");
+    expect(calls.created).toEqual([]);
+  });
+
+  test("a disabled kill-switch is silent (an intentional off-switch is not a failure)", async () => {
+    const { deps: d, calls } = deps();
+    const res = await openBriefWindow(
+      {
+        date: DATE,
+        hasBriefConfig: true,
+        sessionCount: 1,
+        maxSessions: 10,
+        env: { CORP_BRIEF_WINDOW_DISABLED: "1" },
+      },
+      d,
+    );
+
+    expect(res).toEqual({ ok: false, stage: "skipped", reason: "disabled" });
+    expect(calls.channel).toEqual([]);
+    expect(calls.failures).toEqual([]);
+  });
+
+  test("a start failure is reported to the channel and paged, never silent", async () => {
+    const { deps: d, calls } = deps({
+      start: async () => {
+        throw new Error("最大セッション数 (10) に達しています");
+      },
+    });
+
+    const res = await openBriefWindow(
+      { date: DATE, hasBriefConfig: true, sessionCount: 1, maxSessions: 10 },
+      d,
+    );
+
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.stage).toBe("start");
+    expect(calls.channel.length).toBe(1);
+    expect(calls.failures.length).toBe(1);
+    expect(calls.sent).toEqual([]);
+  });
+
+  test("injects anyway when the input-ready marker is missed (RW-025 / RW-047 timing class)", async () => {
+    const { deps: d, calls } = deps({ waitForInputReady: async () => false });
+    const res = await openBriefWindow(
+      { date: DATE, hasBriefConfig: true, sessionCount: 1, maxSessions: 10 },
+      d,
+    );
+
+    expect(res.ok).toBe(true);
+    expect(calls.sent).toEqual([
+      { threadId: "thread-new", text: `/brief-window ${DATE}` },
+    ]);
+  });
+
+  test("an inject failure is reported, and the thread says the window is not usable", async () => {
+    const { deps: d, calls } = deps({
+      sendMessage: async () => {
+        throw new Error("relay refused");
+      },
+    });
+
+    const res = await openBriefWindow(
+      { date: DATE, hasBriefConfig: true, sessionCount: 1, maxSessions: 10 },
+      d,
+    );
+
+    expect(res.ok).toBe(false);
+    if (res.ok) return;
+    expect(res.stage).toBe("inject");
+    expect(calls.thread.length + calls.channel.length).toBeGreaterThan(0);
+    expect(calls.failures.length).toBe(1);
+  });
+});

--- a/supervisor/tests/session/brief-window.test.ts
+++ b/supervisor/tests/session/brief-window.test.ts
@@ -4,10 +4,14 @@ import {
   briefWindowBranch,
   briefWindowInitialCommand,
   briefWindowThreadName,
+  BRIEF_WINDOW_RESTART_NOTICE,
+  createBriefWindowDeps,
   evaluateBriefWindowOpen,
   evaluateBriefWindowRestart,
   isBriefWindowDisabled,
+  handleBriefWindowThreadMessage,
   openBriefWindow,
+  openBriefWindowForBrief,
   parseBriefWindowThreadName,
   type BriefWindowDeps,
 } from "../../src/session/brief-window";
@@ -325,6 +329,211 @@ describe("openBriefWindow", () => {
     if (res.ok) return;
     expect(res.stage).toBe("inject");
     expect(calls.thread.length + calls.channel.length).toBeGreaterThan(0);
+    expect(calls.failures.length).toBe(1);
+  });
+});
+
+describe("createBriefWindowDeps (adapter binding)", () => {
+  function fakeChannel() {
+    const state = {
+      created: [] as Array<{ name: string; autoArchiveDuration: number }>,
+      sent: [] as string[],
+      active: [] as Array<{ id: string; name: string }>,
+    };
+    const channel = {
+      threads: {
+        fetchActive: async () => ({
+          threads: {
+            find: (p: (t: { name: string; id: string }) => boolean) =>
+              state.active.find(p),
+          },
+        }),
+        create: async (o: { name: string; autoArchiveDuration: number }) => {
+          state.created.push(o);
+          return { id: "created-1" };
+        },
+      },
+      send: async (c: string) => {
+        state.sent.push(c);
+        return {};
+      },
+    };
+    return { channel, state };
+  }
+
+  function build(over: { activeThreads?: Array<{ id: string; name: string }> } = {}) {
+    const { channel, state } = fakeChannel();
+    state.active = over.activeThreads ?? [];
+    const sessions = {
+      has: (id: string) => id === "live",
+      started: [] as Array<{ threadId: string; branch: string }>,
+      sent: [] as Array<{ threadId: string; text: string }>,
+      start: async function (threadId: string, branch: string) {
+        this.started.push({ threadId, branch });
+      },
+      waitForInputReady: async () => true,
+      sendMessage: async function (threadId: string, text: string) {
+        this.sent.push({ threadId, text });
+      },
+    };
+    const threadSends: Array<{ threadId: string; content: string }> = [];
+    const pages: Array<{ title: string; body: string }> = [];
+    const deps = createBriefWindowDeps({
+      channel,
+      sessions,
+      fetchThread: async (threadId) =>
+        threadId === "missing"
+          ? null
+          : {
+              send: async (content: string) => {
+                threadSends.push({ threadId, content });
+                return {};
+              },
+            },
+      notifyFailure: async (title, body) => {
+        pages.push({ title, body });
+      },
+    });
+    return { deps, state, sessions, threadSends, pages };
+  }
+
+  test("findThreadByName matches the window thread by exact name", async () => {
+    const { deps } = build({
+      activeThreads: [
+        { id: "other", name: "corp-dispatch-12" },
+        { id: "win", name: `朝レポ窓口 ${DATE}` },
+      ],
+    });
+    expect(await deps.findThreadByName(`朝レポ窓口 ${DATE}`)).toEqual({ id: "win" });
+    expect(await deps.findThreadByName("朝レポ窓口 2026-01-01")).toBeNull();
+  });
+
+  test("createThread uses the dispatch-equivalent auto-archive window", async () => {
+    const { deps, state } = build();
+    expect(await deps.createThread("t")).toEqual({ id: "created-1" });
+    expect(state.created).toEqual([{ name: "t", autoArchiveDuration: 10080 }]);
+  });
+
+  test("postToThread is a no-op when the thread can no longer be fetched", async () => {
+    const { deps, threadSends } = build();
+    await deps.postToThread("missing", "hi");
+    expect(threadSends).toEqual([]);
+    await deps.postToThread("t1", "hi");
+    expect(threadSends).toEqual([{ threadId: "t1", content: "hi" }]);
+  });
+
+  test("postToChannel and hasSession delegate to the bound objects", async () => {
+    const { deps, state } = build();
+    await deps.postToChannel("notice");
+    expect(state.sent).toEqual(["notice"]);
+    expect(deps.hasSession("live")).toBe(true);
+    expect(deps.hasSession("dead")).toBe(false);
+  });
+});
+
+describe("openBriefWindowForBrief (eager entry)", () => {
+  test("returns the window result on the happy path", async () => {
+    const { deps: d, calls } = deps();
+    const res = await openBriefWindowForBrief({
+      date: DATE,
+      channelName: "corp",
+      sessionCount: 1,
+      maxSessions: 10,
+      deps: d,
+    });
+    expect(res).toEqual({ ok: true, threadId: "thread-new", reused: false });
+    expect(calls.created).toEqual([`朝レポ窓口 ${DATE}`]);
+  });
+
+  test("never throws into the decision path — an unexpected error becomes a result", async () => {
+    const { deps: d } = deps({
+      findThreadByName: async () => {
+        throw new Error("discord exploded");
+      },
+      postToChannel: async () => {
+        throw new Error("channel gone too");
+      },
+      notifyFailure: async () => {
+        throw new Error("pushover down");
+      },
+    });
+    const res = await openBriefWindowForBrief({
+      date: DATE,
+      channelName: "corp",
+      sessionCount: 1,
+      maxSessions: 10,
+      deps: d,
+    });
+    expect(res.ok).toBe(false);
+  });
+});
+
+describe("handleBriefWindowThreadMessage (lazy entry)", () => {
+  const base = {
+    threadId: "win-1",
+    threadName: `朝レポ窓口 ${DATE}`,
+    hasBriefConfig: true,
+    sessionCount: 2,
+    maxSessions: 10,
+  };
+
+  test("AC-5: restarts the window and tells the chairman to resend", async () => {
+    const { deps: d, calls } = deps();
+    const consumed = await handleBriefWindowThreadMessage({ ...base, deps: d });
+
+    expect(consumed).toBe(true);
+    expect(calls.started).toEqual([
+      { threadId: "win-1", branch: `corp-brief-window-${DATE}` },
+    ]);
+    expect(calls.sent).toEqual([
+      { threadId: "win-1", text: `/brief-window ${DATE}` },
+    ]);
+    // The message that woke the window is not relayed, so it must be said out loud.
+    expect(calls.thread.length).toBe(1);
+    expect(calls.thread[0]!.content).toBe(BRIEF_WINDOW_RESTART_NOTICE);
+  });
+
+  test("hands non-window threads back to the existing salvage path", async () => {
+    const { deps: d, calls } = deps();
+    const consumed = await handleBriefWindowThreadMessage({
+      ...base,
+      threadName: "corp-dispatch-12 Corp CEO 1",
+      deps: d,
+    });
+    expect(consumed).toBe(false);
+    expect(calls.started).toEqual([]);
+  });
+
+  test("falls through to salvage when the kill-switch is off rather than going quiet", async () => {
+    const { deps: d } = deps();
+    const consumed = await handleBriefWindowThreadMessage({
+      ...base,
+      deps: d,
+      env: { CORP_BRIEF_WINDOW_DISABLED: "1" },
+    });
+    expect(consumed).toBe(false);
+  });
+
+  test("consumes the message at the session cap (the reason was posted in-thread)", async () => {
+    const { deps: d, calls } = deps();
+    const consumed = await handleBriefWindowThreadMessage({
+      ...base,
+      sessionCount: 10,
+      deps: d,
+    });
+    expect(consumed).toBe(true);
+    expect(calls.thread.length).toBe(1);
+    expect(calls.started).toEqual([]);
+  });
+
+  test("consumes the message when the restart itself fails (already reported)", async () => {
+    const { deps: d, calls } = deps({
+      start: async () => {
+        throw new Error("tmux refused");
+      },
+    });
+    const consumed = await handleBriefWindowThreadMessage({ ...base, deps: d });
+    expect(consumed).toBe(true);
     expect(calls.failures.length).toBe(1);
   });
 });


### PR DESCRIPTION
Closes #454

## 目的

会長が #corp のチャンネル直下に返信を書いても**誰にも届いていない**（`bot.ts` の `isThread` ガードで非スレッドメッセージは no-op）。#449 で決裁がセッション非依存のボタンになったのは正しい一方、「OK / NG 以外」を返す口が消えていた。

`/brief <YYYY-MM-DD>` の着信を契機に、**決裁ボタンと並行して**会話用スレッドを 1 本開き、corp の CEO セッションを起動する。

## 変更

- **`src/session/brief-window.ts`（新規）** — 判断は純関数、副作用は `BriefWindowDeps` として注入（`corp-brief.ts` / `dispatch.ts` と同じ設計）
- **`src/bot.ts`**
  - eager: `handleBriefMessage` の決裁フロー直後に窓口を開く
  - lazy: セッション不在スレッドへの発言が窓口なら起動し直す（`tryRestartBriefWindow`）
- **`.github/workflows/ci.yml`** — 新規テストを登録

## 設計上の約束

| 約束 | 実装 |
|---|---|
| **自由文を通さない**（#449 の不変条件） | 注入は検証済み日付から組み立てた固定リテラル `/brief-window <date>` のみ。送信者テキストは 1 バイトも入らない。振る舞い定義は corp 側 playbook（corp#136） |
| **決裁と独立** | `delivered` の真偽に関わらず開く（決裁が失敗した朝こそ窓口が要る）。窓口の失敗は結果型で返し、決裁経路を巻き添えにしない |
| **冪等** | 冪等キーは **スレッド名** `朝レポ窓口 <date>`。in-memory の thread id を持たないので supervisor 再起動を跨いでも同日 2 本にならない |
| **停止機構を足さない** | 生存期間は既存の interactive idle reaper（`SESSION_IDLE_DEFAULT_MS`、既定 6h）に委ねる |
| **サイレントにしない** | capacity / start / inject の失敗は post ＋ Pushover。kill-switch と未設定チャンネルだけは意図的な off なので黙る |
| **枠を食い潰さない** | `MAX_SESSIONS` に達していたら開かず理由を post（決裁ボタンは通常どおり機能する） |

Issue 本文から変わった点が 1 つあります: 窓口の識別を「in-memory の thread id」ではなく **スレッド名**にしました。supervisor 再起動を跨いでも冪等・再起動可能になるためです（この名前を付けたのは supervisor 自身なので、外部 UI 文字列マッチ = RW-027 の anti-pattern には当たりません）。

branch は `corp-brief-window-<date>` の worktree 起動です。branchless（`~/corp` 直）だと projectDir が他の corp セッションと重なり **#150（relay-url 共有で応答が別スレッドへ流入）** を踏みます。

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| AC-1 | 決裁ボタンと窓口スレッドの両方が出る | ハーメティックテスト（`openBriefWindow` が createThread / start / inject を呼ぶ） | 3 つとも呼ばれる | 呼ばれた | **PASS** |
| AC-3 | 同日再送で窓口は 1 本 | 同上（生存窓口がある場合） | createThread / start を呼ばない | 呼ばれず `reused: true` | **PASS** |
| AC-4 | 上限到達時は起動せず理由を post、決裁は生存 | 同上（`sessionCount = maxSessions`） | channel post 1 件・thread 作成 0 件 | 一致 | **PASS** |
| AC-5 | 閉じた窓口への発言で再起動 | `evaluateBriefWindowRestart` / `restartBriefWindow` | 窓口のみ restart、他は `not_window_thread` | 一致 | **PASS** |
| 追加 | 注入文字列に caller text が混入しない | 不正日付で命名・注入ヘルパが throw | throw | throw | **PASS** |
| 追加 | kill-switch が決裁側と独立 | `isBriefWindowDisabled({CORP_BRIEF_DISABLED:"1"})` | false | false | **PASS** |
| 回帰 | 既存スイートに新規失敗なし | `bun test`（全 1557 件） | main と失敗集合が一致 | **完全一致**（33 件はいずれも main 時点から失敗している tmux/socket 系の環境依存） | **PASS** |
| 型 | 型検査 | `bunx tsc --noEmit` | exit 0 | exit 0 | **PASS** |

**AC-2（窓口で自由記述 → CEO が応答）は未検証**です。corp#136（`/brief-window` playbook）の merge と supervisor 再起動が要るため、実機確認は両方が入ったあとに `npm run secretary -- --force-brief` でまとめて行います。

## 既知の挙動（意図的）

lazy 再起動で窓口を起こしたとき、**その引き金になった発言は中継しません**。セッション起動直後の TUI に `/brief-window` と会長の発言を同時に打つと RW-025 / RW-047 と同じ入力取りこぼしを起こすためです。代わりにスレッドへ「再起動したので、もう一度送ってください」と明示します（無言で落とさない）。

## テスト

- `supervisor/tests/session/brief-window.test.ts`（新規 21 件）
- `bun test` 全体: 1517 pass / 33 fail（fail はすべて main baseline と同一の既存 tmux 環境依存）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Awc4fvf8CnDfqYx9y6g4hP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * `/brief` 実行時に、決裁ボタンと朝レポート用の会話ウィンドウを同時に開始できるようになりました。
  * 既存の会話ウィンドウを再利用し、停止後に新しいメッセージを受け取ると自動的に再開します。
  * 起動中の問題は通知され、決裁操作は継続できます。
  * 会話内容の送信前に準備状態を確認し、安全な固定コマンドのみを送信します。

* **テスト**
  * 起動条件、再利用、再開、容量超過、各種失敗時の動作を追加検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->