### PR TITLE
fix(brief): 窓口の待機報告をスレッドへ投稿し、窓口スレッドを汎用 wake から守る（#464 / #463）

### DIFF
--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -116,6 +116,7 @@ import {
   openBriefWindowForBrief,
   parseBriefWindowThreadName,
   type BriefWindowDeps,
+  type BriefWindowMessageOutcome,
 } from "./session/brief-window";
 import {
   ORCHESTRATE_PREFIX,
@@ -1443,8 +1444,11 @@ export async function startBot(token: string): Promise<void> {
         },
         waitForInputReady: (threadId) =>
           sessionManager.waitForInputReady(threadId),
+        // #464: 通常の会話経路と同じく chunks を持ち帰る。捨てると起動直後の
+        // 待機報告がどこにも出ない（投稿するのは brief-window.ts 側）。
         sendMessage: async (threadId, text) => {
-          await sessionManager.sendMessage(threadId, text);
+          const result = await sessionManager.sendMessage(threadId, text);
+          return { chunks: result.chunks, error: result.error };
         },
       },
       fetchThread: async (threadId) => {
@@ -1463,10 +1467,10 @@ export async function startBot(token: string): Promise<void> {
   async function tryRestartBriefWindow(
     message: Message,
     threadId: string,
-  ): Promise<boolean> {
+  ): Promise<BriefWindowMessageOutcome> {
     const thread = message.channel as ThreadChannel;
     // Cheap early-out so an ordinary dead thread never fetches config or channels.
-    if (parseBriefWindowThreadName(thread.name) === null) return false;
+    if (parseBriefWindowThreadName(thread.name) === null) return "not_window";
 
     // thread.parent はキャッシュ依存のゲッターで、起動直後などキャッシュ外だと
     // 実在する親でも null を返す（PR #340 gemini high）。parentId からの明示
@@ -1479,11 +1483,11 @@ export async function startBot(token: string): Promise<void> {
           ? (fetched as TextChannel)
           : null;
     }
-    if (!parent) return false;
+    if (!parent) return "not_window";
 
     const parentName = "name" in parent ? (parent.name as string) : "";
     const config = CHANNEL_MAP.get(parentName);
-    if (!config) return false;
+    if (!config) return "not_window";
 
     return handleBriefWindowThreadMessage({
       threadId,
@@ -1777,7 +1781,12 @@ export async function startBot(token: string): Promise<void> {
       // is still booting (RW-025 / RW-047). The name check inside is a cheap
       // early-out, so ordinary threads reach the wake path unchanged.
       try {
-        if (await tryRestartBriefWindow(message, threadId)) return;
+        // #463: "not_window" 以外＝窓口スレッドと判定できた場合は、起動できた
+        // かどうかに関わらずここで終える。下の汎用 wake（#456）に落とすと素の
+        // --resume が先に噛み、kill-switch で止めたはずの窓口が起き上がる。
+        if ((await tryRestartBriefWindow(message, threadId)) !== "not_window") {
+          return;
+        }
       } catch (err) {
         console.error("[Bot] Brief window restart error:", err);
       }

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -115,7 +115,7 @@ import {
   handleBriefWindowThreadMessage,
   openBriefWindowForBrief,
   parseBriefWindowThreadName,
-  briefWindowResolutionFailure,
+  reportBriefWindowResolutionFailure,
   type BriefWindowDeps,
   type BriefWindowMessageOutcome,
 } from "./session/brief-window";
@@ -1465,18 +1465,6 @@ export async function startBot(token: string): Promise<void> {
   // reaper already stopped restarts it instead of answering with the salvage
   // notice. Returns true when the message was consumed and the caller must stop.
   // Only the Discord-specific parent resolution lives here.
-  /** 窓口スレッドへの通知。失敗しても呼び出し元の判定は変えない。 */
-  async function notifyWindowThread(
-    thread: ThreadChannel,
-    content: string,
-  ): Promise<void> {
-    try {
-      await thread.send(content);
-    } catch (err) {
-      console.error(`[brief-window] notice failed (${thread.id}):`, err);
-    }
-  }
-
   async function tryRestartBriefWindow(
     message: Message,
     threadId: string,
@@ -1501,23 +1489,17 @@ export async function startBot(token: string): Promise<void> {
     // #454 の契約を黙って上書きし、supervisor 再起動直後のキャッシュミスや設定
     // 欠落が「窓口ではない」として扱われる。
     if (!parent) {
-      console.warn(
-        `[brief-window] parent channel unresolved for window thread ${threadId}`,
+      return reportBriefWindowResolutionFailure("parent", threadId, (c) =>
+        thread.send(c),
       );
-      const { outcome, notice } = briefWindowResolutionFailure("parent");
-      await notifyWindowThread(thread, notice);
-      return outcome;
     }
 
     const parentName = "name" in parent ? (parent.name as string) : "";
     const config = CHANNEL_MAP.get(parentName);
     if (!config) {
-      console.warn(
-        `[brief-window] no channel config for window thread ${threadId} (parent=${parentName})`,
+      return reportBriefWindowResolutionFailure("config", threadId, (c) =>
+        thread.send(c),
       );
-      const { outcome, notice } = briefWindowResolutionFailure("config");
-      await notifyWindowThread(thread, notice);
-      return outcome;
     }
 
     return handleBriefWindowThreadMessage({

--- a/supervisor/src/bot.ts
+++ b/supervisor/src/bot.ts
@@ -115,6 +115,7 @@ import {
   handleBriefWindowThreadMessage,
   openBriefWindowForBrief,
   parseBriefWindowThreadName,
+  briefWindowResolutionFailure,
   type BriefWindowDeps,
   type BriefWindowMessageOutcome,
 } from "./session/brief-window";
@@ -1464,6 +1465,18 @@ export async function startBot(token: string): Promise<void> {
   // reaper already stopped restarts it instead of answering with the salvage
   // notice. Returns true when the message was consumed and the caller must stop.
   // Only the Discord-specific parent resolution lives here.
+  /** 窓口スレッドへの通知。失敗しても呼び出し元の判定は変えない。 */
+  async function notifyWindowThread(
+    thread: ThreadChannel,
+    content: string,
+  ): Promise<void> {
+    try {
+      await thread.send(content);
+    } catch (err) {
+      console.error(`[brief-window] notice failed (${thread.id}):`, err);
+    }
+  }
+
   async function tryRestartBriefWindow(
     message: Message,
     threadId: string,
@@ -1483,11 +1496,29 @@ export async function startBot(token: string): Promise<void> {
           ? (fetched as TextChannel)
           : null;
     }
-    if (!parent) return "not_window";
+    // ここから下はスレッド名で窓口と確定済み。解決に失敗しても "not_window" を
+    // 返してはいけない（#463 / CodeRabbit）。汎用 wake に落ちると素の --resume が
+    // #454 の契約を黙って上書きし、supervisor 再起動直後のキャッシュミスや設定
+    // 欠落が「窓口ではない」として扱われる。
+    if (!parent) {
+      console.warn(
+        `[brief-window] parent channel unresolved for window thread ${threadId}`,
+      );
+      const { outcome, notice } = briefWindowResolutionFailure("parent");
+      await notifyWindowThread(thread, notice);
+      return outcome;
+    }
 
     const parentName = "name" in parent ? (parent.name as string) : "";
     const config = CHANNEL_MAP.get(parentName);
-    if (!config) return "not_window";
+    if (!config) {
+      console.warn(
+        `[brief-window] no channel config for window thread ${threadId} (parent=${parentName})`,
+      );
+      const { outcome, notice } = briefWindowResolutionFailure("config");
+      await notifyWindowThread(thread, notice);
+      return outcome;
+    }
 
     return handleBriefWindowThreadMessage({
       threadId,

--- a/supervisor/src/session/brief-window.ts
+++ b/supervisor/src/session/brief-window.ts
@@ -204,6 +204,17 @@ export function evaluateBriefWindowRestart(
   };
 }
 
+/**
+ * 初期コマンド注入に対して relay が返した応答（#464）。
+ *
+ * `chunks` を捨てると CEO の待機報告がどこにも出ない。通常の会話経路は同じ値を
+ * スレッドへ投稿しており、窓口だけがそれを持っていなかった。
+ */
+export interface BriefWindowRelayReply {
+  chunks: string[];
+  error?: string;
+}
+
 /** 窓口を開くために必要な副作用。Discord / SessionManager を直接触らないための注入点。 */
 export interface BriefWindowDeps {
   /** 同名の生存スレッドを探す（冪等キー）。見つからなければ null。 */
@@ -213,11 +224,23 @@ export interface BriefWindowDeps {
   createThread: (name: string) => Promise<{ id: string }>;
   start: (threadId: string, branch: string) => Promise<void>;
   waitForInputReady: (threadId: string) => Promise<boolean>;
-  sendMessage: (threadId: string, text: string) => Promise<void>;
+  sendMessage: (
+    threadId: string,
+    text: string,
+  ) => Promise<BriefWindowRelayReply>;
   postToThread: (threadId: string, content: string) => Promise<void>;
   postToChannel: (content: string) => Promise<void>;
   notifyFailure: (title: string, body: string) => Promise<void>;
 }
+
+/**
+ * 窓口スレッドへの着信メッセージをどう処理したか（#463）。
+ *
+ * `not_window` 以外を返した時点で、呼び出し元は汎用 auto-resume（#456）へ
+ * 落としてはならない。窓口スレッドにも履歴があるため、素の `--resume` が先に
+ * 噛むと「窓口を止めたのに窓口が起き上がる」ようになる。
+ */
+export type BriefWindowMessageOutcome = "restarted" | "blocked" | "not_window";
 
 export type BriefWindowResult =
   | { ok: true; threadId: string; reused: boolean }
@@ -375,8 +398,9 @@ async function startWindowSession(
     );
   }
 
+  let reply: BriefWindowRelayReply;
   try {
-    await deps.sendMessage(threadId, command);
+    reply = await deps.sendMessage(threadId, command);
   } catch (err) {
     const reason = errMsg(err);
     console.error(`[brief-window] inject failed (${threadId}): ${reason}`);
@@ -396,7 +420,50 @@ async function startWindowSession(
     return { ok: false, stage: "inject", reason };
   }
 
+  await deliverStandbyReport(threadId, reply, deps);
+
   return { ok: true, threadId, reused };
+}
+
+/**
+ * 初期コマンドへの応答（＝CEO の待機報告）をスレッドへ出す（#464）。
+ *
+ * 投稿の失敗で窓口の起動そのものを巻き戻さない。窓口は既に使える状態であり、
+ * 挨拶が出ないことと窓口が無いことは別物だから。ただし黙って捨てもしない。
+ */
+async function deliverStandbyReport(
+  threadId: string,
+  reply: BriefWindowRelayReply,
+  deps: BriefWindowDeps,
+): Promise<void> {
+  const chunks = reply.chunks.filter((c) => c.trim().length > 0);
+
+  for (const chunk of chunks) {
+    try {
+      await deps.postToThread(threadId, chunk);
+    } catch (err) {
+      console.error(
+        `[brief-window] standby report post failed (${threadId}): ${errMsg(err)}`,
+      );
+    }
+  }
+
+  if (reply.error) {
+    await deps
+      .postToThread(
+        threadId,
+        `${BRIEF_WINDOW_REPLY_ERROR_NOTICE}\n\`\`\`\n${reply.error}\n\`\`\``,
+      )
+      .catch(() => {});
+    return;
+  }
+
+  if (chunks.length === 0) {
+    // 応答ゼロを「成功」として黙らせない（agent-output-quality #1）。
+    await deps
+      .postToThread(threadId, BRIEF_WINDOW_EMPTY_REPLY_NOTICE)
+      .catch(() => {});
+  }
 }
 
 /* --------------------------------------------------------------------------
@@ -430,7 +497,10 @@ export interface BriefWindowSessionsLike {
   has: (threadId: string) => boolean;
   start: (threadId: string, branch: string) => Promise<void>;
   waitForInputReady: (threadId: string) => Promise<boolean>;
-  sendMessage: (threadId: string, text: string) => Promise<void>;
+  sendMessage: (
+    threadId: string,
+    text: string,
+  ) => Promise<BriefWindowRelayReply>;
 }
 
 /** dispatch スレッドと同じ 7 日。窓口は idle reaper 側で先に閉じる。 */
@@ -515,6 +585,25 @@ export async function openBriefWindowForBrief(args: {
 }
 
 /** 再起動時にスレッドへ出す案内。引き金になった発言は中継しないことを明示する。 */
+/** 応答が 1 つも返らなかったとき（#464）。無言で成功扱いにしない。 */
+export const BRIEF_WINDOW_EMPTY_REPLY_NOTICE =
+  "⚠️ 窓口セッションは起動しましたが、待機報告が返りませんでした。" +
+  "このスレッドで話しかければ通常どおり応答します。";
+
+/** 応答が error で返ったとき（#464）。 */
+export const BRIEF_WINDOW_REPLY_ERROR_NOTICE =
+  "⚠️ 窓口セッションは起動しましたが、待機報告の取得に失敗しました。" +
+  "このスレッドで話しかければ通常どおり応答します。";
+
+/** kill-switch で窓口を止めているとき（#463）。汎用 auto-resume に落とさない。 */
+export const BRIEF_WINDOW_DISABLED_NOTICE =
+  "⏸️ 窓口の自動再起動は停止中です（kill-switch 有効）。\n" +
+  "会話を続けるには、このスレッドで `/session resume` を実行してください。";
+
+/** 親チャンネルに朝レポ設定が無いとき（#463）。設定ミスなので黙らせない。 */
+export const BRIEF_WINDOW_NO_CONFIG_NOTICE =
+  "⚠️ このチャンネルは朝レポ窓口として設定されていないため、窓口を再開できません。";
+
 export const BRIEF_WINDOW_RESTART_NOTICE =
   "🔓 窓口セッションを再起動しました（前回は無操作で自動クローズされていました）。\n" +
   "起動処理中のため、いまの発言はまだ届いていません。**もう一度送ってください**。";
@@ -533,7 +622,7 @@ export async function handleBriefWindowThreadMessage(args: {
   maxSessions: number;
   deps: BriefWindowDeps;
   env?: Record<string, string | undefined>;
-}): Promise<boolean> {
+}): Promise<BriefWindowMessageOutcome> {
   const result = await restartBriefWindow(
     {
       threadName: args.threadName,
@@ -561,18 +650,38 @@ export async function handleBriefWindowThreadMessage(args: {
           err,
         ),
       );
-    return true;
+    return "restarted";
   }
 
   if (result.stage === "skipped") {
-    // capacity は restartBriefWindow がスレッドへ通知済み。それ以外
-    // （kill-switch / brief 未設定 / 窓口でない）は従来の salvage に委ねる。
-    return result.reason === "capacity";
+    // 窓口でないスレッドだけが従来経路（#456 の汎用 wake → salvage）へ戻る。
+    if (result.reason === "not_window_thread") return "not_window";
+
+    // ここから下は「窓口だが今は起こさない」。汎用 wake に落とすと素の
+    // --resume が噛んで #454 の契約（/brief-window 再注入 + 再送依頼）を
+    // 黙って上書きするため、理由を出したうえで消費する（#463）。
+    const notice =
+      result.reason === "disabled"
+        ? BRIEF_WINDOW_DISABLED_NOTICE
+        : result.reason === "no_brief_config"
+          ? BRIEF_WINDOW_NO_CONFIG_NOTICE
+          : null; // capacity は restartBriefWindow がスレッドへ通知済み
+    if (notice) {
+      await args.deps
+        .postToThread(args.threadId, notice)
+        .catch((err) =>
+          console.error(
+            `[brief-window] skip notice failed (thread=${args.threadId}):`,
+            err,
+          ),
+        );
+    }
+    return "blocked";
   }
 
   // start / inject の失敗は既に post + notify 済み。二重に salvage を出さない。
   console.warn(
     `[brief-window] restart failed (thread=${args.threadId}, stage=${result.stage})`,
   );
-  return true;
+  return "blocked";
 }

--- a/supervisor/src/session/brief-window.ts
+++ b/supervisor/src/session/brief-window.ts
@@ -636,6 +636,29 @@ export function briefWindowResolutionFailure(stage: "parent" | "config"): {
   };
 }
 
+/**
+ * 解決失敗を通知まで含めて処理する（#463）。bot.ts 側は分岐 1 行で済ませる。
+ *
+ * 通知に失敗しても判定（`"blocked"`）は変えない。汎用 wake へ落とさないことが
+ * 目的であって、通知はそのついでだから。
+ */
+export async function reportBriefWindowResolutionFailure(
+  stage: "parent" | "config",
+  threadId: string,
+  send: (content: string) => Promise<unknown>,
+): Promise<BriefWindowMessageOutcome> {
+  const { outcome, notice } = briefWindowResolutionFailure(stage);
+  console.warn(
+    `[brief-window] ${stage} unresolved for window thread ${threadId}`,
+  );
+  try {
+    await send(notice);
+  } catch (err) {
+    console.error(`[brief-window] resolution notice failed (${threadId}):`, err);
+  }
+  return outcome;
+}
+
 export const BRIEF_WINDOW_RESTART_NOTICE =
   "🔓 窓口セッションを再起動しました（前回は無操作で自動クローズされていました）。\n" +
   "起動処理中のため、いまの発言はまだ届いていません。**もう一度送ってください**。";

--- a/supervisor/src/session/brief-window.ts
+++ b/supervisor/src/session/brief-window.ts
@@ -600,9 +600,41 @@ export const BRIEF_WINDOW_DISABLED_NOTICE =
   "⏸️ 窓口の自動再起動は停止中です（kill-switch 有効）。\n" +
   "会話を続けるには、このスレッドで `/session resume` を実行してください。";
 
+/**
+ * 窓口スレッドと判定できたが、親チャンネル / その設定を解決できないとき（#463）。
+ *
+ * ここで `not_window` を返して汎用 wake に落とすと、素の `--resume` が #454 の
+ * 契約を黙って上書きする。解決失敗は「窓口ではない」ではなく「今は起こせない」。
+ */
+export const BRIEF_WINDOW_UNRESOLVED_NOTICE =
+  "⚠️ 窓口スレッドの親チャンネルを解決できず、窓口を再開できませんでした。\n" +
+  "しばらく待って再度発言するか、このスレッドで `/session resume` を実行してください。";
+
 /** 親チャンネルに朝レポ設定が無いとき（#463）。設定ミスなので黙らせない。 */
 export const BRIEF_WINDOW_NO_CONFIG_NOTICE =
   "⚠️ このチャンネルは朝レポ窓口として設定されていないため、窓口を再開できません。";
+
+/**
+ * スレッド名で窓口と確定した「あと」に、親チャンネル（`parent`）またはその
+ * チャンネル設定（`CHANNEL_MAP`）を解決できなかったときの応答（#463）。
+ *
+ * 要点は **"not_window" を返さないこと**。解決失敗は「窓口ではない」ではなく
+ * 「今は起こせない」であり、汎用 wake（#456）に落とすと素の `--resume` が
+ * #454 の契約を黙って上書きする（supervisor 再起動直後のキャッシュミスで実際に
+ * 起こる）。bot.ts に分岐を書くとテストが届かないため判断はここに置く。
+ */
+export function briefWindowResolutionFailure(stage: "parent" | "config"): {
+  outcome: BriefWindowMessageOutcome;
+  notice: string;
+} {
+  return {
+    outcome: "blocked",
+    notice:
+      stage === "parent"
+        ? BRIEF_WINDOW_UNRESOLVED_NOTICE
+        : BRIEF_WINDOW_NO_CONFIG_NOTICE,
+  };
+}
 
 export const BRIEF_WINDOW_RESTART_NOTICE =
   "🔓 窓口セッションを再起動しました（前回は無操作で自動クローズされていました）。\n" +

--- a/supervisor/tests/session/brief-window.test.ts
+++ b/supervisor/tests/session/brief-window.test.ts
@@ -4,6 +4,10 @@ import {
   briefWindowBranch,
   briefWindowInitialCommand,
   briefWindowThreadName,
+  BRIEF_WINDOW_DISABLED_NOTICE,
+  BRIEF_WINDOW_EMPTY_REPLY_NOTICE,
+  BRIEF_WINDOW_NO_CONFIG_NOTICE,
+  BRIEF_WINDOW_REPLY_ERROR_NOTICE,
   BRIEF_WINDOW_RESTART_NOTICE,
   createBriefWindowDeps,
   evaluateBriefWindowOpen,
@@ -35,6 +39,10 @@ import {
 
 const DATE = "2026-08-26";
 
+/** CEO が起動直後に返す待機報告の代表（corp#136 の 1 行）。 */
+const STANDBY =
+  "窓口開いてます — 未決提案 1 件 / 会長判断待ち 10 件。決裁はボタン、それ以外はここへどうぞ。";
+
 function deps(over: Partial<BriefWindowDeps> = {}) {
   const calls = {
     created: [] as string[],
@@ -57,6 +65,7 @@ function deps(over: Partial<BriefWindowDeps> = {}) {
     waitForInputReady: async () => true,
     sendMessage: async (threadId, text) => {
       calls.sent.push({ threadId, text });
+      return { chunks: [STANDBY] };
     },
     postToThread: async (threadId, content) => {
       calls.thread.push({ threadId, content });
@@ -374,6 +383,7 @@ describe("createBriefWindowDeps (adapter binding)", () => {
       waitForInputReady: async () => true,
       sendMessage: async function (threadId: string, text: string) {
         this.sent.push({ threadId, text });
+        return { chunks: [STANDBY] };
       },
     };
     const threadSends: Array<{ threadId: string; content: string }> = [];
@@ -468,6 +478,83 @@ describe("openBriefWindowForBrief (eager entry)", () => {
   });
 });
 
+describe("standby report delivery (#464)", () => {
+  const open = (d: BriefWindowDeps) =>
+    openBriefWindow(
+      { date: DATE, hasBriefConfig: true, sessionCount: 1, maxSessions: 10 },
+      d,
+    );
+
+  test("posts the CEO standby report into the window thread", async () => {
+    // 本番初回 (2026-08-27) の回帰: ペインには報告が出ているのにスレッドは空だった。
+    const { deps: d, calls } = deps();
+    const res = await open(d);
+
+    expect(res.ok).toBe(true);
+    expect(calls.thread).toEqual([{ threadId: "thread-new", content: STANDBY }]);
+  });
+
+  test("posts every non-empty chunk and drops blank ones", async () => {
+    const { deps: d, calls } = deps({
+      sendMessage: async () => ({ chunks: ["one", "   ", "two"] }),
+    });
+    await open(d);
+
+    expect(calls.thread.map((c) => c.content)).toEqual(["one", "two"]);
+  });
+
+  test("says so instead of going quiet when no chunk comes back", async () => {
+    const { deps: d, calls } = deps({
+      sendMessage: async () => ({ chunks: [] }),
+    });
+    const res = await open(d);
+
+    expect(res.ok).toBe(true);
+    expect(calls.thread.map((c) => c.content)).toEqual([
+      BRIEF_WINDOW_EMPTY_REPLY_NOTICE,
+    ]);
+  });
+
+  test("surfaces a relay error in the thread", async () => {
+    const { deps: d, calls } = deps({
+      sendMessage: async () => ({ chunks: [], error: "relay timeout" }),
+    });
+    const res = await open(d);
+
+    expect(res.ok).toBe(true);
+    expect(calls.thread.length).toBe(1);
+    expect(calls.thread[0]!.content).toContain(BRIEF_WINDOW_REPLY_ERROR_NOTICE);
+    expect(calls.thread[0]!.content).toContain("relay timeout");
+  });
+
+  test("a failed post does not undo the window itself", async () => {
+    // 窓口は既に使える。挨拶が出ないことと窓口が無いことは別物。
+    const { deps: d } = deps({
+      postToThread: async () => {
+        throw new Error("discord 500");
+      },
+    });
+    const res = await open(d);
+
+    expect(res.ok).toBe(true);
+    if (res.ok) expect(res.threadId).toBe("thread-new");
+  });
+
+  test("an inject failure reports the failure and never a standby report", async () => {
+    const { deps: d, calls } = deps({
+      sendMessage: async () => {
+        throw new Error("pane gone");
+      },
+    });
+    const res = await open(d);
+
+    expect(res.ok).toBe(false);
+    expect(calls.thread.length).toBe(1);
+    expect(calls.thread[0]!.content).toContain("pane gone");
+    expect(calls.failures.length).toBe(1);
+  });
+});
+
 describe("handleBriefWindowThreadMessage (lazy entry)", () => {
   const base = {
     threadId: "win-1",
@@ -481,16 +568,18 @@ describe("handleBriefWindowThreadMessage (lazy entry)", () => {
     const { deps: d, calls } = deps();
     const consumed = await handleBriefWindowThreadMessage({ ...base, deps: d });
 
-    expect(consumed).toBe(true);
+    expect(consumed).toBe("restarted");
     expect(calls.started).toEqual([
       { threadId: "win-1", branch: `corp-brief-window-${DATE}` },
     ]);
     expect(calls.sent).toEqual([
       { threadId: "win-1", text: `/brief-window ${DATE}` },
     ]);
-    // The message that woke the window is not relayed, so it must be said out loud.
-    expect(calls.thread.length).toBe(1);
-    expect(calls.thread[0]!.content).toBe(BRIEF_WINDOW_RESTART_NOTICE);
+    // 待機報告 → 再送依頼の順で出る（#464 で前者が加わった）。
+    expect(calls.thread.map((c) => c.content)).toEqual([
+      STANDBY,
+      BRIEF_WINDOW_RESTART_NOTICE,
+    ]);
   });
 
   test("hands non-window threads back to the existing salvage path", async () => {
@@ -500,18 +589,37 @@ describe("handleBriefWindowThreadMessage (lazy entry)", () => {
       threadName: "corp-dispatch-12 Corp CEO 1",
       deps: d,
     });
-    expect(consumed).toBe(false);
+    expect(consumed).toBe("not_window");
     expect(calls.started).toEqual([]);
   });
 
-  test("falls through to salvage when the kill-switch is off rather than going quiet", async () => {
-    const { deps: d } = deps();
+  test("#463: keeps a disabled window away from the generic wake and says why", async () => {
+    const { deps: d, calls } = deps();
     const consumed = await handleBriefWindowThreadMessage({
       ...base,
       deps: d,
       env: { CORP_BRIEF_WINDOW_DISABLED: "1" },
     });
-    expect(consumed).toBe(false);
+    // "not_window" ではないので bot.ts は汎用 auto-resume に落とさない。
+    expect(consumed).toBe("blocked");
+    expect(calls.started).toEqual([]);
+    expect(calls.thread.map((c) => c.content)).toEqual([
+      BRIEF_WINDOW_DISABLED_NOTICE,
+    ]);
+  });
+
+  test("#463: same for a window thread whose channel has no brief config", async () => {
+    const { deps: d, calls } = deps();
+    const consumed = await handleBriefWindowThreadMessage({
+      ...base,
+      hasBriefConfig: false,
+      deps: d,
+    });
+    expect(consumed).toBe("blocked");
+    expect(calls.started).toEqual([]);
+    expect(calls.thread.map((c) => c.content)).toEqual([
+      BRIEF_WINDOW_NO_CONFIG_NOTICE,
+    ]);
   });
 
   test("consumes the message at the session cap (the reason was posted in-thread)", async () => {
@@ -521,7 +629,7 @@ describe("handleBriefWindowThreadMessage (lazy entry)", () => {
       sessionCount: 10,
       deps: d,
     });
-    expect(consumed).toBe(true);
+    expect(consumed).toBe("blocked");
     expect(calls.thread.length).toBe(1);
     expect(calls.started).toEqual([]);
   });
@@ -533,7 +641,7 @@ describe("handleBriefWindowThreadMessage (lazy entry)", () => {
       },
     });
     const consumed = await handleBriefWindowThreadMessage({ ...base, deps: d });
-    expect(consumed).toBe(true);
+    expect(consumed).toBe("blocked");
     expect(calls.failures.length).toBe(1);
   });
 });

--- a/supervisor/tests/session/brief-window.test.ts
+++ b/supervisor/tests/session/brief-window.test.ts
@@ -8,6 +8,8 @@ import {
   BRIEF_WINDOW_EMPTY_REPLY_NOTICE,
   BRIEF_WINDOW_NO_CONFIG_NOTICE,
   BRIEF_WINDOW_REPLY_ERROR_NOTICE,
+  BRIEF_WINDOW_UNRESOLVED_NOTICE,
+  briefWindowResolutionFailure,
   BRIEF_WINDOW_RESTART_NOTICE,
   createBriefWindowDeps,
   evaluateBriefWindowOpen,
@@ -552,6 +554,25 @@ describe("standby report delivery (#464)", () => {
     expect(calls.thread.length).toBe(1);
     expect(calls.thread[0]!.content).toContain("pane gone");
     expect(calls.failures.length).toBe(1);
+  });
+});
+
+describe("briefWindowResolutionFailure (#463 / CodeRabbit)", () => {
+  // スレッド名で窓口と確定した「あと」の解決失敗は、窓口でないことを意味しない。
+  // "not_window" を返すと汎用 wake (#456) が素の --resume で起こしてしまう。
+  test("never reports a resolution failure as a non-window thread", () => {
+    for (const stage of ["parent", "config"] as const) {
+      expect(briefWindowResolutionFailure(stage).outcome).toBe("blocked");
+    }
+  });
+
+  test("explains which resolution failed", () => {
+    expect(briefWindowResolutionFailure("parent").notice).toBe(
+      BRIEF_WINDOW_UNRESOLVED_NOTICE,
+    );
+    expect(briefWindowResolutionFailure("config").notice).toBe(
+      BRIEF_WINDOW_NO_CONFIG_NOTICE,
+    );
   });
 });
 

--- a/supervisor/tests/session/brief-window.test.ts
+++ b/supervisor/tests/session/brief-window.test.ts
@@ -10,6 +10,7 @@ import {
   BRIEF_WINDOW_REPLY_ERROR_NOTICE,
   BRIEF_WINDOW_UNRESOLVED_NOTICE,
   briefWindowResolutionFailure,
+  reportBriefWindowResolutionFailure,
   BRIEF_WINDOW_RESTART_NOTICE,
   createBriefWindowDeps,
   evaluateBriefWindowOpen,
@@ -576,6 +577,36 @@ describe("briefWindowResolutionFailure (#463 / CodeRabbit)", () => {
   });
 });
 
+describe("reportBriefWindowResolutionFailure (#463 / CodeRabbit)", () => {
+  test("posts the matching notice and blocks the generic wake", async () => {
+    const sent: string[] = [];
+    const outcome = await reportBriefWindowResolutionFailure(
+      "parent",
+      "win-1",
+      async (c) => {
+        sent.push(c);
+        return {};
+      },
+    );
+
+    expect(outcome).toBe("blocked");
+    expect(sent).toEqual([BRIEF_WINDOW_UNRESOLVED_NOTICE]);
+  });
+
+  test("still blocks when the notice cannot be posted", async () => {
+    // 通知は目的ではない。汎用 wake へ落とさないことが目的。
+    const outcome = await reportBriefWindowResolutionFailure(
+      "config",
+      "win-1",
+      async () => {
+        throw new Error("discord 500");
+      },
+    );
+
+    expect(outcome).toBe("blocked");
+  });
+});
+
 describe("handleBriefWindowThreadMessage (lazy entry)", () => {
   const base = {
     threadId: "win-1",
@@ -627,6 +658,20 @@ describe("handleBriefWindowThreadMessage (lazy entry)", () => {
     expect(calls.thread.map((c) => c.content)).toEqual([
       BRIEF_WINDOW_DISABLED_NOTICE,
     ]);
+  });
+
+  test("#463: a failed skip notice still blocks the generic wake", async () => {
+    const { deps: d } = deps({
+      postToThread: async () => {
+        throw new Error("discord 500");
+      },
+    });
+    const consumed = await handleBriefWindowThreadMessage({
+      ...base,
+      deps: d,
+      env: { CORP_BRIEF_WINDOW_DISABLED: "1" },
+    });
+    expect(consumed).toBe("blocked");
   });
 
   test("#463: same for a window thread whose channel has no brief config", async () => {


### PR DESCRIPTION
Closes #464
Closes #463

窓口（#454）の契約の穴を 2 つ塞ぐ。どちらも `brief-window.ts` の同じ関数群に触るため 1 本にまとめた。

## #464 — 起動直後の待機報告がスレッドに出ない

2026-08-27 の本番初回で、tmux ペインには CEO の待機報告が出ているのにスレッドは空だった。スレッドの 1 通目は 4 時間後の会長発言で、開幕の要約（未決提案数・判断待ち件数）が丸ごと落ちていた。

原因は `bot.ts` の bind が `sessionManager.sendMessage()` の `RelayResult` を捨てていたこと。通常の会話経路は同じ値から `chunks` を取り出してスレッドへ投稿しており、**窓口の初期注入だけがその投稿を持っていなかった**。

- `BriefWindowDeps.sendMessage` / `BriefWindowSessionsLike.sendMessage` を `BriefWindowRelayReply`（`chunks` + `error`）を返す契約に変更
- eager / lazy 共通の `startWindowSession` が受け取った chunks をスレッドへ投稿（`deliverStandbyReport`）
- 応答が空 / error のときも黙って成功扱いにせず理由を出す（`agent-output-quality.md` #1）
- **投稿の失敗で窓口の起動成功を巻き戻さない**。窓口は既に使えており、挨拶が出ないことと窓口が無いことは別物

影響範囲は起動直後の 1 行のみ。会長の書き込みへの応答は通常経路を通るため無傷で、同日の運用（記事公開・SNS 連携・close 指示）は窓口経由で正常に完了していた。

## #463 — kill-switch を効かせても窓口スレッドが起き上がる

`handleBriefWindowThreadMessage` が kill-switch / brief 未設定の skip で `false` を返していたため、窓口スレッドにも `sessions.db` の履歴がある以上、#456 の汎用 auto-resume が拾って素の `--resume` で復帰させていた。会長が窓口の自動再起動を止めたつもりでも別経路で起きる。

- 戻り値を `restarted` / `blocked` / `not_window` の 3 値に変更
- `bot.ts` は `not_window` 以外なら汎用 wake へ落とさない
- 止めている理由（kill-switch 有効 / チャンネル未設定）はスレッドへ明示する。silent に消費しない

`AUTO_RESUME_DISABLED` の併用で運用上の詰みは無かったが、「窓口を止めたのに窓口が起きる」挙動そのものを消した。

### 挙動の変化（意図的）

kill-switch 有効なスレッドに書き込むと毎回 1 通の停止通知が出る。無言で消費するより誤解が少ないと判断した。窓口を止めている状態自体が稀なので、実運用での増分は小さい。

## AC 検証結果

| AC | 検証内容 | コマンド | 期待 | 実測 | 判定 |
|---|---|---|---|---|---|
| #464-1 | 待機報告がスレッドへ投稿される | `bun test tests/session/brief-window.test.ts` | postToThread に chunk | 一致 | **PASS** |
| #464-2 | 空 chunk は落とし、非空だけ出す | 同上 | `["one","two"]` | 一致 | **PASS** |
| #464-3 | 応答ゼロでも無言にしない | 同上 | 通知 1 件 | 一致 | **PASS** |
| #464-4 | relay error を理由込みで出す | 同上 | 通知に error 文字列 | 一致 | **PASS** |
| #464-5 | 投稿失敗が起動成功を巻き戻さない | 同上 | `ok: true` | 一致 | **PASS** |
| #464-6 | 注入失敗時は待機報告を出さない | 同上 | `ok: false` + 失敗通知 | 一致 | **PASS** |
| #463-1 | kill-switch 時に汎用 wake へ落とさない | 同上 | `blocked` + 停止通知 | 一致 | **PASS** |
| #463-2 | brief 未設定でも同様 | 同上 | `blocked` + 通知 | 一致 | **PASS** |
| #463-3 | 窓口でないスレッドは従来どおり | 同上 | `not_window` | 一致 | **PASS** |
| 回帰 | 既存スイート | `bun test`（1598 件） | origin/main と失敗集合が一致 | **完全一致**（33 件はいずれも origin/main 時点から失敗している tmux/socket 系の環境依存） | **PASS** |
| 型 | 型検査 | `bunx tsc --noEmit` | exit 0 | exit 0 | **PASS** |

新規テスト 7 件を追加し、当該ファイルは 39/39 PASS。

## 実機検証について

本番の窓口は毎朝 07:00 の launchd 朝レポで開く。merge + supervisor 再起動のうえ、次の朝レポで「スレッドの 1 通目が CEO の待機報告であること」を `fetch_messages` で確認する。同日中に見たい場合は `npm run secretary -- --force-brief` のリハーサル経路でも再現できる。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Awc4fvf8CnDfqYx9y6g4hP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 待機報告をスレッドに表示するようになりました。
  * 空の応答やエラー発生時に、状況を知らせる通知を表示します。
  * 再起動できない状態（無効化、設定不足、容量超過など）を明示します。

* **不具合修正**
  * 窓口スレッドが意図せず汎用の再開処理へ進む問題を修正しました。
  * 再起動後の再送依頼が正しく表示されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->